### PR TITLE
feat: use token limit from all senders for rollup

### DIFF
--- a/src/deriver/consumer.py
+++ b/src/deriver/consumer.py
@@ -8,13 +8,12 @@ from rich.console import Console
 from src.config import settings
 from src.dependencies import tracked_db
 from src.deriver.deriver import process_representation_tasks_batch
+from src.models import Message
 from src.utils import summarizer
 from src.utils.logging import log_performance_metrics
 from src.webhooks import webhook_delivery
 
 from .queue_payload import (
-    RepresentationPayload,
-    RepresentationPayloads,
     SummaryPayload,
     WebhookPayload,
 )
@@ -66,7 +65,7 @@ async def process_item(task_type: str, queue_payload: dict[str, Any]) -> None:
 
 
 async def process_representation_batch(
-    payloads: list[dict[str, Any]],
+    messages: list[Message],
     sender_name: str | None,
     target_name: str | None,
 ) -> None:
@@ -84,7 +83,7 @@ async def process_representation_batch(
         target_name (optional): For representation tasks, the target_name from work_unit_key
                      to identify which messages should be focused on
     """
-    if not payloads or not payloads[0]:
+    if not messages or not messages[0]:
         logger.debug("process_representation_batch received no payloads")
         return
 
@@ -95,7 +94,7 @@ async def process_representation_batch(
 
     logger.debug(
         "process_representation_batch received %s payloads",
-        len(payloads),
+        len(messages),
     )
 
     if settings.LANGFUSE_PUBLIC_KEY:
@@ -104,18 +103,5 @@ async def process_representation_batch(
                 "critical_analysis_model": settings.DERIVER.MODEL,
             }
         )
-    try:
-        validated_payloads = RepresentationPayloads(
-            payloads=[RepresentationPayload(**payload) for payload in payloads]
-        )
-    except ValidationError as e:
-        logger.error(
-            "Invalid representation payloads received: %s. Payloads: %s",
-            str(e),
-            payloads,
-        )
-        raise ValueError(f"Invalid payload structure: {str(e)}") from e
 
-    await process_representation_tasks_batch(
-        validated_payloads.payloads, sender_name, target_name
-    )
+    await process_representation_tasks_batch(sender_name, target_name, messages)

--- a/src/deriver/consumer.py
+++ b/src/deriver/consumer.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any
 
-import sentry_sdk
 from langfuse import get_client
 from pydantic import ValidationError
 from rich.console import Console
@@ -28,11 +27,48 @@ console = Console(markup=True)
 lf = get_client()
 
 
-async def process_items(
-    task_type: str,
-    queue_payloads: list[dict[str, Any]],
-    sender_name: str | None = None,
-    target_name: str | None = None,
+async def process_item(task_type: str, queue_payload: dict[str, Any]) -> None:
+    """Process a single item from the queue."""
+    if task_type == "webhook":
+        try:
+            validated = WebhookPayload(**queue_payload)
+        except ValidationError as e:
+            logger.error(
+                "Invalid webhook payload received: %s. Payload: %s",
+                str(e),
+                queue_payload,
+            )
+            raise ValueError(f"Invalid payload structure: {str(e)}") from e
+        async with tracked_db() as db:
+            await webhook_delivery.deliver_webhook(db, validated)
+
+    elif task_type == "summary":
+        try:
+            validated = SummaryPayload(**queue_payload)
+        except ValidationError as e:
+            logger.error(
+                "Invalid summary payload received: %s. Payload: %s",
+                str(e),
+                queue_payload,
+            )
+            raise ValueError(f"Invalid payload structure: {str(e)}") from e
+        await summarizer.summarize_if_needed(
+            validated.workspace_name,
+            validated.session_name,
+            validated.message_id,
+            validated.message_seq_in_session,
+        )
+        log_performance_metrics(
+            f"summary_{validated.workspace_name}_{validated.message_id}"
+        )
+    else:
+        raise ValueError(f"Invalid task type: {task_type}")
+
+
+async def process_representation_batch(
+    payloads: list[dict[str, Any]],
+    sender_name: str | None,
+    target_name: str | None,
 ) -> None:
     """Validate incoming queue payloads and dispatch to the appropriate handler.
 
@@ -48,101 +84,38 @@ async def process_items(
         target_name (optional): For representation tasks, the target_name from work_unit_key
                      to identify which messages should be focused on
     """
-    if not queue_payloads or not queue_payloads[0]:
-        logger.debug("process_items received no payloads for task type %s", task_type)
+    if not payloads or not payloads[0]:
+        logger.debug("process_representation_batch received no payloads")
         return
 
-    logger.debug(
-        "process_items received %s payloads for task type %s",
-        len(queue_payloads),
-        task_type,
-    )
-
-    if task_type == "webhook":
-        try:
-            validated = WebhookPayload(**queue_payloads[0])
-        except ValidationError as e:
-            logger.error(
-                "Invalid webhook payload received: %s. Payload: %s",
-                str(e),
-                queue_payloads[0],
-            )
-            raise ValueError(f"Invalid payload structure: {str(e)}") from e
-        await process_webhook(validated)
-        logger.debug("Finished processing webhook %s", validated.event_type)
-
-    elif task_type == "summary":
-        if settings.LANGFUSE_PUBLIC_KEY:
-            lf.update_current_trace(  # type: ignore
-                metadata={
-                    "critical_analysis_model": settings.DERIVER.MODEL,
-                }
-            )
-        try:
-            validated = SummaryPayload(**queue_payloads[0])
-        except ValidationError as e:
-            logger.error(
-                "Invalid summary payload received: %s. Payload: %s",
-                str(e),
-                queue_payloads[0],
-            )
-            raise ValueError(f"Invalid payload structure: {str(e)}") from e
-        await process_summary_task(validated)
-
-    elif task_type == "representation":
-        if settings.LANGFUSE_PUBLIC_KEY:
-            lf.update_current_trace(
-                metadata={
-                    "critical_analysis_model": settings.DERIVER.MODEL,
-                }
-            )
-        try:
-            validated_payloads = RepresentationPayloads(
-                payloads=[
-                    RepresentationPayload(**payload) for payload in queue_payloads
-                ]
-            )
-        except ValidationError as e:
-            logger.error(
-                "Invalid representation payloads received: %s. Payloads: %s",
-                str(e),
-                queue_payloads,
-            )
-            raise ValueError(f"Invalid payload structure: {str(e)}") from e
-
-        # Validate that sender_name and target_name are provided for representation tasks
-        if sender_name is None or target_name is None:
-            raise ValueError(
-                "sender_name and target_name are required for representation tasks"
-            )
-
-        await process_representation_tasks_batch(
-            validated_payloads.payloads, sender_name, target_name
+    if sender_name is None or target_name is None:
+        raise ValueError(
+            "sender_name and target_name are required for representation tasks"
         )
 
-    else:
-        raise ValueError(f"Invalid task type: {task_type}")
-
-
-@sentry_sdk.trace
-async def process_webhook(
-    payload: WebhookPayload,
-) -> None:
-    async with tracked_db() as db:
-        await webhook_delivery.deliver_webhook(db, payload)
-
-
-@sentry_sdk.trace
-async def process_summary_task(
-    payload: SummaryPayload,
-) -> None:
-    """
-    Process a summary task by generating summaries if needed.
-    """
-    await summarizer.summarize_if_needed(
-        payload.workspace_name,
-        payload.session_name,
-        payload.message_id,
-        payload.message_seq_in_session,
+    logger.debug(
+        "process_representation_batch received %s payloads",
+        len(payloads),
     )
-    log_performance_metrics(f"summary_{payload.workspace_name}_{payload.message_id}")
+
+    if settings.LANGFUSE_PUBLIC_KEY:
+        lf.update_current_trace(
+            metadata={
+                "critical_analysis_model": settings.DERIVER.MODEL,
+            }
+        )
+    try:
+        validated_payloads = RepresentationPayloads(
+            payloads=[RepresentationPayload(**payload) for payload in payloads]
+        )
+    except ValidationError as e:
+        logger.error(
+            "Invalid representation payloads received: %s. Payloads: %s",
+            str(e),
+            payloads,
+        )
+        raise ValueError(f"Invalid payload structure: {str(e)}") from e
+
+    await process_representation_tasks_batch(
+        validated_payloads.payloads, sender_name, target_name
+    )

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -27,7 +27,6 @@ from src.utils.formatting import (
 from src.utils.logging import (
     accumulate_metric,
     conditional_observe,
-    format_reasoning_inputs_as_markdown,
     format_reasoning_response_as_markdown,
     log_observations_tree,
     log_performance_metrics,
@@ -423,15 +422,15 @@ class CertaintyReasoner:
         # For logging, we can just show the content of the last message
         latest_message = self.ctx[-1]
 
-        if settings.LANGFUSE_PUBLIC_KEY:
-            lf.update_current_generation(
-                input=format_reasoning_inputs_as_markdown(
-                    working_representation,
-                    history,
-                    latest_message.content,
-                    latest_message.created_at,
-                )
-            )
+        # if settings.LANGFUSE_PUBLIC_KEY:
+        #     lf.update_current_generation(
+        #         input=format_reasoning_inputs_as_markdown(
+        #             working_representation,
+        #             history,
+        #             latest_message.content,
+        #             latest_message.created_at,
+        #         )
+        #     )
 
         new_turns = [
             format_new_turn_with_timestamp(m.content, m.created_at, m.peer_name)
@@ -513,10 +512,10 @@ class CertaintyReasoner:
             len(thinking) if thinking else 0,
         )
 
-        if settings.LANGFUSE_PUBLIC_KEY:
-            lf.update_current_generation(
-                output=format_reasoning_response_as_markdown(response),
-            )
+        # if settings.LANGFUSE_PUBLIC_KEY:
+        #     lf.update_current_generation(
+        #         output=format_reasoning_response_as_markdown(response),
+        #     )
 
         return response
 

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -60,7 +60,7 @@ async def critical_analysis_call(
     working_representation: str | None,
     history: str,
     new_turns: list[str],
-) -> ReasoningResponse:
+) -> ReasoningResponse | None:
     prompt = critical_analysis_prompt(
         peer_id=peer_id,
         peer_card=peer_card,

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -37,9 +37,8 @@ def critical_analysis_prompt(
     # Format the peer card as a string with newlines
     peer_card_section = (
         f"""
-The user's known biographical information:
+{peer_id}'s known biographical information:
 <peer_card>
-Peer ID: {peer_id}
 {chr(10).join(peer_card)}
 </peer_card>
 """
@@ -49,7 +48,7 @@ Peer ID: {peer_id}
 
     working_representation_section = (
         f"""
-The current user understanding:
+Current understanding of {peer_id}:
 <current_context>
 {working_representation}
 </current_context>
@@ -64,12 +63,19 @@ The current user understanding:
         f"""
 You are an agent who critically analyzes user messages through rigorous logical reasoning to produce only conclusions about the user that are CERTAIN.
 
+TARGET USER TO ANALYZE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+You are analyzing: {peer_id}
+
+The conversation may include messages from multiple participants, but you MUST focus ONLY on deriving conclusions about {peer_id}. Only use other participants' messages as context for understanding {peer_id}.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
 IMPORTANT NAMING RULES
-• When you write a conclusion about the current user, always start the sentence with the user's name (e.g. "Anthony is 25 years old").
+• When you write a conclusion about {peer_id}, always start the sentence with their name (e.g. "Anthony is 25 years old").
 • NEVER start a conclusion with generic phrases like "The user …" unless the user name is not known.
 • If you must reference a third person, use their explicit name, and add clarifiers such as "(third-party)" when confusion is possible.
 
-Your goal is to IMPROVE understanding of the user through careful analysis. Your task is to arrive at truthful, factual conclusions via explicit and deductive reasoning.
+Your goal is to IMPROVE understanding of {peer_id} through careful analysis. Your task is to arrive at truthful, factual conclusions via explicit and deductive reasoning.
 
 Here are strict definitions for the reasoning modes you are to employ:
 

--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -331,7 +331,6 @@ class QueueManager:
                             sender_name = parsed_key["sender_name"]
                             target_name = parsed_key["target_name"]
 
-                            # TODO: skip this to isolate queue manager logs
                             await process_representation_batch(
                                 messages_context,
                                 sender_name=sender_name,

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -188,7 +188,9 @@ class TestDeriverProcessing:
                 )
             )
 
-        await process_representation_tasks_batch(payloads)
+        await process_representation_tasks_batch(
+            payloads, sender_name="alice", target_name="alice"
+        )
 
         # Verify that the earliest message ID was used as the cutoff
         assert captured_cutoffs == [payloads[0].message_id]

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -8,7 +8,6 @@ import pytest
 
 from src import models
 from src.deriver.deriver import process_representation_tasks_batch
-from src.deriver.queue_payload import RepresentationPayload
 from src.utils.shared_models import ReasoningResponseWithThinking
 
 
@@ -168,29 +167,26 @@ class TestDeriverProcessing:
             AsyncMock(),
         )
 
-        # Create test payloads with different message IDs (earlier message has lower ID)
+        # Create test messages with different IDs (earlier message has lower ID)
         now = datetime.now(timezone.utc)
-        payloads: list[RepresentationPayload] = []
+        messages: list[models.Message] = []
         for i in range(8):
             message_id = 100 + i  # 100, 101, 102, ..., 107
-            payloads.append(
-                RepresentationPayload(
+            messages.append(
+                models.Message(
+                    id=message_id,
                     workspace_name="test_workspace",
                     session_name="test_session",
-                    message_id=message_id,
+                    peer_name="alice",
                     content=f"message {message_id}",
-                    sender_name="alice",
-                    target_name="alice",
-                    created_at=now
-                    - timedelta(
-                        minutes=7 - i
-                    ),  # Earlier messages have earlier timestamps
+                    token_count=0,
+                    created_at=now - timedelta(minutes=7 - i),
                 )
             )
 
         await process_representation_tasks_batch(
-            payloads, sender_name="alice", target_name="alice"
+            sender_name="alice", target_name="alice", messages=messages
         )
 
         # Verify that the earliest message ID was used as the cutoff
-        assert captured_cutoffs == [payloads[0].message_id]
+        assert captured_cutoffs == [messages[0].id]

--- a/tests/deriver/test_queue_processing.py
+++ b/tests/deriver/test_queue_processing.py
@@ -333,15 +333,14 @@ class TestQueueProcessing:
         # Mock process_items to capture batches
         processed_batches: list[dict[str, Any]] = []
 
-        async def mock_process_items(
-            task_type: str,
+        async def mock_process_representation_batch(
             queue_payloads: list[dict[str, Any]],
             sender_name: str | None = None,  # pyright: ignore[reportUnusedParameter]
             target_name: str | None = None,  # pyright: ignore[reportUnusedParameter]
         ) -> None:
             processed_batches.append(
                 {
-                    "task_type": task_type,
+                    "task_type": "representation",
                     "payload_count": len(queue_payloads),
                 }
             )
@@ -359,8 +358,8 @@ class TestQueueProcessing:
         )
 
         with patch(
-            "src.deriver.queue_manager.process_items",
-            side_effect=mock_process_items,
+            "src.deriver.queue_manager.process_representation_batch",
+            side_effect=mock_process_representation_batch,
         ):
             await qm.process_work_unit(work_unit_key, worker_id)
 
@@ -716,15 +715,11 @@ class TestQueueProcessing:
         # Mock and process work unit
         processed_batches: list[dict[str, Any]] = []
 
-        async def mock_process_items(
+        async def mock_process_item(
             task_type: str,
-            queue_payloads: list[dict[str, Any]],
-            sender_name: str | None = None,  # pyright: ignore[reportUnusedParameter]
-            target_name: str | None = None,  # pyright: ignore[reportUnusedParameter]
+            queue_payload: dict[str, Any],  # pyright: ignore[reportUnusedParameter]
         ) -> None:
-            processed_batches.append(
-                {"task_type": task_type, "payload_count": len(queue_payloads)}
-            )
+            processed_batches.append({"task_type": task_type, "payload_count": 1})
 
         qm = QueueManager()
         work_unit_key = queue_items[0].work_unit_key
@@ -738,8 +733,8 @@ class TestQueueProcessing:
         )
 
         with patch(
-            "src.deriver.queue_manager.process_items",
-            side_effect=mock_process_items,
+            "src.deriver.queue_manager.process_item",
+            side_effect=mock_process_item,
         ):
             await qm.process_work_unit(work_unit_key, worker_id)
 
@@ -845,15 +840,14 @@ class TestQueueProcessing:
         # Mock process_items to capture batches
         processed_batches: list[dict[str, Any]] = []
 
-        async def mock_process_items(
-            task_type: str,
+        async def mock_process_representation_batch(
             queue_payloads: list[dict[str, Any]],
             sender_name: str | None = None,  # pyright: ignore[reportUnusedParameter]
             target_name: str | None = None,  # pyright: ignore[reportUnusedParameter]
         ) -> None:
             processed_batches.append(
                 {
-                    "task_type": task_type,
+                    "task_type": "representation",
                     "payload_count": len(queue_payloads),
                 }
             )
@@ -870,8 +864,8 @@ class TestQueueProcessing:
         )
 
         with patch(
-            "src.deriver.queue_manager.process_items",
-            side_effect=mock_process_items,
+            "src.deriver.queue_manager.process_representation_batch",
+            side_effect=mock_process_representation_batch,
         ):
             await qm.process_work_unit(work_unit_key, worker_id)
 
@@ -957,15 +951,14 @@ class TestQueueProcessing:
         # Mock process_items to capture batches
         processed_batches: list[dict[str, Any]] = []
 
-        async def mock_process_items(
-            task_type: str,
+        async def mock_process_representation_batch(
             queue_payloads: list[dict[str, Any]],
             sender_name: str | None = None,  # pyright: ignore[reportUnusedParameter]
             target_name: str | None = None,  # pyright: ignore[reportUnusedParameter]
         ) -> None:
             processed_batches.append(
                 {
-                    "task_type": task_type,
+                    "task_type": "representation",
                     "payload_count": len(queue_payloads),
                 }
             )
@@ -982,8 +975,8 @@ class TestQueueProcessing:
         )
 
         with patch(
-            "src.deriver.queue_manager.process_items",
-            side_effect=mock_process_items,
+            "src.deriver.queue_manager.process_representation_batch",
+            side_effect=mock_process_representation_batch,
         ):
             await qm.process_work_unit(work_unit_key, worker_id)
 


### PR DESCRIPTION
- Resolves DEV-1174
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message processing now respects work-unit scoping and ownership, ensuring processed items are tracked and cleaned up correctly across peers.

* **New Features**
  * Representation processing uses message-level batches with explicit sender/target context for more accurate, personalized analysis.
  * Webhook and summary flows now validate and process single payloads for faster, immediate handling.
  * Prompts updated to focus analysis on the specific peer.

* **Tests**
  * Expanded token-batching and per-work-unit tests to verify ordering, limits, and anchoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->