### PR TITLE
refactor: update history parameter to be optional in critical analysis and representation functions

### DIFF
--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -17,7 +17,7 @@ def critical_analysis_prompt(
     peer_card: list[str] | None,
     message_created_at: datetime.datetime,
     working_representation: str | None,
-    history: str,
+    history: str | None,
     new_turn: str,
 ) -> str:
     """
@@ -28,7 +28,7 @@ def critical_analysis_prompt(
         peer_card (list[str] | None): The bio card of the user being analyzed.
         message_created_at (datetime.datetime): Timestamp of the message.
         working_representation (str | None): Current user understanding context.
-        history (str): Recent conversation history.
+        history (str | None): Recent conversation history.
         new_turn (str): New conversation turn to analyze.
 
     Returns:
@@ -55,6 +55,17 @@ The current user understanding:
 </current_context>
 """
         if working_representation is not None
+        else ""
+    )
+
+    history_section = (
+        f"""
+Recent conversation history for context:
+<history>
+{history}
+</history>
+"""
+        if history is not None
         else ""
     )
 
@@ -89,10 +100,7 @@ Here are strict definitions for the reasoning modes you are to employ:
 
 {working_representation_section}
 
-Recent conversation history for context:
-<history>
-{history}
-</history>
+{history_section}
 
 New conversation turn to analyze:
 <new_turn>

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -115,7 +115,7 @@ def format_reasoning_response_as_markdown(
 
 def format_reasoning_inputs_as_markdown(
     context: ReasoningResponseWithThinking | None,
-    history: str,
+    history: str | None,
     new_turn: str,
     message_created_at: datetime.datetime,
 ) -> str:


### PR DESCRIPTION
- Changed the `history` parameter type in `critical_analysis_call`, `critical_analysis_prompt`, and `process_representation_task` to `str | None` for improved flexibility.
- Adjusted handling of `formatted_history` in `process_representation_task` to set it to `None` when `payload.message_id` is not greater than 0, ensuring consistent behavior.
- Updated docstrings to reflect the new optional nature of the `history` parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Seamless handling of conversations that start without prior history.
- Bug Fixes
  - Prevented errors when no previous messages exist.
  - Prompts no longer include empty or placeholder history sections.
  - Logging displays inputs correctly even when history is missing.
- Refactor
  - Standardized optional history handling across reasoning and analysis flows for more robust behavior.
  - Improved control flow to fetch context only when prior messages exist, reducing unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->