### PR TITLE
Switch SessionLocal in Dialectic to use get_db

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -410,7 +410,7 @@ async def generate_semantic_queries(query: str) -> list[str]:
                 logger.debug("LLM response not a list, using as single query")
                 queries = [result]
         except json.JSONDecodeError:
-            # Fallback if response is not valid JSONe
+            # Fallback if response is not valid JSON
             logger.debug("Failed to parse JSON response, using raw response as query")
             queries = [query]  # Fall back to the original query
 

--- a/src/agent.py
+++ b/src/agent.py
@@ -152,6 +152,7 @@ async def chat(
     user_id: str,
     session_id: str,
     queries: str | list[str],
+    db: AsyncSession,
     stream: bool = False,
 ) -> schemas.DialecticResponse | MessageStreamManager:
     """
@@ -175,80 +176,79 @@ async def chat(
 
     start_time = asyncio.get_event_loop().time()
 
-    async with SessionLocal() as db:
-        # Setup phase - create resources we'll need for all operations
+    # Setup phase - create resources we'll need for all operations
 
-        # 1. Create embedding store
-        collection = await crud.get_or_create_user_protected_collection(
-            db, app_id, user_id
-        )
+    # 1. Create embedding store
+    collection = await crud.get_or_create_user_protected_collection(
+        db, app_id, user_id
+    )
 
-        embedding_store = CollectionEmbeddingStore(
-            db=db,
-            app_id=app_id,
-            user_id=user_id,
-            collection_id=collection.public_id,  # type: ignore
-        )
-        logger.debug(
-            f"Created embedding store with collection_id: {collection.public_id if collection else None}"
-        )
+    embedding_store = CollectionEmbeddingStore(
+        db=db,
+        app_id=app_id,
+        user_id=user_id,
+        collection_id=collection.public_id,  # type: ignore
+    )
+    logger.debug(
+        f"Created embedding store with collection_id: {collection.public_id if collection else None}"
+    )
 
-        # 2. Get the latest user message to attach the user representation to
-        stmt = (
-            select(models.Message)
-            .join(models.Session, models.Session.public_id == models.Message.session_id)
-            .join(models.User, models.User.public_id == models.Session.user_id)
-            .join(models.App, models.App.public_id == models.User.app_id)
-            .where(models.App.public_id == app_id)
-            .where(models.User.public_id == user_id)
-            .where(models.Message.session_id == session_id)
-            .where(models.Message.is_user)
-            .order_by(models.Message.id.desc())
-            .limit(1)
-        )
-        latest_messages = await db.execute(stmt)
-        latest_message = latest_messages.scalar_one_or_none()
-        latest_message_id = latest_message.public_id if latest_message else None
-        logger.debug(f"Latest user message ID: {latest_message_id}")
+    # 2. Get the latest user message to attach the user representation to
+    stmt = (
+        select(models.Message)
+        .join(models.Session, models.Session.public_id == models.Message.session_id)
+        .join(models.User, models.User.public_id == models.Session.user_id)
+        .join(models.App, models.App.public_id == models.User.app_id)
+        .where(models.App.public_id == app_id)
+        .where(models.User.public_id == user_id)
+        .where(models.Message.session_id == session_id)
+        .where(models.Message.is_user)
+        .order_by(models.Message.id.desc())
+        .limit(1)
+    )
+    latest_messages = await db.execute(stmt)
+    latest_message = latest_messages.scalar_one_or_none()
+    latest_message_id = latest_message.public_id if latest_message else None
+    logger.debug(f"Latest user message ID: {latest_message_id}")
 
-        # Get chat history for the session
-        chat_history, _, _ = await history.get_summarized_history(
-            db, session_id, summary_type=history.SummaryType.SHORT
-        )
-        if not chat_history:
-            logger.warning(f"No chat history found for session {session_id}")
-            chat_history = f"someone asked this about the user's message: {final_query}"
-        logger.debug(f"IDs: {app_id}, {user_id}, {session_id}")
-        message_count = len(chat_history.split("\n"))
-        logger.debug(f"Retrieved chat history: {message_count} messages")
+    # Get chat history for the session
+    chat_history, _, _ = await history.get_summarized_history(
+        db, session_id, summary_type=history.SummaryType.SHORT
+    )
+    if not chat_history:
+        logger.warning(f"No chat history found for session {session_id}")
+        chat_history = f"someone asked this about the user's message: {final_query}"
+    logger.debug(f"IDs: {app_id}, {user_id}, {session_id}")
+    message_count = len(chat_history.split("\n"))
+    logger.debug(f"Retrieved chat history: {message_count} messages")
 
-        # Run both long-term and short-term context retrieval concurrently
-        logger.debug("Starting parallel tasks for context retrieval")
-        long_term_task = get_long_term_facts(final_query, embedding_store)
-        short_term_task = run_tom_inference(chat_history, session_id)
+    # Run both long-term and short-term context retrieval concurrently
+    logger.debug("Starting parallel tasks for context retrieval")
+    long_term_task = get_long_term_facts(final_query, embedding_store)
+    short_term_task = run_tom_inference(chat_history, session_id)
 
-        # Wait for both tasks to complete
-        facts, tom_inference = await asyncio.gather(long_term_task, short_term_task)
-        logger.debug(f"Retrieved {len(facts)} facts from long-term memory")
-        logger.debug(f"TOM inference completed with {len(tom_inference)} characters")
+    # Wait for both tasks to complete
+    facts, tom_inference = await asyncio.gather(long_term_task, short_term_task)
+    logger.debug(f"Retrieved {len(facts)} facts from long-term memory")
+    logger.debug(f"TOM inference completed with {len(tom_inference)} characters")
 
-        # Generate a fresh user representation
-        logger.debug("Generating user representation")
-        user_representation = await generate_user_representation(
-            app_id=app_id,
-            user_id=user_id,
-            session_id=session_id,
-            chat_history=chat_history,
-            tom_inference=tom_inference,
-            facts=facts,
-            embedding_store=embedding_store,
-            db=db,
-            message_id=latest_message_id,
-            with_inference=False,
-        )
-        logger.debug(
-            f"User representation generated: {len(user_representation)} characters"
-        )
+    # Generate a fresh user representation
+    logger.debug("Generating user representation")
+    user_representation = await generate_user_representation(
+        app_id=app_id,
+        user_id=user_id,
+        session_id=session_id,
+        chat_history=chat_history,
+        tom_inference=tom_inference,
+        facts=facts,
+        embedding_store=embedding_store,
+        db=db,
+        message_id=latest_message_id,
+        with_inference=False,
+    )
+    logger.debug(
+        f"User representation generated: {len(user_representation)} characters"
+    )
 
     # Create a Dialectic chain with the fresh user representation
     chain = Dialectic(
@@ -410,7 +410,7 @@ async def generate_semantic_queries(query: str) -> list[str]:
                 logger.debug("LLM response not a list, using as single query")
                 queries = [result]
         except json.JSONDecodeError:
-            # Fallback if response is not valid JSON
+            # Fallback if response is not valid JSONe
             logger.debug("Failed to parse JSON response, using raw response as query")
             queries = [query]  # Fall back to the original query
 

--- a/src/db.py
+++ b/src/db.py
@@ -1,3 +1,4 @@
+import contextvars
 import os
 
 from dotenv import load_dotenv
@@ -7,9 +8,10 @@ from sqlalchemy.orm import declarative_base
 
 load_dotenv()
 
-connect_args = {
-    "prepare_threshold": None,
-}
+connect_args = {"prepare_threshold": None}
+
+# Context variable to store request context
+request_context = contextvars.ContextVar("request_context", default=None)
 
 engine = create_async_engine(
     os.environ["CONNECTION_URI"],

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -1,13 +1,21 @@
+import uuid
+from contextlib import asynccontextmanager
+
 from fastapi import Depends
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .db import SessionLocal
+from .db import SessionLocal, request_context
 
 
 async def get_db():
     """FastAPI Dependency Generator for Database"""
+
+    context = request_context.get() or "unknown"
+
     db: AsyncSession = SessionLocal()
     try:
+        await db.execute(text(f"SET application_name = '{context}'"))
         yield db
     except Exception:
         await db.rollback()
@@ -16,6 +24,38 @@ async def get_db():
         if db.in_transaction():
             await db.rollback()
         await db.close()
+
+
+@asynccontextmanager
+async def tracked_db(operation_name=None):
+    """Context manager for tracked database sessions"""
+    # Get request ID if available, or create operation-specific one
+    context = request_context.get()
+    token = None
+
+    if not context and operation_name:
+        context = f"task:{operation_name}:{str(uuid.uuid4())[:8]}"
+        token = request_context.set(context)
+
+    # Create session with tracking info
+    db = SessionLocal()
+
+    try:
+        await db.execute(
+            text(f"SET application_name = '{context or f'task:{operation_name}'}'")
+        )
+
+        yield db
+        # Explicitly end transaction if still open
+        if db.in_transaction():
+            await db.rollback()  # Or commit if needed for write operations
+    except Exception:
+        await db.rollback()
+        raise
+    finally:
+        await db.close()
+        if token:  # Only reset if we set it
+            request_context.reset(token)
 
 
 db: AsyncSession = Depends(get_db)

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -13,6 +13,8 @@ async def get_db():
         await db.rollback()
         raise
     finally:
+        if db.in_transaction():
+            await db.rollback()
         await db.close()
 
 

--- a/src/routers/sessions.py
+++ b/src/routers/sessions.py
@@ -206,7 +206,9 @@ async def chat(
     options: schemas.DialecticOptions = Body(
         ..., description="Dialectic Endpoint Parameters"
     ),
+    db=db,
 ):
+
     """Chat with the Dialectic API"""
     if not options.stream:
         return await agent.chat(
@@ -214,6 +216,7 @@ async def chat(
             user_id=user_id,
             session_id=session_id,
             queries=options.queries,
+            db=db,
         )
     else:
 
@@ -225,6 +228,7 @@ async def chat(
                     session_id=session_id,
                     queries=options.queries,
                     stream=True,
+                    db=db,
                 )
                 if type(stream) is AsyncMessageStreamManager:
                     async with stream as stream_manager:


### PR DESCRIPTION
- use `get_db` inside of agent.chat
- add rollback before closing db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced request tracking middleware generating unique request IDs per request.
	- Added a tracked database session context manager for enhanced transaction safety and context management.
- **Bug Fixes**
	- Improved database session handling to prevent potential issues with open transactions during chat interactions.
	- Centralized rollback logic to ensure consistent transaction cleanup across various components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->