### PR TITLE
docs: add teams and logging sections to Claude Code guide

### DIFF
--- a/docs/v3/guides/integrations/claude-code.mdx
+++ b/docs/v3/guides/integrations/claude-code.mdx
@@ -84,7 +84,7 @@ Claude will interview you about your personal preferences to kickstart a represe
 
 Honcho works naturally for teams. Every team member contributes to and retrieves from a shared workspace, while Honcho models each person individually. Your sessions within a repo are scoped to your peer name (`HONCHO_PEER_NAME`), so your memory stays yours even though the workspace is shared.
 
-- **Session naming** is automatic — set to `{user}_{repo}` by default so each team member gets their own session per project
+- **Session naming** is automatic — set to `{user}-{repo}` by default so each team member gets their own session per project
 - **Workspace** (`HONCHO_WORKSPACE`) groups all your team's sessions together. Set it to a shared value across the team
 - **Peer name** (`HONCHO_PEER_NAME`) identifies you individually within the workspace
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Building with Teammates" section explaining shared workspace behavior, per-peer memory scoping, and automatic per-project session naming
  * Added a "Logging" section detailing activity logging to local storage, verbose mode, and how to disable file logging
  * Added HONCHO_LOGGING to the Environment Variables Reference with its usage and default value
<!-- end of auto-generated comment: release notes by coderabbit.ai -->