### PR TITLE
fix: Upgrade Cashews to prevent NoScriptError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "prometheus-client>=0.20.0",
     "json-repair>=0.49.0",
     "redis>=7.0.0,<8.0.0",
-    "cashews[redis]==7.4.1",
+    "cashews[redis]==7.4.4",
 ]
 [tool.uv]
 dev-dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -157,11 +157,11 @@ wheels = [
 
 [[package]]
 name = "cashews"
-version = "7.4.1"
+version = "7.4.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/02/6c63550c84263219367e027038ccdac9bff900775262027ac35b6de91973/cashews-7.4.1.tar.gz", hash = "sha256:9d4ac7b0d0e20ec96680af60ae15dc26c19ccc267baa84a472c54bef86a93a8a", size = 91757, upload-time = "2025-07-14T22:39:48.137Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/5d/26eb556824a7ac9e24f751645961d2078b7b15be105f7fc39eda5308896f/cashews-7.4.4.tar.gz", hash = "sha256:dca761c60192bfe354abd6e9eb98d6f62c817e675df3fbe7d1bdfaa4303d1320", size = 92948, upload-time = "2025-12-06T22:31:56.187Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e6/e77b27292b560725c35e478e90bdc9fe84c6ec849daac4360b4150083b4f/cashews-7.4.1-py3-none-any.whl", hash = "sha256:868019e9c8b0a75f345ea58b71197640b20dc2fe0892eb5ef6537f5652299ba4", size = 79356, upload-time = "2025-07-14T22:39:46.719Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/65/29d94c27dfa3cdb213ae62a328c6efe6cd37b888d334e90ecaa22eadafe9/cashews-7.4.4-py3-none-any.whl", hash = "sha256:d5b8fc3cb590ed388823388b972947fd5659e2a94109af107cb508a3240f5ef0", size = 79893, upload-time = "2025-12-06T22:31:53.918Z" },
 ]
 
 [package.optional-dependencies]
@@ -792,7 +792,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.14.0" },
-    { name = "cashews", extras = ["redis"], specifier = "==7.4.1" },
+    { name = "cashews", extras = ["redis"], specifier = "==7.4.4" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.111.0" },
     { name = "fastapi-pagination", specifier = ">=0.12.24" },
     { name = "google-genai", specifier = ">=1.32.0" },


### PR DESCRIPTION
Issue: NoScriptError: No matching script. Please use EVAL. in process_representation_tasks_batch

Root Cause: The cashews Redis caching library (v7.4.1) was using EVALSHA to run Lua scripts by SHA hash. When Redis restarts or flushes its script cache, these SHA references become invalid, causing NoScriptError.

Fix Applied: Upgraded cashews[redis] from 7.4.1 to 7.4.4 in pyproject.toml:37

What the upgrade fixes:

v7.4.2 (https://github.com/Krukov/cashews/releases): Changed to use register_script instead of custom Lua script eval execution - this enables automatic NOSCRIPT fallback handling

v7.4.4 (https://github.com/Krukov/cashews/releases): Fixed scripts not getting created for SafeRedis

The error was occurring 811 times since Dec 3rd 2025 and was affecting the deriver's distributed locking mechanism used by @cache.locked decorators in src/crud/workspace.py, src/crud/peer.py, and src/crud/session.py.

Sources:

https://github.com/Krukov/cashews/releases

https://redis.io/docs/latest/commands/evalsha/

https://wjwh.eu/posts/2020-06-15-redis-eval-trick.html

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR upgrades the `cashews` Redis caching library from version 7.4.1 to 7.4.4 to resolve `NoScriptError` exceptions that were occurring in production.

**Key Changes:**
- Bumped `cashews[redis]` dependency from `==7.4.1` to `==7.4.4` in `pyproject.toml`
- Updated lock file with new package hashes and metadata

**Context:**
The codebase currently suppresses cashews Redis error logs (including `NoScriptError`) at the CRITICAL level in `src/main.py:70`, indicating these errors have been problematic. This upgrade addresses the root cause rather than just suppressing the symptoms. The cache system in `src/cache/client.py` already implements robust fallback logic to in-memory caching when Redis issues occur, so this upgrade improves reliability without introducing breaking changes.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- This is a straightforward patch-level dependency upgrade (7.4.1 → 7.4.4) within the same minor version that addresses a known production issue. The change is minimal, contained to dependency declarations, and the codebase already has extensive error handling and fallback mechanisms for cache failures. No breaking changes expected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pyproject.toml | Upgraded `cashews[redis]` from 7.4.1 to 7.4.4 to address NoScriptError issue |
| uv.lock | Lock file updated to reflect cashews 7.4.4 with new hash values and upload timestamps |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as FastAPI App
    participant Cache as Cache Client
    participant Cashews as Cashews Library
    participant Redis as Redis Server
    
    App->>Cache: init_cache() on startup
    Cache->>Cashews: setup() with Redis URL
    Cashews->>Redis: Connect & ping
    
    alt Redis Connection Success
        Redis-->>Cashews: Pong
        Cashews-->>Cache: Connected
        Cache-->>App: Cache ready
    else NoScriptError (v7.4.1)
        Redis-->>Cashews: NoScriptError
        Cashews-->>Cache: Error raised
        Note over Cache: Logs suppressed at CRITICAL level
        Cache->>Cache: Fallback to in-memory
        Cache-->>App: Cache ready (in-memory)
    else NoScriptError Fixed (v7.4.4)
        Redis-->>Cashews: Error handled internally
        Cashews-->>Cache: Graceful recovery
        Cache-->>App: Cache ready
    end
    
    App->>Cache: Cache operations during runtime
    Cache->>Cashews: get/set operations
    Cashews->>Redis: Execute commands
    Redis-->>Cashews: Results
    Cashews-->>Cache: Data
    Cache-->>App: Response
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cashews[redis] dependency to version 7.4.4.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->