### PR TITLE
docs: add pi-honcho-memory community integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -114,7 +114,8 @@
               {
                 "group": "Community Integrations",
                 "pages": [
-                  "v3/guides/community/agent0"
+                  "v3/guides/community/agent0",
+                  "v3/guides/community/pi-honcho-memory"
                 ]
               },
               {

--- a/docs/v3/guides/community/pi-honcho-memory.mdx
+++ b/docs/v3/guides/community/pi-honcho-memory.mdx
@@ -1,0 +1,38 @@
+---
+title: "Pi"
+icon: 'pi'
+description: "Persistent memory extension for the pi coding agent"
+sidebarTitle: 'Pi'
+---
+
+[pi-honcho-memory](https://github.com/agneym/pi-honcho-memory) is a persistent memory extension for [pi](https://pi.dev), a coding agent CLI. It gives pi long-term memory across sessions — user preferences, project context, and past decisions are remembered and automatically injected into the system prompt.
+
+## Getting Started
+
+Install the extension inside pi:
+
+```bash
+pi install npm:@agney/pi-honcho-memory
+```
+
+The integration requires:
+1. A Honcho API key from [app.honcho.dev](https://app.honcho.dev)
+2. Running `/honcho-setup` inside pi for interactive configuration, or setting `HONCHO_API_KEY` in your environment
+
+The Honcho plugin is a community integration. See the [plugin README](https://github.com/agneym/pi-honcho-memory/blob/main/README.md) for full installation and configuration instructions.
+
+## How It Works
+
+The extension hooks into pi's extension system. It automatically syncs user and assistant messages to Honcho after each agent response, injects cached user profile and project context into the system prompt with zero network latency, and exposes LLM tools (`honcho_search`, `honcho_chat`, `honcho_remember`) for active memory operations. Session scoping is configurable — memory can be shared per repo, per git branch, or per directory. If Honcho is unavailable, pi continues working normally.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Extension Repository" icon="github" href="https://github.com/agneym/pi-honcho-memory">
+    Source code, installation, and full documentation.
+  </Card>
+
+  <Card title="Honcho Architecture" icon="sitemap" href="../../documentation/core-concepts/architecture">
+    Learn about peers, sessions, and dialectic reasoning.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Adds [pi-honcho-memory](https://github.com/agneym/pi-honcho-memory) to the Community Integrations section of the docs, sitting next to Agent Zero.

**pi-honcho-memory** is a persistent memory extension for [pi](https://github.com/mariozechner/pi-coding-agent) that gives it long-term memory via Honcho — user preferences, project context, and past decisions are remembered across sessions.

### Changes
- New page: `docs/v3/guides/community/pi-honcho-memory.mdx`
- Nav entry added to `docs/docs.json` under Community Integrations

> [!NOTE]
> I was advised to add the extension to docs [on Twitter](https://x.com/spigabi/status/2037196238710354250) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for the Pi Honcho Memory extension, covering installation, API key configuration, session scoping options, available memory tools, and integration next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->