### PR TITLE
feat: increase iam role duration. alter s3 file name and add to discord message

### DIFF
--- a/.github/workflows/unified-tests.yml
+++ b/.github/workflows/unified-tests.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::444554165670:role/GitHubActionsS3Role
           aws-region: us-east-1
+          role-duration-seconds: 43200 # 12 hours
 
       - name: Fetch secrets from AWS Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@v2

--- a/tests/unified/runner.py
+++ b/tests/unified/runner.py
@@ -86,8 +86,12 @@ async def save_results_to_s3(
     failed_count: int,
     total_count: int,
     execution_time: float,
-) -> str | None:
-    """Save comprehensive test results to S3."""
+) -> tuple[str | None, str | None]:
+    """Save comprehensive test results to S3.
+
+    Returns:
+        Tuple of (presigned_url, s3_key). Either or both may be None if upload/URL generation fails.
+    """
     try:
         import boto3
 
@@ -102,10 +106,10 @@ async def save_results_to_s3(
             credentials = session.get_credentials()  # pyright: ignore
             if not credentials:
                 logger.warning("No AWS credentials available, skipping S3 upload")
-                return
+                return None, None
         except Exception as e:
             logger.warning(f"Could not verify AWS credentials: {e}, skipping S3 upload")
-            return
+            return None, None
 
         # Create comprehensive results object
         timestamp = datetime.now(timezone.utc).isoformat()
@@ -136,10 +140,12 @@ async def save_results_to_s3(
             ],
         }
 
-        # Upload to S3
-        s3_client = boto3.client("s3", region_name=aws_region)  # pyright: ignore
-        key = f"{s3_prefix}/{github_run_id}-{timestamp}.json"
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        sha_short = github_sha[:7] if github_sha != "unknown" else "unknown"
+        ref_name = github_ref if github_ref != "unknown" else "unknown"
+        key = f"{s3_prefix}/{date_str}-{ref_name}-{sha_short}.json"
 
+        s3_client = boto3.client("s3", region_name=aws_region)  # pyright: ignore
         s3_client.put_object(  # pyright: ignore
             Bucket=s3_bucket,
             Key=key,
@@ -154,14 +160,15 @@ async def save_results_to_s3(
                 ExpiresIn=259200,  # 3 days
             )
             logger.info(f"Saved test results to s3://{s3_bucket}/{key}")
-            return url  # pyright: ignore
+            return url, key  # pyright: ignore
         except Exception as e:
             logger.warning(f"Could not generate S3 presigned URL: {e}")
             logger.info(f"Saved test results to s3://{s3_bucket}/{key}")
-            return None
+            return None, key
 
     except Exception as e:
         logger.error(f"Failed to save results to S3: {e}", exc_info=True)
+        return None, None
 
 
 class UnifiedTestExecutor:
@@ -611,7 +618,9 @@ class UnifiedTestRunner:
 
             # 5. Save results and send notifications
             # Always attempt S3 upload - save_results_to_s3 will check for credentials
-            url: str | None = await save_results_to_s3(
+            url: str | None
+            s3_key: str | None
+            url, s3_key = await save_results_to_s3(
                 results, failed_count, total_count, total_suite_time
             )
 
@@ -620,14 +629,14 @@ class UnifiedTestRunner:
             if discord_webhook_url:
                 passed_count = total_count - failed_count
                 status_emoji = "✅" if failed_count == 0 else "⚠️"
-                github_run_id = os.getenv("GITHUB_RUN_ID", "local")
 
                 message_lines = [
                     f"{status_emoji} **Unified Test Results**",
                     f"Results: {passed_count}/{total_count} passed, {failed_count}/{total_count} failed",
                     f"Execution time: {total_suite_time:.2f}s",
-                    f"Run ID: {github_run_id}",
                 ]
+                if s3_key:
+                    message_lines.append(f"File: `{s3_key}`")
                 if url:
                     message_lines.append(f"[View Complete Results]({url})")
                 message = "\n".join(message_lines)


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

This PR extends AWS IAM role session duration to 12 hours and improves S3 test result file naming and Discord notifications. The IAM role duration increase ensures presigned URLs remain valid for 12 hours, supporting longer-lived test results. The S3 file naming was enhanced from `{github_run_id}-{timestamp}.json` to `{date}-{ref}-{sha}.json`, making files more discoverable and human-readable. The Discord notification now includes both the S3 file path and presigned URL for easier access to results.

Key changes:
- Extended AWS role session duration from default (1 hour) to 12 hours in workflow
- Changed S3 key format to include date, ref name, and short SHA for better organization
- Updated `save_results_to_s3` return type to tuple containing both presigned URL and S3 key
- Added S3 file path to Discord notification messages
- Removed redundant `github_run_id` from Discord messages (now in S3 metadata)

### Confidence Score: 5/5

- This PR is safe to merge with minimal risk
- The changes are well-scoped infrastructure improvements. The IAM role duration increase is a simple configuration change that aligns with the stated goal of supporting 12-hour result persistence. The S3 file naming enhancement improves organization without breaking functionality, and the return type change is handled correctly throughout the codebase. All error paths properly return the updated tuple format.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/unified-tests.yml | 5/5 | Added 12-hour duration to AWS IAM role assumption to support long-running test results |
| tests/unified/runner.py | 5/5 | Enhanced S3 file naming with date/ref/SHA and added file path to Discord notifications; improved return signature |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant AWS as AWS IAM/S3
    participant Runner as Test Runner
    participant Discord as Discord Webhook
    
    GHA->>AWS: Assume IAM role (12hr duration)
    AWS-->>GHA: Temporary credentials
    GHA->>Runner: Start unified tests
    Runner->>Runner: Execute test suite
    Runner->>AWS: Upload results to S3
    Note over AWS: File: {date}-{ref}-{sha}.json
    AWS-->>Runner: Presigned URL & S3 key
    Runner->>Discord: Send notification with file path & URL
    Note over Discord: Includes: status, file path, presigned URL
```