### PR TITLE
added basic config for smithery.ai mcp 

### DIFF
--- a/smithery.json
+++ b/smithery.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "startCommand": {
+    "type": "stdio",
+    "command": "uv",
+    "args": [
+      "run",
+      "--with",
+      "mcp[cli]",
+      "mcp",
+      "run",
+      "mcp/main.py"
+    ],
+    "env": {
+      "HONCHO_URL": "${config.honchoUrl}",
+      "HONCHO_API_KEY": "${config.honchoApiKey}"
+    },
+    "configSchema": {
+      "type": "object",
+      "required": ["honchoUrl", "honchoApiKey"],
+      "properties": {
+        "honchoUrl": {
+          "type": "string",
+          "description": "URL of the Honcho API server"
+        },
+        "honchoApiKey": {
+          "type": "string",
+          "description": "API key for authenticating with the Honcho API"
+        }
+      }
+    }
+  }
+}
+

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,28 @@
+build:
+  dockerfile: Dockerfile
+
+startCommand:
+  type: http
+  command: sh
+  args:
+    - -c
+    - |
+      npm install
+      npx wrangler dev --local --persist --port 8000
+  env:
+    CF_ACCOUNT_ID: "${config.cfAccountId}"
+    CF_API_TOKEN: "${config.cfApiToken}"
+
+configSchema:
+  type: object
+  required:
+    - cfAccountId
+    - cfApiToken
+  properties:
+    cfAccountId:
+      type: string
+      description: Cloudflare account ID
+    cfApiToken:
+      type: string
+      description: API token for Workers (must allow “Workers:Read” and “Workers:Write”)
+


### PR DESCRIPTION
Created two config files to deploye honcho mcp on smithery.ai

smithery.json – config for the Honcho MCP 
smithery.yaml – config for the Cloudflare Worker proxy via Wrangler