### PR TITLE
feat: add message-search fallback in dialectic tools for short sessions

### DIFF
--- a/docs/v3/documentation/introduction/overview.mdx
+++ b/docs/v3/documentation/introduction/overview.mdx
@@ -65,7 +65,7 @@ Honcho has four storage primitives that work together:
 - **Workspaces** - Top-level containers that isolate different applications or environments
 - **Peers** - Any entity that persists but changes over time (users, agents, objects, and more)
 - **Sessions** - Interaction threads between peers with temporal boundaries
-- **Messages** - Units of data that trigger reasoning (conversations, events, activity, documents, and more) 
+- **Messages** - Units of data that trigger reasoning (conversations, events, activity, documents, and more)
 
 When you write messages to Honcho, they're stored and processed in the background. Custom reasoning models perform formal logical [_reasoning_](/v3/documentation/core-concepts/reasoning) to generate conclusions about each peer. These conclusions are stored as [_representations_](/v3/documentation/core-concepts/representation) that you can query to provide rich context for your agents.
 


### PR DESCRIPTION
This addresses an issue we're seeing where certain reasoning levels in the chat endpoint will short-circuit and stop calling tools after seeing an empty representation. Fixed by having the search_memory tool fallback to message search if no memories exist yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling with clearer, more specific error messages
  * Improved handling of empty AI responses with automatic retry mechanism

* **New Features**
  * Enhanced search fallback behavior to provide message search results when observations are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->