### PR TITLE
docs: fix blog link in Dialectic endpoint documentation

### DIFF
--- a/docs/v2/documentation/core-concepts/features/dialectic-endpoint.mdx
+++ b/docs/v2/documentation/core-concepts/features/dialectic-endpoint.mdx
@@ -84,4 +84,4 @@ for await (const line of responseStream.iter_text()) {
 ```
 </CodeGroup>
 
-We've designed the Dialectic endpoint to be infinitely flexible. We wrote an incomplete list of ideas on how to use it on our blog [here](https://blog.plasticlabs.ai/blog/Introducing-Honcho's-Dialectic-API#how-it-works).
+We've designed the Dialectic endpoint to be infinitely flexible. We wrote an incomplete list of ideas on how to use it on our blog [here](https://blog.plasticlabs.ai/archive/ARCHIVED;-Introducing-Honcho's-Dialectic-API#how-it-works).


### PR DESCRIPTION
Updated the blog link for the Dialectic endpoint documentation to the archived version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a documentation link to reference an archived blog post instead of the current blog.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->