### PR TITLE
add system prompt injection into dialectic

### DIFF
--- a/sdks/python/src/honcho/peer.py
+++ b/sdks/python/src/honcho/peer.py
@@ -91,7 +91,6 @@ class Peer(BaseModel):
         stream: bool = False,
         target: str | Peer | None = None,
         session_id: str | None = None,
-        system_prompt: str | None = None,
     ) -> str | None:
         """
         Query the peer's representation with a natural language question.

--- a/sdks/python/src/honcho/peer.py
+++ b/sdks/python/src/honcho/peer.py
@@ -122,7 +122,6 @@ class Peer(BaseModel):
             stream=stream,
             target=str(target.id) if isinstance(target, Peer) else target,
             session_id=session_id,
-            system_prompt=system_prompt,
         )
         if response.content in ("", None, "None"):
             return None

--- a/sdks/python/src/honcho/peer.py
+++ b/sdks/python/src/honcho/peer.py
@@ -115,28 +115,15 @@ class Peer(BaseModel):
             Response string containing the answer to the query, or None if no
             relevant information is available
         """
-        # Prepare chat arguments
-        chat_args = {
-            "peer_id": self.id,
-            "workspace_id": self.workspace_id,
-            "query": query,
-            "stream": stream,
-            "target": str(target.id) if isinstance(target, Peer) else target,
-            "session_id": session_id,
-        }
-        
-        # Add system_prompt if provided and client supports it
-        if system_prompt is not None and system_prompt != "":
-            try:
-                # Try to include system_prompt parameter
-                chat_args["system_prompt"] = system_prompt
-                response = self._client.workspaces.peers.chat(**chat_args)
-            except TypeError:
-                # Fallback if client doesn't support system_prompt yet
-                chat_args.pop("system_prompt", None)
-                response = self._client.workspaces.peers.chat(**chat_args)
-        else:
-            response = self._client.workspaces.peers.chat(**chat_args)
+        response = self._client.workspaces.peers.chat(
+            peer_id=self.id,
+            workspace_id=self.workspace_id,
+            query=query,
+            stream=stream,
+            target=str(target.id) if isinstance(target, Peer) else target,
+            session_id=session_id,
+            system_prompt=system_prompt,
+        )
         if response.content in ("", None, "None"):
             return None
         return response.content

--- a/sdks/typescript/src/validation.ts
+++ b/sdks/typescript/src/validation.ts
@@ -114,6 +114,13 @@ export const SearchQuerySchema = z
 export const FilterSchema = z.record(z.string(), z.unknown()).optional()
 
 /**
+ * Schema for system prompt validation.
+ */
+export const SystemPromptSchema = z
+  .string()
+  .max(5000, 'System prompt must be 5000 characters or less')
+
+/**
  * Schema for chat query parameters.
  */
 export const ChatQuerySchema = z.object({
@@ -121,6 +128,7 @@ export const ChatQuerySchema = z.object({
   stream: z.boolean().optional(),
   target: z.union([z.string(), z.object({ id: z.string() })]).optional(),
   sessionId: z.string().optional(),
+  systemPrompt: SystemPromptSchema.optional(),
 })
 
 /**
@@ -250,6 +258,7 @@ export type SessionConfig = z.infer<typeof SessionConfigSchema>
 export type SessionPeerConfig = z.infer<typeof SessionPeerConfigSchema>
 export type MessageCreate = z.infer<typeof MessageCreateSchema>
 export type Filters = z.infer<typeof FilterSchema>
+export type SystemPrompt = z.infer<typeof SystemPromptSchema>
 export type ChatQuery = z.infer<typeof ChatQuerySchema>
 export type ContextParams = z.infer<typeof ContextParamsSchema>
 export type DeriverStatusOptions = z.infer<typeof DeriverStatusOptionsSchema>

--- a/src/dialectic/chat.py
+++ b/src/dialectic/chat.py
@@ -57,7 +57,7 @@ async def dialectic_call(
     peer_card: list[str] | None,
     target_name: str | None = None,
     target_peer_card: list[str] | None = None,
-    system_injection: str | None,
+    system_injection: str | None = None,
 ):
     """
     Make a direct call to the dialectic model for context synthesis.
@@ -119,7 +119,7 @@ async def dialectic_stream(
     peer_card: list[str] | None,
     target_name: str | None = None,
     target_peer_card: list[str] | None = None,
-    system_injection: str | None,
+    system_injection: str | None = None,
 ):
     """
     Make a streaming call to the dialectic model for context synthesis.

--- a/src/dialectic/chat.py
+++ b/src/dialectic/chat.py
@@ -168,6 +168,7 @@ async def chat(
     query: str,
     *,
     stream: bool = False,
+    system_prompt: str | None = None,
 ) -> Stream | str:
     """
     Chat with the Dialectic API that builds on-demand user representations.
@@ -185,6 +186,7 @@ async def chat(
         session_name: Optional session name for scoping
         query: Input Dialectic Query
         stream: Whether to stream the response
+        system_prompt: Optional system prompt to inject into the dialectic context
 
     Returns:
         Dialectic response (streaming or complete)
@@ -323,6 +325,7 @@ async def chat(
             peer_card,
             target_name,
             target_peer_card,
+            system_prompt,
         )
 
     response = await dialectic_call(
@@ -334,6 +337,7 @@ async def chat(
         peer_card,
         target_name,
         target_peer_card,
+        system_prompt,
     )
     dialectic_call_duration = (
         asyncio.get_event_loop().time() - dialectic_call_start_time

--- a/src/dialectic/chat.py
+++ b/src/dialectic/chat.py
@@ -57,6 +57,7 @@ async def dialectic_call(
     peer_card: list[str] | None,
     target_name: str | None = None,
     target_peer_card: list[str] | None = None,
+    system_injection: str | None,
 ):
     """
     Make a direct call to the dialectic model for context synthesis.
@@ -80,6 +81,7 @@ async def dialectic_call(
         peer_card,
         target_name,
         target_peer_card,
+        system_injection,
     )
 
     # Pretty print the prompt content
@@ -117,6 +119,7 @@ async def dialectic_stream(
     peer_card: list[str] | None,
     target_name: str | None = None,
     target_peer_card: list[str] | None = None,
+    system_injection: str | None,
 ):
     """
     Make a streaming call to the dialectic model for context synthesis.
@@ -140,6 +143,7 @@ async def dialectic_stream(
         peer_card,
         target_name,
         target_peer_card,
+        system_injection,
     )
 
     # Pretty print the prompt content

--- a/src/dialectic/prompts.py
+++ b/src/dialectic/prompts.py
@@ -13,7 +13,7 @@ def dialectic_prompt(
     peer_card: list[str] | None,
     target_name: str | None = None,
     target_peer_card: list[str] | None = None,
-    system_injection: str | '',
+    system_injection: str | None,
 ) -> str:
     """
     Generate the main dialectic prompt for context synthesis.
@@ -52,7 +52,7 @@ If the user's name or nickname is known, exclusively refer to them by that name.
     return c(
         f"""
 You are a context synthesis agent that operates as a natural language API for AI applications. Your role is to analyze application queries about users and synthesize relevant conclusions into coherent, actionable insights that directly address what the application needs to know.
-{system_injection}
+{system_injection if system_injection else ""}
 
 ## INPUT STRUCTURE
 

--- a/src/dialectic/prompts.py
+++ b/src/dialectic/prompts.py
@@ -13,6 +13,7 @@ def dialectic_prompt(
     peer_card: list[str] | None,
     target_name: str | None = None,
     target_peer_card: list[str] | None = None,
+    system_injection: str | None = None,
 ) -> str:
     """
     Generate the main dialectic prompt for context synthesis.
@@ -51,6 +52,7 @@ If the user's name or nickname is known, exclusively refer to them by that name.
     return c(
         f"""
 You are a context synthesis agent that operates as a natural language API for AI applications. Your role is to analyze application queries about users and synthesize relevant conclusions into coherent, actionable insights that directly address what the application needs to know.
+{system_injection}
 
 ## INPUT STRUCTURE
 

--- a/src/dialectic/prompts.py
+++ b/src/dialectic/prompts.py
@@ -13,7 +13,7 @@ def dialectic_prompt(
     peer_card: list[str] | None,
     target_name: str | None = None,
     target_peer_card: list[str] | None = None,
-    system_injection: str | None = None,
+    system_injection: str | '',
 ) -> str:
     """
     Generate the main dialectic prompt for context synthesis.

--- a/src/dialectic/prompts.py
+++ b/src/dialectic/prompts.py
@@ -13,7 +13,7 @@ def dialectic_prompt(
     peer_card: list[str] | None,
     target_name: str | None = None,
     target_peer_card: list[str] | None = None,
-    system_injection: str | None,
+    system_injection: str | None = None,
 ) -> str:
     """
     Generate the main dialectic prompt for context synthesis.

--- a/src/routers/peers.py
+++ b/src/routers/peers.py
@@ -175,6 +175,7 @@ async def chat(
             session_name=options.session_id,
             query=options.query,
             stream=options.stream,
+            system_prompt=options.system_prompt,
         )
         return schemas.DialecticResponse(content=str(response))
 
@@ -187,6 +188,7 @@ async def chat(
                 session_name=options.session_id,
                 query=options.query,
                 stream=options.stream,
+                system_prompt=options.system_prompt,
             )
             if isinstance(stream, Stream):
                 async for chunk, _ in stream:

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -300,6 +300,12 @@ class DialecticOptions(BaseModel):
     query: Annotated[
         str, Field(min_length=1, max_length=10000, description="Dialectic API Prompt")
     ]
+    system_prompt: Annotated[
+        str, Field(min_length=0, max_length=5000, description="Dialectic API System Prompt Injection")
+    ] = Field(
+        default="",
+        description="Optional system prompt instructions to add to the context for the dialectic model",
+    )
     stream: bool = False
 
 


### PR DESCRIPTION
Added functionality to perform prompt injection into dialectic prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional system prompt can be included to guide model tone/behavior; ignored when empty.
  * System prompt is respected in both streaming and non-streaming chat flows.

* **Chores**
  * SDKs and API surface updated to accept and forward an optional system prompt (validated, max 5000 chars).
  * Client SDKs gracefully fall back if system prompt isn't supported; Python docs updated to document the parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->