### PR TITLE
Fix Sentry IntegrityError

### DIFF
--- a/src/crud.py
+++ b/src/crud.py
@@ -124,7 +124,7 @@ async def create_app(db: AsyncSession, app: schemas.AppCreate) -> models.App:
         return honcho_app
     except IntegrityError as e:
         await db.rollback()
-        logger.error(f"IntegrityError creating app with name '{app.name}': {str(e)}")
+        logger.warning(f"IntegrityError creating app with name '{app.name}': {str(e)}")
         raise ConflictException(f"App with name '{app.name}' already exists") from e
 
 
@@ -158,7 +158,7 @@ async def update_app(
         return honcho_app
     except IntegrityError as e:
         await db.rollback()
-        logger.error(f"IntegrityError updating app {app_id}: {str(e)}")
+        logger.warning(f"IntegrityError updating app {app_id}: {str(e)}")
         raise ConflictException(
             "App update failed - unique constraint violation"
         ) from e

--- a/src/main.py
+++ b/src/main.py
@@ -79,6 +79,12 @@ if SENTRY_ENABLED:
 
         return event
 
+    # Sentry SDK's default behavior:
+    # - Captures INFO+ level logs as breadcrumbs
+    # - Captures ERROR+ level logs as Sentry events
+    # 
+    # For custom log levels, use the LoggingIntegration class:
+    # sentry_sdk.init(..., integrations=[LoggingIntegration(level=logging.INFO, event_level=logging.ERROR)])
     sentry_sdk.init(
         dsn=os.getenv("SENTRY_DSN"),
         traces_sample_rate=0.4,


### PR DESCRIPTION
- Change integrity error logger.error -> logger.warning in `crud.py` for apps because we don't want the error logs to raise a sentry event
- Add comment explaining how logging integration works in sentry