### PR TITLE
fix: don't expose metrics endpoints for fly to scrape

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -28,13 +28,3 @@ kill_timeout = '5s'
   cpu_kind = 'shared'
   cpus = 1
   processes = ['api', 'deriver']
-
-[[metrics]]
-port = 8000
-path = "/metrics"
-processes = ["api"]
-
-[[metrics]]
-port = 9090
-path = "/metrics"
-processes = ["deriver"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed metrics monitoring configuration from deployment settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->