### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ The `Session` object represents a set of interactions a `User` has with an
 **Messages**
 
 The `Message` represents an atomic interaction of a `User` in a `Session`.
-`Message`s are labed as either a `User` or AI message.
+`Message`s are labeled as either a `User` or AI message.
 
 #### Collections
 
 At a high level a `Collection` is a named group of `Documents`. Developers
-familiar with RAG based applications will be familar with these. `Collection`s
+familiar with RAG based applications will be familiar with these. `Collection`s
 store vector embedded data that developers and agents can retrieve against using
 functions like cosine similarity.
 


### PR DESCRIPTION
This pull request fixes two typos in the README.md file:
- Corrected "labled" to "labeled" in the Message section
- Corrected "familar" to "familiar" in the Collections section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed typographical errors in the README for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->