### PR TITLE
filter out HonchoException in sentry.sdk init

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -71,6 +71,7 @@ if SENTRY_ENABLED:
         dsn=os.getenv("SENTRY_DSN"),
         traces_sample_rate=0.4,
         profiles_sample_rate=0.4,
+        ignore_errors=[HonchoException],
         integrations=[
             StarletteIntegration(
                 transaction_style="endpoint",


### PR DESCRIPTION
- Ignore-errors doc: https://docs.sentry.io/platforms/python/configuration/options/#ignore_errors
- Although we have global exception handlers in Honcho, it seems our middleware integration for FastAPI/Starlette send the exceptions to sentry direction.
- Example sentry error from a ConflictException (that inherits from HonchoException): https://plastic-labs.sentry.io/issues/6587924431/?alert_rule_id=14678159&alert_timestamp=1746500674610&alert_type=email&environment=production&notification_uuid=cc47a31b-fa9a-40e6-ac34-66fcc8e40e8f&project=4505903820570624&referrer=alert_email
In the below screenshot, we can see that Starlette’s ExceptionMiddleware raised the exception which is then captured by sentry. This is opposed to a manual sentry capture exception.
<img width="548" alt="Screenshot 2025-05-05 at 10 48 54 PM" src="https://github.com/user-attachments/assets/49208d80-7518-4f5b-beb2-3c5a515dc069" />
