### PR TITLE
fix: pin cashews version to 7.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "prometheus-client>=0.20.0",
     "json-repair>=0.49.0",
     "redis>=6.0.0",
-    "cashews[redis]>=7.4.3",
+    "cashews[redis]==7.4.1",
 ]
 [tool.uv]
 dev-dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -129,11 +129,11 @@ wheels = [
 
 [[package]]
 name = "cashews"
-version = "7.4.3"
+version = "7.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/d9/e7b3daee814680e9a4a02835beb8c13b489a4422e902a7f39371c811ed2b/cashews-7.4.3.tar.gz", hash = "sha256:72cc1931b558e1bbe1e80395f9be6707131ffe21768f55e359d3e760c802fbb1", size = 92426, upload-time = "2025-10-11T21:08:41.761Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/02/6c63550c84263219367e027038ccdac9bff900775262027ac35b6de91973/cashews-7.4.1.tar.gz", hash = "sha256:9d4ac7b0d0e20ec96680af60ae15dc26c19ccc267baa84a472c54bef86a93a8a", size = 91757, upload-time = "2025-07-14T22:39:48.137Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/6b/40059c0d5fe32b6434aae14b55afe6a7e6d158826582a5a44101bb5daaed/cashews-7.4.3-py3-none-any.whl", hash = "sha256:33449b26b44c36d3ab6e73f91f71ade1e29e918e85a820238f1947beaae26322", size = 79729, upload-time = "2025-10-11T21:08:40.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e6/e77b27292b560725c35e478e90bdc9fe84c6ec849daac4360b4150083b4f/cashews-7.4.1-py3-none-any.whl", hash = "sha256:868019e9c8b0a75f345ea58b71197640b20dc2fe0892eb5ef6537f5652299ba4", size = 79356, upload-time = "2025-07-14T22:39:46.719Z" },
 ]
 
 [package.optional-dependencies]
@@ -761,7 +761,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.14.0" },
-    { name = "cashews", extras = ["redis"], specifier = ">=7.4.3" },
+    { name = "cashews", extras = ["redis"], specifier = "==7.4.1" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.111.0" },
     { name = "fastapi-pagination", specifier = ">=0.12.24" },
     { name = "google-genai", specifier = ">=1.32.0" },


### PR DESCRIPTION
  - Cashews 7.4.2 introduced a breaking change in how it initializes internal ContextVar state.
 
```
  Previously (7.4.1), ContextVars were created with a default= parameter:

  self.__disable: ContextVar[set[Command]] = ContextVar(str(id(self)), default=set())

  In 7.4.3, this was changed to:

  self.__disable: ContextVar[set[Command]] = ContextVar(str(id(self)))
  self.__disable.set(set())
```

- we initialize the cache in FastAPI's lifespan context (via init_cache()) but our requests all run in separate request contexts, so we get a LookupError: <ContextVar name='...' at 0x...> whenever a cache decorator tried to access internal state during request processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions for compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->