### PR TITLE
feat: support configurable embedding dimensions via VECTOR_STORE_DIMENSIONS

### DIFF
--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -82,7 +82,7 @@ class _EmbeddingClient:
             response = await self.client.aio.models.embed_content(
                 model=self.model,
                 contents=query,
-                config={"output_dimensionality": 1536},
+                config={"output_dimensionality": settings.VECTOR_STORE.DIMENSIONS},
             )
             if not response.embeddings or not response.embeddings[0].values:
                 raise ValueError("No embedding returned from Gemini API")
@@ -116,7 +116,7 @@ class _EmbeddingClient:
                     response = await self.client.aio.models.embed_content(
                         model=self.model,
                         contents=batch,  # pyright: ignore[reportArgumentType]
-                        config={"output_dimensionality": 1536},
+                        config={"output_dimensionality": settings.VECTOR_STORE.DIMENSIONS},
                     )
                     if response.embeddings:
                         for emb in response.embeddings:
@@ -252,7 +252,7 @@ class _EmbeddingClient:
                     response = await self.client.aio.models.embed_content(
                         model=self.model,
                         contents=[item.text for item in batch],
-                        config={"output_dimensionality": 1536},
+                        config={"output_dimensionality": settings.VECTOR_STORE.DIMENSIONS},
                     )
                     if response.embeddings:
                         for item, embedding in zip(

--- a/src/models.py
+++ b/src/models.py
@@ -27,6 +27,7 @@ from typing_extensions import override
 
 from src.utils.types import DocumentLevel, TaskType, VectorSyncState
 
+from .config import settings
 from .db import Base
 
 load_dotenv(override=True)
@@ -278,7 +279,7 @@ class MessageEmbedding(Base):
         BigInteger, Identity(), primary_key=True, autoincrement=True
     )
     content: Mapped[str] = mapped_column(TEXT)
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(settings.VECTOR_STORE.DIMENSIONS), nullable=True)
     message_id: Mapped[str] = mapped_column(
         ForeignKey("messages.public_id", ondelete="CASCADE"), nullable=False, index=True
     )
@@ -386,7 +387,7 @@ class Document(Base):
     times_derived: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("1")
     )
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(settings.VECTOR_STORE.DIMENSIONS), nullable=True)
     source_ids: Mapped[list[str] | None] = mapped_column(
         JSONB, nullable=True, server_default=text("NULL")
     )


### PR DESCRIPTION
## Summary

Currently `embedding_client.py` and `models.py` hardcode `1536` as the embedding dimension. This prevents using embedding providers with different dimensions (e.g., BGE-M3 at 1024 dimensions).

## Changes

Replace hardcoded `1536` with `settings.VECTOR_STORE.DIMENSIONS` in:

- **embedding_client.py**: 3 `Gemini embed_content` calls (lines ~85, ~119, ~255)
- **models.py**: 2 `Vector()` columns — `MessageEmbedding.embedding` and `Document.embedding` — and add `from .config import settings`

## Motivation

The `VECTOR_STORE_DIMENSIONS` config field already existed in `src/config.py` but was not being used in `embedding_client.py` or `models.py`. This change wires it up, allowing users to configure embedding dimensions via the `VECTOR_STORE_DIMENSIONS` environment variable instead of being locked to 1536.

This is particularly useful for embedding providers like **BGE-M3** (1024 dimensions).

## Backwards Compatibility

Default remains `1536` when the `VECTOR_STORE_DIMENSIONS` env var is unset.

## Issue

Closes #463


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated embedding vector configuration to use centralized settings instead of hardcoded values, improving system flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->