### PR TITLE
fix(deriver): reduce ephemeral explicit observations

### DIFF
--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -37,13 +37,18 @@ Analyze messages from {peer_id} to extract **explicit atomic facts** about them.
 RULES:
 - Properly attribute observations to the correct subject: if it is about {peer_id}, say so. If {peer_id} is referencing someone or something else, make that clear.
 - Observations should make sense on their own. Each observation will be used in the future to better understand {peer_id}.
-- Extract ALL observations from {peer_id} messages, using others as context.
+- Extract observations that are likely to remain useful beyond the current session.
+- Prefer durable facts, standing instructions, long-lived preferences, relationships, commitments, and ongoing situations that would still matter in a future conversation.
+- Do NOT extract one-off tasks, temporary workflow steps, ephemeral process updates, or short-lived session logistics unless the user clearly states they are an enduring preference, rule, or responsibility.
 - Contextualize each observation sufficiently (e.g. "Ann is nervous about the job interview at the pharmacy" not just "Ann is nervous")
 
 EXAMPLES:
 - EXPLICIT: "I just had my 25th birthday last Saturday" → "{peer_id} is 25 years old", "{peer_id}'s birthday is June 21st"
 - EXPLICIT: "I took my dog for a walk in NYC" → "{peer_id} has a dog", "{peer_id} lives in NYC"
 - EXPLICIT: "{peer_id} attended college" + general knowledge → "{peer_id} completed high school or equivalent"
+- EXPLICIT: "Please always give me the short version first" → "{peer_id} prefers to receive the short version first"
+- SKIP: "I'm going to copy this into a markdown file now" → temporary task for the current session
+- SKIP: "The sync job is at step 1000 of 3000" → transient process status update
 
 Messages to analyze:
 <messages>

--- a/tests/deriver/test_prompts.py
+++ b/tests/deriver/test_prompts.py
@@ -1,0 +1,28 @@
+import importlib.util
+from pathlib import Path
+
+_PROMPTS_PATH = Path(__file__).resolve().parents[2] / "src" / "deriver" / "prompts.py"
+_PROMPTS_SPEC = importlib.util.spec_from_file_location(
+    "deriver_prompts", _PROMPTS_PATH
+)
+assert _PROMPTS_SPEC is not None and _PROMPTS_SPEC.loader is not None
+_PROMPTS_MODULE = importlib.util.module_from_spec(_PROMPTS_SPEC)
+_PROMPTS_SPEC.loader.exec_module(_PROMPTS_MODULE)
+
+minimal_deriver_prompt = _PROMPTS_MODULE.minimal_deriver_prompt
+
+
+def test_minimal_deriver_prompt_prefers_durable_observations() -> None:
+    """The deriver prompt should bias toward durable memory, not session noise."""
+    prompt = minimal_deriver_prompt(
+        peer_id="alice",
+        messages="alice: Please always give me the short version first.",
+    )
+
+    assert "likely to remain useful beyond the current session" in prompt
+    assert "Do NOT extract one-off tasks" in prompt
+    assert "temporary workflow steps" in prompt
+    assert "ephemeral process updates" in prompt
+    assert 'SKIP: "I\'m going to copy this into a markdown file now"' in prompt
+    assert 'SKIP: "The sync job is at step 1000 of 3000"' in prompt
+    assert 'EXPLICIT: "Please always give me the short version first"' in prompt

--- a/tests/deriver/test_prompts.py
+++ b/tests/deriver/test_prompts.py
@@ -5,7 +5,8 @@ _PROMPTS_PATH = Path(__file__).resolve().parents[2] / "src" / "deriver" / "promp
 _PROMPTS_SPEC = importlib.util.spec_from_file_location(
     "deriver_prompts", _PROMPTS_PATH
 )
-assert _PROMPTS_SPEC is not None and _PROMPTS_SPEC.loader is not None
+if _PROMPTS_SPEC is None or _PROMPTS_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load deriver prompts module from {_PROMPTS_PATH}")
 _PROMPTS_MODULE = importlib.util.module_from_spec(_PROMPTS_SPEC)
 _PROMPTS_SPEC.loader.exec_module(_PROMPTS_MODULE)
 


### PR DESCRIPTION
## Summary
- narrow the minimal deriver prompt toward durable, cross-session-useful observations
- explicitly exclude one-off tasks, transient workflow updates, and short-lived session logistics from explicit observation extraction
- add a focused prompt regression test covering the new durable vs ephemeral guidance

Closes #444

## Validation
- `uv run ruff check src/deriver/prompts.py tests/deriver/test_prompts.py tests/deriver/test_representation_crud.py`
- `uv run pytest --noconftest -n0 tests/deriver/test_prompts.py tests/deriver/test_representation_crud.py -q`
- `uv run pytest -n0 tests/deriver -q`

All tests passed.

## Notes
- this change is intentionally prompt-first and does not add heuristic filtering to the deriver pipeline, as that would require bigger changes
- the codebase currently doesn't include a dedicated benchmark for ephemeral-observation suppression vs durable-memory retention, so validation here is minimal. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened observation filtering to prioritize durable facts (standing instructions, long-lived preferences, relationships, commitments, ongoing situations) and exclude transient items (one-off tasks, temporary workflow steps, ephemeral process updates).
  * Added explicit handling for declared enduring preferences (e.g., “short version first”).

* **Tests**
  * Added test coverage verifying durable-observation bias, explicit skip examples for transient items, and respect for declared preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->