### PR TITLE
feat: get peer cards endpoint

### DIFF
--- a/src/routers/peers.py
+++ b/src/routers/peers.py
@@ -234,7 +234,7 @@ async def get_working_representation(
 
 
 @router.get(
-    "/{peer_id}/peer-cards",
+    "/{peer_id}/card",
     response_model=schemas.PeerCardResponse,
     dependencies=[
         Depends(require_auth(workspace_name="workspace_id", peer_name="peer_id"))

--- a/src/routers/peers.py
+++ b/src/routers/peers.py
@@ -255,20 +255,14 @@ async def get_peer_card(
 ):
     """Get a peer card for a specific peer relationship.
 
-    Returns the peer card that the observer peer has for the target peer.
+    Returns the peer card that the observer peer has for the target peer if it exists.
     If no target is specified, returns the observer's own peer card.
     """
     # If no target specified, get the observer's own card
     target_peer = options.target if options.target is not None else peer_id
 
-    try:
-        peer_card = await crud.get_peer_card(db, workspace_id, target_peer, peer_id)
-        return schemas.PeerCardResponse(peer_card=peer_card)
-    except Exception as e:
-        logger.warning(
-            f"Failed to get peer card for observer {peer_id}, target {target_peer}: {str(e)}"
-        )
-        raise ResourceNotFoundException("Peer card not found") from e
+    peer_card = await crud.get_peer_card(db, workspace_id, target_peer, peer_id)
+    return schemas.PeerCardResponse(peer_card=peer_card)
 
 
 @router.post(

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -104,6 +104,19 @@ class PeerRepresentationGet(BaseModel):
     )
 
 
+class PeerCardGet(BaseModel):
+    target: str | None = Field(
+        None,
+        description="The peer whose card to retrieve. If not provided, gets the observer's own card",
+    )
+
+
+class PeerCardResponse(BaseModel):
+    peer_card: list[str] | None = Field(
+        None, description="The peer card content, or None if not found"
+    )
+
+
 class PeerConfig(BaseModel):
     observe_me: bool = Field(
         default=True,

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -104,13 +104,6 @@ class PeerRepresentationGet(BaseModel):
     )
 
 
-class PeerCardGet(BaseModel):
-    target: str | None = Field(
-        None,
-        description="The peer whose card to retrieve. If not provided, gets the observer's own card",
-    )
-
-
 class PeerCardResponse(BaseModel):
     peer_card: list[str] | None = Field(
         None, description="The peer card content, or None if not found"

--- a/tests/routes/test_peers.py
+++ b/tests/routes/test_peers.py
@@ -572,18 +572,17 @@ def test_get_peer_card(client: TestClient, sample_data: tuple[Workspace, Peer]):
     assert response.status_code == 200
 
     # Test getting observer's own card (should return null initially)
-    response = client.post(
-        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/peer-cards",
-        json={},
+    response = client.get(
+        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/peer-cards"
     )
     assert response.status_code == 200
     data = response.json()
     assert data["peer_card"] is None
 
     # Test getting card for target peer (should return null initially)
-    response = client.post(
+    response = client.get(
         f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/peer-cards",
-        json={"target": target_peer_name},
+        params={"target": target_peer_name},
     )
     assert response.status_code == 200
     data = response.json()
@@ -629,18 +628,17 @@ async def test_get_peer_card_with_data(
     )
 
     # Test getting observer's own card
-    response = client.post(
-        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/peer-cards",
-        json={},
+    response = client.get(
+        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/peer-cards"
     )
     assert response.status_code == 200
     data = response.json()
     assert data["peer_card"] == self_card_content
 
     # Test getting card for target peer
-    response = client.post(
+    response = client.get(
         f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/peer-cards",
-        json={"target": target_peer_name},
+        params={"target": target_peer_name},
     )
     assert response.status_code == 200
     data = response.json()

--- a/tests/routes/test_peers.py
+++ b/tests/routes/test_peers.py
@@ -573,7 +573,7 @@ def test_get_peer_card(client: TestClient, sample_data: tuple[Workspace, Peer]):
 
     # Test getting observer's own card (should return null initially)
     response = client.get(
-        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/peer-cards"
+        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/card"
     )
     assert response.status_code == 200
     data = response.json()
@@ -581,7 +581,7 @@ def test_get_peer_card(client: TestClient, sample_data: tuple[Workspace, Peer]):
 
     # Test getting card for target peer (should return null initially)
     response = client.get(
-        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/peer-cards",
+        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/card",
         params={"target": target_peer_name},
     )
     assert response.status_code == 200
@@ -629,7 +629,7 @@ async def test_get_peer_card_with_data(
 
     # Test getting observer's own card
     response = client.get(
-        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/peer-cards"
+        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/card"
     )
     assert response.status_code == 200
     data = response.json()
@@ -637,7 +637,7 @@ async def test_get_peer_card_with_data(
 
     # Test getting card for target peer
     response = client.get(
-        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/peer-cards",
+        f"/v2/workspaces/{test_workspace.name}/peers/{observer_peer.name}/card",
         params={"target": target_peer_name},
     )
     assert response.status_code == 200


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an authenticated GET endpoint to retrieve a peer card in a workspace; returns the observer’s own card or a specified target’s card (null when none).

- **Schemas**
  - Introduced a PeerCardResponse model to wrap returned peer card content.

- **Tests**
  - Added tests for empty and populated peer-card retrieval, including async DB setup and verification of observer/self and target views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->