### PR TITLE
feat(files): add Mistral OCR and configurable OCR backends for uploads

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -60,6 +60,7 @@ class TomlConfigSettingsSource(PydanticBaseSettingsSource):
         "AUTH": "auth",
         "SENTRY": "sentry",
         "CACHE": "cache",
+        "OCR": "ocr",
         "LLM": "llm",
         "DERIVER": "deriver",
         "PEER_CARD": "peer_card",
@@ -448,6 +449,44 @@ class WebhookSettings(HonchoSettings):
     MAX_WORKSPACE_LIMIT: int = 10
 
 
+class OCRSettings(HonchoSettings):
+    model_config = SettingsConfigDict(env_prefix="OCR_", extra="ignore")  # pyright: ignore
+
+    PROVIDER: Literal["mistral", "deepseek_compatible"] | None = None
+    MODE: Literal["off", "fallback", "force"] = "off"
+    TIMEOUT_SECONDS: Annotated[int, Field(default=60, gt=0, le=300)] = 60
+    MIN_EXTRACTED_TEXT_CHARS: Annotated[int, Field(default=100, ge=0, le=10_000)] = (
+        100
+    )
+
+    MISTRAL_API_KEY: str | None = None
+    MISTRAL_MODEL: str = "mistral-ocr-latest"
+
+    DEEPSEEK_BASE_URL: str | None = None
+    DEEPSEEK_API_KEY: str | None = None
+    DEEPSEEK_MODEL: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_configuration(self) -> "OCRSettings":
+        if self.MODE == "off":
+            return self
+
+        if self.PROVIDER is None:
+            raise ValueError("OCR.PROVIDER must be set when OCR.MODE is not 'off'")
+
+        if self.PROVIDER == "mistral" and not self.MISTRAL_API_KEY:
+            raise ValueError(
+                "OCR_MISTRAL_API_KEY must be set when OCR.PROVIDER is 'mistral'"
+            )
+
+        if self.PROVIDER == "deepseek_compatible" and not self.DEEPSEEK_BASE_URL:
+            raise ValueError(
+                "OCR_DEEPSEEK_BASE_URL must be set when OCR.PROVIDER is 'deepseek_compatible'"
+            )
+
+        return self
+
+
 class MetricsSettings(HonchoSettings):
     model_config = SettingsConfigDict(env_prefix="METRICS_", extra="ignore")  # pyright: ignore
     ENABLED: bool = False
@@ -656,6 +695,7 @@ class AppSettings(HonchoSettings):
     PEER_CARD: PeerCardSettings = Field(default_factory=PeerCardSettings)
     SUMMARY: SummarySettings = Field(default_factory=SummarySettings)
     WEBHOOK: WebhookSettings = Field(default_factory=WebhookSettings)
+    OCR: OCRSettings = Field(default_factory=OCRSettings)
     METRICS: MetricsSettings = Field(default_factory=MetricsSettings)
     TELEMETRY: TelemetrySettings = Field(default_factory=TelemetrySettings)
     CACHE: CacheSettings = Field(default_factory=CacheSettings)

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -172,7 +172,7 @@ class JSONProcessor:
 
 class ImageProcessor:
     def supports_file_type(self, content_type: str) -> bool:
-        return content_type.startswith("image/")
+        return content_type.startswith("image/") and settings.OCR.MODE != "off"
 
     async def extract_text(self, content: bytes, content_type: str) -> str:
         return await _ocr_extract_text(content, content_type)

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -122,10 +122,13 @@ class PDFProcessor:
         return content_type == "application/pdf"
 
     async def extract_text(self, content: bytes, content_type: str) -> str:
-        native_text = _native_pdf_text(content)
-
         if settings.OCR.MODE == "off":
-            return native_text
+            return _native_pdf_text(content)
+
+        if settings.OCR.MODE == "force":
+            return await _ocr_extract_text(content, content_type)
+
+        native_text = _native_pdf_text(content)
 
         if (
             settings.OCR.MODE == "fallback"
@@ -136,7 +139,7 @@ class PDFProcessor:
         try:
             return await _ocr_extract_text(content, content_type)
         except Exception as e:
-            if native_text.strip():
+            if settings.OCR.MODE == "fallback" and native_text.strip():
                 logger.warning(
                     "OCR failed for PDF upload, falling back to native text: %s", e
                 )
@@ -184,8 +187,9 @@ class FileProcessingService:
             PDFProcessor(),
             TextProcessor(),
             JSONProcessor(),
-            ImageProcessor(),
         ]
+        if settings.OCR.MODE != "off":
+            self.processors.append(ImageProcessor())
 
     async def extract_text_from_upload(self, file: UploadFile) -> str:
         """Extract text from uploaded file without saving to disk."""
@@ -197,7 +201,7 @@ class FileProcessingService:
         processor = self._get_processor(file.content_type or "")
         if not processor:
             raise UnsupportedFileTypeError(
-                f"Unsupported file type: {file.content_type}. Supported types: {[p.__class__.__name__ for p in self.processors]}"
+                f"Unsupported file type: {file.content_type}. Supported types: {self._supported_types()}"
             )
 
         return await processor.extract_text(content, file.content_type or "")
@@ -207,6 +211,12 @@ class FileProcessingService:
             if processor.supports_file_type(content_type):
                 return processor
         return None
+
+    def _supported_types(self) -> list[str]:
+        supported_types = ["application/pdf", "text/*", "application/json"]
+        if any(isinstance(processor, ImageProcessor) for processor in self.processors):
+            supported_types.append("image/*")
+        return supported_types
 
 
 def split_text_into_chunks(text: str, max_chars: int = 49500) -> list[str]:

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -1,8 +1,10 @@
 import datetime
+import base64
 import logging
 from io import BytesIO
 from typing import Any, Protocol
 
+import httpx
 from fastapi import UploadFile
 from nanoid import generate as generate_nanoid
 from sqlalchemy import Integer, select
@@ -17,31 +19,134 @@ logger = logging.getLogger(__name__)
 
 
 class FileProcessor(Protocol):
-    async def extract_text(self, content: bytes) -> str: ...
+    async def extract_text(self, content: bytes, content_type: str) -> str: ...
     def supports_file_type(self, content_type: str) -> bool: ...
+
+
+def _native_pdf_text(content: bytes) -> str:
+    import pdfplumber
+
+    with pdfplumber.open(BytesIO(content)) as pdf_reader:
+        text_parts: list[str] = []
+        for page_num, page in enumerate(pdf_reader.pages):
+            text = page.extract_text()
+            if text and text.strip():
+                text_parts.append(f"[Page {page_num + 1}]\n{text}")
+        return "\n\n".join(text_parts)
+
+
+def _ocr_endpoint() -> str:
+    if settings.OCR.PROVIDER == "mistral":
+        return "https://api.mistral.ai/v1/ocr"
+
+    base_url = settings.OCR.DEEPSEEK_BASE_URL
+    if not base_url:
+        raise UnsupportedFileTypeError("DeepSeek-compatible OCR endpoint not configured")
+    return (
+        base_url
+        if base_url.rstrip("/").endswith("/ocr")
+        else f"{base_url.rstrip('/')}/ocr"
+    )
+
+
+def _ocr_headers() -> dict[str, str]:
+    if settings.OCR.PROVIDER == "mistral":
+        return {
+            "Authorization": f"Bearer {settings.OCR.MISTRAL_API_KEY}",
+            "Content-Type": "application/json",
+        }
+
+    headers = {"Content-Type": "application/json"}
+    if settings.OCR.DEEPSEEK_API_KEY:
+        headers["Authorization"] = f"Bearer {settings.OCR.DEEPSEEK_API_KEY}"
+    return headers
+
+
+def _ocr_payload(content: bytes, content_type: str) -> dict[str, Any]:
+    encoded = base64.b64encode(content).decode("ascii")
+    data_url = f"data:{content_type};base64,{encoded}"
+
+    document: dict[str, Any]
+    if content_type.startswith("image/"):
+        document = {"type": "image_url", "image_url": data_url}
+    else:
+        document = {"type": "document_url", "document_url": data_url}
+
+    payload = {"document": document}
+    if settings.OCR.PROVIDER == "mistral":
+        payload["model"] = settings.OCR.MISTRAL_MODEL
+        payload["include_image_base64"] = False
+    elif settings.OCR.DEEPSEEK_MODEL:
+        payload["model"] = settings.OCR.DEEPSEEK_MODEL
+    return payload
+
+
+def _coerce_ocr_text(response_json: dict[str, Any]) -> str:
+    pages = response_json.get("pages")
+    if isinstance(pages, list):
+        text_parts: list[str] = []
+        for page in pages:
+            if not isinstance(page, dict):
+                continue
+            text = page.get("markdown") or page.get("text")
+            if isinstance(text, str) and text.strip():
+                index = len(text_parts) + 1
+                text_parts.append(f"[Page {index}]\n{text.strip()}")
+        if text_parts:
+            return "\n\n".join(text_parts)
+
+    for key in ("markdown", "text", "content"):
+        value = response_json.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    raise ValueError("OCR response did not contain extracted text")
+
+
+async def _ocr_extract_text(content: bytes, content_type: str) -> str:
+    if settings.OCR.MODE == "off":
+        raise UnsupportedFileTypeError("OCR is not enabled")
+
+    async with httpx.AsyncClient(timeout=settings.OCR.TIMEOUT_SECONDS) as client:
+        response = await client.post(
+            _ocr_endpoint(),
+            headers=_ocr_headers(),
+            json=_ocr_payload(content, content_type),
+        )
+        response.raise_for_status()
+        return _coerce_ocr_text(response.json())
 
 
 class PDFProcessor:
     def supports_file_type(self, content_type: str) -> bool:
         return content_type == "application/pdf"
 
-    async def extract_text(self, content: bytes) -> str:
-        import pdfplumber
+    async def extract_text(self, content: bytes, content_type: str) -> str:
+        native_text = _native_pdf_text(content)
 
-        with pdfplumber.open(BytesIO(content)) as pdf_reader:
-            text_parts: list[str] = []
-            for page_num, page in enumerate(pdf_reader.pages):
-                text = page.extract_text()
-                if text and text.strip():
-                    text_parts.append(f"[Page {page_num + 1}]\n{text}")
-            return "\n\n".join(text_parts)
+        if settings.OCR.MODE == "off":
+            return native_text
+
+        if (
+            settings.OCR.MODE == "fallback"
+            and len(native_text.strip()) >= settings.OCR.MIN_EXTRACTED_TEXT_CHARS
+        ):
+            return native_text
+
+        try:
+            return await _ocr_extract_text(content, content_type)
+        except Exception:
+            if native_text.strip():
+                logger.warning("OCR failed for PDF upload, falling back to native text")
+                return native_text
+            raise
 
 
 class TextProcessor:
     def supports_file_type(self, content_type: str) -> bool:
         return content_type.startswith("text/")
 
-    async def extract_text(self, content: bytes) -> str:
+    async def extract_text(self, content: bytes, content_type: str) -> str:
         # Try different encodings
         for encoding in ["utf-8", "utf-16", "latin-1"]:
             try:
@@ -55,12 +160,20 @@ class JSONProcessor:
     def supports_file_type(self, content_type: str) -> bool:
         return content_type == "application/json"
 
-    async def extract_text(self, content: bytes) -> str:
+    async def extract_text(self, content: bytes, content_type: str) -> str:
         import json
 
         data = json.loads(content.decode("utf-8"))
         # Convert JSON to readable text format
         return json.dumps(data, ensure_ascii=False)
+
+
+class ImageProcessor:
+    def supports_file_type(self, content_type: str) -> bool:
+        return content_type.startswith("image/")
+
+    async def extract_text(self, content: bytes, content_type: str) -> str:
+        return await _ocr_extract_text(content, content_type)
 
 
 class FileProcessingService:
@@ -69,7 +182,7 @@ class FileProcessingService:
             PDFProcessor(),
             TextProcessor(),
             JSONProcessor(),
-            # Add more processors as needed
+            ImageProcessor(),
         ]
 
     async def extract_text_from_upload(self, file: UploadFile) -> str:
@@ -85,7 +198,7 @@ class FileProcessingService:
                 f"Unsupported file type: {file.content_type}. Supported types: {[p.__class__.__name__ for p in self.processors]}"
             )
 
-        return await processor.extract_text(content)
+        return await processor.extract_text(content, file.content_type or "")
 
     def _get_processor(self, content_type: str) -> FileProcessor | None:
         for processor in self.processors:

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -135,9 +135,11 @@ class PDFProcessor:
 
         try:
             return await _ocr_extract_text(content, content_type)
-        except Exception:
+        except Exception as e:
             if native_text.strip():
-                logger.warning("OCR failed for PDF upload, falling back to native text")
+                logger.warning(
+                    "OCR failed for PDF upload, falling back to native text: %s", e
+                )
                 return native_text
             raise
 

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -128,7 +128,11 @@ class PDFProcessor:
         if settings.OCR.MODE == "force":
             return await _ocr_extract_text(content, content_type)
 
-        native_text = _native_pdf_text(content)
+        native_text = ""
+        try:
+            native_text = _native_pdf_text(content)
+        except Exception:
+            logger.warning("Native PDF extraction failed; trying OCR", exc_info=True)
 
         if (
             settings.OCR.MODE == "fallback"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -431,6 +431,8 @@ def mock_openai_embeddings(request: pytest.FixtureRequest):
 
     with (
         patch("src.embedding_client.embedding_client.embed") as mock_embed,
+        patch("src.embedding_client.embedding_client.simple_batch_embed")
+        as mock_simple_batch_embed,
         patch("src.embedding_client.embedding_client.batch_embed") as mock_batch_embed,
     ):
         # Mock the embed method to return content-dependent embedding
@@ -448,9 +450,17 @@ def mock_openai_embeddings(request: pytest.FixtureRequest):
                 for text_id, resource in id_resource_dict.items()
             }
 
-        mock_batch_embed.side_effect = mock_batch_embed_func
+        async def mock_simple_batch_embed_func(texts: list[str]) -> list[list[float]]:
+            return [_content_to_embedding(text) for text in texts]
 
-        yield {"embed": mock_embed, "batch_embed": mock_batch_embed}
+        mock_batch_embed.side_effect = mock_batch_embed_func
+        mock_simple_batch_embed.side_effect = mock_simple_batch_embed_func
+
+        yield {
+            "embed": mock_embed,
+            "simple_batch_embed": mock_simple_batch_embed,
+            "batch_embed": mock_batch_embed,
+        }
 
 
 @pytest.fixture(autouse=True)

--- a/tests/routes/test_files.py
+++ b/tests/routes/test_files.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src import models
 from src.config import settings
 from src.models import Peer, Workspace
+from src.utils import files as file_utils
 
 
 async def _create_test_session(
@@ -586,3 +587,112 @@ async def test_large_file_upload_with_metadata(
         assert message["peer_id"] == test_peer.name
         assert message["session_id"] == session_name
         assert message["metadata"] == metadata
+
+
+@pytest.mark.asyncio
+async def test_create_messages_with_image_ocr(
+    client: TestClient,
+    db_session: AsyncSession,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test image uploads use OCR when configured."""
+    test_workspace, test_peer = sample_data
+    test_session = await _create_test_session(db_session, test_workspace)
+
+    monkeypatch.setattr(settings.OCR, "PROVIDER", "mistral")
+    monkeypatch.setattr(settings.OCR, "MODE", "force")
+
+    async def mock_ocr_extract_text(content: bytes, content_type: str) -> str:
+        assert content == b"fake-image-bytes"
+        assert content_type == "image/png"
+        return "Extracted image text"
+
+    monkeypatch.setattr(file_utils, "_ocr_extract_text", mock_ocr_extract_text)
+
+    files = {"file": ("test.png", io.BytesIO(b"fake-image-bytes"), "image/png")}
+    form_data = {"peer_id": test_peer.name}
+
+    response = client.post(
+        _get_upload_url(test_workspace.name, test_session.name),
+        files=files,
+        data=form_data,
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["content"] == "Extracted image text"
+
+
+@pytest.mark.asyncio
+async def test_pdf_upload_uses_native_text_when_fallback_succeeds(
+    client: TestClient,
+    db_session: AsyncSession,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test PDF uploads avoid OCR when native extraction is sufficient."""
+    test_workspace, test_peer = sample_data
+    test_session = await _create_test_session(db_session, test_workspace)
+
+    native_text = "A" * (settings.OCR.MIN_EXTRACTED_TEXT_CHARS + 1)
+
+    monkeypatch.setattr(settings.OCR, "PROVIDER", "mistral")
+    monkeypatch.setattr(settings.OCR, "MODE", "fallback")
+    monkeypatch.setattr(file_utils, "_native_pdf_text", lambda content: native_text)
+
+    async def fail_if_called(content: bytes, content_type: str) -> str:
+        raise AssertionError("OCR should not be called when native PDF extraction works")
+
+    monkeypatch.setattr(file_utils, "_ocr_extract_text", fail_if_called)
+
+    files = {"file": ("test.pdf", io.BytesIO(b"fake-pdf-bytes"), "application/pdf")}
+    form_data = {"peer_id": test_peer.name}
+
+    response = client.post(
+        _get_upload_url(test_workspace.name, test_session.name),
+        files=files,
+        data=form_data,
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["content"] == native_text
+
+
+@pytest.mark.asyncio
+async def test_pdf_upload_falls_back_to_ocr_when_native_text_missing(
+    client: TestClient,
+    db_session: AsyncSession,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test PDF uploads use OCR when native extraction does not yield useful text."""
+    test_workspace, test_peer = sample_data
+    test_session = await _create_test_session(db_session, test_workspace)
+
+    monkeypatch.setattr(settings.OCR, "PROVIDER", "mistral")
+    monkeypatch.setattr(settings.OCR, "MODE", "fallback")
+    monkeypatch.setattr(file_utils, "_native_pdf_text", lambda content: "")
+
+    async def mock_ocr_extract_text(content: bytes, content_type: str) -> str:
+        assert content_type == "application/pdf"
+        return "OCR fallback text"
+
+    monkeypatch.setattr(file_utils, "_ocr_extract_text", mock_ocr_extract_text)
+
+    files = {"file": ("test.pdf", io.BytesIO(b"fake-pdf-bytes"), "application/pdf")}
+    form_data = {"peer_id": test_peer.name}
+
+    response = client.post(
+        _get_upload_url(test_workspace.name, test_session.name),
+        files=files,
+        data=form_data,
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["content"] == "OCR fallback text"

--- a/tests/routes/test_files.py
+++ b/tests/routes/test_files.py
@@ -1,6 +1,7 @@
 # File upload tests for session endpoints
 import io
 import json
+import os
 from typing import Any
 
 import pytest
@@ -30,6 +31,48 @@ async def _create_test_session(
 def _get_upload_url(workspace_name: str, session_name: str) -> str:
     """Helper function to get the session upload URL"""
     return f"/v3/workspaces/{workspace_name}/sessions/{session_name}/messages/upload"
+
+
+def _build_test_pdf(text: str) -> bytes:
+    """Create a minimal single-page PDF with the supplied text."""
+
+    def pdf_obj(number: int, body: str) -> str:
+        return f"{number} 0 obj\n{body}\nendobj\n"
+
+    content_stream = f"BT\n/F1 24 Tf\n72 110 Td\n({text}) Tj\nET"
+    objects = [
+        pdf_obj(1, "<< /Type /Catalog /Pages 2 0 R >>"),
+        pdf_obj(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        pdf_obj(
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 200] "
+            "/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+        ),
+        pdf_obj(
+            4,
+            f"<< /Length {len(content_stream.encode('utf-8'))} >>\nstream\n"
+            f"{content_stream}\nendstream",
+        ),
+        pdf_obj(5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"),
+    ]
+
+    pdf = "%PDF-1.4\n"
+    offsets = [0]
+    for obj in objects:
+        offsets.append(len(pdf.encode("utf-8")))
+        pdf += obj
+
+    xref_offset = len(pdf.encode("utf-8"))
+    pdf += f"xref\n0 {len(objects) + 1}\n"
+    pdf += "0000000000 65535 f \n"
+    for offset in offsets[1:]:
+        pdf += f"{offset:010d} 00000 n \n"
+    pdf += (
+        "trailer\n"
+        f"<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n"
+    )
+    return pdf.encode("utf-8")
 
 
 @pytest.mark.asyncio
@@ -696,3 +739,51 @@ async def test_pdf_upload_falls_back_to_ocr_when_native_text_missing(
     data = response.json()
     assert len(data) == 1
     assert data[0]["content"] == "OCR fallback text"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.getenv("RUN_LIVE_MISTRAL_OCR_TEST")
+    or not (os.getenv("MISTRAL_API_KEY") or os.getenv("OCR_MISTRAL_API_KEY")),
+    reason="Set RUN_LIVE_MISTRAL_OCR_TEST=1 and provide a Mistral API key to run",
+)
+async def test_create_messages_with_live_mistral_ocr(
+    client: TestClient,
+    db_session: AsyncSession,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Opt-in smoke test for the live Mistral OCR upload path."""
+    test_workspace, test_peer = sample_data
+    test_session = await _create_test_session(db_session, test_workspace)
+
+    monkeypatch.setattr(settings.OCR, "PROVIDER", "mistral")
+    monkeypatch.setattr(settings.OCR, "MODE", "force")
+    monkeypatch.setattr(
+        settings.OCR,
+        "MISTRAL_API_KEY",
+        os.getenv("MISTRAL_API_KEY") or os.getenv("OCR_MISTRAL_API_KEY"),
+    )
+    monkeypatch.setattr(settings.OCR, "TIMEOUT_SECONDS", 120)
+
+    files = {
+        "file": (
+            "mistral-live.pdf",
+            io.BytesIO(_build_test_pdf("MISTRAL OCR LIVE TEST")),
+            "application/pdf",
+        )
+    }
+    form_data = {"peer_id": test_peer.name}
+
+    response = client.post(
+        _get_upload_url(test_workspace.name, test_session.name),
+        files=files,
+        data=form_data,
+    )
+
+    assert response.status_code == 201, response.text
+    data = response.json()
+    assert len(data) == 1
+    content = data[0]["content"].lower()
+    assert "mistral" in content
+    assert "ocr" in content

--- a/tests/routes/test_files.py
+++ b/tests/routes/test_files.py
@@ -766,6 +766,31 @@ async def test_pdf_force_mode_skips_native_extraction_and_propagates_ocr_error(
 
 
 @pytest.mark.asyncio
+async def test_pdf_fallback_mode_uses_ocr_when_native_extraction_raises(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test fallback mode still attempts OCR if native PDF parsing fails."""
+    monkeypatch.setattr(settings.OCR, "PROVIDER", "mistral")
+    monkeypatch.setattr(settings.OCR, "MODE", "fallback")
+
+    def raise_native_error(content: bytes) -> str:
+        raise ValueError("pdf parse failure")
+
+    async def mock_ocr_extract_text(content: bytes, content_type: str) -> str:
+        assert content_type == "application/pdf"
+        return "OCR after parse error"
+
+    monkeypatch.setattr(file_utils, "_native_pdf_text", raise_native_error)
+    monkeypatch.setattr(file_utils, "_ocr_extract_text", mock_ocr_extract_text)
+
+    result = await file_utils.PDFProcessor().extract_text(
+        b"fake-pdf-bytes", "application/pdf"
+    )
+
+    assert result == "OCR after parse error"
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif(
     not os.getenv("RUN_LIVE_MISTRAL_OCR_TEST")
     or not (os.getenv("MISTRAL_API_KEY") or os.getenv("OCR_MISTRAL_API_KEY")),

--- a/tests/routes/test_files.py
+++ b/tests/routes/test_files.py
@@ -200,6 +200,8 @@ async def test_create_messages_with_unsupported_file_type(
     response = client.post(url, files=files, data=form_data)
 
     assert response.status_code == 415
+    assert "image/*" not in response.json()["detail"]
+    assert "application/pdf" in response.json()["detail"]
 
 
 @pytest.mark.asyncio
@@ -739,6 +741,28 @@ async def test_pdf_upload_falls_back_to_ocr_when_native_text_missing(
     data = response.json()
     assert len(data) == 1
     assert data[0]["content"] == "OCR fallback text"
+
+
+@pytest.mark.asyncio
+async def test_pdf_force_mode_skips_native_extraction_and_propagates_ocr_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test force mode uses OCR directly and does not fall back to native extraction."""
+    monkeypatch.setattr(settings.OCR, "PROVIDER", "mistral")
+    monkeypatch.setattr(settings.OCR, "MODE", "force")
+
+    def fail_if_called(content: bytes) -> str:
+        raise AssertionError("Native PDF extraction should not run in force mode")
+
+    async def raise_ocr_error(content: bytes, content_type: str) -> str:
+        assert content_type == "application/pdf"
+        raise RuntimeError("OCR unavailable")
+
+    monkeypatch.setattr(file_utils, "_native_pdf_text", fail_if_called)
+    monkeypatch.setattr(file_utils, "_ocr_extract_text", raise_ocr_error)
+
+    with pytest.raises(RuntimeError, match="OCR unavailable"):
+        await file_utils.PDFProcessor().extract_text(b"fake-pdf-bytes", "application/pdf")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds configurable OCR support to the upload pipeline for PDFs and images.

This introduces Mistral OCR as the primary hosted OCR backend for uploaded files, while also supporting DeepSeek-compatible OCR endpoints. Native PDF extraction via `pdfplumber` remains in place, and OCR can be configured to run in `off`, `fallback`, or `force` mode.

## Motivation

Honcho currently relies on native PDF text extraction, which does not work well for scanned PDFs or image-based uploads. This change adds OCR support directly to the file-ingestion path so uploads can still be converted into messages when native extraction is insufficient.

Closes #410

## What Changed

- Added OCR settings in `src/config.py`
- Extended `src/utils/files.py` to support:
  - native PDF extraction only
  - native-first OCR fallback
  - forced OCR
- Added Mistral OCR support for uploaded PDFs and images
- Added support for DeepSeek-compatible OCR endpoints
- Added image OCR support for uploads
- Added focused upload tests for:
  - image OCR
  - PDF native extraction in fallback mode
  - PDF OCR fallback when native extraction is insufficient
- Added an opt-in live Mistral OCR smoke test for the upload route
- Updated the shared embedding test mock to cover `simple_batch_embed()` so tests remain hermetic

## Design Notes

- The OCR integration is intentionally limited to the existing upload/text-extraction path
- Existing behavior remains unchanged when OCR mode is `off`
- No changes were made to deriver, dialectic, queue orchestration, or the primary LLM client abstraction

## Testing

Validated with:

```bash
env DB_CONNECTION_URI=postgresql+psycopg://testuser:testpwd@127.0.0.1:5433/honcho \
LLM_GEMINI_API_KEY=test-gemini-key \
LLM_ANTHROPIC_API_KEY=test-anthropic-key \
LLM_OPENAI_API_KEY=test-openai-key \
LLM_GROQ_API_KEY=test-groq-key \
uv run pytest -n 0 -q
```

Result:

- `916 passed`

Additional OCR-specific checks:

```bash
env DB_CONNECTION_URI=postgresql+psycopg://testuser:testpwd@127.0.0.1:5433/honcho \
LLM_GEMINI_API_KEY=test-gemini-key \
LLM_ANTHROPIC_API_KEY=test-anthropic-key \
LLM_OPENAI_API_KEY=test-openai-key \
LLM_GROQ_API_KEY=test-groq-key \
uv run pytest -n 0 tests/routes/test_files.py -q
```

Result:

- `19 passed, 1 skipped`

Opt-in live Mistral OCR smoke test:

```bash
env DB_CONNECTION_URI=postgresql+psycopg://testuser:testpwd@127.0.0.1:5433/honcho \
LLM_GEMINI_API_KEY=test-gemini-key \
LLM_ANTHROPIC_API_KEY=test-anthropic-key \
LLM_OPENAI_API_KEY=test-openai-key \
LLM_GROQ_API_KEY=test-groq-key \
RUN_LIVE_MISTRAL_OCR_TEST=1 \
MISTRAL_API_KEY=... \
uv run pytest -n 0 tests/routes/test_files.py -q -k live_mistral
```

Result:

- `1 passed`

## Notes

- The repository's default parallel pytest configuration (`-n auto`) hit Postgres teardown contention in this environment, so verification was performed with `-n 0`
- The live Mistral test is skipped by default and only runs when explicitly opted in with a real API key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OCR support for images and PDFs with configurable providers, modes (force/fallback/off), timeouts, and minimum-text thresholds.
  * App config exposes OCR settings and recognizes an "ocr" config section.
  * File processing updated to prefer native extraction but use OCR according to configuration, with image OCR enabled when configured.

* **Tests**
  * Expanded coverage for OCR flows, PDF native/OCR fallback and force modes, image OCR, metadata/chunking, embedding mocks, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->