### PR TITLE
Add MiniMax integration patches

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -203,6 +203,8 @@ class LLMSettings(HonchoSettings):
 
     # API Keys for LLM providers
     ANTHROPIC_API_KEY: str | None = None
+    # Base URL for Anthropic-compatible endpoints (e.g., MiniMax: https://api.minimax.io/anthropic)
+    ANTHROPIC_BASE_URL: str | None = None
     OPENAI_API_KEY: str | None = None
     OPENAI_COMPATIBLE_API_KEY: str | None = None
     GEMINI_API_KEY: str | None = None
@@ -212,6 +214,10 @@ class LLMSettings(HonchoSettings):
     # Separate vLLM endpoint (for local models)
     VLLM_API_KEY: str | None = None
     VLLM_BASE_URL: str | None = None
+    # Embedding model when using OpenRouter provider (e.g., google/gemini-embedding-001)
+    OPENAI_COMPATIBLE_EMBEDDING_MODEL: str | None = None
+    # Separate base URL for embedding provider (overrides OPENAI_COMPATIBLE_BASE_URL for embeddings)
+    EMBEDDING_BASE_URL: str | None = None
 
     EMBEDDING_PROVIDER: Literal["openai", "gemini", "openrouter"] = "openai"
 
@@ -256,7 +262,7 @@ class DeriverSettings(BackupLLMSettingsMixin, HonchoSettings):
     DEDUPLICATE: bool = True
 
     MAX_OUTPUT_TOKENS: Annotated[int, Field(default=4096, gt=0, le=100_000)] = 4096
-    THINKING_BUDGET_TOKENS: Annotated[int, Field(default=1024, gt=0, le=5000)] = 1024
+    THINKING_BUDGET_TOKENS: Annotated[int, Field(default=1024, ge=0, le=5000)] = 1024
 
     LOG_OBSERVATIONS: bool = False
 

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -48,11 +48,16 @@ class _EmbeddingClient:
                     "OpenRouter API key (LLM_OPENAI_COMPATIBLE_API_KEY) is required"
                 )
             base_url = (
-                settings.LLM.OPENAI_COMPATIBLE_BASE_URL
+                settings.LLM.EMBEDDING_BASE_URL
+                or settings.LLM.OPENAI_COMPATIBLE_BASE_URL
                 or "https://openrouter.ai/api/v1"
             )
             self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-            self.model = "openai/text-embedding-3-small"
+            # Use configurable model if set (e.g., google/gemini-embedding-001), otherwise default
+            self.model = (
+                settings.LLM.OPENAI_COMPATIBLE_EMBEDDING_MODEL
+                or "openai/text-embedding-3-small"
+            )
             self.max_embedding_tokens = settings.MAX_EMBEDDING_TOKENS
             self.max_batch_size = 2048  # Same as OpenAI
         else:  # openai

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -251,10 +251,13 @@ CLIENTS: dict[
 ] = {}
 
 if settings.LLM.ANTHROPIC_API_KEY:
-    anthropic = AsyncAnthropic(
-        api_key=settings.LLM.ANTHROPIC_API_KEY,
-        timeout=600.0,  # 10 minutes timeout for long-running operations
-    )
+    anthropic_kwargs = {
+        "api_key": settings.LLM.ANTHROPIC_API_KEY,
+        "timeout": 600.0,  # 10 minutes timeout for long-running operations
+    }
+    if settings.LLM.ANTHROPIC_BASE_URL:
+        anthropic_kwargs["base_url"] = settings.LLM.ANTHROPIC_BASE_URL
+    anthropic = AsyncAnthropic(**anthropic_kwargs)
     CLIENTS["anthropic"] = anthropic
 
 if settings.LLM.OPENAI_API_KEY:
@@ -1737,14 +1740,19 @@ async def honcho_llm_call_inner(
             # For response models, we need to request JSON and parse manually
             # Note: tools and response_model should not be used together
             if response_model or json_mode:
-                # Add JSON schema instructions to the prompt if using response_model
+                # Add JSON schema instructions to system prompt (more reliable than user message)
+                # especially for MiniMax which sometimes echoes schema when it's in user message
                 if response_model:
                     schema_json = json.dumps(
                         response_model.model_json_schema(), indent=2
                     )
-                    anthropic_params["messages"][-1]["content"] += (
+                    schema_instruction = (
                         f"\n\nRespond with valid JSON matching this schema:\n{schema_json}"
                     )
+                    if "system" in anthropic_params and anthropic_params["system"]:
+                        anthropic_params["system"] += schema_instruction
+                    else:
+                        anthropic_params["system"] = schema_instruction.strip()
                 anthropic_params["messages"].append(
                     {"role": "assistant", "content": "{"}
                 )
@@ -1813,9 +1821,33 @@ async def honcho_llm_call_inner(
             # If using response_model, parse the JSON response
             if response_model:
                 try:
-                    # Add back the opening brace that we prefilled
-                    json_content = "{" + text_content
-                    parsed_json = json.loads(json_content)
+                    # Strip markdown code fences that some providers (e.g. MiniMax) add around JSON
+                    cleaned_content = text_content.strip()
+                    if cleaned_content.startswith("```json"):
+                        # Remove leading ```json\n and trailing ```
+                        lines = cleaned_content.split("\n")
+                        if lines and lines[0].strip() in ("```json", "```json\n", "```"):
+                            lines = lines[1:]
+                        if lines and lines[-1].strip() == "```":
+                            lines = lines[:-1]
+                        cleaned_content = "\n".join(lines).strip()
+
+                    # Some providers (e.g. MiniMax Anthropic endpoint) return the full schema JSON
+                    # as content instead of respecting response_model for structured output.
+                    # Detect: if cleaned_content looks like the schema (has "$defs" or "model_config")
+                    # rather than actual PromptRepresentation data, skip response_model validation.
+                    if '"$defs"' in cleaned_content or '"model_config"' in cleaned_content:
+                        # MiniMax returned the schema itself - fall back to plain JSON parsing
+                        # without response_model validation
+                        logger.warning(
+                            f"MiniMax returned schema JSON instead of structured output; "
+                            f"falling back to plain JSON parse of text content"
+                        )
+                        text_for_plain_parse = cleaned_content
+                    else:
+                        text_for_plain_parse = "{" + cleaned_content if not cleaned_content.startswith("{") else cleaned_content
+
+                    parsed_json = json.loads(text_for_plain_parse)
                     parsed_content = response_model.model_validate(parsed_json)
 
                     return HonchoLLMCallResponse(
@@ -1927,6 +1959,17 @@ async def honcho_llm_call_inner(
                     test_rep = ""
                     if vllm_response.choices[0].message.content is not None:
                         test_rep = vllm_response.choices[0].message.content
+
+                    # Strip thinking tags that some providers (e.g. MiniMax OpenAI endpoint)
+                    # inject into the content as <thinking>...</thinking>
+                    import re as regex_module
+                    test_rep = regex_module.sub(
+                        r"<thinking>.*?</thinking>", "", test_rep, flags=regex_module.DOTALL
+                    )
+                    # Also strip remaining HTML/XML style thinking tags
+                    test_rep = regex_module.sub(
+                        r"<think>.*?</think>", "", test_rep, flags=regex_module.DOTALL
+                    )
 
                     final = validate_and_repair_json(test_rep)
 


### PR DESCRIPTION
Patches:
- config.py: ge=0 for THINKING_BUDGET_TOKENS (allows zero thinking budget)
- utils/clients.py: base_url param for Anthropic, markdown fence stripping, double-brace handling
- embedding_client.py: configurable OpenRouter embedding model support
- Dockerfile: include docker/ directory in build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom Anthropic-compatible endpoint configuration
  * Added configurable embedding model and base URL settings for enhanced flexibility

* **Bug Fixes**
  * Improved response parsing and handling for structured outputs with Anthropic

* **Chores**
  * Updated validation constraints for thinking budget token configuration to allow zero values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->