### PR TITLE
fix: implement deriver custom instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Then modify the values as needed. The TOML file is organized into sections:
 - `[auth]` - Authentication configuration
 - `[cache]` - Redis cache configuration
 - `[llm]` - LLM provider API keys and general settings
-- `[deriver]` - Background worker settings and representation configuration
+- `[deriver]` - Background worker settings and representation configuration, including reasoning input budgets
 - `[peer_card]` - Peer card generation settings
 - `[dialectic]` - Dialectic API configuration with per-level reasoning settings
 - `[summary]` - Session summarization settings
@@ -429,10 +429,13 @@ Examples:
 - `AUTH_JWT_SECRET` - JWT secret key
 - `DIALECTIC_LEVELS__low__MODEL` - Model for low reasoning level
 - `DERIVER_PROVIDER` - Provider for background deriver
+- `DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS` - Optional cap for `reasoning.custom_instructions`
 - `SUMMARY_PROVIDER` - Summary generation provider
 - `LOG_LEVEL` - Application log level
 - `METRICS_ENABLED` - Enable Prometheus metrics
 - `TELEMETRY_ENABLED` - Enable CloudEvents telemetry
+
+When using `reasoning.custom_instructions`, keep in mind that those instructions count against the deriver input budget along with discussion/history. If `DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS` is unset, Honcho derives a conservative cap from `DERIVER_MAX_INPUT_TOKENS` and rejects oversized values instead of truncating them silently.
 
 ### Configuration Priority
 

--- a/README.md
+++ b/README.md
@@ -429,13 +429,13 @@ Examples:
 - `AUTH_JWT_SECRET` - JWT secret key
 - `DIALECTIC_LEVELS__low__MODEL` - Model for low reasoning level
 - `DERIVER_PROVIDER` - Provider for background deriver
-- `DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS` - Optional cap for `reasoning.custom_instructions`
+- `DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS` - Explicit cap for `reasoning.custom_instructions`
 - `SUMMARY_PROVIDER` - Summary generation provider
 - `LOG_LEVEL` - Application log level
 - `METRICS_ENABLED` - Enable Prometheus metrics
 - `TELEMETRY_ENABLED` - Enable CloudEvents telemetry
 
-When using `reasoning.custom_instructions`, keep in mind that those instructions count against the deriver input budget along with discussion/history. If `DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS` is unset, Honcho derives a conservative cap from `DERIVER_MAX_INPUT_TOKENS` and rejects oversized values instead of truncating them silently.
+When using `reasoning.custom_instructions`, keep in mind that those instructions count against the deriver input budget along with discussion/history. `DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS` must be set explicitly; Honcho does not derive it from `DERIVER_MAX_INPUT_TOKENS`. If custom instructions are provided without that setting, validation fails with a config error instead of silently assuming a fallback.
 
 ### Configuration Priority
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -84,8 +84,8 @@ MAX_OUTPUT_TOKENS = 4096
 THINKING_BUDGET_TOKENS = 1024
 LOG_OBSERVATIONS = false
 MAX_INPUT_TOKENS = 23000
-# Optional override for reasoning.custom_instructions token budget.
-# If unset, Honcho derives a conservative cap from MAX_INPUT_TOKENS.
+# Explicit token budget for reasoning.custom_instructions.
+# Honcho does not derive this from MAX_INPUT_TOKENS.
 MAX_CUSTOM_INSTRUCTIONS_TOKENS = 2048
 WORKING_REPRESENTATION_MAX_OBSERVATIONS = 100
 REPRESENTATION_BATCH_MAX_TOKENS = 1024

--- a/config.toml.example
+++ b/config.toml.example
@@ -84,6 +84,9 @@ MAX_OUTPUT_TOKENS = 4096
 THINKING_BUDGET_TOKENS = 1024
 LOG_OBSERVATIONS = false
 MAX_INPUT_TOKENS = 23000
+# Optional override for reasoning.custom_instructions token budget.
+# If unset, Honcho derives a conservative cap from MAX_INPUT_TOKENS.
+MAX_CUSTOM_INSTRUCTIONS_TOKENS = 2048
 WORKING_REPRESENTATION_MAX_OBSERVATIONS = 100
 REPRESENTATION_BATCH_MAX_TOKENS = 1024
 FLUSH_ENABLED = false  # Bypass batch token threshold, process work immediately

--- a/docs/v3/contributing/configuration.mdx
+++ b/docs/v3/contributing/configuration.mdx
@@ -371,6 +371,7 @@ DERIVER_MODEL=gemini-2.5-flash-lite
 DERIVER_MAX_OUTPUT_TOKENS=4096
 DERIVER_THINKING_BUDGET_TOKENS=1024
 DERIVER_MAX_INPUT_TOKENS=23000  # Maximum input tokens for deriver
+DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS=2048  # Optional cap for reasoning.custom_instructions
 DERIVER_TEMPERATURE=  # Optional temperature override (unset by default)
 
 # Backup provider (optional, must set both or neither)
@@ -393,6 +394,8 @@ DERIVER_LOG_OBSERVATIONS=false  # Log all observations
 DERIVER_WORKING_REPRESENTATION_MAX_OBSERVATIONS=100  # Max observations stored
 DERIVER_REPRESENTATION_BATCH_MAX_TOKENS=1024  # Max tokens per batch (must be <= MAX_INPUT_TOKENS)
 ```
+
+`reasoning.custom_instructions` consumes the same deriver input budget as the discussion/history sent to the model. If `DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS` is unset, Honcho derives a conservative cap from `DERIVER_MAX_INPUT_TOKENS`. If the custom instructions exceed that cap, the request/configuration is rejected instead of being truncated.
 
 **Peer Card:**
 

--- a/docs/v3/contributing/configuration.mdx
+++ b/docs/v3/contributing/configuration.mdx
@@ -371,7 +371,7 @@ DERIVER_MODEL=gemini-2.5-flash-lite
 DERIVER_MAX_OUTPUT_TOKENS=4096
 DERIVER_THINKING_BUDGET_TOKENS=1024
 DERIVER_MAX_INPUT_TOKENS=23000  # Maximum input tokens for deriver
-DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS=2048  # Optional cap for reasoning.custom_instructions
+DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS=2048  # Explicit cap for reasoning.custom_instructions
 DERIVER_TEMPERATURE=  # Optional temperature override (unset by default)
 
 # Backup provider (optional, must set both or neither)
@@ -395,7 +395,7 @@ DERIVER_WORKING_REPRESENTATION_MAX_OBSERVATIONS=100  # Max observations stored
 DERIVER_REPRESENTATION_BATCH_MAX_TOKENS=1024  # Max tokens per batch (must be <= MAX_INPUT_TOKENS)
 ```
 
-`reasoning.custom_instructions` consumes the same deriver input budget as the discussion/history sent to the model. If `DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS` is unset, Honcho derives a conservative cap from `DERIVER_MAX_INPUT_TOKENS`. If the custom instructions exceed that cap, the request/configuration is rejected instead of being truncated.
+`reasoning.custom_instructions` consumes the same deriver input budget as the discussion/history sent to the model. `DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS` must be configured explicitly; Honcho does not derive it from `DERIVER_MAX_INPUT_TOKENS`. If custom instructions are supplied without that setting, or if they exceed it, the request/configuration is rejected instead of being truncated.
 
 **Peer Card:**
 

--- a/src/config.py
+++ b/src/config.py
@@ -261,6 +261,9 @@ class DeriverSettings(BackupLLMSettingsMixin, HonchoSettings):
     LOG_OBSERVATIONS: bool = False
 
     MAX_INPUT_TOKENS: Annotated[int, Field(default=23000, gt=0, le=23000)] = 23000
+    MAX_CUSTOM_INSTRUCTIONS_TOKENS: Annotated[
+        int | None, Field(default=None, gt=0, le=100_000)
+    ] = None
 
     # Maximum number of observations to return in working representation
     # This is applied to both explicit and deductive observations
@@ -276,11 +279,27 @@ class DeriverSettings(BackupLLMSettingsMixin, HonchoSettings):
     # When enabled, bypasses the batch token threshold and processes work immediately
     FLUSH_ENABLED: bool = False
 
+    @property
+    def effective_max_custom_instructions_tokens(self) -> int:
+        """Resolve the custom instruction budget from explicit or derived settings."""
+        if self.MAX_CUSTOM_INSTRUCTIONS_TOKENS is not None:
+            return self.MAX_CUSTOM_INSTRUCTIONS_TOKENS
+
+        # Reserve most of the deriver input budget for discussion/history while
+        # still allowing moderately detailed custom instructions by default.
+        return max(1, min(2048, self.MAX_INPUT_TOKENS // 4))
+
     @model_validator(mode="after")
     def validate_batch_tokens_vs_context_limit(self):
         if self.REPRESENTATION_BATCH_MAX_TOKENS > self.MAX_INPUT_TOKENS:
             raise ValueError(
                 f"REPRESENTATION_BATCH_MAX_TOKENS ({self.REPRESENTATION_BATCH_MAX_TOKENS}) cannot exceed max deriver input tokens ({self.MAX_INPUT_TOKENS})"
+            )
+        if self.effective_max_custom_instructions_tokens > self.MAX_INPUT_TOKENS:
+            raise ValueError(
+                "MAX_CUSTOM_INSTRUCTIONS_TOKENS "
+                f"({self.effective_max_custom_instructions_tokens}) cannot exceed "
+                f"max deriver input tokens ({self.MAX_INPUT_TOKENS})"
             )
         return self
 

--- a/src/config.py
+++ b/src/config.py
@@ -281,13 +281,14 @@ class DeriverSettings(BackupLLMSettingsMixin, HonchoSettings):
 
     @property
     def effective_max_custom_instructions_tokens(self) -> int:
-        """Resolve the custom instruction budget from explicit or derived settings."""
-        if self.MAX_CUSTOM_INSTRUCTIONS_TOKENS is not None:
-            return self.MAX_CUSTOM_INSTRUCTIONS_TOKENS
+        """Return the explicit custom instruction budget."""
+        if self.MAX_CUSTOM_INSTRUCTIONS_TOKENS is None:
+            raise ValueError(
+                "No value configured for DERIVER.MAX_CUSTOM_INSTRUCTIONS_TOKENS. "
+                "Set [deriver].MAX_CUSTOM_INSTRUCTIONS_TOKENS in config.toml."
+            )
 
-        # Reserve most of the deriver input budget for discussion/history while
-        # still allowing moderately detailed custom instructions by default.
-        return max(1, min(2048, self.MAX_INPUT_TOKENS // 4))
+        return self.MAX_CUSTOM_INSTRUCTIONS_TOKENS
 
     @model_validator(mode="after")
     def validate_batch_tokens_vs_context_limit(self):
@@ -295,10 +296,13 @@ class DeriverSettings(BackupLLMSettingsMixin, HonchoSettings):
             raise ValueError(
                 f"REPRESENTATION_BATCH_MAX_TOKENS ({self.REPRESENTATION_BATCH_MAX_TOKENS}) cannot exceed max deriver input tokens ({self.MAX_INPUT_TOKENS})"
             )
-        if self.effective_max_custom_instructions_tokens > self.MAX_INPUT_TOKENS:
+        if (
+            self.MAX_CUSTOM_INSTRUCTIONS_TOKENS is not None
+            and self.MAX_CUSTOM_INSTRUCTIONS_TOKENS > self.MAX_INPUT_TOKENS
+        ):
             raise ValueError(
                 "MAX_CUSTOM_INSTRUCTIONS_TOKENS "
-                f"({self.effective_max_custom_instructions_tokens}) cannot exceed "
+                f"({self.MAX_CUSTOM_INSTRUCTIONS_TOKENS}) cannot exceed "
                 f"max deriver input tokens ({self.MAX_INPUT_TOKENS})"
             )
         return self

--- a/src/config.py
+++ b/src/config.py
@@ -285,7 +285,7 @@ class DeriverSettings(BackupLLMSettingsMixin, HonchoSettings):
         if self.MAX_CUSTOM_INSTRUCTIONS_TOKENS is None:
             raise ValueError(
                 "No value configured for DERIVER.MAX_CUSTOM_INSTRUCTIONS_TOKENS. "
-                "Set [deriver].MAX_CUSTOM_INSTRUCTIONS_TOKENS in config.toml."
+                + "Set [deriver].MAX_CUSTOM_INSTRUCTIONS_TOKENS in config.toml."
             )
 
         return self.MAX_CUSTOM_INSTRUCTIONS_TOKENS
@@ -301,9 +301,7 @@ class DeriverSettings(BackupLLMSettingsMixin, HonchoSettings):
             and self.MAX_CUSTOM_INSTRUCTIONS_TOKENS > self.MAX_INPUT_TOKENS
         ):
             raise ValueError(
-                "MAX_CUSTOM_INSTRUCTIONS_TOKENS "
-                f"({self.MAX_CUSTOM_INSTRUCTIONS_TOKENS}) cannot exceed "
-                f"max deriver input tokens ({self.MAX_INPUT_TOKENS})"
+                f"MAX_CUSTOM_INSTRUCTIONS_TOKENS ({self.MAX_CUSTOM_INSTRUCTIONS_TOKENS}) cannot exceed max deriver input tokens ({self.MAX_INPUT_TOKENS})"
             )
         return self
 

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -23,7 +23,7 @@ from src.utils.representation import PromptRepresentation, Representation
 from src.utils.tokens import track_deriver_input_tokens
 
 from .prompts import (
-    estimate_minimal_deriver_prompt_tokens,
+    estimate_deriver_prompt_tokens,
     minimal_deriver_system_prompt,
     minimal_deriver_user_prompt,
 )
@@ -98,7 +98,8 @@ async def process_representation_tasks_batch(
     )
 
     # Track token usage - count only tokens from messages being processed
-    prompt_tokens = estimate_minimal_deriver_prompt_tokens()
+    custom_instructions = message_level_configuration.reasoning.custom_instructions
+    prompt_tokens = estimate_deriver_prompt_tokens(custom_instructions)
     queue_item_message_ids_set = set(queue_item_message_ids)
     messages_tokens = sum(
         msg.token_count for msg in messages if msg.id in queue_item_message_ids_set
@@ -143,7 +144,11 @@ async def process_representation_tasks_batch(
             {"role": "system", "content": minimal_deriver_system_prompt()},
             {
                 "role": "user",
-                "content": minimal_deriver_user_prompt(observed, formatted_messages),
+                "content": minimal_deriver_user_prompt(
+                    observed,
+                    formatted_messages,
+                    custom_instructions=custom_instructions,
+                ),
             },
         ],
     )

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -11,6 +11,19 @@ from inspect import cleandoc as c
 from src.utils.tokens import estimate_tokens
 
 
+def _custom_instructions_section(custom_instructions: str | None) -> str:
+    """Render the optional custom instructions block for the deriver prompt."""
+    if not custom_instructions or not custom_instructions.strip():
+        return ""
+
+    return c(
+        f"""
+        CUSTOM INSTRUCTIONS:
+        {custom_instructions.strip()}
+        """
+    )
+
+
 def minimal_deriver_system_prompt() -> str:
     """Generate the cacheable instructions for observation extraction."""
     return c(
@@ -38,11 +51,19 @@ EXAMPLES:
     )
 
 
-def minimal_deriver_user_prompt(peer_id: str, messages: str) -> str:
+def minimal_deriver_user_prompt(
+    peer_id: str,
+    messages: str,
+    *,
+    custom_instructions: str | None = None,
+) -> str:
     """Generate the per-request message payload for observation extraction."""
+    instructions_section = _custom_instructions_section(custom_instructions)
     return c(
         f"""
 Peer identifier: {peer_id}
+
+{instructions_section}
 
 Messages to analyze:
 <messages>
@@ -55,6 +76,8 @@ Messages to analyze:
 def minimal_deriver_prompt(
     peer_id: str,
     messages: str,
+    *,
+    custom_instructions: str | None = None,
 ) -> str:
     """
     Generate the combined prompt for fast observation extraction.
@@ -66,7 +89,7 @@ def minimal_deriver_prompt(
         f"""
 {minimal_deriver_system_prompt()}
 
-{minimal_deriver_user_prompt(peer_id, messages)}
+{minimal_deriver_user_prompt(peer_id, messages, custom_instructions=custom_instructions)}
 """
     )
 
@@ -84,3 +107,22 @@ def estimate_minimal_deriver_prompt_tokens() -> int:
         return estimate_tokens(prompt)
     except ValueError:
         return 300
+
+
+def estimate_deriver_prompt_tokens(custom_instructions: str | None = None) -> int:
+    """Estimate deriver prompt tokens, including optional custom instructions."""
+    if not custom_instructions or not custom_instructions.strip():
+        return estimate_minimal_deriver_prompt_tokens()
+
+    return estimate_tokens(
+        "\n\n".join(
+            [
+                minimal_deriver_system_prompt(),
+                minimal_deriver_user_prompt(
+                    peer_id="",
+                    messages="",
+                    custom_instructions=custom_instructions,
+                ),
+            ]
+        )
+    )

--- a/src/schemas/configuration.py
+++ b/src/schemas/configuration.py
@@ -53,7 +53,7 @@ class ReasoningConfiguration(BaseModel):
     )
     custom_instructions: str | None = Field(
         default=None,
-        description="Optional custom instructions for the reasoning system on this workspace/session/message. May be omitted or set to a blank string. Non-blank values are rejected if they exceed the configured deriver custom-instructions token budget.",
+        description="Optional custom instructions for the reasoning system on this workspace/session/message. May be omitted or set to a blank string. Non-blank values are rejected if they exceed the explicitly configured deriver custom-instructions token budget.",
     )
 
     _validate_custom_instructions = field_validator(

--- a/src/schemas/configuration.py
+++ b/src/schemas/configuration.py
@@ -5,7 +5,7 @@ the fully-resolved variants used at runtime.
 """
 
 from enum import Enum
-from typing import Any, Self, cast
+from typing import Any, ClassVar, Self, cast
 
 import tiktoken
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -32,9 +32,7 @@ def _validate_custom_instructions_budget(value: str | None) -> str | None:
     token_limit = settings.DERIVER.effective_max_custom_instructions_tokens
     if token_count > token_limit:
         raise ValueError(
-            "reasoning.custom_instructions uses "
-            f"{token_count} tokens and exceeds DERIVER.MAX_CUSTOM_INSTRUCTIONS_TOKENS "
-            f"({token_limit})"
+            f"reasoning.custom_instructions uses {token_count} tokens and exceeds DERIVER.MAX_CUSTOM_INSTRUCTIONS_TOKENS ({token_limit})"
         )
 
     return value
@@ -56,7 +54,7 @@ class ReasoningConfiguration(BaseModel):
         description="Optional custom instructions for the reasoning system on this workspace/session/message. May be omitted or set to a blank string. Non-blank values are rejected if they exceed the explicitly configured deriver custom-instructions token budget.",
     )
 
-    _validate_custom_instructions = field_validator(
+    _validate_custom_instructions: ClassVar[Any] = field_validator(
         "custom_instructions", mode="after"
     )(_validate_custom_instructions_budget)
 
@@ -163,7 +161,7 @@ class ResolvedReasoningConfiguration(BaseModel):
     enabled: bool
     custom_instructions: str | None = None
 
-    _validate_custom_instructions = field_validator(
+    _validate_custom_instructions: ClassVar[Any] = field_validator(
         "custom_instructions", mode="after"
     )(_validate_custom_instructions_budget)
 

--- a/src/schemas/configuration.py
+++ b/src/schemas/configuration.py
@@ -7,7 +7,37 @@ the fully-resolved variants used at runtime.
 from enum import Enum
 from typing import Any, Self, cast
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+import tiktoken
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from src.config import settings
+
+_TOKENIZER = tiktoken.get_encoding("o200k_base")
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count for reasoning configuration validation."""
+    try:
+        return len(_TOKENIZER.encode(text))
+    except Exception:
+        return len(text) // 4
+
+
+def _validate_custom_instructions_budget(value: str | None) -> str | None:
+    """Reject custom instructions that exceed the configured deriver budget."""
+    if value is None or not value.strip():
+        return value
+
+    token_count = _estimate_tokens(value)
+    token_limit = settings.DERIVER.effective_max_custom_instructions_tokens
+    if token_count > token_limit:
+        raise ValueError(
+            "reasoning.custom_instructions uses "
+            f"{token_count} tokens and exceeds DERIVER.MAX_CUSTOM_INSTRUCTIONS_TOKENS "
+            f"({token_limit})"
+        )
+
+    return value
 
 
 class DreamType(str, Enum):
@@ -23,8 +53,12 @@ class ReasoningConfiguration(BaseModel):
     )
     custom_instructions: str | None = Field(
         default=None,
-        description="TODO: currently unused. Custom instructions to use for the reasoning system on this workspace/session/message.",
+        description="Optional custom instructions for the reasoning system on this workspace/session/message. May be omitted or set to a blank string. Non-blank values are rejected if they exceed the configured deriver custom-instructions token budget.",
     )
+
+    _validate_custom_instructions = field_validator(
+        "custom_instructions", mode="after"
+    )(_validate_custom_instructions_budget)
 
 
 class PeerCardConfiguration(BaseModel):
@@ -128,6 +162,10 @@ class MessageConfiguration(BaseModel):
 class ResolvedReasoningConfiguration(BaseModel):
     enabled: bool
     custom_instructions: str | None = None
+
+    _validate_custom_instructions = field_validator(
+        "custom_instructions", mode="after"
+    )(_validate_custom_instructions_budget)
 
 
 class ResolvedPeerCardConfiguration(BaseModel):

--- a/src/schemas/configuration.py
+++ b/src/schemas/configuration.py
@@ -127,6 +127,7 @@ class MessageConfiguration(BaseModel):
 
 class ResolvedReasoningConfiguration(BaseModel):
     enabled: bool
+    custom_instructions: str | None = None
 
 
 class ResolvedPeerCardConfiguration(BaseModel):

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -15,8 +15,11 @@ from src.schemas import (
     ResolvedSummaryConfiguration,
 )
 from src.utils.clients import HonchoLLMCallResponse
-from src.utils.representation import ExplicitObservationBase, PromptRepresentation
-from src.utils.representation import Representation
+from src.utils.representation import (
+    ExplicitObservationBase,
+    PromptRepresentation,
+    Representation,
+)
 from src.utils.work_unit import construct_work_unit_key, parse_work_unit_key
 
 
@@ -256,8 +259,12 @@ class TestCustomInstructions:
         assert mock_call.await_args is not None
         call_messages = mock_call.await_args.kwargs["messages"]
         assert call_messages[0]["role"] == "system"
-        assert "Analyze messages from alice" in call_messages[0]["content"]
+        assert (
+            "Analyze messages to extract **explicit atomic facts** about the peer."
+            in call_messages[0]["content"]
+        )
         assert call_messages[1]["role"] == "user"
+        assert "Peer identifier: alice" in call_messages[1]["content"]
         assert "CUSTOM INSTRUCTIONS:" in call_messages[1]["content"]
         assert (
             "Focus on durable preferences only." in call_messages[1]["content"]

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -1,6 +1,5 @@
 import signal
 from datetime import datetime, timezone
-from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -234,12 +233,14 @@ class TestCustomInstructions:
             AsyncMock(),
         )
 
-        message = SimpleNamespace(
+        message = models.Message(
             id=1,
+            public_id="msg_1",
             content="I like tea.",
             created_at=datetime.now(timezone.utc),
             peer_name="alice",
             token_count=4,
+            seq_in_session=1,
             session_name="session-1",
             workspace_name="workspace-1",
         )

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -1,9 +1,22 @@
 import signal
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
 from src import models
+from src.deriver.deriver import process_representation_tasks_batch
+from src.schemas import (
+    ResolvedConfiguration,
+    ResolvedDreamConfiguration,
+    ResolvedPeerCardConfiguration,
+    ResolvedReasoningConfiguration,
+    ResolvedSummaryConfiguration,
+)
+from src.utils.clients import HonchoLLMCallResponse
+from src.utils.representation import ExplicitObservationBase, PromptRepresentation
 from src.utils.representation import Representation
 from src.utils.work_unit import construct_work_unit_key, parse_work_unit_key
 
@@ -182,6 +195,79 @@ class TestBackwardsCompatibility:
             observers = [legacy_observer] if legacy_observer else []
 
         assert observers == []
+
+
+@pytest.mark.asyncio
+class TestCustomInstructions:
+    async def test_deriver_passes_custom_instructions_into_prompt(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_prompt(
+            peer_id: str,
+            messages: str,
+            *,
+            custom_instructions: str | None = None,
+        ) -> str:
+            captured["peer_id"] = peer_id
+            captured["messages"] = messages
+            captured["custom_instructions"] = custom_instructions
+            return "prompt"
+
+        mock_response = HonchoLLMCallResponse(
+            content=PromptRepresentation(
+                explicit=[ExplicitObservationBase(content="Alice likes tea")]
+            ),
+            output_tokens=5,
+            finish_reasons=["stop"],
+        )
+
+        monkeypatch.setattr("src.deriver.deriver.minimal_deriver_prompt", fake_prompt)
+        monkeypatch.setattr(
+            "src.deriver.deriver.honcho_llm_call",
+            AsyncMock(return_value=mock_response),
+        )
+        monkeypatch.setattr(
+            "src.crud.representation.RepresentationManager.save_representation",
+            AsyncMock(),
+        )
+
+        message = SimpleNamespace(
+            id=1,
+            content="I like tea.",
+            created_at=datetime.now(timezone.utc),
+            peer_name="alice",
+            token_count=4,
+            session_name="session-1",
+            workspace_name="workspace-1",
+        )
+        configuration = ResolvedConfiguration(
+            reasoning=ResolvedReasoningConfiguration(
+                enabled=True,
+                custom_instructions="Focus on durable preferences only.",
+            ),
+            peer_card=ResolvedPeerCardConfiguration(use=True, create=True),
+            summary=ResolvedSummaryConfiguration(
+                enabled=True,
+                messages_per_short_summary=10,
+                messages_per_long_summary=20,
+            ),
+            dream=ResolvedDreamConfiguration(enabled=True),
+        )
+
+        await process_representation_tasks_batch(
+            messages=[message],
+            message_level_configuration=configuration,
+            observers=["alice"],
+            observed="alice",
+            queue_item_message_ids=[1],
+        )
+
+        assert captured["peer_id"] == "alice"
+        assert captured["custom_instructions"] == "Focus on durable preferences only."
+        assert "I like tea." in captured["messages"]
 
     # async def test_representation_batch_uses_earliest_cutoff(
     #     self,

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from src import models
+from src.config import settings
 from src.deriver.deriver import process_representation_tasks_batch
 from src.schemas import (
     ResolvedConfiguration,
@@ -221,6 +222,11 @@ class TestCustomInstructions:
         monkeypatch.setattr(
             "src.crud.representation.RepresentationManager.save_representation",
             AsyncMock(),
+        )
+        monkeypatch.setattr(
+            settings.DERIVER,
+            "MAX_CUSTOM_INSTRUCTIONS_TOKENS",
+            100,
         )
 
         message = models.Message(

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -202,19 +202,6 @@ class TestCustomInstructions:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        captured: dict[str, Any] = {}
-
-        def fake_prompt(
-            peer_id: str,
-            messages: str,
-            *,
-            custom_instructions: str | None = None,
-        ) -> str:
-            captured["peer_id"] = peer_id
-            captured["messages"] = messages
-            captured["custom_instructions"] = custom_instructions
-            return "prompt"
-
         mock_response = HonchoLLMCallResponse(
             content=PromptRepresentation(
                 explicit=[ExplicitObservationBase(content="Alice likes tea")]
@@ -223,10 +210,10 @@ class TestCustomInstructions:
             finish_reasons=["stop"],
         )
 
-        monkeypatch.setattr("src.deriver.deriver.minimal_deriver_prompt", fake_prompt)
+        mock_call = AsyncMock(return_value=mock_response)
         monkeypatch.setattr(
             "src.deriver.deriver.honcho_llm_call",
-            AsyncMock(return_value=mock_response),
+            mock_call,
         )
         monkeypatch.setattr(
             "src.crud.representation.RepresentationManager.save_representation",
@@ -266,9 +253,16 @@ class TestCustomInstructions:
             queue_item_message_ids=[1],
         )
 
-        assert captured["peer_id"] == "alice"
-        assert captured["custom_instructions"] == "Focus on durable preferences only."
-        assert "I like tea." in captured["messages"]
+        assert mock_call.await_args is not None
+        call_messages = mock_call.await_args.kwargs["messages"]
+        assert call_messages[0]["role"] == "system"
+        assert "Analyze messages from alice" in call_messages[0]["content"]
+        assert call_messages[1]["role"] == "user"
+        assert "CUSTOM INSTRUCTIONS:" in call_messages[1]["content"]
+        assert (
+            "Focus on durable preferences only." in call_messages[1]["content"]
+        )
+        assert "I like tea." in call_messages[1]["content"]
 
     # async def test_representation_batch_uses_earliest_cutoff(
     #     self,

--- a/tests/deriver/test_prompts.py
+++ b/tests/deriver/test_prompts.py
@@ -1,0 +1,30 @@
+from src.deriver.prompts import (
+    estimate_deriver_prompt_tokens,
+    estimate_minimal_deriver_prompt_tokens,
+    minimal_deriver_prompt,
+)
+
+
+class TestMinimalDeriverPrompt:
+    def test_includes_custom_instructions_section_when_present(self) -> None:
+        prompt = minimal_deriver_prompt(
+            peer_id="alice",
+            messages="alice: hello",
+            custom_instructions="Focus on durable preferences only.",
+        )
+
+        assert "CUSTOM INSTRUCTIONS:" in prompt
+        assert "Focus on durable preferences only." in prompt
+
+    def test_omits_custom_instructions_section_when_absent(self) -> None:
+        prompt = minimal_deriver_prompt(peer_id="alice", messages="alice: hello")
+
+        assert "CUSTOM INSTRUCTIONS:" not in prompt
+
+    def test_custom_instructions_increase_prompt_token_estimate(self) -> None:
+        base_tokens = estimate_minimal_deriver_prompt_tokens()
+        custom_tokens = estimate_deriver_prompt_tokens(
+            "Focus on durable preferences only."
+        )
+
+        assert custom_tokens > base_tokens

--- a/tests/routes/test_sessions.py
+++ b/tests/routes/test_sessions.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import pytest
 from fastapi.testclient import TestClient
 from nanoid import generate as generate_nanoid
 
@@ -93,7 +94,7 @@ def test_create_session_with_configuration(
 def test_create_session_rejects_over_budget_reasoning_custom_instructions(
     client: TestClient,
     sample_data: tuple[Workspace, Peer],
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     test_workspace, test_peer = sample_data
     session_id = str(generate_nanoid())

--- a/tests/routes/test_sessions.py
+++ b/tests/routes/test_sessions.py
@@ -3,6 +3,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 from nanoid import generate as generate_nanoid
 
+from src.config import settings
 from src.models import Peer, Workspace
 
 
@@ -87,6 +88,39 @@ def test_create_session_with_configuration(
     assert data["configuration"] == configuration
     assert data["id"] == session_id
     assert data["workspace_id"] == test_workspace.name
+
+
+def test_create_session_rejects_over_budget_reasoning_custom_instructions(
+    client: TestClient,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch,
+):
+    test_workspace, test_peer = sample_data
+    session_id = str(generate_nanoid())
+    monkeypatch.setattr(
+        settings.DERIVER,
+        "MAX_CUSTOM_INSTRUCTIONS_TOKENS",
+        5,
+    )
+
+    response = client.post(
+        f"/v3/workspaces/{test_workspace.name}/sessions",
+        json={
+            "id": session_id,
+            "peer_names": {test_peer.name: {}},
+            "configuration": {
+                "reasoning": {
+                    "enabled": True,
+                    "custom_instructions": "focus on stable preferences and long-term plans",
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    error = response.json()["detail"][0]
+    assert "configuration" in str(error["loc"])
+    assert "custom_instructions" in error["msg"]
 
 
 def test_create_session_with_all_optional_params(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,15 +5,14 @@ from src.config import DeriverSettings
 
 
 class TestDeriverSettings:
-    def test_derives_custom_instruction_token_limit_from_input_budget(self) -> None:
+    def test_requires_explicit_custom_instruction_token_limit(self) -> None:
         settings = DeriverSettings(MAX_INPUT_TOKENS=2000)
 
-        assert settings.effective_max_custom_instructions_tokens == 500
+        with pytest.raises(ValueError) as exc_info:
+            _ = settings.effective_max_custom_instructions_tokens
 
-    def test_caps_derived_custom_instruction_token_limit(self) -> None:
-        settings = DeriverSettings(MAX_INPUT_TOKENS=23000)
-
-        assert settings.effective_max_custom_instructions_tokens == 2048
+        assert "MAX_CUSTOM_INSTRUCTIONS_TOKENS" in str(exc_info.value)
+        assert "config.toml" in str(exc_info.value)
 
     def test_uses_explicit_custom_instruction_token_limit(self) -> None:
         settings = DeriverSettings(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,36 @@
+import pytest
+from pydantic import ValidationError
+
+from src.config import DeriverSettings
+
+
+class TestDeriverSettings:
+    def test_derives_custom_instruction_token_limit_from_input_budget(self) -> None:
+        settings = DeriverSettings(MAX_INPUT_TOKENS=2000)
+
+        assert settings.effective_max_custom_instructions_tokens == 500
+
+    def test_caps_derived_custom_instruction_token_limit(self) -> None:
+        settings = DeriverSettings(MAX_INPUT_TOKENS=23000)
+
+        assert settings.effective_max_custom_instructions_tokens == 2048
+
+    def test_uses_explicit_custom_instruction_token_limit(self) -> None:
+        settings = DeriverSettings(
+            MAX_INPUT_TOKENS=23000,
+            MAX_CUSTOM_INSTRUCTIONS_TOKENS=777,
+        )
+
+        assert settings.effective_max_custom_instructions_tokens == 777
+
+    def test_rejects_explicit_custom_instruction_token_limit_above_input_budget(
+        self,
+    ) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            DeriverSettings(
+                MAX_INPUT_TOKENS=1100,
+                REPRESENTATION_BATCH_MAX_TOKENS=512,
+                MAX_CUSTOM_INSTRUCTIONS_TOKENS=1101,
+            )
+
+        assert "MAX_CUSTOM_INSTRUCTIONS_TOKENS" in str(exc_info.value)

--- a/tests/test_schema_validations.py
+++ b/tests/test_schema_validations.py
@@ -242,14 +242,16 @@ class TestResolvedConfigurationMigration:
 
 class TestReasoningConfigurationValidation:
     def test_session_create_allows_blank_custom_instructions(self):
-        session = SessionCreate(
-            name="test-session",
-            configuration={
-                "reasoning": {
-                    "enabled": True,
-                    "custom_instructions": "",
-                }
-            },
+        session = SessionCreate.model_validate(
+            {
+                "name": "test-session",
+                "configuration": {
+                    "reasoning": {
+                        "enabled": True,
+                        "custom_instructions": "",
+                    }
+                },
+            }
         )
 
         assert session.configuration is not None
@@ -266,14 +268,16 @@ class TestReasoningConfigurationValidation:
         )
 
         with pytest.raises(ValidationError) as exc_info:
-            SessionCreate(
-                name="test-session",
-                configuration={
-                    "reasoning": {
-                        "enabled": True,
-                        "custom_instructions": "focus on durable preferences",
-                    }
-                },
+            SessionCreate.model_validate(
+                {
+                    "name": "test-session",
+                    "configuration": {
+                        "reasoning": {
+                            "enabled": True,
+                            "custom_instructions": "focus on durable preferences",
+                        }
+                    },
+                }
             )
 
         assert "MAX_CUSTOM_INSTRUCTIONS_TOKENS" in str(exc_info.value)
@@ -289,14 +293,16 @@ class TestReasoningConfigurationValidation:
         )
 
         with pytest.raises(ValidationError) as exc_info:
-            SessionCreate(
-                name="test-session",
-                configuration={
-                    "reasoning": {
-                        "enabled": True,
-                        "custom_instructions": "focus on stable preferences and long-term plans",
-                    }
-                },
+            SessionCreate.model_validate(
+                {
+                    "name": "test-session",
+                    "configuration": {
+                        "reasoning": {
+                            "enabled": True,
+                            "custom_instructions": "focus on stable preferences and long-term plans",
+                        }
+                    },
+                }
             )
 
         assert "custom_instructions" in str(exc_info.value)

--- a/tests/test_schema_validations.py
+++ b/tests/test_schema_validations.py
@@ -256,6 +256,29 @@ class TestReasoningConfigurationValidation:
         assert session.configuration.reasoning is not None
         assert session.configuration.reasoning.custom_instructions == ""
 
+    def test_session_create_requires_explicit_custom_instruction_token_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            settings.DERIVER,
+            "MAX_CUSTOM_INSTRUCTIONS_TOKENS",
+            None,
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            SessionCreate(
+                name="test-session",
+                configuration={
+                    "reasoning": {
+                        "enabled": True,
+                        "custom_instructions": "focus on durable preferences",
+                    }
+                },
+            )
+
+        assert "MAX_CUSTOM_INSTRUCTIONS_TOKENS" in str(exc_info.value)
+        assert "config.toml" in str(exc_info.value)
+
     def test_session_create_rejects_over_budget_custom_instructions(
         self, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/test_schema_validations.py
+++ b/tests/test_schema_validations.py
@@ -3,13 +3,14 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
+from src.config import settings
 from src.schemas import (
     ConclusionCreate,
     DialecticOptions,
     DocumentCreate,
     DocumentMetadata,
-    MessageSearchOptions,
     MessageCreate,
+    MessageSearchOptions,
     ObservationInput,
     PeerCreate,
     ResolvedConfiguration,
@@ -215,6 +216,68 @@ class TestResolvedConfigurationMigration:
             ResolvedConfiguration.model_validate(payload)
 
         assert any(e["loc"] == ("reasoning",) for e in exc_info.value.errors())
+
+    def test_rejects_over_budget_custom_instructions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            settings.DERIVER,
+            "MAX_CUSTOM_INSTRUCTIONS_TOKENS",
+            5,
+        )
+
+        payload = self._make_config(
+            reasoning={
+                "enabled": True,
+                "custom_instructions": "focus on stable preferences and long-term plans",
+            }
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            ResolvedConfiguration.model_validate(payload)
+
+        assert "custom_instructions" in str(exc_info.value)
+        assert "MAX_CUSTOM_INSTRUCTIONS_TOKENS" in str(exc_info.value)
+
+
+class TestReasoningConfigurationValidation:
+    def test_session_create_allows_blank_custom_instructions(self):
+        session = SessionCreate(
+            name="test-session",
+            configuration={
+                "reasoning": {
+                    "enabled": True,
+                    "custom_instructions": "",
+                }
+            },
+        )
+
+        assert session.configuration is not None
+        assert session.configuration.reasoning is not None
+        assert session.configuration.reasoning.custom_instructions == ""
+
+    def test_session_create_rejects_over_budget_custom_instructions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            settings.DERIVER,
+            "MAX_CUSTOM_INSTRUCTIONS_TOKENS",
+            5,
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            SessionCreate(
+                name="test-session",
+                configuration={
+                    "reasoning": {
+                        "enabled": True,
+                        "custom_instructions": "focus on stable preferences and long-term plans",
+                    }
+                },
+            )
+
+        assert "custom_instructions" in str(exc_info.value)
+        assert "MAX_CUSTOM_INSTRUCTIONS_TOKENS" in str(exc_info.value)
 
 
 class TestSanitizedRequiredFields:

--- a/tests/utils/test_config_helpers.py
+++ b/tests/utils/test_config_helpers.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+from src.schemas import MessageConfiguration, ReasoningConfiguration
+from src.utils.config_helpers import get_configuration
+
+
+class TestGetConfiguration:
+    def test_preserves_workspace_custom_instructions(self) -> None:
+        workspace = SimpleNamespace(
+            configuration={
+                "reasoning": {
+                    "enabled": True,
+                    "custom_instructions": "Focus on durable preferences.",
+                }
+            }
+        )
+
+        config = get_configuration(None, None, workspace)
+
+        assert config.reasoning.enabled is True
+        assert config.reasoning.custom_instructions == "Focus on durable preferences."
+
+    def test_message_custom_instructions_override_session_and_workspace(self) -> None:
+        workspace = SimpleNamespace(
+            configuration={"reasoning": {"custom_instructions": "workspace scope"}}
+        )
+        session = SimpleNamespace(
+            configuration={"reasoning": {"custom_instructions": "session scope"}}
+        )
+        message = MessageConfiguration(
+            reasoning=ReasoningConfiguration(custom_instructions="message scope")
+        )
+
+        config = get_configuration(message, session, workspace)
+
+        assert config.reasoning.custom_instructions == "message scope"

--- a/tests/utils/test_config_helpers.py
+++ b/tests/utils/test_config_helpers.py
@@ -8,7 +8,15 @@ from src.utils.config_helpers import get_configuration
 
 
 class TestGetConfiguration:
-    def test_preserves_workspace_custom_instructions(self) -> None:
+    def test_preserves_workspace_custom_instructions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            settings.DERIVER,
+            "MAX_CUSTOM_INSTRUCTIONS_TOKENS",
+            100,
+        )
+
         workspace = models.Workspace(
             name="workspace-1",
             configuration={
@@ -24,7 +32,15 @@ class TestGetConfiguration:
         assert config.reasoning.enabled is True
         assert config.reasoning.custom_instructions == "Focus on durable preferences."
 
-    def test_message_custom_instructions_override_session_and_workspace(self) -> None:
+    def test_message_custom_instructions_override_session_and_workspace(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            settings.DERIVER,
+            "MAX_CUSTOM_INSTRUCTIONS_TOKENS",
+            100,
+        )
+
         workspace = models.Workspace(
             name="workspace-1",
             configuration={"reasoning": {"custom_instructions": "workspace scope"}}

--- a/tests/utils/test_config_helpers.py
+++ b/tests/utils/test_config_helpers.py
@@ -1,12 +1,12 @@
-from types import SimpleNamespace
-
+from src import models
 from src.schemas import MessageConfiguration, ReasoningConfiguration
 from src.utils.config_helpers import get_configuration
 
 
 class TestGetConfiguration:
     def test_preserves_workspace_custom_instructions(self) -> None:
-        workspace = SimpleNamespace(
+        workspace = models.Workspace(
+            name="workspace-1",
             configuration={
                 "reasoning": {
                     "enabled": True,
@@ -21,10 +21,13 @@ class TestGetConfiguration:
         assert config.reasoning.custom_instructions == "Focus on durable preferences."
 
     def test_message_custom_instructions_override_session_and_workspace(self) -> None:
-        workspace = SimpleNamespace(
+        workspace = models.Workspace(
+            name="workspace-1",
             configuration={"reasoning": {"custom_instructions": "workspace scope"}}
         )
-        session = SimpleNamespace(
+        session = models.Session(
+            name="session-1",
+            workspace_name="workspace-1",
             configuration={"reasoning": {"custom_instructions": "session scope"}}
         )
         message = MessageConfiguration(

--- a/tests/utils/test_config_helpers.py
+++ b/tests/utils/test_config_helpers.py
@@ -1,4 +1,8 @@
+import pytest
+from pydantic import ValidationError
+
 from src import models
+from src.config import settings
 from src.schemas import MessageConfiguration, ReasoningConfiguration
 from src.utils.config_helpers import get_configuration
 
@@ -37,3 +41,27 @@ class TestGetConfiguration:
         config = get_configuration(message, session, workspace)
 
         assert config.reasoning.custom_instructions == "message scope"
+
+    def test_get_configuration_rejects_over_budget_custom_instructions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            settings.DERIVER,
+            "MAX_CUSTOM_INSTRUCTIONS_TOKENS",
+            5,
+        )
+
+        workspace = models.Workspace(
+            name="workspace-1",
+            configuration={
+                "reasoning": {
+                    "enabled": True,
+                    "custom_instructions": "focus on stable preferences and long-term plans",
+                }
+            },
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            get_configuration(None, None, workspace)
+
+        assert "custom_instructions" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Implements `reasoning.custom_instructions` for the deriver on top of the prefix-cache prompt split from #425.

## What Changed

- keeps `custom_instructions` in resolved reasoning config
- adds `custom_instructions` to the deriver user prompt
- updates deriver prompt token estimation to include optional custom instructions
- adds tests for config precedence, prompt rendering, and deriver wiring

## Scope

This only implements `custom_instructions` for the deriver.

It does not add `custom_instructions` support to:
- dialectic
- dreamer

## Why

The schema already exposed `reasoning.custom_instructions`, but it was not used at runtime. This wires it into the deriver while preserving the cache-friendly split introduced in #425 by keeping the instructions in the user message rather than the stable system prompt.

## Testing

Verified locally with:
- `python -m py_compile` on changed files
- `basedpyright` on changed files
- targeted pytest on:
  - `tests/deriver/test_deriver_processing.py`
  - `tests/deriver/test_prompts.py`
  - `tests/utils/test_config_helpers.py`

Targeted pytest result:
- `15 passed`
