### PR TITLE
fix: add migration to alter vector column dimensions to match VECTOR_STORE.DIMENSIONS

### DIFF
--- a/migrations/versions/Nj-2KD-Cc2XG_alter_vector_dimensions.py
+++ b/migrations/versions/Nj-2KD-Cc2XG_alter_vector_dimensions.py
@@ -27,11 +27,18 @@ down_revision: str | None = "e4eba9cfaa6f"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
-schema = get_schema()
 
+def _get_atttypmod(table: str, column: str, schema: str | None) -> int | None:
+    """Return pg_attribute.atttypmod for a vector column, or None if not found.
 
-def _get_atttypmod(table: str, column: str) -> int | None:
-    """Return pg_attribute.atttypmod for a vector column, or None if not found."""
+    Uses the migration's resolved schema rather than current_schema() to handle
+    non-default schema deployments correctly.
+    """
+    schema_filter = "n.nspname = :schema" if schema else "n.nspname = current_schema()"
+    params: dict = {"table": table, "column": column}
+    if schema:
+        params["schema"] = schema
+
     result = op.get_bind().execute(
         text(
             f"""
@@ -41,10 +48,10 @@ def _get_atttypmod(table: str, column: str) -> int | None:
             JOIN pg_namespace n ON n.oid = c.relnamespace
             WHERE c.relname = :table
               AND a.attname = :column
-              AND n.nspname = current_schema()
+              AND {schema_filter}
             """
         ),
-        {"table": table, "column": column},
+        params,
     )
     row = result.fetchone()
     return int(row[0]) if row else None
@@ -55,10 +62,10 @@ def upgrade() -> None:
     # Import settings at runtime so we read the deployed configuration
     from src.config import settings
 
+    schema = get_schema()
     target_dim: int = settings.VECTOR_STORE.DIMENSIONS
 
     inspector = sa.inspect(op.get_bind())
-    conn = op.get_bind()
 
     tables = [
         {
@@ -70,20 +77,21 @@ def upgrade() -> None:
         {
             "name": "message_embeddings",
             "column": "embedding",
-            "ix_name": None,  # no HNSW index on this column in current DB
-            "has_ix": False,
+            "ix_name": "ix_message_embeddings_embedding_hnsw",
+            "has_ix": None,
         },
     ]
 
-    # Check which indexes actually exist in the DB
-    existing_indexes = {r[0] for r in inspector.get_indexes("documents")}
-    existing_indexes |= {r[0] for r in inspector.get_indexes("message_embeddings")}
+    # Check which indexes actually exist in the DB using inspector dict access
+    doc_indexes = {idx["name"] for idx in inspector.get_indexes("documents", schema=schema)}
+    msg_indexes = {idx["name"] for idx in inspector.get_indexes("message_embeddings", schema=schema)}
+    existing_indexes = doc_indexes | msg_indexes
 
     for t in tables:
         t["has_ix"] = t["ix_name"] in existing_indexes if t["ix_name"] else False
 
     for t in tables:
-        current_dim = _get_atttypmod(t["name"], t["column"])
+        current_dim = _get_atttypmod(t["name"], t["column"], schema)
 
         if current_dim is None:
             # Column absent (LanceDB-only backend) — skip
@@ -97,9 +105,10 @@ def upgrade() -> None:
         if t["has_ix"] and t["ix_name"]:
             op.drop_index(t["ix_name"], table_name=t["name"], schema=schema)
 
-        # Alter column type to new vector dimension
-        # The USING clause casts the existing vector to the new dimension
+        # Build fully-qualified ALTER TABLE statement
+        table_ref = f'"{schema}"."{t["name"]}"' if schema else f'"{t["name"]}"'
         op.execute(
+            f"ALTER TABLE {table_ref} "
             f'ALTER COLUMN "embedding" TYPE vector({target_dim}) '
             f'USING "embedding"::vector({target_dim})'
         )


### PR DESCRIPTION
## Problem

Alembic migrations in `migrations/versions/` hardcode `Vector(1536)` in:
- `a1b2c3d4e5f6_initial_schema.py`
- `917195d9b5e9_add_messageembedding_table.py`
- `119a52b73c60_support_external_embeddings.py` (as `existing_type`)

This means that when a user sets `VECTOR_STORE.DIMENSIONS` to a value other than `1536` (e.g., `768` for nomic-embed-text or `1024` for qwen3-embedding), the ORM and embedding client correctly use the configured dimension, but **existing tables still have `vector(1536)` columns** — causing dimension mismatch errors on insert/query.

This is the issue raised by @VVoruganti in PR #465's review: migrations must also respect the configured vector dimensions.

## Solution

New migration `Nj-2KD-Cc2XG_alter_vector_dimensions.py` (revises `e4eba9cfaa6f`):

1. Reads `settings.VECTOR_STORE.DIMENSIONS` at runtime
2. Queries `pg_attribute.atttypmod` to get the **current** column dimension
3. If current ≠ target: drops the HNSW index (dimension-typed), alters the column via `ALTER COLUMN ... TYPE vector(N) USING embedding::vector(N)`, recreates the index
4. **Idempotent** — skips tables/columns that are already at the correct dimension or don't exist (LanceDB-only backends)

## Notes

- **Downgrade intentionally not implemented** — reducing vector dimensions would silently truncate embedding data; a full re-embedding pipeline is required and is out of scope for a schema migration
- Handles the case where `ix_message_embeddings_embedding_hnsw` doesn't exist in the DB (it isn't created by any migration, only by the ORM metadata)
- Uses `inspector.get_indexes()` to check actual DB state rather than assuming index existence

## Related PRs

- PR #465 — configurable vector dimensions in ORM + embedding client (this migration is the Alembic counterpart requested by the reviewer)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted database vector column dimensions for embedding storage to match runtime configuration. Migration runs automatically, updates affected indexes as needed, and is non-reversible (downgrade not supported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->