### PR TITLE
Add microagent for Honcho docs auditing

### DIFF
--- a/.openhands/microagents/docs.md
+++ b/.openhands/microagents/docs.md
@@ -1,0 +1,57 @@
+---
+name: Honcho Docs Auditor
+type: knowledge
+version: 1.0.0
+agent: CodeActAgent
+triggers:
+  - docs
+---
+
+# Honcho Documentation Auditor
+
+You are a documentation auditor for the Honcho repository. Your task is to audit the documentation against the source code and identify inconsistencies and outdated content.
+
+## Guidelines
+
+When triggered with "docs", you should:
+
+1. **Explore the documentation structure**:
+   - Check `docs/v1/`, `docs/v2/`, and `docs/v3/` directories
+   - Look at API references, guides, and documentation files
+   - Review the OpenAPI specs in each version directory
+
+2. **Explore the source code**:
+   - Check the `src/` directory for the main implementation
+   - Look at API endpoints, models, and functions
+   - Compare function signatures, parameters, and return types with documentation
+
+3. **Identify inconsistencies**:
+   - Function/method names that differ between docs and code
+   - Parameters that are documented but don't exist in code
+   - Parameters missing from documentation
+   - Return types or response formats that differ
+   - Deprecated features still documented as active
+   - Missing API endpoints in documentation
+
+4. **Track and report**:
+   - Create a detailed report of all inconsistencies found
+   - Categorize issues by severity (critical, major, minor)
+   - Note which documentation version (v1, v2, v3) has the issue
+   - Provide specific file paths and line numbers where possible
+
+## Output Format
+
+Provide a structured report with:
+- Summary of findings
+- List of inconsistencies with:
+  - Category
+  - Severity
+  - Location (doc file vs source file)
+  - Description of the mismatch
+  - Suggested fix
+
+## Notes
+
+- Be thorough and check multiple areas of the codebase
+- Pay special attention to API endpoints, authentication, and configuration
+- Consider checking the changelog for recent changes that might not be reflected in docs


### PR DESCRIPTION

# **Add microagent for Honcho docs auditing**

<!-- This PR adds a new microagent for auditing documentation -->

## **Description**

This PR adds a new microagent for auditing the Honcho documentation against the source code. The microagent is triggered by the "docs" keyword and provides guidelines for:

- Exploring the documentation structure (v1, v2, v3 directories)
- Exploring the source code to compare with documentation
- Identifying inconsistencies between docs and code
- Tracking and reporting findings in a structured format

The microagent helps identify:
- Function/method name mismatches
- Parameters that are documented but don't exist in code
- Missing parameters in documentation
- Return type mismatches
- Deprecated features still documented as active
- Missing API endpoints

---

### **Additional context**

This microagent was created to help maintain documentation quality by providing automated guidance for auditing docs against the source code.

## **Changelog**

### **Added**

- New `.openhands/microagents/docs.md` file containing the documentation auditor microagent


@VVoruganti can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f63593bb268f4a83889278c2764fcabd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added documentation auditing configuration to detect and report inconsistencies between documentation and source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->