### PR TITLE
fix: retry on RuntimeError for stale Redis connections

### DIFF
--- a/src/cache/client.py
+++ b/src/cache/client.py
@@ -49,6 +49,7 @@ async def init_cache() -> None:
             cache.setup(
                 settings.CACHE.URL,
                 pickle_type=PicklerType.SQLALCHEMY,
+                retry_on_error=[RuntimeError],
             )
 
         except Exception as setup_err:


### PR DESCRIPTION
## Summary

Adds \`retry_on_error=[RuntimeError]\` to \`cache.setup()\` in \`src/cache/client.py\` to prevent stale Redis connections from surfacing as unhandled errors.

Fixes HONCHO-18H

## Root cause

cashews already defaults \`health_check_interval=10\` and \`socket_keepalive=True\`, so connections are health-checked before use. The gap is in what happens when that health check fails.

When a Redis TCP transport goes stale (closed server-side), uvloop raises \`RuntimeError\` from \`UVHandle._ensure_alive()\` during the connection's PING health check. redis-py's \`Retry\` object only covers \`ConnectionError\`/\`TimeoutError\` by default, so \`RuntimeError\` propagates out of the retry loop uncaught.

\`SafeRedis.execute_command\` (used because cashews defaults \`suppress=True\`) also doesn't catch it — its except clause only covers \`(RedisConnectionError, socket.gaierror, OSError, asyncio.TimeoutError)\`. So the error escaped all the way to the router and Sentry.

## Data flow with fix applied

```
SafeRedis.execute_command("GET", key)
  → super().execute_command("GET")          ← redis-py
    → connection.retry.call_with_retry(...)
      → send_packed_command → check_health()
        → retry.call_with_retry(_send_ping, _ping_failed)
          → _send_ping() → RuntimeError     ← closed transport
          [retry now catches RuntimeError, calls _ping_failed → disconnect]
          → _send_ping() again → reconnect → PING OK
      → GET succeeds normally
```

Without the fix, \`RuntimeError\` exits the retry loop, exits \`super().execute_command\`, and exits \`SafeRedis.execute_command\` uncaught.

## Remaining edge case

If the reconnect attempt also fails with \`RuntimeError\` (retry exhausted), it propagates out of \`SafeRedis\` uncaught — same as before. In that degenerate scenario, the DB path still works fine; it would just Sentry again. Not worth adding more handling for what would indicate a severe Redis failure beyond a single stale connection.

## Impact

Transient — occurred once in production (HONCHO-18H). No persistent degradation. Fix prevents recurrence when idle connections go stale, which is expected behavior for any long-running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache system reliability with automatic retry capability during cache initialization, maintaining fallback to in-memory cache when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->