### PR TITLE
feat(config): make embedding vector dimensions and model configurable

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -52,6 +52,10 @@ PROFILES_SAMPLE_RATE = 0.1
 [llm]
 DEFAULT_MAX_TOKENS = 2500
 EMBEDDING_PROVIDER = "openai"
+# Override the default embedding model for the chosen provider.
+# Defaults: "text-embedding-3-small" (openai), "openai/text-embedding-3-small" (openrouter),
+# "gemini-embedding-001" (gemini). Useful for Ollama or other OpenAI-compatible endpoints.
+# EMBEDDING_MODEL = "nomic-embed-text"
 MAX_TOOL_OUTPUT_CHARS = 10000  # Max chars for tool output (~2500 tokens)
 MAX_MESSAGE_CONTENT_CHARS = 2000  # Max chars per message in tool results
 
@@ -220,6 +224,9 @@ TYPE = "pgvector"
 # Migration flag: set to true when migration from pgvector is complete
 MIGRATED = false
 NAMESPACE = "honcho"
+# Embedding vector dimensions. Must match your embedding model's output dimensions.
+# Default 1536 matches OpenAI text-embedding-3-small. Changing this requires a fresh
+# database or manual column alteration + re-indexing.
 DIMENSIONS = 1536
 # TURBOPUFFER_API_KEY = "your-turbopuffer-api-key"
 # TURBOPUFFER_REGION = "us-east-1"

--- a/migrations/versions/a3f7b8c9d0e1_make_embedding_dimensions_configurable.py
+++ b/migrations/versions/a3f7b8c9d0e1_make_embedding_dimensions_configurable.py
@@ -1,0 +1,38 @@
+"""make embedding dimensions configurable
+
+This is a no-op migration that documents the change from hardcoded 1536-dimension
+vectors to configurable dimensions via VECTOR_STORE_DIMENSIONS setting.
+
+Existing deployments using the default 1536 dimensions are unaffected.
+Changing VECTOR_STORE_DIMENSIONS to a different value requires either:
+  - A fresh database, or
+  - Manually altering the embedding columns and re-indexing all embeddings.
+
+The Vector column type in SQLAlchemy models now reads from settings.VECTOR_STORE.DIMENSIONS
+at class definition time. This migration exists to mark the schema's logical dependency
+on that configuration value.
+
+Revision ID: a3f7b8c9d0e1
+Revises: 119a52b73c60
+Create Date: 2025-12-01 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "a3f7b8c9d0e1"
+down_revision: str | None = "119a52b73c60"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # No-op: embedding dimensions are now read from VECTOR_STORE_DIMENSIONS setting.
+    # The default (1536) matches the previous hardcoded value.
+    pass
+
+
+def downgrade() -> None:
+    # No-op: reverting to hardcoded 1536 is handled by reverting the code change.
+    pass

--- a/src/config.py
+++ b/src/config.py
@@ -215,6 +215,11 @@ class LLMSettings(HonchoSettings):
 
     EMBEDDING_PROVIDER: Literal["openai", "gemini", "openrouter"] = "openai"
 
+    # Override the default embedding model name for the chosen provider.
+    # When None, provider defaults are used (text-embedding-3-small for OpenAI,
+    # openai/text-embedding-3-small for OpenRouter, gemini-embedding-001 for Gemini).
+    EMBEDDING_MODEL: str | None = None
+
     # General LLM settings
     DEFAULT_MAX_TOKENS: Annotated[int, Field(default=1000, gt=0, le=100_000)] = 2500
 

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -35,7 +35,7 @@ class _EmbeddingClient:
             if not api_key:
                 raise ValueError("Gemini API key is required")
             self.client: genai.Client | AsyncOpenAI = genai.Client(api_key=api_key)
-            self.model: str = "gemini-embedding-001"
+            self.model: str = settings.LLM.EMBEDDING_MODEL or "gemini-embedding-001"
             # Gemini has a 2048 token limit
             self.max_embedding_tokens: int = min(settings.MAX_EMBEDDING_TOKENS, 2048)
             # Gemini batch size is not documented, using conservative estimate
@@ -52,7 +52,7 @@ class _EmbeddingClient:
                 or "https://openrouter.ai/api/v1"
             )
             self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-            self.model = "openai/text-embedding-3-small"
+            self.model = settings.LLM.EMBEDDING_MODEL or "openai/text-embedding-3-small"
             self.max_embedding_tokens = settings.MAX_EMBEDDING_TOKENS
             self.max_batch_size = 2048  # Same as OpenAI
         else:  # openai
@@ -61,7 +61,7 @@ class _EmbeddingClient:
             if not api_key:
                 raise ValueError("OpenAI API key is required")
             self.client = AsyncOpenAI(api_key=api_key)
-            self.model = "text-embedding-3-small"
+            self.model = settings.LLM.EMBEDDING_MODEL or "text-embedding-3-small"
             self.max_embedding_tokens = settings.MAX_EMBEDDING_TOKENS
             self.max_batch_size = 2048  # OpenAI batch limit
 
@@ -82,7 +82,7 @@ class _EmbeddingClient:
             response = await self.client.aio.models.embed_content(
                 model=self.model,
                 contents=query,
-                config={"output_dimensionality": 1536},
+                config={"output_dimensionality": settings.VECTOR_STORE.DIMENSIONS},
             )
             if not response.embeddings or not response.embeddings[0].values:
                 raise ValueError("No embedding returned from Gemini API")
@@ -116,7 +116,7 @@ class _EmbeddingClient:
                     response = await self.client.aio.models.embed_content(
                         model=self.model,
                         contents=batch,  # pyright: ignore[reportArgumentType]
-                        config={"output_dimensionality": 1536},
+                        config={"output_dimensionality": settings.VECTOR_STORE.DIMENSIONS},
                     )
                     if response.embeddings:
                         for emb in response.embeddings:
@@ -252,7 +252,7 @@ class _EmbeddingClient:
                     response = await self.client.aio.models.embed_content(
                         model=self.model,
                         contents=[item.text for item in batch],
-                        config={"output_dimensionality": 1536},
+                        config={"output_dimensionality": settings.VECTOR_STORE.DIMENSIONS},
                     )
                     if response.embeddings:
                         for item, embedding in zip(

--- a/src/models.py
+++ b/src/models.py
@@ -27,6 +27,7 @@ from typing_extensions import override
 
 from src.utils.types import DocumentLevel, TaskType, VectorSyncState
 
+from .config import settings
 from .db import Base
 
 load_dotenv(override=True)
@@ -278,7 +279,7 @@ class MessageEmbedding(Base):
         BigInteger, Identity(), primary_key=True, autoincrement=True
     )
     content: Mapped[str] = mapped_column(TEXT)
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(settings.VECTOR_STORE.DIMENSIONS), nullable=True)
     message_id: Mapped[str] = mapped_column(
         ForeignKey("messages.public_id", ondelete="CASCADE"), nullable=False, index=True
     )
@@ -386,7 +387,7 @@ class Document(Base):
     times_derived: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("1")
     )
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(settings.VECTOR_STORE.DIMENSIONS), nullable=True)
     source_ids: Mapped[list[str] | None] = mapped_column(
         JSONB, nullable=True, server_default=text("NULL")
     )


### PR DESCRIPTION
## Summary

- **`VECTOR_STORE_DIMENSIONS`** (existing setting, default 1536) is now used by the SQLAlchemy `Vector()` column definitions in `MessageEmbedding` and `Document` models, instead of being hardcoded to 1536
- **`LLM_EMBEDDING_MODEL`** (new setting, default `None`) allows overriding the embedding model name per provider — enables using Ollama, local models, or any OpenAI-compatible endpoint with the `openrouter` provider
- Gemini `output_dimensionality` now reads from `VECTOR_STORE_DIMENSIONS` instead of hardcoded 1536
- No-op migration documents the schema's dependency on the dimension config
- Existing deployments using default 1536 dimensions are completely unaffected

## Motivation

When self-hosting Honcho with local embedding models (e.g., `nomic-embed-text` via Ollama at 768 dims, or `mxbai-embed-large` at 1024 dims), the hardcoded 1536-dimension vectors and `openai/text-embedding-3-small` model name prevent using alternative providers. The `VECTOR_STORE.DIMENSIONS` setting already existed in config but wasn't wired through to the actual column definitions or Gemini API calls.

## Changes

| File | Change |
|---|---|
| `src/models.py` | `Vector(1536)` → `Vector(settings.VECTOR_STORE.DIMENSIONS)` (2 places) |
| `src/embedding_client.py` | 3× hardcoded model names → `settings.LLM.EMBEDDING_MODEL or <default>`; 3× `1536` → `settings.VECTOR_STORE.DIMENSIONS` |
| `src/config.py` | Added `EMBEDDING_MODEL: str \| None = None` to `LLMSettings` |
| `config.toml.example` | Documented both settings with usage notes |
| `migrations/versions/...` | No-op migration documenting the change |

## Example usage with Ollama

```toml
[llm]
EMBEDDING_PROVIDER = "openrouter"
EMBEDDING_MODEL = "nomic-embed-text"
OPENAI_COMPATIBLE_BASE_URL = "http://localhost:11434/v1"

[vector_store]
DIMENSIONS = 768
```

## Test plan

- [ ] Verify default behavior unchanged (1536 dims, standard model names)
- [ ] Verify `LLM_EMBEDDING_MODEL` env var override works
- [ ] Verify `VECTOR_STORE_DIMENSIONS` env var override works
- [ ] Verify Ollama embedding endpoint works with openrouter provider + custom model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedding model selection is now configurable with provider-specific defaults available as overrides.
  * Embedding vector dimensions are now configurable through settings (default: 1536), enabling compatibility with various embedding models and their different output dimensions.

* **Database**
  * Added migration to support configurable embedding dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->