### PR TITLE
fix: remove hardcoded responses

### DIFF
--- a/src/crud.py
+++ b/src/crud.py
@@ -1088,10 +1088,10 @@ async def get_working_representation(
         latest_representation_obj = result.scalar_one_or_none()
         latest_representation = (
             latest_representation_obj.internal_metadata.get(
-                USER_REPRESENTATION_METADATA_KEY, "No user representation available."
+                USER_REPRESENTATION_METADATA_KEY, ""
             )
             if latest_representation_obj
-            else "No user representation available."
+            else ""
         )
     else:
         # Fetch the latest global level user representation
@@ -1105,10 +1105,10 @@ async def get_working_representation(
         latest_representation_obj = result.scalar_one_or_none()
         latest_representation = (
             latest_representation_obj.internal_metadata.get(
-                USER_REPRESENTATION_METADATA_KEY, "No user representation available."
+                USER_REPRESENTATION_METADATA_KEY, ""
             )
             if latest_representation_obj
-            else "No user representation available."
+            else ""
         )
 
     return latest_representation

--- a/src/utils/history.py
+++ b/src/utils/history.py
@@ -213,7 +213,7 @@ Provide a {"comprehensive" if summary_type == SummaryType.LONG else "concise"} s
             content=(
                 f"Conversation with {len(messages)} messages about {messages[-1].content[:30]}..."
                 if messages
-                else "No messages to summarize!"
+                else ""
             ),
             message_count=0,
             summary_type=summary_type.value,


### PR DESCRIPTION
After using Honcho 2.0 I realized that there are some hardcoded strings returned in relatively common cases. We should return either an error or an empty string so that it's easier for developers to recognize this output and route around it in their software. This PR goes with the empty string option -- LMK if an error would be better.