### PR TITLE
feat: replace list_peers with analytics-first peer discovery for work…

### DIFF
--- a/src/crud/__init__.py
+++ b/src/crud/__init__.py
@@ -58,11 +58,15 @@ from .webhook import (
     list_webhook_endpoints,
 )
 from .workspace import (
+    ActivePeer,
     WorkspaceDeletionResult,
+    WorkspaceStats,
     delete_workspace,
+    get_active_peers,
     get_all_workspaces,
     get_or_create_workspace,
     get_workspace,
+    get_workspace_stats,
     update_workspace,
 )
 
@@ -127,10 +131,14 @@ __all__ = [
     "delete_webhook_endpoint",
     "list_webhook_endpoints",
     # Workspace
+    "ActivePeer",
     "WorkspaceDeletionResult",
+    "WorkspaceStats",
     "delete_workspace",
+    "get_active_peers",
+    "get_all_workspaces",
     "get_or_create_workspace",
     "get_workspace",
-    "get_all_workspaces",
+    "get_workspace_stats",
     "update_workspace",
 ]


### PR DESCRIPTION
…space chat

Replace the enumerate-all-peers approach with get_workspace_stats and get_active_peers tools. The agent now discovers relevant peers through stats, message search, and targeted observations instead of loading every peer into the prompt.