### PR TITLE
typo: workspaceId in quickstart.mdx

### DIFF
--- a/docs/v2/documentation/introduction/quickstart.mdx
+++ b/docs/v2/documentation/introduction/quickstart.mdx
@@ -87,7 +87,7 @@ client = Honcho(
     api_key=os.environ["HONCHO_API_KEY"],
     environment="production",
     # Create a workspace, otherwise set to "default"
-    # workspace="your-workspace-id"
+    # workspaceId="your-workspace-id"
 )
 ```
 


### PR DESCRIPTION
Current docs imply `workspace: "your-workspace-id"` is the right key for the initialization, though the right property should be `workspaceId: "your-workspace-id"`

Just a small confusion as I was setting up docs, thought this might be helpful for future

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Quickstart’s production client initialization example to use the correct workspaceId parameter in the Python snippet, improving accuracy and consistency with the current API.
  * Clarifies parameter naming to reduce setup confusion for new users.
  * No functional changes; this update affects documentation examples only.
  * Other language examples remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->