### PR TITLE
fix: add migration for 'deriver' to 'reasoning' in ResolvedConfiguration

### DIFF
--- a/src/schemas.py
+++ b/src/schemas.py
@@ -1,7 +1,7 @@
 import datetime
 import ipaddress
 from enum import Enum
-from typing import Annotated, Any, Self
+from typing import Annotated, Any, Self, cast
 from urllib.parse import urlparse
 
 import tiktoken
@@ -172,6 +172,20 @@ class ResolvedConfiguration(BaseModel):
     peer_card: ResolvedPeerCardConfiguration
     summary: ResolvedSummaryConfiguration
     dream: ResolvedDreamConfiguration
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_deriver_to_reasoning(cls, data: Any) -> Any:
+        """Handle v3.0.0 migration: 'deriver' was renamed to 'reasoning'."""
+        if not isinstance(data, dict):
+            return data
+
+        config = cast(dict[str, Any], data)
+
+        if "deriver" in config and "reasoning" not in config:
+            config["reasoning"] = config.pop("deriver")
+
+        return config
 
 
 class PeerConfig(BaseModel):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration system now supports backward compatibility, automatically migrating legacy field references to the current format without requiring manual updates.

* **Tests**
  * Added comprehensive test coverage for configuration migration scenarios, including field compatibility and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->