### PR TITLE
fix: stabilize self-hosted Docker restarts for api/deriver

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    entrypoint: ["sh", "docker/entrypoint.sh"]
+    entrypoint: ["sh", "-lc", "/app/.venv/bin/python scripts/provision_db.py && exec /app/.venv/bin/fastapi run --host 0.0.0.0 src/main.py"]
     depends_on:
       database:
         condition: service_healthy
@@ -12,9 +12,6 @@ services:
         condition: service_healthy
     ports:
       - 8000:8000
-    volumes:
-      - .:/app
-      - venv:/app/.venv
     environment:
       - DB_CONNECTION_URI=postgresql+psycopg://postgres:postgres@database:5432/postgres
       - CACHE_URL=redis://redis:6379/0?suppress=true
@@ -26,14 +23,17 @@ services:
       context: .
       dockerfile: Dockerfile
     entrypoint: ["/app/.venv/bin/python", "-m", "src.deriver"]
+    healthcheck:
+      test: ["CMD-SHELL", "python -c 'import src.deriver' || exit 1"]
+      interval: 30s
+      timeout: 10s
+      start_period: 5s
+      retries: 3
     depends_on:
       database:
         condition: service_healthy
       redis:
         condition: service_healthy
-    volumes:
-      - .:/app
-      - venv:/app/.venv
     environment:
       - DB_CONNECTION_URI=postgresql+psycopg://postgres:postgres@database:5432/postgres
       - CACHE_URL=redis://redis:6379/0?suppress=true
@@ -100,5 +100,4 @@ services:
         condition: service_started
 volumes:
   pgdata:
-  venv:
   prometheus-data:


### PR DESCRIPTION
## Summary
- remove the development bind mounts (`.:/app` and `venv:/app/.venv`) from the Docker compose example for `api` and `deriver`
- replace the API entrypoint with an image-local command that runs DB migrations and then starts FastAPI
- add a deriver-specific healthcheck instead of probing `/openapi.json`

## Why
The previous compose example could fail after `docker compose restart api deriver` with errors like:

- `ModuleNotFoundError: No module named 'sqlalchemy'`
- deriver reporting unhealthy because it inherited an API-style web healthcheck

The root cause was the dev-oriented runtime mount structure overlaying `/app` and `/app/.venv`, which made dependency resolution unstable across restarts.

## Verification
I verified all of the following locally:
- `docker compose up -d --build api deriver`
- `docker compose restart api deriver`
- `api` becomes healthy and `http://localhost:8000/openapi.json` responds
- `deriver` becomes healthy with the new healthcheck
- `hermes honcho status` connects successfully after restart


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration to automatically provision the database on API startup.
  * Optimized Docker setup by streamlining volume and mount configurations.
  * Added health monitoring to the deriver service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->