### PR TITLE
feat: add support for custom message timestamps in API

### DIFF
--- a/docs/v2/documentation/reference/sdk.mdx
+++ b/docs/v2/documentation/reference/sdk.mdx
@@ -555,6 +555,37 @@ const response = await openai.chat.completions.create({
 ```
 </CodeGroup>
 
+### Custom Message Timestamps
+
+<Note>
+**API-Level Feature**: The `created_at` parameter is available when using the raw Honcho API directly. It will be supported in the SDKs in a future release.
+</Note>
+
+When creating messages via the raw API, you can optionally specify a custom `created_at` timestamp instead of using the server's current time:
+
+```bash curl
+curl -X POST "https://api.honcho.dev/v2/workspaces/{workspace_id}/sessions/{session_id}/messages" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      {
+        "peer_id": "user123",
+        "content": "This message happened yesterday",
+        "created_at": "2024-01-01T12:00:00Z",
+        "metadata": {"source": "historical_data"}
+      }
+    ]
+  }'
+```
+
+This is useful for:
+- Importing historical conversation data
+- Backfilling messages from other systems
+- Maintaining accurate timeline ordering when processing batch data
+
+If `created_at` is not provided, messages will use the server's current timestamp.
+
 ### Metadata and Filtering
 
 See [Using Filters](/v2/guides/using-filters) for more examples on how to use filters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,11 @@ dependencies = [
     "google-generativeai>=0.8.5",
     "pdfplumber>=0.11.7",
     "typing-extensions>=4.11.0",
+    "honcho-core",
 ]
 [tool.uv]
 dev-dependencies = [
-    "honcho-core==1.3.0",
+    "honcho-core @ git+https://github.com/plastic-labs/honcho-python-core.git#7e77a7764e77629383e59a55a0b9d651a5c03848",
     "honcho-ai==1.3.0",
     "pytest>=8.2.2",
     "sqlalchemy-utils>=0.41.2",
@@ -45,6 +46,9 @@ dev-dependencies = [
     "pre-commit>=4.2.0",
     "pytest-cov>=6.2.1",
 ]
+
+[tool.uv.sources]
+honcho-core = { url = "https://pkg.stainless.com/s/honcho-python/ffa0cb18fd084729c30f2f723cc3287103e1edd0/honcho_core-1.3.0-py3-none-any.whl" }
 
 [tool.ruff.lint]
 # from https://docs.astral.sh/ruff/linter/#rule-selection example

--- a/sdks/python/examples/pydantic_validation_example.py
+++ b/sdks/python/examples/pydantic_validation_example.py
@@ -5,10 +5,12 @@ This example shows how the SDK now uses Pydantic to validate inputs at runtime,
 providing better error messages and type safety.
 """
 
+import datetime
 import logging
 
-from honcho import Honcho
 from pydantic import ValidationError
+
+from honcho import Honcho
 
 logging.basicConfig(level=logging.INFO)
 
@@ -116,6 +118,24 @@ def demonstrate_validation():
         # Valid peer operations (validation passes, but no API calls made)
         print("✅ All validations passed for standard operations")
 
+    except ValidationError as e:
+        print(f"❌ Validation error: {e}")
+
+    # Example 10: Custom created_at timestamps
+    print("10. Custom created_at timestamps:")
+    try:
+        honcho = Honcho(environment="local", workspace_id="test")
+        peer = honcho.peer("alice")
+        message = peer.message("Hello, world!", created_at=datetime.datetime.now())
+        print(f"✅ Created message: {message}")
+        message = peer.message(
+            "Hello, world!",
+            created_at=datetime.datetime(1999, 1, 1, tzinfo=datetime.timezone.utc),
+        )
+        print(f"✅ Created message: {message}")
+        session = honcho.session("conversation_1")
+        session.add_messages([message])
+        print(f"✅ Added message to session: {session}")
     except ValidationError as e:
         print(f"❌ Validation error: {e}")
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 { name = "Plastic Labs", email = "hello@plasticlabs.ai" },
 ]
 dependencies = [
-    "honcho-core==1.3.0",
+    "honcho-core",
     "httpx>=0.28.0, <1",
     "pydantic>=2.0.0, <3",
 ]
@@ -53,6 +53,9 @@ name = "testpypi"
 url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
 explicit = true
+
+[tool.uv.sources]
+honcho-core = { url = "https://pkg.stainless.com/s/honcho-python/ffa0cb18fd084729c30f2f723cc3287103e1edd0/honcho_core-1.3.0-py3-none-any.whl" }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/sdks/python/src/honcho/async_client/peer.py
+++ b/sdks/python/src/honcho/async_client/peer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING
 
 from honcho_core import AsyncHoncho as AsyncHonchoCore
@@ -175,6 +176,10 @@ class AsyncPeer(BaseModel):
         metadata: dict[str, object] | None = Field(
             None, description="Optional metadata dictionary"
         ),
+        created_at: datetime.datetime | str | None = Field(
+            None,
+            description="Optional created-at timestamp for the message. Accepts a datetime which will be converted to an ISO 8601 string, or a preformatted string.",
+        ),
     ) -> MessageCreateParam:
         """
         Create a MessageCreateParam object attributed to this peer.
@@ -189,7 +194,18 @@ class AsyncPeer(BaseModel):
         Returns:
             A new MessageCreateParam object with this peer's ID and the provided content
         """
-        return MessageCreateParam(peer_id=self.id, content=content, metadata=metadata)
+        created_at_str: str | None
+        if isinstance(created_at, datetime.datetime):
+            created_at_str = created_at.isoformat()
+        else:
+            created_at_str = created_at
+
+        return MessageCreateParam(
+            peer_id=self.id,
+            content=content,
+            metadata=metadata,
+            created_at=created_at_str,
+        )
 
     async def get_metadata(self) -> dict[str, object]:
         """

--- a/sdks/python/src/honcho/peer.py
+++ b/sdks/python/src/honcho/peer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING
 
 from honcho_core import Honcho as HonchoCore
@@ -158,6 +159,10 @@ class Peer(BaseModel):
         metadata: dict[str, object] | None = Field(
             None, description="Optional metadata dictionary"
         ),
+        created_at: datetime.datetime | str | None = Field(
+            None,
+            description="Optional created-at timestamp for the message. Accepts a datetime which will be converted to an ISO 8601 string, or a preformatted string.",
+        ),
     ) -> MessageCreateParam:
         """
         Create a MessageCreateParam object attributed to this peer.
@@ -172,7 +177,18 @@ class Peer(BaseModel):
         Returns:
             A new MessageCreateParam object with this peer's ID and the provided content
         """
-        return MessageCreateParam(peer_id=self.id, content=content, metadata=metadata)
+        created_at_str: str | None
+        if isinstance(created_at, datetime.datetime):
+            created_at_str = created_at.isoformat()
+        else:
+            created_at_str = created_at
+
+        return MessageCreateParam(
+            peer_id=self.id,
+            content=content,
+            metadata=metadata,
+            created_at=created_at_str,
+        )
 
     def get_metadata(self) -> dict[str, object]:
         """

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -38,7 +38,7 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.9.0"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.9'",
@@ -47,20 +47,20 @@ dependencies = [
     { name = "exceptiongroup", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
     { name = "idna", marker = "python_full_version >= '3.9'" },
     { name = "sniffio", marker = "python_full_version >= '3.9'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
 ]
 
 [[package]]
 name = "certifi"
-version = "2025.4.26"
+version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705, upload-time = "2025-04-26T02:12:29.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618, upload-time = "2025-04-26T02:12:27.662Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
 ]
 
 [[package]]
@@ -78,7 +78,7 @@ version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -102,7 +102,7 @@ dependencies = [
     { name = "honcho-core" },
     { name = "httpx" },
     { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pydantic", version = "2.11.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 
 [package.dev-dependencies]
@@ -112,7 +112,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "honcho-core", specifier = "==1.3.0" },
+    { name = "honcho-core", url = "https://pkg.stainless.com/s/honcho-python/ffa0cb18fd084729c30f2f723cc3287103e1edd0/honcho_core-1.3.0-py3-none-any.whl" },
     { name = "httpx", specifier = ">=0.28.0,<1" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
 ]
@@ -123,22 +123,34 @@ dev = [{ name = "ruff", specifier = ">=0.11.13" }]
 [[package]]
 name = "honcho-core"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { url = "https://pkg.stainless.com/s/honcho-python/ffa0cb18fd084729c30f2f723cc3287103e1edd0/honcho_core-1.3.0-py3-none-any.whl" }
 dependencies = [
     { name = "anyio", version = "4.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "anyio", version = "4.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "distro" },
     { name = "httpx" },
     { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pydantic", version = "2.11.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "sniffio" },
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/49/1810de2351be1fdff330ffadcc5eef709889b2f698b0340966cae2c1eef9/honcho_core-1.3.0.tar.gz", hash = "sha256:276a73e8d523f7d22f06746922fda97e4a11fbbef4a51a0b43573bc817089cec", size = 123333, upload-time = "2025-08-06T16:42:10.941Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/3f/3beb750ed65bb1b604c585ae1c51a54f8b34ea3002f4525f93fe86549531/honcho_core-1.3.0-py3-none-any.whl", hash = "sha256:c7c0bf77b61162e6c65a580327fc054785aef794923abc35acd3dbd8287245db", size = 112895, upload-time = "2025-08-06T16:42:08.967Z" },
+    { url = "https://pkg.stainless.com/s/honcho-python/ffa0cb18fd084729c30f2f723cc3287103e1edd0/honcho_core-1.3.0-py3-none-any.whl", hash = "sha256:4c64a9db1d90ef9733baa44fced589085eaf5fe7906752e7c49fc0c7606a36f4" },
 ]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", marker = "extra == 'aiohttp'" },
+    { name = "anyio", specifier = ">=3.5.0,<5" },
+    { name = "distro", specifier = ">=1.7.0,<2" },
+    { name = "httpx", specifier = ">=0.23.0,<1" },
+    { name = "httpx-aiohttp", marker = "extra == 'aiohttp'", specifier = ">=0.1.8" },
+    { name = "pydantic", specifier = ">=1.9.0,<3" },
+    { name = "sniffio" },
+    { name = "typing-extensions", specifier = ">=4.10,<5" },
+]
+provides-extras = ["aiohttp"]
 
 [[package]]
 name = "httpcore"
@@ -159,7 +171,7 @@ version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "anyio", version = "4.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "certifi" },
     { name = "httpcore" },
     { name = "idna" },
@@ -197,7 +209,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.5"
+version = "2.11.7"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.9'",
@@ -205,12 +217,12 @@ resolution-markers = [
 dependencies = [
     { name = "annotated-types", marker = "python_full_version >= '3.9'" },
     { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "typing-inspection", marker = "python_full_version >= '3.9'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/86/8ce9040065e8f924d642c58e4a344e33163a07f6b57f836d0d734e0ad3fb/pydantic-2.11.5.tar.gz", hash = "sha256:7f853db3d0ce78ce8bbb148c401c2cdd6431b3473c0cdff2755c7690952a7b7a", size = 787102, upload-time = "2025-05-22T21:18:08.761Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350, upload-time = "2025-06-14T08:33:17.137Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/69/831ed22b38ff9b4b64b66569f0e5b7b97cf3638346eb95a2147fdb49ad5f/pydantic-2.11.5-py3-none-any.whl", hash = "sha256:f9c26ba06f9747749ca1e5c94d6a85cb84254577553c8785576fd38fa64dc0f7", size = 444229, upload-time = "2025-05-22T21:18:06.329Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
 ]
 
 [[package]]
@@ -334,7 +346,7 @@ resolution-markers = [
     "python_full_version >= '3.9'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
 wheels = [
@@ -440,27 +452,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.11.13"
+version = "0.12.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/da/9c6f995903b4d9474b39da91d2d626659af3ff1eeb43e9ae7c119349dba6/ruff-0.11.13.tar.gz", hash = "sha256:26fa247dc68d1d4e72c179e08889a25ac0c7ba4d78aecfc835d49cbfd60bf514", size = 4282054, upload-time = "2025-06-05T21:00:15.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/da/5bd7565be729e86e1442dad2c9a364ceeff82227c2dece7c29697a9795eb/ruff-0.12.8.tar.gz", hash = "sha256:4cb3a45525176e1009b2b64126acf5f9444ea59066262791febf55e40493a033", size = 5242373, upload-time = "2025-08-07T19:05:47.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/ce/a11d381192966e0b4290842cc8d4fac7dc9214ddf627c11c1afff87da29b/ruff-0.11.13-py3-none-linux_armv6l.whl", hash = "sha256:4bdfbf1240533f40042ec00c9e09a3aade6f8c10b6414cf11b519488d2635d46", size = 10292516, upload-time = "2025-06-05T20:59:32.944Z" },
-    { url = "https://files.pythonhosted.org/packages/78/db/87c3b59b0d4e753e40b6a3b4a2642dfd1dcaefbff121ddc64d6c8b47ba00/ruff-0.11.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aef9c9ed1b5ca28bb15c7eac83b8670cf3b20b478195bd49c8d756ba0a36cf48", size = 11106083, upload-time = "2025-06-05T20:59:37.03Z" },
-    { url = "https://files.pythonhosted.org/packages/77/79/d8cec175856ff810a19825d09ce700265f905c643c69f45d2b737e4a470a/ruff-0.11.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53b15a9dfdce029c842e9a5aebc3855e9ab7771395979ff85b7c1dedb53ddc2b", size = 10436024, upload-time = "2025-06-05T20:59:39.741Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/5b/f6d94f2980fa1ee854b41568368a2e1252681b9238ab2895e133d303538f/ruff-0.11.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab153241400789138d13f362c43f7edecc0edfffce2afa6a68434000ecd8f69a", size = 10646324, upload-time = "2025-06-05T20:59:42.185Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/9c/b4c2acf24ea4426016d511dfdc787f4ce1ceb835f3c5fbdbcb32b1c63bda/ruff-0.11.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6c51f93029d54a910d3d24f7dd0bb909e31b6cd989a5e4ac513f4eb41629f0dc", size = 10174416, upload-time = "2025-06-05T20:59:44.319Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/10/e2e62f77c65ede8cd032c2ca39c41f48feabedb6e282bfd6073d81bb671d/ruff-0.11.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1808b3ed53e1a777c2ef733aca9051dc9bf7c99b26ece15cb59a0320fbdbd629", size = 11724197, upload-time = "2025-06-05T20:59:46.935Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/f0/466fe8469b85c561e081d798c45f8a1d21e0b4a5ef795a1d7f1a9a9ec182/ruff-0.11.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d28ce58b5ecf0f43c1b71edffabe6ed7f245d5336b17805803312ec9bc665933", size = 12511615, upload-time = "2025-06-05T20:59:49.534Z" },
-    { url = "https://files.pythonhosted.org/packages/17/0e/cefe778b46dbd0cbcb03a839946c8f80a06f7968eb298aa4d1a4293f3448/ruff-0.11.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55e4bc3a77842da33c16d55b32c6cac1ec5fb0fbec9c8c513bdce76c4f922165", size = 12117080, upload-time = "2025-06-05T20:59:51.654Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/2c/caaeda564cbe103bed145ea557cb86795b18651b0f6b3ff6a10e84e5a33f/ruff-0.11.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:633bf2c6f35678c56ec73189ba6fa19ff1c5e4807a78bf60ef487b9dd272cc71", size = 11326315, upload-time = "2025-06-05T20:59:54.469Z" },
-    { url = "https://files.pythonhosted.org/packages/75/f0/782e7d681d660eda8c536962920c41309e6dd4ebcea9a2714ed5127d44bd/ruff-0.11.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ffbc82d70424b275b089166310448051afdc6e914fdab90e08df66c43bb5ca9", size = 11555640, upload-time = "2025-06-05T20:59:56.986Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/d4/3d580c616316c7f07fb3c99dbecfe01fbaea7b6fd9a82b801e72e5de742a/ruff-0.11.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4a9ddd3ec62a9a89578c85842b836e4ac832d4a2e0bfaad3b02243f930ceafcc", size = 10507364, upload-time = "2025-06-05T20:59:59.154Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/dc/195e6f17d7b3ea6b12dc4f3e9de575db7983db187c378d44606e5d503319/ruff-0.11.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d237a496e0778d719efb05058c64d28b757c77824e04ffe8796c7436e26712b7", size = 10141462, upload-time = "2025-06-05T21:00:01.481Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/8e/39a094af6967faa57ecdeacb91bedfb232474ff8c3d20f16a5514e6b3534/ruff-0.11.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26816a218ca6ef02142343fd24c70f7cd8c5aa6c203bca284407adf675984432", size = 11121028, upload-time = "2025-06-05T21:00:04.06Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/c0/b0b508193b0e8a1654ec683ebab18d309861f8bd64e3a2f9648b80d392cb/ruff-0.11.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:51c3f95abd9331dc5b87c47ac7f376db5616041173826dfd556cfe3d4977f492", size = 11602992, upload-time = "2025-06-05T21:00:06.249Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/91/263e33ab93ab09ca06ce4f8f8547a858cc198072f873ebc9be7466790bae/ruff-0.11.13-py3-none-win32.whl", hash = "sha256:96c27935418e4e8e77a26bb05962817f28b8ef3843a6c6cc49d8783b5507f250", size = 10474944, upload-time = "2025-06-05T21:00:08.459Z" },
-    { url = "https://files.pythonhosted.org/packages/46/f4/7c27734ac2073aae8efb0119cae6931b6fb48017adf048fdf85c19337afc/ruff-0.11.13-py3-none-win_amd64.whl", hash = "sha256:29c3189895a8a6a657b7af4e97d330c8a3afd2c9c8f46c81e2fc5a31866517e3", size = 11548669, upload-time = "2025-06-05T21:00:11.147Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/bf/b273dd11673fed8a6bd46032c0ea2a04b2ac9bfa9c628756a5856ba113b0/ruff-0.11.13-py3-none-win_arm64.whl", hash = "sha256:b4385285e9179d608ff1d2fb9922062663c658605819a6876d8beef0c30b7f3b", size = 10683928, upload-time = "2025-06-05T21:00:13.758Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1e/c843bfa8ad1114fab3eb2b78235dda76acd66384c663a4e0415ecc13aa1e/ruff-0.12.8-py3-none-linux_armv6l.whl", hash = "sha256:63cb5a5e933fc913e5823a0dfdc3c99add73f52d139d6cd5cc8639d0e0465513", size = 11675315, upload-time = "2025-08-07T19:05:06.15Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ee/af6e5c2a8ca3a81676d5480a1025494fd104b8896266502bb4de2a0e8388/ruff-0.12.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a9bbe28f9f551accf84a24c366c1aa8774d6748438b47174f8e8565ab9dedbc", size = 12456653, upload-time = "2025-08-07T19:05:09.759Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9d/e91f84dfe3866fa648c10512904991ecc326fd0b66578b324ee6ecb8f725/ruff-0.12.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2fae54e752a3150f7ee0e09bce2e133caf10ce9d971510a9b925392dc98d2fec", size = 11659690, upload-time = "2025-08-07T19:05:12.551Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ac/a363d25ec53040408ebdd4efcee929d48547665858ede0505d1d8041b2e5/ruff-0.12.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0acbcf01206df963d9331b5838fb31f3b44fa979ee7fa368b9b9057d89f4a53", size = 11896923, upload-time = "2025-08-07T19:05:14.821Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9f/ea356cd87c395f6ade9bb81365bd909ff60860975ca1bc39f0e59de3da37/ruff-0.12.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ae3e7504666ad4c62f9ac8eedb52a93f9ebdeb34742b8b71cd3cccd24912719f", size = 11477612, upload-time = "2025-08-07T19:05:16.712Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/46/92e8fa3c9dcfd49175225c09053916cb97bb7204f9f899c2f2baca69e450/ruff-0.12.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb82efb5d35d07497813a1c5647867390a7d83304562607f3579602fa3d7d46f", size = 13182745, upload-time = "2025-08-07T19:05:18.709Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c4/f2176a310f26e6160deaf661ef60db6c3bb62b7a35e57ae28f27a09a7d63/ruff-0.12.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:dbea798fc0065ad0b84a2947b0aff4233f0cb30f226f00a2c5850ca4393de609", size = 14206885, upload-time = "2025-08-07T19:05:21.025Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9d/98e162f3eeeb6689acbedbae5050b4b3220754554526c50c292b611d3a63/ruff-0.12.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:49ebcaccc2bdad86fd51b7864e3d808aad404aab8df33d469b6e65584656263a", size = 13639381, upload-time = "2025-08-07T19:05:23.423Z" },
+    { url = "https://files.pythonhosted.org/packages/81/4e/1b7478b072fcde5161b48f64774d6edd59d6d198e4ba8918d9f4702b8043/ruff-0.12.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ac9c570634b98c71c88cb17badd90f13fc076a472ba6ef1d113d8ed3df109fb", size = 12613271, upload-time = "2025-08-07T19:05:25.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/67/0c3c9179a3ad19791ef1b8f7138aa27d4578c78700551c60d9260b2c660d/ruff-0.12.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:560e0cd641e45591a3e42cb50ef61ce07162b9c233786663fdce2d8557d99818", size = 12847783, upload-time = "2025-08-07T19:05:28.14Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2a/0b6ac3dd045acf8aa229b12c9c17bb35508191b71a14904baf99573a21bd/ruff-0.12.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:71c83121512e7743fba5a8848c261dcc454cafb3ef2934a43f1b7a4eb5a447ea", size = 11702672, upload-time = "2025-08-07T19:05:30.413Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ee/f9fdc9f341b0430110de8b39a6ee5fa68c5706dc7c0aa940817947d6937e/ruff-0.12.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:de4429ef2ba091ecddedd300f4c3f24bca875d3d8b23340728c3cb0da81072c3", size = 11440626, upload-time = "2025-08-07T19:05:32.492Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/b3aa2d482d05f44e4d197d1de5e3863feb13067b22c571b9561085c999dc/ruff-0.12.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a2cab5f60d5b65b50fba39a8950c8746df1627d54ba1197f970763917184b161", size = 12462162, upload-time = "2025-08-07T19:05:34.449Z" },
+    { url = "https://files.pythonhosted.org/packages/18/9f/5c5d93e1d00d854d5013c96e1a92c33b703a0332707a7cdbd0a4880a84fb/ruff-0.12.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:45c32487e14f60b88aad6be9fd5da5093dbefb0e3e1224131cb1d441d7cb7d46", size = 12913212, upload-time = "2025-08-07T19:05:36.541Z" },
+    { url = "https://files.pythonhosted.org/packages/71/13/ab9120add1c0e4604c71bfc2e4ef7d63bebece0cfe617013da289539cef8/ruff-0.12.8-py3-none-win32.whl", hash = "sha256:daf3475060a617fd5bc80638aeaf2f5937f10af3ec44464e280a9d2218e720d3", size = 11694382, upload-time = "2025-08-07T19:05:38.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/dc/a2873b7c5001c62f46266685863bee2888caf469d1edac84bf3242074be2/ruff-0.12.8-py3-none-win_amd64.whl", hash = "sha256:7209531f1a1fcfbe8e46bcd7ab30e2f43604d8ba1c49029bb420b103d0b5f76e", size = 12740482, upload-time = "2025-08-07T19:05:40.391Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5c/799a1efb8b5abab56e8a9f2a0b72d12bd64bb55815e9476c7d0a2887d2f7/ruff-0.12.8-py3-none-win_arm64.whl", hash = "sha256:c90e1a334683ce41b0e7a04f41790c429bf5073b62c1ae701c9dc5b3d14f0749", size = 11884718, upload-time = "2025-08-07T19:05:42.866Z" },
 ]
 
 [[package]]
@@ -486,14 +498,14 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.0"
+version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.9'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423, upload-time = "2025-06-02T14:52:11.399Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839, upload-time = "2025-06-02T14:52:10.026Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
 ]
 
 [[package]]
@@ -501,7 +513,7 @@ name = "typing-inspection"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [

--- a/sdks/typescript/__tests__/session.test.ts
+++ b/sdks/typescript/__tests__/session.test.ts
@@ -455,6 +455,107 @@ describe('Session', () => {
 
       await expect(session.addMessages({ peer_id: 'peer1', content: 'test' })).rejects.toThrow();
     });
+
+    it('should add message with custom timestamp', async () => {
+      const message = {
+        peer_id: 'peer1',
+        content: 'Message with timestamp',
+        created_at: '2023-01-01T12:00:00Z',
+        metadata: { test: 'timestamp' },
+      };
+      mockClient.workspaces.sessions.messages.create.mockResolvedValue({});
+
+      await session.addMessages(message);
+
+      expect(mockClient.workspaces.sessions.messages.create).toHaveBeenCalledWith(
+        'test-workspace',
+        'test-session',
+        {
+          messages: [{
+            peer_id: 'peer1',
+            content: 'Message with timestamp',
+            created_at: '2023-01-01T12:00:00Z',
+            metadata: { test: 'timestamp' }
+          }]
+        }
+      );
+    });
+
+    it('should add message with null timestamp', async () => {
+      const message = {
+        peer_id: 'peer1',
+        content: 'Message without timestamp',
+        created_at: null,
+        metadata: { test: 'no_timestamp' },
+      };
+      mockClient.workspaces.sessions.messages.create.mockResolvedValue({});
+
+      await session.addMessages(message);
+
+      expect(mockClient.workspaces.sessions.messages.create).toHaveBeenCalledWith(
+        'test-workspace',
+        'test-session',
+        {
+          messages: [{
+            peer_id: 'peer1',
+            content: 'Message without timestamp',
+            created_at: null,
+            metadata: { test: 'no_timestamp' }
+          }]
+        }
+      );
+    });
+
+    it('should add mixed messages with and without timestamps', async () => {
+      const messages = [
+        {
+          peer_id: 'peer1',
+          content: 'Message with timestamp',
+          created_at: '2023-01-01T12:00:00Z',
+          metadata: { type: 'historical' }
+        },
+        {
+          peer_id: 'peer2',
+          content: 'Message without timestamp',
+          metadata: { type: 'current' }
+        },
+        {
+          peer_id: 'peer3',
+          content: 'Message with null timestamp',
+          created_at: null,
+          metadata: { type: 'default' }
+        }
+      ];
+      mockClient.workspaces.sessions.messages.create.mockResolvedValue({});
+
+      await session.addMessages(messages);
+
+      expect(mockClient.workspaces.sessions.messages.create).toHaveBeenCalledWith(
+        'test-workspace',
+        'test-session',
+        {
+          messages: [
+            {
+              peer_id: 'peer1',
+              content: 'Message with timestamp',
+              created_at: '2023-01-01T12:00:00Z',
+              metadata: { type: 'historical' }
+            },
+            {
+              peer_id: 'peer2',
+              content: 'Message without timestamp',
+              metadata: { type: 'current' }
+            },
+            {
+              peer_id: 'peer3',
+              content: 'Message with null timestamp',
+              created_at: null,
+              metadata: { type: 'default' }
+            }
+          ]
+        }
+      );
+    });
   });
 
   describe('getMessages', () => {

--- a/sdks/typescript/bun.lock
+++ b/sdks/typescript/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@honcho-ai/sdk",
       "dependencies": {
-        "@honcho-ai/core": "1.3.0",
+        "@honcho-ai/core": "https://pkg.stainless.com/s/honcho-node/56d3b6b02646e70f3ae1e6a3a4c6ef90bb570e5c/dist.tar.gz",
         "@types/node": "^24.0.1",
         "zod": "4.0.0",
       },
@@ -108,7 +108,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.1.3", "", { "os": "win32", "cpu": "x64" }, "sha512-dxy599q6lgp8ANPpR8sDMscwdp9oOumEsVXuVCVT9N2vAho8uYXlCz53JhxX6LtJOXaE73qzgkGQ7QqvFlMC0g=="],
 
-    "@honcho-ai/core": ["@honcho-ai/core@1.3.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-yhxpZ00sQhO24PrHoTlj1cwR1q7/8FKSFZoCImqsFFmdERiXtE74YXhhfqzseyuShu1WfM7IwD8T2oCOB3hu7A=="],
+    "@honcho-ai/core": ["@honcho-ai/core@https://pkg.stainless.com/s/honcho-node/56d3b6b02646e70f3ae1e6a3a4c6ef90bb570e5c/dist.tar.gz", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }],
 
     "@istanbuljs/load-nyc-config": ["@istanbuljs/load-nyc-config@1.1.0", "", { "dependencies": { "camelcase": "^5.3.1", "find-up": "^4.1.0", "get-package-type": "^0.1.0", "js-yaml": "^3.13.1", "resolve-from": "^5.0.0" } }, "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ=="],
 

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -20,7 +20,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@honcho-ai/core": "1.3.0",
+    "@honcho-ai/core": "https://pkg.stainless.com/s/honcho-node/56d3b6b02646e70f3ae1e6a3a4c6ef90bb570e5c/dist.tar.gz",
     "@types/node": "^24.0.1",
     "zod": "4.0.0"
   },

--- a/sdks/typescript/src/peer.ts
+++ b/sdks/typescript/src/peer.ts
@@ -131,11 +131,15 @@ export class Peer {
    *
    * @param content - The text content for the message
    * @param metadata - Optional metadata to associate with the message
+   * @param created_at - Optional ISO 8601 timestamp for the message
    * @returns A new message object with this peer's ID and the provided content
    */
   message(
     content: string,
-    options?: { metadata?: Record<string, unknown> }
+    options?: {
+      metadata?: Record<string, unknown>
+      created_at?: string
+    }
   ): ValidatedMessageCreate {
     const validatedContent = MessageContentSchema.parse(content)
     const validatedMetadata = options?.metadata
@@ -146,6 +150,7 @@ export class Peer {
       peer_id: this.id,
       content: validatedContent,
       metadata: validatedMetadata,
+      created_at: options?.created_at,
     }
   }
 

--- a/sdks/typescript/src/session.ts
+++ b/sdks/typescript/src/session.ts
@@ -350,6 +350,12 @@ export class Session {
    *   { peer_id: 'user1', content: 'Hello!' },
    *   { peer_id: 'assistant', content: 'Hi there!' }
    * ])
+   * // Add message with custom ISO 8601 timestamp
+   * await session.addMessages({
+   *   peer_id: 'user123',
+   *   content: 'Hello world!',
+   *   created_at: '2021-01-01T00:00:00.000Z'
+   * })
    * ```
    */
   async addMessages(messages: MessageAddition): Promise<void> {

--- a/sdks/typescript/src/validation.ts
+++ b/sdks/typescript/src/validation.ts
@@ -94,7 +94,7 @@ export const MessageCreateSchema = z.object({
   peer_id: PeerIdSchema,
   content: MessageContentSchema,
   metadata: MessageMetadataSchema,
-  created_at: z.date().optional(),
+  created_at: z.string().nullable().optional(),
 })
 
 /**

--- a/sdks/typescript/src/validation.ts
+++ b/sdks/typescript/src/validation.ts
@@ -94,6 +94,7 @@ export const MessageCreateSchema = z.object({
   peer_id: PeerIdSchema,
   content: MessageContentSchema,
   metadata: MessageMetadataSchema,
+  created_at: z.date().optional(),
 })
 
 /**

--- a/src/crud/message.py
+++ b/src/crud/message.py
@@ -89,6 +89,7 @@ async def create_messages(
             workspace_name=workspace_name,
             public_id=generate_nanoid(),
             token_count=len(message.encoded_message),
+            created_at=message.created_at,  # Use provided created_at if available
         )
         message_objects.append(message_obj)
 

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -19,6 +19,7 @@ from src.utils.formatting import (
     find_new_observations,
     format_context_for_prompt,
     format_new_turn_with_timestamp,
+    utc_now_iso,
 )
 from src.utils.logging import (
     accumulate_metric,
@@ -628,7 +629,7 @@ async def save_working_representation_to_peer(
     working_rep_data = {
         "final_observations": final_obs_dict,
         "message_id": message_id,
-        "created_at": datetime.datetime.now().isoformat(),
+        "created_at": utc_now_iso(),
     }
 
     # if session_name is supplied, save working representation to session peer

--- a/src/dialectic/utils.py
+++ b/src/dialectic/utils.py
@@ -11,6 +11,7 @@ from src.utils.clients import honcho_llm_call
 from src.utils.embedding_store import EmbeddingStore
 from src.utils.formatting import (
     format_premises_for_display,
+    parse_datetime_iso,
 )
 from src.utils.logging import conditional_observe
 from src.utils.shared_models import SemanticQueries
@@ -190,11 +191,9 @@ def _format_observations(
         if last_accessed:
             # Format the last_accessed datetime for display
             try:
-                from datetime import datetime
-
                 if isinstance(last_accessed, str):
                     # Parse ISO format datetime string
-                    dt = datetime.fromisoformat(last_accessed.replace("Z", "+00:00"))
+                    dt = parse_datetime_iso(last_accessed)
                     formatted_last_accessed: str = dt.strftime("%Y-%m-%d %H:%M")
                     access_parts.append(f"last accessed {formatted_last_accessed}")
             except (ValueError, AttributeError):

--- a/src/routers/keys.py
+++ b/src/routers/keys.py
@@ -10,6 +10,7 @@ from src.security import (
     create_jwt,
     require_auth,
 )
+from src.utils.formatting import format_datetime_utc
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ async def create_key(
 
     key_str = create_jwt(
         JWTParams(
-            exp=expires_at.isoformat() if expires_at else None,
+            exp=format_datetime_utc(expires_at) if expires_at else None,
             w=workspace_id,
             p=peer_id,
             s=session_id,

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -117,6 +117,7 @@ class MessageCreate(MessageBase):
     content: Annotated[str, Field(min_length=0, max_length=50000)]
     peer_name: str = Field(alias="peer_id")
     metadata: dict[str, Any] | None = None
+    created_at: datetime.datetime | None = None
 
     _encoded_message: list[int] = PrivateAttr(default=[])
 

--- a/src/security.py
+++ b/src/security.py
@@ -8,6 +8,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
 from src.config import settings
+from src.utils.formatting import utc_now_iso
 
 from .exceptions import AuthenticationException
 
@@ -54,7 +55,7 @@ class JWTParams(BaseModel):
     `s`: (string) session name
     """
 
-    t: str = datetime.datetime.now().isoformat()
+    t: str = utc_now_iso()
     exp: str | None = None
     ad: bool | None = None
     w: str | None = None

--- a/src/utils/embedding_store.py
+++ b/src/utils/embedding_store.py
@@ -12,6 +12,7 @@ from src import crud, models
 from src.config import settings
 from src.dependencies import tracked_db
 from src.embedding_client import embedding_client
+from src.utils.formatting import format_datetime_utc
 from src.utils.logging import conditional_observe
 from src.utils.shared_models import (
     Observation,
@@ -115,7 +116,7 @@ class EmbeddingStore:
                     "message_id": message_id,
                     "session_name": session_name,
                     "premises": obs.premises,  # Store premises in metadata
-                    "created_at": message_created_at.isoformat()
+                    "created_at": format_datetime_utc(message_created_at)
                     if message_created_at
                     else None,
                 }

--- a/src/utils/filter.py
+++ b/src/utils/filter.py
@@ -7,6 +7,7 @@ from sqlalchemy import ColumnElement, Select, and_, case, cast, literal, not_, o
 from sqlalchemy.types import Numeric
 
 from ..exceptions import FilterError
+from .formatting import parse_datetime_iso
 
 logger = getLogger(__name__)
 
@@ -561,9 +562,9 @@ def _validate_datetime_string(value: str) -> datetime.datetime | None:
         except ValueError:
             continue
 
-    # Try fromisoformat as a fallback (Python 3.7+)
+    # Try fromisoformat as a fallback (Python 3.7+) with Z format support
     try:
-        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parse_datetime_iso(value)
     except ValueError:
         pass
 

--- a/src/utils/summarizer.py
+++ b/src/utils/summarizer.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import logging
 import time
 from enum import Enum
@@ -13,6 +12,7 @@ from src.config import settings
 from src.dependencies import tracked_db
 from src.exceptions import ResourceNotFoundException
 from src.utils.clients import honcho_llm_call
+from src.utils.formatting import utc_now_iso
 from src.utils.logging import accumulate_metric
 
 from .. import crud, models
@@ -386,7 +386,7 @@ async def _create_summary(
         content=summary_text,
         message_id=messages[-1].id if messages else 0,
         summary_type=summary_type.value,
-        created_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        created_at=utc_now_iso(),
         token_count=summary_tokens,
     )
 

--- a/src/webhooks/webhook_delivery.py
+++ b/src/webhooks/webhook_delivery.py
@@ -3,7 +3,6 @@ import hashlib
 import hmac
 import json
 import logging
-from datetime import datetime, timezone
 
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.config import settings
 from src.crud.webhook import list_webhook_endpoints
 from src.deriver.queue_payload import WebhookPayload
+from src.utils.formatting import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ async def deliver_webhook(db: AsyncSession, payload: WebhookPayload) -> None:
             event_payload = {
                 "type": payload.event_type,
                 "data": payload.data,
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_now_iso(),
             }
             event_json = json.dumps(
                 event_payload, separators=(",", ":"), sort_keys=True

--- a/uv.lock
+++ b/uv.lock
@@ -830,6 +830,7 @@ dependencies = [
     { name = "fastapi-pagination" },
     { name = "google-generativeai" },
     { name = "greenlet" },
+    { name = "honcho-core" },
     { name = "httpx" },
     { name = "mirascope", extra = ["anthropic", "google", "groq", "langfuse"] },
     { name = "nanoid" },
@@ -871,6 +872,7 @@ requires-dist = [
     { name = "fastapi-pagination", specifier = ">=0.12.24" },
     { name = "google-generativeai", specifier = ">=0.8.5" },
     { name = "greenlet", specifier = ">=3.0.3" },
+    { name = "honcho-core", url = "https://pkg.stainless.com/s/honcho-python/ffa0cb18fd084729c30f2f723cc3287103e1edd0/honcho_core-1.3.0-py3-none-any.whl" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mirascope", extras = ["anthropic", "google", "groq", "langfuse"], specifier = ">=1.25.1" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -894,7 +896,7 @@ dev = [
     { name = "basedpyright", specifier = ">=1.29.4" },
     { name = "coverage", specifier = ">=7.6.0" },
     { name = "honcho-ai", specifier = "==1.3.0" },
-    { name = "honcho-core", specifier = "==1.3.0" },
+    { name = "honcho-core", url = "https://pkg.stainless.com/s/honcho-python/ffa0cb18fd084729c30f2f723cc3287103e1edd0/honcho_core-1.3.0-py3-none-any.whl" },
     { name = "interrogate", specifier = ">=1.7.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "py-spy", specifier = ">=0.3.14" },
@@ -922,7 +924,7 @@ wheels = [
 [[package]]
 name = "honcho-core"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { url = "https://pkg.stainless.com/s/honcho-python/ffa0cb18fd084729c30f2f723cc3287103e1edd0/honcho_core-1.3.0-py3-none-any.whl" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -931,10 +933,22 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/49/1810de2351be1fdff330ffadcc5eef709889b2f698b0340966cae2c1eef9/honcho_core-1.3.0.tar.gz", hash = "sha256:276a73e8d523f7d22f06746922fda97e4a11fbbef4a51a0b43573bc817089cec", size = 123333, upload-time = "2025-08-06T16:42:10.941Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/3f/3beb750ed65bb1b604c585ae1c51a54f8b34ea3002f4525f93fe86549531/honcho_core-1.3.0-py3-none-any.whl", hash = "sha256:c7c0bf77b61162e6c65a580327fc054785aef794923abc35acd3dbd8287245db", size = 112895, upload-time = "2025-08-06T16:42:08.967Z" },
+    { url = "https://pkg.stainless.com/s/honcho-python/ffa0cb18fd084729c30f2f723cc3287103e1edd0/honcho_core-1.3.0-py3-none-any.whl", hash = "sha256:4c64a9db1d90ef9733baa44fced589085eaf5fe7906752e7c49fc0c7606a36f4" },
 ]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", marker = "extra == 'aiohttp'" },
+    { name = "anyio", specifier = ">=3.5.0,<5" },
+    { name = "distro", specifier = ">=1.7.0,<2" },
+    { name = "httpx", specifier = ">=0.23.0,<1" },
+    { name = "httpx-aiohttp", marker = "extra == 'aiohttp'", specifier = ">=0.1.8" },
+    { name = "pydantic", specifier = ">=1.9.0,<3" },
+    { name = "sniffio" },
+    { name = "typing-extensions", specifier = ">=4.10,<5" },
+]
+provides-extras = ["aiohttp"]
 
 [[package]]
 name = "httpcore"


### PR DESCRIPTION
Fixes DEV-1038

- Introduced `created_at` parameter for message creation, allowing users to specify custom timestamps.
- **Single source of truth for timestamp string format**
- Updated SDK documentation to reflect this new feature and its use cases.
- Enhanced validation schemas to include the optional `created_at` field.
- Added tests to verify functionality for messages with and without custom timestamps, ensuring correct behavior and default timestamp usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support custom created_at timestamps when creating messages via API and SDKs (Python, TypeScript). If omitted or null, server time is used.
- Improvements
  - Standardized UTC timestamp formatting (Z) across webhooks, summaries, embeddings, and defaults.
- Bug Fixes
  - Key creation now requires at least one of workspace_id, peer_id, or session_id, with a clear error if missing.
- Documentation
  - Added examples and guidance for using custom message timestamps.
- Tests
  - Expanded coverage for timestamp handling (custom, null, mixed).
- Chores
  - Updated core dependency sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->