### PR TITLE
feat: add filter params everywhere

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test-python:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  test-python:
     runs-on: ubuntu-latest
 
     services:
@@ -59,3 +59,45 @@ jobs:
           DIALECTIC_QUERY_GENERATION_MODEL: test
           SUMMARY_PROVIDER: openai
           SUMMARY_MODEL: test
+
+  test-typescript:
+    runs-on: ubuntu-latest
+
+    services:
+      database:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_DB: test_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: 'sdks/typescript/package-lock.json'
+
+      - name: Install TypeScript SDK dependencies
+        run: |
+          cd sdks/typescript
+          npm ci
+
+      - name: Run TypeScript SDK tests
+        run: |
+          cd sdks/typescript
+          npm test
+        env:
+          HONCHO_API_KEY: test-key
+          HONCHO_BASE_URL: http://localhost:8000

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -63,41 +63,23 @@ jobs:
   test-typescript:
     runs-on: ubuntu-latest
 
-    services:
-      database:
-        image: pgvector/pgvector:pg15
-        env:
-          POSTGRES_DB: test_db
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_HOST_AUTH_METHOD: trust
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v1
         with:
-          node-version: '18'
-          cache: 'npm'
-          cache-dependency-path: 'sdks/typescript/package-lock.json'
+          bun-version: latest
 
       - name: Install TypeScript SDK dependencies
         run: |
           cd sdks/typescript
-          npm ci
+          bun install
 
       - name: Run TypeScript SDK tests
         run: |
           cd sdks/typescript
-          npm test
+          bun test
         env:
           HONCHO_API_KEY: test-key
           HONCHO_BASE_URL: http://localhost:8000

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Run TypeScript SDK tests
         run: |
           cd sdks/typescript
-          bun test
+          bun run test
         env:
           HONCHO_API_KEY: test-key
           HONCHO_BASE_URL: http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ docs/node_modules
 timing_logs.csv
 
 config.toml
+.aider*

--- a/docs/changelog/compatibility-guide.mdx
+++ b/docs/changelog/compatibility-guide.mdx
@@ -12,50 +12,29 @@ This guide helps you understand which versions of Honcho's API are compatible wi
 
 <CardGroup cols={2}>
   <Card title="TypeScript SDK" icon="js">
-    **Compatible Version:** v1.2.0
+    **Compatible Version:** v1.2.1
     
     Install with:
     ```bash
-    npm install @honcho-ai/sdk@1.2.0
+    npm install @honcho-ai/sdk@1.2.1
     ```
   </Card>
   
   <Card title="Python SDK" icon="python">
-    **Compatible Version:** v1.2.0
+    **Compatible Version:** v1.2.2
 
     Install with:
     ```bash
-    pip install honcho-ai==1.2.0
+    pip install honcho-ai==1.2.2
     ```
   </Card>
-</CardGroup>
 
-### Honcho API v2.0.5
-
-<CardGroup cols={2}>
-  <Card title="TypeScript SDK" icon="js">
-    **Compatible Version:** v1.1.0
-    
-    Install with:
-    ```bash
-    npm install @honcho-ai/sdk@1.1.0
-    ```
-  </Card>
-  
-  <Card title="Python SDK" icon="python">
-    **Compatible Version:** v1.1.0
-    
-    Install with:
-    ```bash
-    pip install honcho-ai==1.1.0
-    ```
-  </Card>
 </CardGroup>
 
 ## Version Compatibility Table
 
 | Honcho API Version | TypeScript SDK | Python SDK |
 |-------------------|---------------|------------|
-| v2.1.0 (Current) | v1.2.0 | v1.2.0 | Latest release |
+| v2.1.0 (Current) | v1.2.1 | v1.2.2 |
 | v2.0.5 | v1.1.0 | v1.1.0 |
 | v2.0.4 | v1.1.0 | v1.1.0 |

--- a/docs/changelog/introduction.mdx
+++ b/docs/changelog/introduction.mdx
@@ -223,7 +223,7 @@ Welcome to the Honcho changelog! This section documents all notable changes to t
         <Update label="v1.2.1 (Current)">
             ### Added
             
-            - linting via biome
+            - linting via Biome
             - Adding filter parameter to various endpoints
 
             ### Fixed

--- a/docs/changelog/introduction.mdx
+++ b/docs/changelog/introduction.mdx
@@ -184,7 +184,34 @@ Welcome to the Honcho changelog! This section documents all notable changes to t
 
     <Tab title="Python SDK">
         [Python SDK](https://pypi.org/project/honcho-ai/)
-        <Update label="v1.1.0 (Current)">
+        <Update label="v1.2.2 (Current)">
+            ### Added
+
+            - Filter parameter to various endpoints
+
+        </Update>
+        <Update label="v1.2.1">
+            ### Fixed
+
+            - Honcho util import paths
+
+        </Update>
+        <Update label="v1.2.0">
+            ### Added
+
+            - Get/poll deriver queue status endpoints added to workspace
+            - Added endpoint to upload files as messages
+            
+            ### Removed
+
+            - Removed peer messages in accordance with Honcho 2.1.0
+
+            ### Changed
+
+            - Updated chat endpoint to use singular `query` in accordance with Honcho 2.1.0
+
+        </Update>
+        <Update label="v1.1.0">
             ### Fixed
 
             - Properly handle AsyncClient
@@ -193,7 +220,31 @@ Welcome to the Honcho changelog! This section documents all notable changes to t
 
     <Tab title="TypeScript SDK">
         [TypeScript SDK](https://www.npmjs.com/package/@honcho-ai/sdk)
-        <Update label="v1.1.0 (Current)">
+        <Update label="v1.2.1 (Current)">
+            ### Added
+            
+            - linting via biome
+            - Adding filter parameter to various endpoints
+
+            ### Fixed
+
+            - Order of parameters in `getSessions` endpoint
+        </Update>
+        <Update label="v1.2.0">
+            ### Added
+
+            - Get/poll deriver queue status endpoints added to workspace
+            - Added endpoint to upload files as messages
+
+            ### Removed
+
+            - Removed peer messages in accordance with Honcho 2.1.0
+
+            ### Changed
+
+            - Updated chat endpoint to use singular `query` in accordance with Honcho 2.1.0
+        </Update>
+        <Update label="v1.1.0">
             ### Fixed
 
             - Create default workspace on Honcho client instantiation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ select = [
     # isort
     "I",
 ]
-ignore = ["E501", "B008"]
+ignore = ["E501", "B008", "COM812"]
 
 [tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["fastapi.Depends"]

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.2] - 2025-07-21
+
+### Added
+
+- Filter parameter to various endpoints
+
+## [1.2.1] - 2025-07-17
+
+### Fixed
+
+- honcho utils import path
+
 ## [1.2.0] - 2025-07-16
 
 ### Added
@@ -19,7 +31,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Updated chat endpoint to use singular `query` in accordance with Honcho 2.1.0
-
 
 ## [1.1.0] - 2025-07-08
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -38,6 +38,9 @@ dev = [
     "ruff>=0.11.13",
 ]
 
+[tool.ruff.lint]
+ignore = ["E501", "B008", "COM812"]
+
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"], content-type = "text/markdown"}
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "honcho-ai"
-version = "1.2.1"
+version = "1.2.2"
 description = "Official DX Optimized Python SDK for Honcho"
 dynamic = ["readme"]
 license = "Apache-2.0"

--- a/sdks/python/src/honcho/async_client/client.py
+++ b/sdks/python/src/honcho/async_client/client.py
@@ -169,7 +169,9 @@ class AsyncHoncho(BaseModel):
             )
         return AsyncPeer(id, self.workspace_id, self._client)
 
-    async def get_peers(self) -> AsyncPage[AsyncPeer]:
+    async def get_peers(
+        self, filter: dict[str, object] | None = None
+    ) -> AsyncPage[AsyncPeer]:
         """
         Get all peers in the current workspace.
 
@@ -182,7 +184,7 @@ class AsyncHoncho(BaseModel):
             The page preserves pagination functionality while transforming objects
         """
         peers_page = await self._client.workspaces.peers.list(
-            workspace_id=self.workspace_id
+            workspace_id=self.workspace_id, filter=filter
         )
         return AsyncPage(
             peers_page, lambda peer: AsyncPeer(peer.id, self.workspace_id, self._client)
@@ -226,7 +228,9 @@ class AsyncHoncho(BaseModel):
             )
         return AsyncSession(id, self.workspace_id, self._client)
 
-    async def get_sessions(self) -> AsyncPage[AsyncSession]:
+    async def get_sessions(
+        self, filter: dict[str, object] | None = None
+    ) -> AsyncPage[AsyncSession]:
         """
         Get all sessions in the current workspace.
 
@@ -238,7 +242,7 @@ class AsyncHoncho(BaseModel):
             Returns an empty page if no sessions exist
         """
         sessions_page = await self._client.workspaces.sessions.list(
-            workspace_id=self.workspace_id
+            workspace_id=self.workspace_id, filter=filter
         )
         return AsyncPage(
             sessions_page,
@@ -277,7 +281,9 @@ class AsyncHoncho(BaseModel):
         """
         await self._client.workspaces.update(self.workspace_id, metadata=metadata)
 
-    async def get_workspaces(self) -> list[str]:
+    async def get_workspaces(
+        self, filter: dict[str, object] | None = None
+    ) -> list[str]:
         """
         Get all workspace IDs from the Honcho instance.
 
@@ -288,7 +294,7 @@ class AsyncHoncho(BaseModel):
             A list of workspace ID strings. Returns an empty list if no workspaces
             are accessible or none exist
         """
-        workspaces_page = await self._client.workspaces.list()
+        workspaces_page = await self._client.workspaces.list(filter=filter)
         workspace_ids: list[str] = []
         async for workspace in workspaces_page:
             workspace_ids.append(workspace.id)

--- a/sdks/python/src/honcho/async_client/peer.py
+++ b/sdks/python/src/honcho/async_client/peer.py
@@ -132,7 +132,9 @@ class AsyncPeer(BaseModel):
             return None
         return response.content
 
-    async def get_sessions(self) -> AsyncPage[AsyncSession]:
+    async def get_sessions(
+        self, filter: dict[str, object] | None = None
+    ) -> AsyncPage[AsyncSession]:
         """
         Get all sessions this peer is a member of.
 
@@ -148,6 +150,7 @@ class AsyncPeer(BaseModel):
         sessions_page = await self._client.workspaces.peers.sessions.list(
             peer_id=self.id,
             workspace_id=self.workspace_id,
+            filter=filter,
         )
         return AsyncPage(
             sessions_page,

--- a/sdks/python/src/honcho/client.py
+++ b/sdks/python/src/honcho/client.py
@@ -153,7 +153,7 @@ class Honcho(BaseModel):
         """
         return Peer(id, self.workspace_id, self._client, config=config)
 
-    def get_peers(self) -> SyncPage[Peer]:
+    def get_peers(self, filter: dict[str, object] | None = None) -> SyncPage[Peer]:
         """
         Get all peers in the current workspace.
 
@@ -165,7 +165,9 @@ class Honcho(BaseModel):
             A SyncPage of Peer objects representing all peers in the workspace.
             The page preserves pagination functionality while transforming objects
         """
-        peers_page = self._client.workspaces.peers.list(workspace_id=self.workspace_id)
+        peers_page = self._client.workspaces.peers.list(
+            workspace_id=self.workspace_id, filter=filter
+        )
         return SyncPage(
             peers_page, lambda peer: Peer(peer.id, self.workspace_id, self._client)
         )
@@ -204,7 +206,9 @@ class Honcho(BaseModel):
         """
         return Session(id, self.workspace_id, self._client, config=config)
 
-    def get_sessions(self) -> SyncPage[Session]:
+    def get_sessions(
+        self, filter: dict[str, object] | None = None
+    ) -> SyncPage[Session]:
         """
         Get all sessions in the current workspace.
 
@@ -216,7 +220,7 @@ class Honcho(BaseModel):
             Returns an empty page if no sessions exist
         """
         sessions_page = self._client.workspaces.sessions.list(
-            workspace_id=self.workspace_id
+            workspace_id=self.workspace_id, filter=filter
         )
         return SyncPage(
             sessions_page,
@@ -255,7 +259,7 @@ class Honcho(BaseModel):
         """
         self._client.workspaces.update(self.workspace_id, metadata=metadata)
 
-    def get_workspaces(self) -> list[str]:
+    def get_workspaces(self, filter: dict[str, object] | None = None) -> list[str]:
         """
         Get all workspace IDs from the Honcho instance.
 
@@ -266,7 +270,7 @@ class Honcho(BaseModel):
             A list of workspace ID strings. Returns an empty list if no workspaces
             are accessible or none exist
         """
-        workspaces = self._client.workspaces.list()
+        workspaces = self._client.workspaces.list(filter=filter)
         return [workspace.id for workspace in workspaces]
 
     @validate_call

--- a/sdks/python/src/honcho/peer.py
+++ b/sdks/python/src/honcho/peer.py
@@ -112,7 +112,9 @@ class Peer(BaseModel):
             return None
         return response.content
 
-    def get_sessions(self) -> SyncPage[Session]:
+    def get_sessions(
+        self, filter: dict[str, object] | None = None
+    ) -> SyncPage[Session]:
         """
         Get all sessions this peer is a member of.
 
@@ -128,6 +130,7 @@ class Peer(BaseModel):
         sessions_page = self._client.workspaces.peers.sessions.list(
             peer_id=self.id,
             workspace_id=self.workspace_id,
+            filter=filter,
         )
         return SyncPage(
             sessions_page,

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Linting via biome
+- Linting via Biome
 - Adding filter parameter to various endpoints
 
 ## [1.2.0] - 2025-07-16

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.1] - 2025-07-21
+
+### Fixed
+
+- Order of parameters in `getSessions` endpoint
+
+### Added
+
+- Linting via biome
+- Adding filter parameter to various endpoints
+
 ## [1.2.0] - 2025-07-16
 
 ### Added
@@ -19,7 +30,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Updated chat endpoint to use singular `query` in accordance with Honcho 2.1.0
-
 
 ## [1.1.0] - 2025-07-08
 

--- a/sdks/typescript/__tests__/client.test.ts
+++ b/sdks/typescript/__tests__/client.test.ts
@@ -123,7 +123,7 @@ describe('Honcho Client', () => {
       const peersPage = await honcho.getPeers();
 
       expect(peersPage).toBeInstanceOf(Page);
-      expect(mockClient.workspaces.peers.list).toHaveBeenCalledWith('test-workspace');
+      expect(mockClient.workspaces.peers.list).toHaveBeenCalledWith('test-workspace', { filter: undefined });
     });
 
     it('should handle empty peers list', async () => {
@@ -138,7 +138,7 @@ describe('Honcho Client', () => {
       const peersPage = await honcho.getPeers();
 
       expect(peersPage).toBeInstanceOf(Page);
-      expect(mockClient.workspaces.peers.list).toHaveBeenCalledWith('test-workspace');
+      expect(mockClient.workspaces.peers.list).toHaveBeenCalledWith('test-workspace', { filter: undefined });
     });
 
     it('should handle API errors', async () => {
@@ -183,7 +183,7 @@ describe('Honcho Client', () => {
       const sessionsPage = await honcho.getSessions();
 
       expect(sessionsPage).toBeInstanceOf(Page);
-      expect(mockClient.workspaces.sessions.list).toHaveBeenCalledWith('test-workspace');
+      expect(mockClient.workspaces.sessions.list).toHaveBeenCalledWith('test-workspace', { filter: undefined });
     });
 
     it('should handle empty sessions list', async () => {

--- a/sdks/typescript/__tests__/peer.test.ts
+++ b/sdks/typescript/__tests__/peer.test.ts
@@ -183,8 +183,9 @@ describe('Peer', () => {
 
       expect(sessionsPage).toBeInstanceOf(Page);
       expect(mockClient.workspaces.peers.sessions.list).toHaveBeenCalledWith(
+        'test-workspace',
         'test-peer',
-        'test-workspace'
+        { filter: undefined }
       );
     });
 

--- a/sdks/typescript/biome.json
+++ b/sdks/typescript/biome.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": [
+      "**",
+      "!**/node_modules/**",
+      "!**/.next/**",
+      "!**/dist/**",
+      "!**/build/**",
+      "!**/out/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "asNeeded",
+      "trailingCommas": "es5"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "nursery": {
+        "useSortedClasses": "error"
+      },
+      "style": {
+        "noNonNullAssertion": "warn",
+        "useImportType": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn"
+      }
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/sdks/typescript/bun.lock
+++ b/sdks/typescript/bun.lock
@@ -8,8 +8,8 @@
         "@types/node": "^24.0.1",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.1.2",
         "@types/jest": "^29.5.14",
-        "eslint": "^8.0.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.0",
@@ -89,21 +89,25 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
 
-    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.7.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.1.2", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.1.2", "@biomejs/cli-darwin-x64": "2.1.2", "@biomejs/cli-linux-arm64": "2.1.2", "@biomejs/cli-linux-arm64-musl": "2.1.2", "@biomejs/cli-linux-x64": "2.1.2", "@biomejs/cli-linux-x64-musl": "2.1.2", "@biomejs/cli-win32-arm64": "2.1.2", "@biomejs/cli-win32-x64": "2.1.2" }, "bin": { "biome": "bin/biome" } }, "sha512-yq8ZZuKuBVDgAS76LWCfFKHSYIAgqkxVB3mGVVpOe2vSkUTs7xG46zXZeNPRNVjiJuw0SZ3+J2rXiYx0RUpfGg=="],
 
-    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.1", "", {}, "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.1.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-leFAks64PEIjc7MY/cLjE8u5OcfBKkcDB0szxsWUB4aDfemBep1WVKt0qrEyqZBOW8LPHzrFMyDl3FhuuA0E7g=="],
 
-    "@eslint/eslintrc": ["@eslint/eslintrc@2.1.4", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^9.6.0", "globals": "^13.19.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.1.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-Nmmv7wRX5Nj7lGmz0FjnWdflJg4zii8Ivruas6PBKzw5SJX/q+Zh2RfnO+bBnuKLXpj8kiI2x2X12otpH6a32A=="],
 
-    "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-NWNy2Diocav61HZiv2enTQykbPP/KrA/baS7JsLSojC7Xxh2nl9IczuvE5UID7+ksRy2e7yH7klm/WkA72G1dw=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-qgHvafhjH7Oca114FdOScmIKf1DlXT1LqbOrrbR30kQDLFPEOpBG0uzx6MhmsrmhGiCFCr2obDamu+czk+X0HQ=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Km/UYeVowygTjpX6sGBzlizjakLoMQkxWbruVZSNE6osuSI63i4uCeIL+6q2AJlD3dxoiBJX70dn1enjQnQqwA=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-xlB3mU14ZUa3wzLtXfmk2IMOGL+S0aHFhSix/nssWS/2XlD27q+S6f0dlQ8WOCbYoXcuz8BCM7rCn2lxdTrlQA=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.1.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-G8KWZli5ASOXA3yUQgx+M4pZRv3ND16h77UsdunUL17uYpcL/UC7RkWTdkfvMQvogVsAuz5JUcBDjgZHXxlKoA=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.1.2", "", { "os": "win32", "cpu": "x64" }, "sha512-9zajnk59PMpjBkty3bK2IrjUsUHvqe9HWwyAWQBjGLE7MIBjbX2vwv1XPEhmO2RRuGoTkVx3WCanHrjAytICLA=="],
 
     "@honcho-ai/core": ["@honcho-ai/core@1.2.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-VPHCFIGfC00GeE4P83DDIT7hkuMnMVkWlMTmMd2tw4HSEUciqLBh09AX/6aMKfJAzprg1diub6pJJ6LJP6eJ+g=="],
-
-    "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
-
-    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
-
-    "@humanwhocodes/object-schema": ["@humanwhocodes/object-schema@2.0.3", "", {}, "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="],
 
     "@istanbuljs/load-nyc-config": ["@istanbuljs/load-nyc-config@1.1.0", "", { "dependencies": { "camelcase": "^5.3.1", "find-up": "^4.1.0", "get-package-type": "^0.1.0", "js-yaml": "^3.13.1", "resolve-from": "^5.0.0" } }, "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ=="],
 
@@ -145,12 +149,6 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
 
-    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
-
-    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
-
-    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
-
     "@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
 
     "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
@@ -185,17 +183,9 @@
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
-    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
-
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
-    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
-
-    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
-
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
-
-    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
@@ -205,7 +195,7 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
-    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
@@ -275,8 +265,6 @@
 
     "dedent": ["dedent@1.6.0", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA=="],
 
-    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
-
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
@@ -284,8 +272,6 @@
     "detect-newline": ["detect-newline@3.1.0", "", {}, "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="],
 
     "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
-
-    "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -309,25 +295,9 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
-    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
-
-    "eslint": ["eslint@8.57.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.6.1", "@eslint/eslintrc": "^2.1.4", "@eslint/js": "8.57.1", "@humanwhocodes/config-array": "^0.13.0", "@humanwhocodes/module-importer": "^1.0.1", "@nodelib/fs.walk": "^1.2.8", "@ungap/structured-clone": "^1.2.0", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.2", "debug": "^4.3.2", "doctrine": "^3.0.0", "escape-string-regexp": "^4.0.0", "eslint-scope": "^7.2.2", "eslint-visitor-keys": "^3.4.3", "espree": "^9.6.1", "esquery": "^1.4.2", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^6.0.1", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "globals": "^13.19.0", "graphemer": "^1.4.0", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "is-path-inside": "^3.0.3", "js-yaml": "^4.1.0", "json-stable-stringify-without-jsonify": "^1.0.1", "levn": "^0.4.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3", "strip-ansi": "^6.0.1", "text-table": "^0.2.0" }, "bin": { "eslint": "bin/eslint.js" } }, "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA=="],
-
-    "eslint-scope": ["eslint-scope@7.2.2", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg=="],
-
-    "eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
+    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
-
-    "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
-
-    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
-
-    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
-
-    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
@@ -337,27 +307,15 @@
 
     "expect": ["expect@29.7.0", "", { "dependencies": { "@jest/expect-utils": "^29.7.0", "jest-get-type": "^29.6.3", "jest-matcher-utils": "^29.7.0", "jest-message-util": "^29.7.0", "jest-util": "^29.7.0" } }, "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw=="],
 
-    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
-
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
-    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
-
-    "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
-
     "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
-
-    "file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
 
     "filelist": ["filelist@1.0.4", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
-
-    "flat-cache": ["flat-cache@3.2.0", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.3", "rimraf": "^3.0.2" } }, "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw=="],
-
-    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "form-data": ["form-data@4.0.3", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA=="],
 
@@ -385,15 +343,9 @@
 
     "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
-    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
-
-    "globals": ["globals@13.24.0", "", { "dependencies": { "type-fest": "^0.20.2" } }, "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ=="],
-
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
-
-    "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -409,10 +361,6 @@
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
-    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
-
     "import-local": ["import-local@3.2.0", "", { "dependencies": { "pkg-dir": "^4.2.0", "resolve-cwd": "^3.0.0" }, "bin": { "import-local-fixture": "fixtures/cli.js" } }, "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
@@ -425,17 +373,11 @@
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
-    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
-
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-generator-fn": ["is-generator-fn@2.1.0", "", {}, "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="],
 
-    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
-
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
-
-    "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
@@ -507,35 +449,23 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+    "js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
-    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
-
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
-    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
-
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
-
-    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
-    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
-
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "lodash.memoize": ["lodash.memoize@4.1.2", "", {}, "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="],
-
-    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -579,15 +509,11 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
-    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
-
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
-    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
-
-    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
@@ -607,17 +533,11 @@
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
-    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
-
     "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
-    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
-
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
-
-    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
@@ -627,15 +547,9 @@
 
     "resolve-cwd": ["resolve-cwd@3.0.0", "", { "dependencies": { "resolve-from": "^5.0.0" } }, "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg=="],
 
-    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "resolve.exports": ["resolve.exports@2.0.3", "", {}, "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A=="],
-
-    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
-
-    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
-
-    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
@@ -675,8 +589,6 @@
 
     "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
 
-    "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
-
     "tmpl": ["tmpl@1.0.5", "", {}, "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
@@ -684,8 +596,6 @@
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "ts-jest": ["ts-jest@29.4.0", "", { "dependencies": { "bs-logger": "^0.2.6", "ejs": "^3.1.10", "fast-json-stable-stringify": "^2.1.0", "json5": "^2.2.3", "lodash.memoize": "^4.1.2", "make-error": "^1.3.6", "semver": "^7.7.2", "type-fest": "^4.41.0", "yargs-parser": "^21.1.1" }, "peerDependencies": { "@babel/core": ">=7.0.0-beta.0 <8", "@jest/transform": "^29.0.0 || ^30.0.0", "@jest/types": "^29.0.0 || ^30.0.0", "babel-jest": "^29.0.0 || ^30.0.0", "jest": "^29.0.0 || ^30.0.0", "jest-util": "^29.0.0 || ^30.0.0", "typescript": ">=4.3 <6" }, "optionalPeers": ["@babel/core", "@jest/transform", "@jest/types", "babel-jest", "jest-util"], "bin": { "ts-jest": "cli.js" } }, "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q=="],
-
-    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
 
@@ -696,8 +606,6 @@
     "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
-
-    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
 
@@ -710,8 +618,6 @@
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
-
-    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -737,12 +643,6 @@
 
     "@istanbuljs/load-nyc-config/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
-    "@istanbuljs/load-nyc-config/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
-
-    "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
-
-    "@istanbuljs/load-nyc-config/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
-
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
@@ -751,36 +651,16 @@
 
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
-    "globals/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
-
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
-
-    "resolve-cwd/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
-
-    "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+    "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@honcho-ai/core/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
-    "@istanbuljs/load-nyc-config/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
-
-    "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
     "babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
-
-    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
-    "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
-    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
-
-    "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }
 }

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honcho-ai/sdk",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "Official DX Optimized TypeScript SDK for Honcho",
   "author": "Plastic Labs <hello@plasticlabs.ai>",
   "license": "Apache-2.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -11,10 +11,9 @@
   ],
   "scripts": {
     "build": "tsc --project tsconfig.json",
-    "lint": "eslint src --ext .ts",
-    "lint:fix": "eslint src --ext .ts --fix",
-    "format": "prettier --write \"src/**/*.ts\"",
-    "format:check": "prettier --check \"src/**/*.ts\"",
+    "lint": "biome check src/",
+    "lint:fix": "biome check src/ --write",
+    "format": "biome format src/ --write",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
@@ -24,14 +23,9 @@
     "@honcho-ai/core": "1.2.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.1.2",
     "@types/jest": "^29.5.14",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
-    "eslint": "^8.0.0",
-    "eslint-config-prettier": "^9.0.0",
-    "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.7.0",
-    "prettier": "^3.0.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.0"
   }

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -12,6 +12,9 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
@@ -22,8 +25,13 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.7.0",
+    "prettier": "^3.0.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.0"
   }

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honcho-ai/sdk",
-  "version": "1.2.2",
+  "version": "1.2.1",
   "description": "Official DX Optimized TypeScript SDK for Honcho",
   "author": "Plastic Labs <hello@plasticlabs.ai>",
   "license": "Apache-2.0",

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -50,8 +50,8 @@ export class Honcho {
   /**
    * Get all peers in the current workspace.
    */
-  async getPeers(): Promise<Page<Peer>> {
-    const peersPage = await this._client.workspaces.peers.list(this.workspaceId);
+  async getPeers(filter?: { [key: string]: unknown } | null): Promise<Page<Peer>> {
+    const peersPage = await this._client.workspaces.peers.list(this.workspaceId, { filter });
     return new Page(peersPage, (peer: any) => new Peer(peer.id, this));
   }
 
@@ -68,8 +68,8 @@ export class Honcho {
   /**
    * Get all sessions in the current workspace.
    */
-  async getSessions(): Promise<Page<Session>> {
-    const sessionsPage = await this._client.workspaces.sessions.list(this.workspaceId);
+  async getSessions(filter?: { [key: string]: unknown } | null): Promise<Page<Session>> {
+    const sessionsPage = await this._client.workspaces.sessions.list(this.workspaceId, { filter });
     return new Page(sessionsPage, (session: any) => new Session(session.id, this));
   }
 
@@ -91,8 +91,8 @@ export class Honcho {
   /**
    * Get all workspace IDs from the Honcho instance.
    */
-  async getWorkspaces(): Promise<string[]> {
-    const workspacesPage = await this._client.workspaces.list();
+  async getWorkspaces(filter?: { [key: string]: unknown } | null): Promise<string[]> {
+    const workspacesPage = await this._client.workspaces.list({ filter });
     const ids: string[] = [];
     for await (const workspace of workspacesPage) {
       ids.push(workspace.id);

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -1,30 +1,31 @@
-import HonchoCore from '@honcho-ai/core';
-import { Page } from './pagination';
-import { Peer } from './peer';
-import { Session } from './session';
+import HonchoCore from '@honcho-ai/core'
+import { Page } from './pagination'
+import { Peer } from './peer'
+import { Session } from './session'
 
 /**
  * Main client for the Honcho TypeScript SDK.
  * Provides access to peers, sessions, and workspace operations.
  */
 export class Honcho {
-  private _client: InstanceType<typeof HonchoCore>;
-  readonly workspaceId: string;
+  private _client: InstanceType<typeof HonchoCore>
+  readonly workspaceId: string
 
   /**
    * Initialize the Honcho client.
    */
   constructor(options: {
-    apiKey?: string;
-    environment?: 'local' | 'production' | 'demo';
-    baseURL?: string;
-    workspaceId?: string;
-    timeout?: number;
-    maxRetries?: number;
-    defaultHeaders?: Record<string, string>;
-    defaultQuery?: Record<string, unknown>;
+    apiKey?: string
+    environment?: 'local' | 'production' | 'demo'
+    baseURL?: string
+    workspaceId?: string
+    timeout?: number
+    maxRetries?: number
+    defaultHeaders?: Record<string, string>
+    defaultQuery?: Record<string, unknown>
   }) {
-    this.workspaceId = options.workspaceId || process.env.HONCHO_WORKSPACE_ID || 'default';
+    this.workspaceId =
+      options.workspaceId || process.env.HONCHO_WORKSPACE_ID || 'default'
     this._client = new HonchoCore({
       apiKey: options.apiKey || process.env.HONCHO_API_KEY,
       environment: options.environment,
@@ -33,7 +34,7 @@ export class Honcho {
       maxRetries: options.maxRetries,
       defaultHeaders: options.defaultHeaders,
       defaultQuery: options.defaultQuery as any,
-    }) as any;
+    }) as any
     this._client.workspaces.getOrCreate({ id: this.workspaceId })
   }
 
@@ -42,17 +43,22 @@ export class Honcho {
    */
   peer(id: string, options?: { config?: Record<string, unknown> }): Peer {
     if (!id || typeof id !== 'string') {
-      throw new Error('Peer ID must be a non-empty string');
+      throw new Error('Peer ID must be a non-empty string')
     }
-    return new Peer(id, this, options?.config);
+    return new Peer(id, this, options?.config)
   }
 
   /**
    * Get all peers in the current workspace.
    */
-  async getPeers(filter?: { [key: string]: unknown } | null): Promise<Page<Peer>> {
-    const peersPage = await this._client.workspaces.peers.list(this.workspaceId, { filter });
-    return new Page(peersPage, (peer: any) => new Peer(peer.id, this));
+  async getPeers(
+    filter?: { [key: string]: unknown } | null
+  ): Promise<Page<Peer>> {
+    const peersPage = await this._client.workspaces.peers.list(
+      this.workspaceId,
+      { filter }
+    )
+    return new Page(peersPage, (peer: any) => new Peer(peer.id, this))
   }
 
   /**
@@ -60,44 +66,56 @@ export class Honcho {
    */
   session(id: string, options?: { config?: Record<string, unknown> }): Session {
     if (!id || typeof id !== 'string') {
-      throw new Error('Session ID must be a non-empty string');
+      throw new Error('Session ID must be a non-empty string')
     }
-    return new Session(id, this, options?.config);
+    return new Session(id, this, options?.config)
   }
 
   /**
    * Get all sessions in the current workspace.
    */
-  async getSessions(filter?: { [key: string]: unknown } | null): Promise<Page<Session>> {
-    const sessionsPage = await this._client.workspaces.sessions.list(this.workspaceId, { filter });
-    return new Page(sessionsPage, (session: any) => new Session(session.id, this));
+  async getSessions(
+    filter?: { [key: string]: unknown } | null
+  ): Promise<Page<Session>> {
+    const sessionsPage = await this._client.workspaces.sessions.list(
+      this.workspaceId,
+      { filter }
+    )
+    return new Page(
+      sessionsPage,
+      (session: any) => new Session(session.id, this)
+    )
   }
 
   /**
    * Get metadata for the current workspace.
    */
   async getMetadata(): Promise<Record<string, unknown>> {
-    const workspace = await this._client.workspaces.getOrCreate({ id: this.workspaceId });
-    return workspace.metadata || {};
+    const workspace = await this._client.workspaces.getOrCreate({
+      id: this.workspaceId,
+    })
+    return workspace.metadata || {}
   }
 
   /**
    * Set metadata for the current workspace.
    */
   async setMetadata(metadata: Record<string, unknown>): Promise<void> {
-    await this._client.workspaces.update(this.workspaceId, { metadata });
+    await this._client.workspaces.update(this.workspaceId, { metadata })
   }
 
   /**
    * Get all workspace IDs from the Honcho instance.
    */
-  async getWorkspaces(filter?: { [key: string]: unknown } | null): Promise<string[]> {
-    const workspacesPage = await this._client.workspaces.list({ filter });
-    const ids: string[] = [];
+  async getWorkspaces(
+    filter?: { [key: string]: unknown } | null
+  ): Promise<string[]> {
+    const workspacesPage = await this._client.workspaces.list({ filter })
+    const ids: string[] = []
     for await (const workspace of workspacesPage) {
-      ids.push(workspace.id);
+      ids.push(workspace.id)
     }
-    return ids;
+    return ids
   }
 
   /**
@@ -111,10 +129,13 @@ export class Honcho {
    */
   async search(query: string): Promise<Page<any>> {
     if (!query || typeof query !== 'string' || query.trim().length === 0) {
-      throw new Error('Search query must be a non-empty string');
+      throw new Error('Search query must be a non-empty string')
     }
-    const messagesPage = await this._client.workspaces.search(this.workspaceId, { body: query });
-    return new Page(messagesPage);
+    const messagesPage = await this._client.workspaces.search(
+      this.workspaceId,
+      { body: query }
+    )
+    return new Page(messagesPage)
   }
 
   /**
@@ -123,26 +144,29 @@ export class Honcho {
    * @param options Configuration options for the status request
    * @param options.observerId Optional observer ID to scope the status to
    * @param options.senderId Optional sender ID to scope the status to
-   * @param options.sessionId Optional session ID to scope the status to  
+   * @param options.sessionId Optional session ID to scope the status to
    * @returns Promise resolving to the deriver status information
    */
   async getDeriverStatus(options?: {
-    observerId?: string;
-    senderId?: string;
-    sessionId?: string;
+    observerId?: string
+    senderId?: string
+    sessionId?: string
   }): Promise<{
-    totalWorkUnits: number;
-    completedWorkUnits: number;
-    inProgressWorkUnits: number;
-    pendingWorkUnits: number;
-    sessions?: Record<string, any>;
+    totalWorkUnits: number
+    completedWorkUnits: number
+    inProgressWorkUnits: number
+    pendingWorkUnits: number
+    sessions?: Record<string, any>
   }> {
-    const queryParams: any = {};
-    if (options?.observerId) queryParams.observer_id = options.observerId;
-    if (options?.senderId) queryParams.sender_id = options.senderId;
-    if (options?.sessionId) queryParams.session_id = options.sessionId;
+    const queryParams: any = {}
+    if (options?.observerId) queryParams.observer_id = options.observerId
+    if (options?.senderId) queryParams.sender_id = options.senderId
+    if (options?.sessionId) queryParams.session_id = options.sessionId
 
-    const status = await this._client.workspaces.deriverStatus(this.workspaceId, queryParams);
+    const status = await this._client.workspaces.deriverStatus(
+      this.workspaceId,
+      queryParams
+    )
 
     return {
       totalWorkUnits: status.total_work_units,
@@ -150,7 +174,7 @@ export class Honcho {
       inProgressWorkUnits: status.in_progress_work_units,
       pendingWorkUnits: status.pending_work_units,
       sessions: status.sessions || undefined,
-    };
+    }
   }
 
   /**
@@ -169,47 +193,48 @@ export class Honcho {
    * @throws Error if timeout is exceeded before processing completes
    */
   async pollDeriverStatus(options?: {
-    observerId?: string;
-    senderId?: string;
-    sessionId?: string;
-    timeoutMs?: number;
+    observerId?: string
+    senderId?: string
+    sessionId?: string
+    timeoutMs?: number
   }): Promise<{
-    totalWorkUnits: number;
-    completedWorkUnits: number;
-    inProgressWorkUnits: number;
-    pendingWorkUnits: number;
-    sessions?: Record<string, any>;
+    totalWorkUnits: number
+    completedWorkUnits: number
+    inProgressWorkUnits: number
+    pendingWorkUnits: number
+    sessions?: Record<string, any>
   }> {
-    const timeoutMs = options?.timeoutMs ?? 300000; // Default to 5 minutes
-    const startTime = Date.now();
+    const timeoutMs = options?.timeoutMs ?? 300000 // Default to 5 minutes
+    const startTime = Date.now()
 
     while (true) {
-      const status = await this.getDeriverStatus(options);
+      const status = await this.getDeriverStatus(options)
       if (status.pendingWorkUnits === 0 && status.inProgressWorkUnits === 0) {
-        return status;
+        return status
       }
 
       // Check if timeout has been exceeded
-      const elapsedTime = Date.now() - startTime;
+      const elapsedTime = Date.now() - startTime
       if (elapsedTime >= timeoutMs) {
         throw new Error(
           `Polling timeout exceeded after ${timeoutMs}ms. ` +
-          `Current status: ${status.pendingWorkUnits} pending, ${status.inProgressWorkUnits} in progress work units.`
-        );
+            `Current status: ${status.pendingWorkUnits} pending, ${status.inProgressWorkUnits} in progress work units.`
+        )
       }
 
       // Sleep for the expected time to complete all current work units
       // Assuming each pending and in-progress work unit takes 1 second
-      const totalWorkUnits = status.pendingWorkUnits + status.inProgressWorkUnits;
-      const sleepMs = Math.max(1000, totalWorkUnits * 1000); // Sleep at least 1 second
+      const totalWorkUnits =
+        status.pendingWorkUnits + status.inProgressWorkUnits
+      const sleepMs = Math.max(1000, totalWorkUnits * 1000) // Sleep at least 1 second
 
       // Ensure we don't sleep past the timeout
-      const remainingTime = timeoutMs - elapsedTime;
-      const actualSleepMs = Math.min(sleepMs, remainingTime);
+      const remainingTime = timeoutMs - elapsedTime
+      const actualSleepMs = Math.min(sleepMs, remainingTime)
 
       if (actualSleepMs > 0) {
-        await new Promise(resolve => setTimeout(resolve, actualSleepMs));
+        await new Promise((resolve) => setTimeout(resolve, actualSleepMs))
       }
     }
   }
-} 
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -1,8 +1,8 @@
 // Main entry point for the Honcho TypeScript SDK
 // Exports all main classes and types
 
-export { Honcho } from './client';
-export { Peer } from './peer';
-export { Session, SessionPeerConfig } from './session';
-export { SessionContext } from './session_context';
-export { Page } from './pagination'; 
+export { Honcho } from './client'
+export { Page } from './pagination'
+export { Peer } from './peer'
+export { Session, SessionPeerConfig } from './session'
+export { SessionContext } from './session_context'

--- a/sdks/typescript/src/pagination.ts
+++ b/sdks/typescript/src/pagination.ts
@@ -3,15 +3,15 @@
  * Provides async iteration and transformation capabilities.
  */
 export class Page<T> implements AsyncIterable<T> {
-  private _originalPage: any;
-  private _transformFunc?: (item: any) => T;
+  private _originalPage: any
+  private _transformFunc?: (item: any) => T
 
   /**
    * Initialize a new Page.
    */
   constructor(originalPage: any, transformFunc?: (item: any) => T) {
-    this._originalPage = originalPage;
-    this._transformFunc = transformFunc;
+    this._originalPage = originalPage
+    this._transformFunc = transformFunc
   }
 
   /**
@@ -19,9 +19,9 @@ export class Page<T> implements AsyncIterable<T> {
    */
   async *[Symbol.asyncIterator](): AsyncIterator<T> {
     // Handle different page structure formats
-    const items = this._originalPage.items || this._originalPage.data || [];
+    const items = this._originalPage.items || this._originalPage.data || []
     for (const item of items) {
-      yield this._transformFunc ? this._transformFunc(item) : item;
+      yield this._transformFunc ? this._transformFunc(item) : item
     }
   }
 
@@ -29,49 +29,52 @@ export class Page<T> implements AsyncIterable<T> {
    * Get an item by index.
    */
   async get(index: number): Promise<T> {
-    if (!this._originalPage?.get || typeof this._originalPage.get !== 'function') {
-      throw new Error('Original page does not support indexed access');
+    if (
+      !this._originalPage?.get ||
+      typeof this._originalPage.get !== 'function'
+    ) {
+      throw new Error('Original page does not support indexed access')
     }
-    const item = await this._originalPage.get(index);
-    return this._transformFunc ? this._transformFunc(item) : item;
+    const item = await this._originalPage.get(index)
+    return this._transformFunc ? this._transformFunc(item) : item
   }
 
   /**
    * Get the size of the page.
    */
   get size(): number {
-    return this._originalPage?.size;
+    return this._originalPage?.size
   }
 
   /**
    * Get the total number of items.
    */
   get total(): number {
-    return this._originalPage?.total;
+    return this._originalPage?.total
   }
 
   /**
    * Get all data as a list.
    */
   async data(): Promise<T[]> {
-    const items = this._originalPage.items || this._originalPage.data || [];
-    const data = typeof items === 'function' ? await items() : items;
-    return this._transformFunc ? data.map(this._transformFunc) : data;
+    const items = this._originalPage.items || this._originalPage.data || []
+    const data = typeof items === 'function' ? await items() : items
+    return this._transformFunc ? data.map(this._transformFunc) : data
   }
 
   /**
    * Check if there's a next page.
    */
   get hasNextPage(): boolean {
-    return this._originalPage?.hasNextPage;
+    return this._originalPage?.hasNextPage
   }
 
   /**
    * Get the next page.
    */
   async nextPage(): Promise<Page<T> | null> {
-    const nextPage = await this._originalPage.nextPage();
-    if (!nextPage) return null;
-    return new Page(nextPage, this._transformFunc);
+    const nextPage = await this._originalPage.nextPage()
+    if (!nextPage) return null
+    return new Page(nextPage, this._transformFunc)
   }
-} 
+}

--- a/sdks/typescript/src/peer.ts
+++ b/sdks/typescript/src/peer.ts
@@ -1,6 +1,6 @@
-import { Session } from './session';
-import { Page } from './pagination';
-import type { Honcho } from './client';
+import type { Honcho } from './client'
+import { Page } from './pagination'
+import { Session } from './session'
 
 /**
  * Represents a peer in the Honcho system.
@@ -9,53 +9,70 @@ export class Peer {
   /**
    * Unique identifier for this peer.
    */
-  readonly id: string;
-  private _honcho: Honcho;
+  readonly id: string
+  private _honcho: Honcho
 
   /**
    * Initialize a new Peer.
    */
   constructor(id: string, honcho: Honcho, config?: Record<string, unknown>) {
-    this.id = id;
-    this._honcho = honcho;
+    this.id = id
+    this._honcho = honcho
 
     if (config) {
       this._honcho['_client'].workspaces.peers.getOrCreate(
         this._honcho.workspaceId,
         { id: this.id, configuration: config }
-      );
+      )
     }
   }
 
   /**
    * Query the peer's representation with a natural language question.
    */
-  async chat(query: string, opts?: {
-    stream?: boolean;
-    target?: string | Peer;
-    sessionId?: string;
-  }): Promise<string | null> {
+  async chat(
+    query: string,
+    opts?: {
+      stream?: boolean
+      target?: string | Peer
+      sessionId?: string
+    }
+  ): Promise<string | null> {
     const response = await this._honcho['_client'].workspaces.peers.chat(
       this._honcho.workspaceId,
       this.id,
-      { query, stream: opts?.stream, target: opts?.target ? (typeof opts.target === 'string' ? opts.target : opts.target.id) : undefined, session_id: opts?.sessionId },
-    );
+      {
+        query,
+        stream: opts?.stream,
+        target: opts?.target
+          ? typeof opts.target === 'string'
+            ? opts.target
+            : opts.target.id
+          : undefined,
+        session_id: opts?.sessionId,
+      }
+    )
     if (!response.content || response.content === 'None') {
-      return null;
+      return null
     }
-    return response.content;
+    return response.content
   }
 
   /**
    * Get all sessions this peer is a member of.
    */
-  async getSessions(filter?: { [key: string]: unknown } | null): Promise<Page<Session>> {
-    const sessionsPage = await this._honcho['_client'].workspaces.peers.sessions.list(
-      this._honcho.workspaceId,
-      this.id,
-      { filter }
-    );
-    return new Page(sessionsPage, (session: any) => new Session(session.id, this._honcho));
+  async getSessions(
+    filter?: { [key: string]: unknown } | null
+  ): Promise<Page<Session>> {
+    const sessionsPage = await this._honcho[
+      '_client'
+    ].workspaces.peers.sessions.list(this._honcho.workspaceId, this.id, {
+      filter,
+    })
+    return new Page(
+      sessionsPage,
+      (session: any) => new Session(session.id, this._honcho)
+    )
   }
 
   /**
@@ -66,7 +83,7 @@ export class Peer {
       peerId: this.id,
       content,
       metadata: opts?.metadata,
-    };
+    }
   }
 
   /**
@@ -76,8 +93,8 @@ export class Peer {
     const peer = await this._honcho['_client'].workspaces.peers.getOrCreate(
       this._honcho.workspaceId,
       { id: this.id }
-    );
-    return peer.metadata || {};
+    )
+    return peer.metadata || {}
   }
 
   /**
@@ -87,8 +104,8 @@ export class Peer {
     await this._honcho['_client'].workspaces.peers.update(
       this._honcho.workspaceId,
       this.id,
-      { metadata },
-    );
+      { metadata }
+    )
   }
 
   /**
@@ -102,14 +119,14 @@ export class Peer {
    */
   async search(query: string): Promise<Page<any>> {
     if (!query || typeof query !== 'string' || query.trim().length === 0) {
-      throw new Error('Search query must be a non-empty string');
+      throw new Error('Search query must be a non-empty string')
     }
     const messagesPage = await this._honcho['_client'].workspaces.peers.search(
       this._honcho.workspaceId,
       this.id,
       { query: query }
-    );
-    return new Page(messagesPage);
+    )
+    return new Page(messagesPage)
   }
 
   /**
@@ -121,30 +138,30 @@ export class Peer {
    *
    * @param file File to upload. Should be an object with filename, content (as Buffer or Uint8Array), and content_type
    * @returns A list of Message objects representing the created messages
-   * 
+   *
    * @note Supported file types include PDFs, text files, and JSON documents.
    *       Large files will be automatically split into multiple messages to fit
    *       within message size limits.
    */
-  async uploadFile(
-    file: { filename: string; content: Buffer | Uint8Array; content_type: string }
-  ): Promise<any[]> {
+  async uploadFile(file: {
+    filename: string
+    content: Buffer | Uint8Array
+    content_type: string
+  }): Promise<any[]> {
     // Convert file to the format expected by the API
     const fileData = {
       filename: file.filename,
       content: file.content,
-      content_type: file.content_type
-    };
+      content_type: file.content_type,
+    }
 
     // Call the upload endpoint
-    const response = await (this._honcho['_client'] as any).workspaces.peers.messages.upload(
-      this._honcho.workspaceId,
-      this.id,
-      {
-        file: fileData
-      }
-    );
+    const response = await (
+      this._honcho['_client'] as any
+    ).workspaces.peers.messages.upload(this._honcho.workspaceId, this.id, {
+      file: fileData,
+    })
 
-    return response;
+    return response
   }
-} 
+}

--- a/sdks/typescript/src/peer.ts
+++ b/sdks/typescript/src/peer.ts
@@ -49,10 +49,11 @@ export class Peer {
   /**
    * Get all sessions this peer is a member of.
    */
-  async getSessions(): Promise<Page<Session>> {
+  async getSessions(filter?: { [key: string]: unknown } | null): Promise<Page<Session>> {
     const sessionsPage = await this._honcho['_client'].workspaces.peers.sessions.list(
-      this.id,
       this._honcho.workspaceId,
+      this.id,
+      { filter }
     );
     return new Page(sessionsPage, (session: any) => new Session(session.id, this._honcho));
   }

--- a/sdks/typescript/src/session.ts
+++ b/sdks/typescript/src/session.ts
@@ -1,19 +1,17 @@
-import { Peer } from './peer';
-import { Page } from './pagination';
-import { SessionContext } from './session_context';
-import type { Honcho } from './client';
-
+import type { Honcho } from './client'
+import { Page } from './pagination'
+import { Peer } from './peer'
+import { SessionContext } from './session_context'
 
 export class SessionPeerConfig {
-  observe_others: boolean;
-  observe_me: boolean;
+  observe_others: boolean
+  observe_me: boolean
 
   constructor(opts?: { observe_others?: boolean; observe_me?: boolean }) {
-    this.observe_others = opts?.observe_others ?? false;
-    this.observe_me = opts?.observe_me ?? true;
+    this.observe_others = opts?.observe_others ?? false
+    this.observe_me = opts?.observe_me ?? true
   }
 }
-
 
 /**
  * Represents a session in Honcho.
@@ -22,86 +20,124 @@ export class Session {
   /**
    * Unique identifier for this session.
    */
-  readonly id: string;
-  private _honcho: Honcho;
+  readonly id: string
+  private _honcho: Honcho
 
   /**
    * Initialize a new Session.
    */
   constructor(id: string, honcho: Honcho, config?: Record<string, unknown>) {
-    this.id = id;
-    this._honcho = honcho;
+    this.id = id
+    this._honcho = honcho
 
     if (config) {
       this._honcho['_client'].workspaces.sessions.getOrCreate(
         this._honcho.workspaceId,
         { id: this.id, configuration: config }
-      );
+      )
     }
   }
 
   /**
    * Add peers to this session.
    */
-  async addPeers(peers: string | Peer | Array<string | Peer> | [string | Peer, SessionPeerConfig] | Array<[string | Peer, SessionPeerConfig]> | Array<string | Peer | [string | Peer, SessionPeerConfig]>): Promise<void> {
-    const peerDict: Record<string, SessionPeerConfig> = {};
+  async addPeers(
+    peers:
+      | string
+      | Peer
+      | Array<string | Peer>
+      | [string | Peer, SessionPeerConfig]
+      | Array<[string | Peer, SessionPeerConfig]>
+      | Array<string | Peer | [string | Peer, SessionPeerConfig]>
+  ): Promise<void> {
+    const peerDict: Record<string, SessionPeerConfig> = {}
     if (!Array.isArray(peers)) {
-      peers = [peers];
+      peers = [peers]
     }
     for (const peer of peers) {
       if (typeof peer === 'string') {
-        peerDict[peer] = { observe_others: false, observe_me: true };
+        peerDict[peer] = { observe_others: false, observe_me: true }
       } else if (typeof peer === 'object' && 'id' in peer) {
-        peerDict[peer.id] = { observe_others: false, observe_me: true };
+        peerDict[peer.id] = { observe_others: false, observe_me: true }
       } else if (Array.isArray(peer)) {
-        const peerId = typeof peer[0] === 'string' ? peer[0] : peer[0].id;
-        peerDict[peerId] = peer[1];
-      } else if (typeof peer === 'object' && 'id' in peer && 'observe_others' in peer && 'observe_me' in peer) {
-        peerDict[(peer as any).id] = { observe_others: (peer as any).observe_others, observe_me: (peer as any).observe_me };
+        const peerId = typeof peer[0] === 'string' ? peer[0] : peer[0].id
+        peerDict[peerId] = peer[1]
+      } else if (
+        typeof peer === 'object' &&
+        'id' in peer &&
+        'observe_others' in peer &&
+        'observe_me' in peer
+      ) {
+        peerDict[(peer as any).id] = {
+          observe_others: (peer as any).observe_others,
+          observe_me: (peer as any).observe_me,
+        }
       }
     }
     await (this._honcho['_client'] as any).workspaces.sessions.peers.add(
       this._honcho.workspaceId,
       this.id,
       peerDict
-    );
+    )
   }
 
   /**
    * Set the complete peer list for this session.
    */
-  async setPeers(peers: string | Peer | Array<string | Peer> | [string | Peer, SessionPeerConfig] | Array<[string | Peer, SessionPeerConfig]> | Array<string | Peer | [string | Peer, SessionPeerConfig]>): Promise<void> {
-    const peerDict: Record<string, SessionPeerConfig> = {};
+  async setPeers(
+    peers:
+      | string
+      | Peer
+      | Array<string | Peer>
+      | [string | Peer, SessionPeerConfig]
+      | Array<[string | Peer, SessionPeerConfig]>
+      | Array<string | Peer | [string | Peer, SessionPeerConfig]>
+  ): Promise<void> {
+    const peerDict: Record<string, SessionPeerConfig> = {}
     if (!Array.isArray(peers)) {
-      peers = [peers];
+      peers = [peers]
     }
     for (const peer of peers) {
       if (typeof peer === 'string') {
-        peerDict[peer] = { observe_others: false, observe_me: true };
+        peerDict[peer] = { observe_others: false, observe_me: true }
       } else if (typeof peer === 'object' && 'id' in peer) {
-        peerDict[peer.id] = { observe_others: false, observe_me: true };
+        peerDict[peer.id] = { observe_others: false, observe_me: true }
       } else if (Array.isArray(peer)) {
-        const peerId = typeof peer[0] === 'string' ? peer[0] : peer[0].id;
-        peerDict[peerId] = peer[1];
-      } else if (typeof peer === 'object' && 'id' in peer && 'observe_others' in peer && 'observe_me' in peer) {
-        peerDict[(peer as any).id] = { observe_others: (peer as any).observe_others, observe_me: (peer as any).observe_me };
+        const peerId = typeof peer[0] === 'string' ? peer[0] : peer[0].id
+        peerDict[peerId] = peer[1]
+      } else if (
+        typeof peer === 'object' &&
+        'id' in peer &&
+        'observe_others' in peer &&
+        'observe_me' in peer
+      ) {
+        peerDict[(peer as any).id] = {
+          observe_others: (peer as any).observe_others,
+          observe_me: (peer as any).observe_me,
+        }
       }
     }
     await (this._honcho['_client'] as any).workspaces.sessions.peers.set(
       this._honcho.workspaceId,
       this.id,
       peerDict
-    );
+    )
   }
 
   /**
    * Remove peers from this session.
    */
-  async removePeers(peers: string | Peer | Array<string | Peer>): Promise<void> {
+  async removePeers(
+    peers: string | Peer | Array<string | Peer>
+  ): Promise<void> {
     const peerIds = Array.isArray(peers)
       ? peers.map((p) => (typeof p === 'string' ? p : p.id))
-      : [typeof peers === 'string' ? peers : peers.id];
-    await (this._honcho['_client'] as any).workspaces.sessions.peers.remove(this._honcho.workspaceId, this.id, peerIds);
+      : [typeof peers === 'string' ? peers : peers.id]
+    await (this._honcho['_client'] as any).workspaces.sessions.peers.remove(
+      this._honcho.workspaceId,
+      this.id,
+      peerIds
+    )
   }
 
   /**
@@ -109,43 +145,50 @@ export class Session {
    * into a list for us -- the max number of peers in a session is usually 10.
    */
   async getPeers(): Promise<Peer[]> {
-    const peersPage = await (this._honcho['_client'] as any).workspaces.sessions.peers.list(this._honcho.workspaceId, this.id);
-    return peersPage.items.map((peer: any) => new Peer(peer.id, this._honcho));
+    const peersPage = await (
+      this._honcho['_client'] as any
+    ).workspaces.sessions.peers.list(this._honcho.workspaceId, this.id)
+    return peersPage.items.map((peer: any) => new Peer(peer.id, this._honcho))
   }
 
   /**
    * Get the configuration for a peer in this session.
    */
   async getPeerConfig(peer: string | Peer): Promise<SessionPeerConfig> {
-    const peerId = typeof peer === 'string' ? peer : peer.id;
-    return await (this._honcho['_client'] as any).workspaces.sessions.peers.getConfig(
+    const peerId = typeof peer === 'string' ? peer : peer.id
+    return await (
+      this._honcho['_client'] as any
+    ).workspaces.sessions.peers.getConfig(
       this._honcho.workspaceId,
       this.id,
       peerId
-    );
+    )
   }
 
   /**
    * Set the configuration for a peer in this session.
    */
-  async setPeerConfig(peer: string | Peer, config: SessionPeerConfig): Promise<void> {
-    const peerId = typeof peer === 'string' ? peer : peer.id;
+  async setPeerConfig(
+    peer: string | Peer,
+    config: SessionPeerConfig
+  ): Promise<void> {
+    const peerId = typeof peer === 'string' ? peer : peer.id
     await (this._honcho['_client'] as any).workspaces.sessions.peers.setConfig(
       this._honcho.workspaceId,
       this.id,
       peerId,
       {
         observe_others: config.observe_others,
-        observe_me: config.observe_me
+        observe_me: config.observe_me,
       }
-    );
+    )
   }
 
   /**
    * Add one or more messages to this session.
    */
   async addMessages(messages: any | any[]): Promise<void> {
-    const msgs = Array.isArray(messages) ? messages : [messages];
+    const msgs = Array.isArray(messages) ? messages : [messages]
     await (this._honcho['_client'] as any).workspaces.sessions.messages.create(
       this._honcho.workspaceId,
       this.id,
@@ -154,50 +197,62 @@ export class Session {
           peer_id: msg.peerId,
           content: msg.content,
           metadata: msg.metadata,
-        }))
+        })),
       }
-    );
+    )
   }
 
   /**
    * Get messages from this session with optional filtering.
    */
-  async getMessages(opts?: { filter?: Record<string, unknown> }): Promise<Page<any>> {
-    const messagesPage = await (this._honcho['_client'] as any).workspaces.sessions.messages.list(this._honcho.workspaceId, this.id, opts?.filter);
-    return new Page(messagesPage);
+  async getMessages(opts?: {
+    filter?: Record<string, unknown>
+  }): Promise<Page<any>> {
+    const messagesPage = await (
+      this._honcho['_client'] as any
+    ).workspaces.sessions.messages.list(
+      this._honcho.workspaceId,
+      this.id,
+      opts?.filter
+    )
+    return new Page(messagesPage)
   }
 
   /**
    * Get metadata for this session.
    */
   async getMetadata(): Promise<Record<string, unknown>> {
-    const session = await (this._honcho['_client'] as any).workspaces.sessions.getOrCreate(
-      this._honcho.workspaceId,
-      { id: this.id }
-    );
-    return session.metadata || {};
+    const session = await (
+      this._honcho['_client'] as any
+    ).workspaces.sessions.getOrCreate(this._honcho.workspaceId, { id: this.id })
+    return session.metadata || {}
   }
 
   /**
    * Set metadata for this session.
    */
   async setMetadata(metadata: Record<string, unknown>): Promise<void> {
-    await (this._honcho['_client'] as any).workspaces.sessions.update(this._honcho.workspaceId, this.id, { metadata });
+    await (this._honcho['_client'] as any).workspaces.sessions.update(
+      this._honcho.workspaceId,
+      this.id,
+      { metadata }
+    )
   }
 
   /**
    * Get optimized context for this session within a token limit.
    */
-  async getContext(opts?: { summary?: boolean; tokens?: number }): Promise<SessionContext> {
-    const context = await (this._honcho['_client'] as any).workspaces.sessions.getContext(
-      this._honcho.workspaceId,
-      this.id,
-      {
-        tokens: opts?.tokens,
-        summary: opts?.summary
-      }
-    );
-    return new SessionContext(this.id, context.messages, context.summary || '');
+  async getContext(opts?: {
+    summary?: boolean
+    tokens?: number
+  }): Promise<SessionContext> {
+    const context = await (
+      this._honcho['_client'] as any
+    ).workspaces.sessions.getContext(this._honcho.workspaceId, this.id, {
+      tokens: opts?.tokens,
+      summary: opts?.summary,
+    })
+    return new SessionContext(this.id, context.messages, context.summary || '')
   }
 
   /**
@@ -211,14 +266,14 @@ export class Session {
    */
   async search(query: string): Promise<Page<any>> {
     if (!query || typeof query !== 'string' || query.trim().length === 0) {
-      throw new Error('Search query must be a non-empty string');
+      throw new Error('Search query must be a non-empty string')
     }
-    const messagesPage = await (this._honcho['_client'] as any).workspaces.sessions.search(
-      this._honcho.workspaceId,
-      this.id,
-      { query: query }
-    );
-    return new Page(messagesPage);
+    const messagesPage = await (
+      this._honcho['_client'] as any
+    ).workspaces.sessions.search(this._honcho.workspaceId, this.id, {
+      query: query,
+    })
+    return new Page(messagesPage)
   }
 
   /**
@@ -231,53 +286,60 @@ export class Session {
    * @param file File to upload. Should be an object with filename, content (as Buffer or Uint8Array), and content_type
    * @param peerId The peer ID to attribute the messages to
    * @returns A list of Message objects representing the created messages
-   * 
+   *
    * @note Supported file types include PDFs, text files, and JSON documents.
    *       Large files will be automatically split into multiple messages to fit
    *       within message size limits.
    */
   async uploadFile(
-    file: { filename: string; content: Buffer | Uint8Array; content_type: string },
-    peerId: string,
+    file: {
+      filename: string
+      content: Buffer | Uint8Array
+      content_type: string
+    },
+    peerId: string
   ): Promise<any[]> {
     // Convert file to the format expected by the API
     const fileData = {
       filename: file.filename,
       content: file.content,
-      content_type: file.content_type
-    };
+      content_type: file.content_type,
+    }
 
     // Call the upload endpoint
-    const response = await (this._honcho['_client'] as any).workspaces.sessions.messages.upload(
-      this._honcho.workspaceId,
-      this.id,
-      {
-        file: fileData,
-        peer_id: peerId,
-      }
-    );
+    const response = await (
+      this._honcho['_client'] as any
+    ).workspaces.sessions.messages.upload(this._honcho.workspaceId, this.id, {
+      file: fileData,
+      peer_id: peerId,
+    })
 
-    return response;
+    return response
   }
 
   /**
    * Get the current working representation of the peer in this session.
-   * 
+   *
    * @param peer The peer to get the working representation of.
    * @param target The target peer to get the representation of. If provided, queries what `peer` knows about the `target`.
    * @returns A dictionary containing information about the peer.
    */
-  async workingRep(peer: string | Peer, target?: string | Peer): Promise<Record<string, unknown>> {
-    const peerId = typeof peer === 'string' ? peer : peer.id;
-    const targetId = target ? (typeof target === 'string' ? target : target.id) : undefined;
+  async workingRep(
+    peer: string | Peer,
+    target?: string | Peer
+  ): Promise<Record<string, unknown>> {
+    const peerId = typeof peer === 'string' ? peer : peer.id
+    const targetId = target
+      ? typeof target === 'string'
+        ? target
+        : target.id
+      : undefined
 
-    return await (this._honcho['_client'] as any).workspaces.peers.workingRepresentation(
-      this._honcho.workspaceId,
-      peerId,
-      {
-        session_id: this.id,
-        target: targetId
-      }
-    );
+    return await (
+      this._honcho['_client'] as any
+    ).workspaces.peers.workingRepresentation(this._honcho.workspaceId, peerId, {
+      session_id: this.id,
+      target: targetId,
+    })
   }
-} 
+}

--- a/sdks/typescript/src/session.ts
+++ b/sdks/typescript/src/session.ts
@@ -51,10 +51,8 @@ export class Session {
       | Array<string | Peer | [string | Peer, SessionPeerConfig]>
   ): Promise<void> {
     const peerDict: Record<string, SessionPeerConfig> = {}
-    if (!Array.isArray(peers)) {
-      peers = [peers]
-    }
-    for (const peer of peers) {
+    const peersArray = Array.isArray(peers) ? peers : [peers]
+    for (const peer of peersArray) {
       if (typeof peer === 'string') {
         peerDict[peer] = { observe_others: false, observe_me: true }
       } else if (typeof peer === 'object' && 'id' in peer) {
@@ -94,10 +92,8 @@ export class Session {
       | Array<string | Peer | [string | Peer, SessionPeerConfig]>
   ): Promise<void> {
     const peerDict: Record<string, SessionPeerConfig> = {}
-    if (!Array.isArray(peers)) {
-      peers = [peers]
-    }
-    for (const peer of peers) {
+    const peersArray = Array.isArray(peers) ? peers : [peers]
+    for (const peer of peersArray) {
       if (typeof peer === 'string') {
         peerDict[peer] = { observe_others: false, observe_me: true }
       } else if (typeof peer === 'object' && 'id' in peer) {

--- a/sdks/typescript/src/session_context.ts
+++ b/sdks/typescript/src/session_context.ts
@@ -1,4 +1,4 @@
-import { Peer } from './peer';
+import type { Peer } from './peer'
 
 /**
  * Represents the context of a session containing a curated list of messages.
@@ -11,17 +11,17 @@ export class SessionContext {
   /**
    * ID of the session this context belongs to.
    */
-  readonly sessionId: string;
+  readonly sessionId: string
 
   /**
    * List of Message objects representing the conversation context.
    */
-  readonly messages: any[];
+  readonly messages: any[]
 
   /**
    * Summary of the session history prior to the message cutoff.
    */
-  readonly summary: string;
+  readonly summary: string
 
   /**
    * Initialize a new SessionContext.
@@ -31,9 +31,9 @@ export class SessionContext {
    * @param summary Summary of the session history prior to the message cutoff
    */
   constructor(sessionId: string, messages: any[], summary: string = '') {
-    this.sessionId = sessionId;
-    this.messages = messages;
-    this.summary = summary || '';
+    this.sessionId = sessionId
+    this.messages = messages
+    this.summary = summary || ''
   }
 
   /**
@@ -50,11 +50,11 @@ export class SessionContext {
    *          "role" and "content" keys suitable for the OpenAI API
    */
   toOpenAI(assistant: string | Peer): Array<{ role: string; content: string }> {
-    const assistantId = typeof assistant === 'string' ? assistant : assistant.id;
+    const assistantId = typeof assistant === 'string' ? assistant : assistant.id
     return this.messages.map((message) => ({
       role: message.peer_name === assistantId ? 'assistant' : 'user',
       content: message.content,
-    }));
+    }))
   }
 
   /**
@@ -69,25 +69,27 @@ export class SessionContext {
    * @returns A list of dictionaries in Anthropic format, where each dictionary contains
    *          "role" and "content" keys suitable for the Anthropic API
    */
-  toAnthropic(assistant: string | Peer): Array<{ role: string; content: string }> {
-    const assistantId = typeof assistant === 'string' ? assistant : assistant.id;
+  toAnthropic(
+    assistant: string | Peer
+  ): Array<{ role: string; content: string }> {
+    const assistantId = typeof assistant === 'string' ? assistant : assistant.id
     return this.messages.map((message) => ({
       role: message.peer_name === assistantId ? 'assistant' : 'user',
       content: message.content,
-    }));
+    }))
   }
 
   /**
    * Return the number of messages in the context.
    */
   get length(): number {
-    return this.messages.length;
+    return this.messages.length
   }
 
   /**
    * Return a string representation of the SessionContext.
    */
   toString(): string {
-    return `SessionContext(messages=${this.messages.length})`;
+    return `SessionContext(messages=${this.messages.length})`
   }
-} 
+}


### PR DESCRIPTION
fix: swap peerId/workspaceId in getSessions()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filtering capabilities to methods for retrieving peers, sessions, and workspaces in both Python and TypeScript SDKs. Users can now apply filters when listing these resources.

* **Chores**
  * Updated the version numbers for the Python and TypeScript SDK packages.
  * Updated linting configuration to ignore an additional code style warning.
  * Replaced ESLint with Biome for linting and formatting in the TypeScript SDK, including new configuration and scripts.
  * Enhanced CI workflow with a new job for running TypeScript SDK tests using Bun runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->