### PR TITLE
bugfix: avoid runtime NameError by using string annotations for Event and Hint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -68,7 +68,7 @@ async def setup_admin_jwt():
 SENTRY_ENABLED = settings.SENTRY.ENABLED
 if SENTRY_ENABLED:
 
-    def before_send(event: Event, hint: Hint) -> Event | None:
+    def before_send(event: "Event", hint: "Hint") -> "Event | None":
         if "exc_info" in hint:
             _, exc_value, _ = hint["exc_info"]
             # Filter out HonchoExceptions from being sent to Sentry


### PR DESCRIPTION
this is currently causing the Honcho API server to fail when starting up in any environment where SENTRY_ENABLED=true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated type annotation syntax for improved code consistency. No changes to app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->