### PR TITLE
expose core client in TS and Python SDKs

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "honcho-ai"
-version = "1.1.0"
+version = "1.2.0"
 description = "Official DX Optimized Python SDK for Honcho"
 dynamic = ["readme"]
 license = "Apache-2.0"

--- a/sdks/python/src/honcho/async_client/client.py
+++ b/sdks/python/src/honcho/async_client/client.py
@@ -24,10 +24,14 @@ class AsyncHoncho(BaseModel):
     from environment variables or explicit parameters. This is the primary entry
     point for interacting with the Honcho conversational memory platform asynchronously.
 
+    For advanced usage, the underlying honcho_core client can be accessed via the
+    `core` property to use functionality not exposed through this SDK.
+
     Attributes:
         api_key: API key for authentication
         base_url: Base URL for the Honcho API
         workspace_id: Workspace ID for scoping operations
+        core: Access to the underlying honcho_core client for advanced usage
     """
 
     workspace_id: str = Field(
@@ -36,6 +40,26 @@ class AsyncHoncho(BaseModel):
         description="Workspace ID for scoping operations",
     )
     _client: AsyncHonchoCore = PrivateAttr()
+
+    @property
+    def core(self) -> AsyncHonchoCore:
+        """
+        Access the underlying honcho_core client. The honcho_core client is the raw Stainless-generated client,
+        allowing users to access functionality that is not exposed through this SDK.
+
+        Returns:
+            The underlying AsyncHonchoCore client instance
+
+        Example:
+            ```python
+            from honcho import AsyncHoncho
+
+            client = AsyncHoncho()
+
+            workspace = await client.core.workspaces.get_or_create(id="custom-workspace-id")
+            ```
+        """
+        return self._client
 
     @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def __init__(

--- a/sdks/python/src/honcho/client.py
+++ b/sdks/python/src/honcho/client.py
@@ -23,10 +23,14 @@ class Honcho(BaseModel):
     from environment variables or explicit parameters. This is the primary entry
     point for interacting with the Honcho conversational memory platform.
 
+    For advanced usage, the underlying honcho_core client can be accessed via the
+    `raw` property to use lower-level functionality not exposed in the ergonomic interface.
+
     Attributes:
         api_key: API key for authentication
         base_url: Base URL for the Honcho API
         workspace_id: Workspace ID for scoping operations
+        raw: Access to the underlying honcho_core client for advanced usage
     """
 
     workspace_id: str = Field(
@@ -35,6 +39,30 @@ class Honcho(BaseModel):
         description="Workspace ID for scoping operations",
     )
     _client: HonchoCore = PrivateAttr()
+
+    @property
+    def core(self) -> HonchoCore:
+        """
+        Access the underlying honcho_core client. The honcho_core client is the raw Stainless-generated client,
+        allowing users to access functionality that is not exposed through the ergonomic SDK interface.
+
+        Returns:
+            The underlying HonchoCore client instance
+
+        Example:
+            ```python
+            from honcho import Honcho
+
+            client = Honcho()
+
+            # Use ergonomic interface
+            peer = client.peer("user123")
+
+            # Access core client
+            workspace = client.core.workspaces.get_or_create(id="custom-workspace")
+            ```
+        """
+        return self._client
 
     @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def __init__(

--- a/sdks/python/src/honcho/client.py
+++ b/sdks/python/src/honcho/client.py
@@ -24,13 +24,13 @@ class Honcho(BaseModel):
     point for interacting with the Honcho conversational memory platform.
 
     For advanced usage, the underlying honcho_core client can be accessed via the
-    `raw` property to use lower-level functionality not exposed in the ergonomic interface.
+    `core` property to use functionality not exposed through this SDK.
 
     Attributes:
         api_key: API key for authentication
         base_url: Base URL for the Honcho API
         workspace_id: Workspace ID for scoping operations
-        raw: Access to the underlying honcho_core client for advanced usage
+        core: Access to the underlying honcho_core client for advanced usage
     """
 
     workspace_id: str = Field(
@@ -44,7 +44,7 @@ class Honcho(BaseModel):
     def core(self) -> HonchoCore:
         """
         Access the underlying honcho_core client. The honcho_core client is the raw Stainless-generated client,
-        allowing users to access functionality that is not exposed through the ergonomic SDK interface.
+        allowing users to access functionality that is not exposed through this SDK.
 
         Returns:
             The underlying HonchoCore client instance
@@ -55,11 +55,7 @@ class Honcho(BaseModel):
 
             client = Honcho()
 
-            # Use ergonomic interface
-            peer = client.peer("user123")
-
-            # Access core client
-            workspace = client.core.workspaces.get_or_create(id="custom-workspace")
+            workspace = client.core.workspaces.get_or_create(id="custom-workspace-id")
             ```
         """
         return self._client

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honcho-ai/sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Official DX Optimized TypeScript SDK for Honcho",
   "author": "Plastic Labs <hello@plasticlabs.ai>",
   "license": "Apache-2.0",
@@ -17,8 +17,8 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@types/node": "^24.0.1",
-    "@honcho-ai/core": "^1.1.0"
+    "@honcho-ai/core": "^1.1.0",
+    "@types/node": "^24.0.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -6,10 +6,40 @@ import { Session } from './session';
 /**
  * Main client for the Honcho TypeScript SDK.
  * Provides access to peers, sessions, and workspace operations.
+ * 
+ * For advanced usage, the underlying @honcho-ai/core client can be accessed via the
+ * `core` property to use lower-level functionality not exposed in the ergonomic interface.
  */
 export class Honcho {
   private _client: InstanceType<typeof HonchoCore>;
   readonly workspaceId: string;
+
+  /**
+   * Access the underlying @honcho-ai/core client for advanced usage.
+   * 
+   * This provides direct access to the raw Stainless-generated client,
+   * allowing advanced users to access lower-level functionality that
+   * may not be exposed through the ergonomic SDK interface.
+   * 
+   * @returns The underlying HonchoCore client instance
+   * 
+   * @example
+   * ```typescript
+   * import { Honcho } from '@honcho-ai/sdk';
+   * 
+   * const client = new Honcho();
+   * 
+   * // Use ergonomic interface
+   * const peer = client.peer("user123");
+   * 
+   * // Access core client for advanced usage
+   * const workspace = await client.core.workspaces.getOrCreate({ id: "custom-workspace" });
+   * const rawPeers = await client.core.workspaces.peers.list("custom-workspace");
+   * ```
+   */
+  get core(): InstanceType<typeof HonchoCore> {
+    return this._client;
+  }
 
   /**
    * Initialize the Honcho client.

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -8,18 +8,15 @@ import { Session } from './session';
  * Provides access to peers, sessions, and workspace operations.
  * 
  * For advanced usage, the underlying @honcho-ai/core client can be accessed via the
- * `core` property to use lower-level functionality not exposed in the ergonomic interface.
+ * `core` property to use functionality not exposed through this SDK.
  */
 export class Honcho {
   private _client: InstanceType<typeof HonchoCore>;
   readonly workspaceId: string;
 
   /**
-   * Access the underlying @honcho-ai/core client for advanced usage.
-   * 
-   * This provides direct access to the raw Stainless-generated client,
-   * allowing advanced users to access lower-level functionality that
-   * may not be exposed through the ergonomic SDK interface.
+   * Access the underlying @honcho-ai/core client. The @honcho-ai/core client is the raw Stainless-generated client,
+   * allowing users to access functionality that is not exposed through this SDK.
    * 
    * @returns The underlying HonchoCore client instance
    * 
@@ -29,12 +26,7 @@ export class Honcho {
    * 
    * const client = new Honcho();
    * 
-   * // Use ergonomic interface
-   * const peer = client.peer("user123");
-   * 
-   * // Access core client for advanced usage
-   * const workspace = await client.core.workspaces.getOrCreate({ id: "custom-workspace" });
-   * const rawPeers = await client.core.workspaces.peers.list("custom-workspace");
+   * const workspace = await client.core.workspaces.getOrCreate({ id: "custom-workspace-id" });
    * ```
    */
   get core(): InstanceType<typeof HonchoCore> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new property to both Python and TypeScript SDK clients, allowing advanced users to access the underlying core client for direct, lower-level operations.

* **Documentation**
  * Enhanced class documentation and added usage examples for the new core client access property.

* **Chores**
  * Updated SDK version numbers to 1.2.0 in both Python and TypeScript packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->