### PR TITLE
docs(self-hosting): fix database name in connection URI

### DIFF
--- a/docs/v2/contributing/self-hosting.mdx
+++ b/docs/v2/contributing/self-hosting.mdx
@@ -59,7 +59,8 @@ OPENAI_API_KEY=your-openai-api-key
 ANTHROPIC_API_KEY=your-anthropic-api-key
 
 # Database will be created automatically by Docker
-DB_CONNECTION_URI=postgresql+psycopg://postgres:postgres@database:5432/honcho
+DB_CONNECTION_URI=postgresql+psycopg://postgres:postgres@database:5432/postgres
+
 
 # Disable auth for local development
 AUTH_USE_AUTH=false

--- a/docs/v3/contributing/self-hosting.mdx
+++ b/docs/v3/contributing/self-hosting.mdx
@@ -59,7 +59,7 @@ OPENAI_API_KEY=your-openai-api-key
 ANTHROPIC_API_KEY=your-anthropic-api-key
 
 # Database will be created automatically by Docker
-DB_CONNECTION_URI=postgresql+psycopg://postgres:postgres@database:5432/honcho
+DB_CONNECTION_URI=postgresql+psycopg://postgres:postgres@database:5432/postgres
 
 # Disable auth for local development
 AUTH_USE_AUTH=false


### PR DESCRIPTION
Fixes Issue #441 reg. typo in docs - The self hosting docs showed honcho as the database name in the connection URI but the docker-compose module uses postgres. Updated both v2 and v3 self-hosting docs in the documentation, so its viable and checked other docs to try to ensure problem doesn't come up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker-local environment configuration examples to use the PostgreSQL default database instead of a custom database name for self-hosting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->