### PR TITLE
fix: make reasoning effort configurable

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -251,6 +251,7 @@ class DeriverSettings(BackupLLMSettingsMixin, HonchoSettings):
     PROVIDER: SupportedProviders = "google"
     MODEL: str = "gemini-2.5-flash-lite"
     TEMPERATURE: float | None = None
+    REASONING_EFFORT: Literal["minimal", "none", "low", "medium", "high", "xhigh"] | None = None
 
     # Whether to deduplicate documents when creating them
     DEDUPLICATE: bool = True
@@ -325,6 +326,10 @@ class DialecticLevelSettings(BaseModel):
     TOOL_CHOICE: Annotated[str | None, Field(validation_alias="tool_choice")] = (
         None  # None/auto lets model decide, "any"/"required" forces tool use
     )
+    REASONING_EFFORT: Annotated[
+        Literal["minimal", "none", "low", "medium", "high", "xhigh"] | None,
+        Field(validation_alias="reasoning_effort"),
+    ] = None
 
     @model_validator(mode="after")
     def _validate_backup_configuration(self) -> "DialecticLevelSettings":

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -134,7 +134,7 @@ async def process_representation_tasks_batch(
         stop_seqs=["   \n", "\n\n\n\n"],
         thinking_budget_tokens=settings.DERIVER.THINKING_BUDGET_TOKENS,
         max_input_tokens=settings.DERIVER.MAX_INPUT_TOKENS,
-        reasoning_effort="minimal",
+        reasoning_effort=settings.DERIVER.REASONING_EFFORT or "minimal",
         enable_retry=True,
         retry_attempts=3,
         trace_name="minimal_deriver",

--- a/src/dialectic/core.py
+++ b/src/dialectic/core.py
@@ -415,6 +415,7 @@ class DialecticAgent:
             messages=self.messages,
             track_name="Dialectic Agent",
             thinking_budget_tokens=level_settings.THINKING_BUDGET_TOKENS,
+            reasoning_effort=level_settings.REASONING_EFFORT,
             max_input_tokens=settings.DIALECTIC.MAX_INPUT_TOKENS,
             trace_name="dialectic_chat",
         )
@@ -483,6 +484,7 @@ class DialecticAgent:
                 messages=self.messages,
                 track_name="Dialectic Agent Stream",
                 thinking_budget_tokens=level_settings.THINKING_BUDGET_TOKENS,
+                reasoning_effort=level_settings.REASONING_EFFORT,
                 max_input_tokens=settings.DIALECTIC.MAX_INPUT_TOKENS,
                 trace_name="dialectic_chat",
             ),

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -68,7 +68,7 @@ IterationCallback = Callable[[IterationData], None]
 T = TypeVar("T")
 
 # Type aliases for OpenAI GPT-5 specific parameters
-ReasoningEffortType = Literal["low", "medium", "high", "minimal"] | None
+ReasoningEffortType = Literal["minimal", "none", "low", "medium", "high", "xhigh"] | None
 VerbosityType = Literal["low", "medium", "high"] | None
 
 
@@ -1198,7 +1198,7 @@ async def honcho_llm_call(
     json_mode: bool = False,
     temperature: float | None = None,
     stop_seqs: list[str] | None = None,
-    reasoning_effort: Literal["low", "medium", "high", "minimal"]
+    reasoning_effort: Literal["minimal", "none", "low", "medium", "high", "xhigh"]
     | None = None,  # OpenAI only
     verbosity: Literal["low", "medium", "high"] | None = None,  # OpenAI only
     thinking_budget_tokens: int | None = None,
@@ -1227,7 +1227,7 @@ async def honcho_llm_call(
     json_mode: bool = False,
     temperature: float | None = None,
     stop_seqs: list[str] | None = None,
-    reasoning_effort: Literal["low", "medium", "high", "minimal"]
+    reasoning_effort: Literal["minimal", "none", "low", "medium", "high", "xhigh"]
     | None = None,  # OpenAI only
     verbosity: Literal["low", "medium", "high"] | None = None,  # OpenAI only
     thinking_budget_tokens: int | None = None,
@@ -1256,7 +1256,7 @@ async def honcho_llm_call(
     json_mode: bool = False,
     temperature: float | None = None,
     stop_seqs: list[str] | None = None,
-    reasoning_effort: Literal["low", "medium", "high", "minimal"]
+    reasoning_effort: Literal["minimal", "none", "low", "medium", "high", "xhigh"]
     | None = None,  # OpenAI only
     verbosity: Literal["low", "medium", "high"] | None = None,  # OpenAI only
     thinking_budget_tokens: int | None = None,
@@ -1285,7 +1285,7 @@ async def honcho_llm_call(
     json_mode: bool = False,
     temperature: float | None = None,
     stop_seqs: list[str] | None = None,
-    reasoning_effort: Literal["low", "medium", "high", "minimal"]
+    reasoning_effort: Literal["minimal", "none", "low", "medium", "high", "xhigh"]
     | None = None,  # OpenAI only
     verbosity: Literal["low", "medium", "high"] | None = None,  # OpenAI only
     thinking_budget_tokens: int | None = None,
@@ -1575,7 +1575,7 @@ async def honcho_llm_call_inner(
     json_mode: bool = False,
     temperature: float | None = None,
     stop_seqs: list[str] | None = None,
-    reasoning_effort: Literal["low", "medium", "high", "minimal"]
+    reasoning_effort: Literal["minimal", "none", "low", "medium", "high", "xhigh"]
     | None = None,  # OpenAI only
     verbosity: Literal["low", "medium", "high"] | None = None,  # OpenAI only
     thinking_budget_tokens: int | None = None,  # Anthropic only
@@ -1596,7 +1596,7 @@ async def honcho_llm_call_inner(
     json_mode: bool = False,
     temperature: float | None = None,
     stop_seqs: list[str] | None = None,
-    reasoning_effort: Literal["low", "medium", "high", "minimal"]
+    reasoning_effort: Literal["minimal", "none", "low", "medium", "high", "xhigh"]
     | None = None,  # OpenAI only
     verbosity: Literal["low", "medium", "high"] | None = None,  # OpenAI only
     thinking_budget_tokens: int | None = None,  # Anthropic only
@@ -1617,7 +1617,7 @@ async def honcho_llm_call_inner(
     json_mode: bool = False,
     temperature: float | None = None,
     stop_seqs: list[str] | None = None,
-    reasoning_effort: Literal["low", "medium", "high", "minimal"]
+    reasoning_effort: Literal["minimal", "none", "low", "medium", "high", "xhigh"]
     | None = None,  # OpenAI only
     verbosity: Literal["low", "medium", "high"] | None = None,  # OpenAI only
     thinking_budget_tokens: int | None = None,  # Anthropic only
@@ -1637,7 +1637,7 @@ async def honcho_llm_call_inner(
     json_mode: bool = False,
     temperature: float | None = None,
     stop_seqs: list[str] | None = None,
-    reasoning_effort: Literal["low", "medium", "high", "minimal"]
+    reasoning_effort: Literal["minimal", "none", "low", "medium", "high", "xhigh"]
     | None = None,  # OpenAI only
     verbosity: Literal["low", "medium", "high"] | None = None,  # OpenAI only
     thinking_budget_tokens: int | None = None,  # Anthropic only
@@ -2351,7 +2351,7 @@ async def handle_streaming_response(
     json_mode: bool,
     thinking_budget_tokens: int | None,
     response_model: type[BaseModel] | None = None,
-    reasoning_effort: Literal["low", "medium", "high", "minimal"] | None = None,
+    reasoning_effort: Literal["minimal", "none", "low", "medium", "high", "xhigh"] | None = None,
     verbosity: Literal["low", "medium", "high"] | None = None,
 ) -> AsyncIterator[HonchoLLMCallStreamChunk]:
     """


### PR DESCRIPTION
## Summary
- Add configurable `REASONING_EFFORT` to deriver settings and dialectic level settings
- Pass configured `reasoning_effort` through deriver and dialectic LLM calls
- Expand OpenAI reasoning effort literals for newer GPT-5 models (`minimal`, `none`, `low`, `medium`, `high`, `xhigh`)

## Why
OpenAI reasoning-effort support has diverged across newer GPT-5-family models. Honcho currently hardcodes a narrower set of values, making local/provider-specific configuration harder than necessary.

This change keeps existing defaults intact while making reasoning effort configurable where it is actually used.

## Files changed
- `src/config.py` — new `REASONING_EFFORT` field in settings
- `src/deriver/deriver.py` — pass configured value to LLM call
- `src/dialectic/core.py` — pass configured value to LLM call
- `src/utils/clients.py` — expanded OpenAI reasoning effort literal types

## Validation
- `python -m py_compile` passes on all 4 files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable reasoning effort settings to control LLM processing behavior.
  * Expanded supported reasoning effort levels to include additional options for finer-grained control over model reasoning intensity.
  * System now respects configured reasoning effort preferences instead of using fixed defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->