### PR TITLE
Security: Unauthenticated Prometheus metrics server may expose sensitive operational data

### DIFF
--- a/src/deriver/__main__.py
+++ b/src/deriver/__main__.py
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 def start_metrics_server() -> None:
-    """Start the Prometheus metrics HTTP server on port 9090."""
-    start_http_server(9090)
-    logger.info("Prometheus metrics server started on port 9090")
+    """Start the Prometheus metrics HTTP server on localhost port 9090."""
+    start_http_server(9090, addr="127.0.0.1")
+    logger.info("Prometheus metrics server started on 127.0.0.1:9090")
 
 
 def setup_logging():


### PR DESCRIPTION
## Problem

`start_http_server(9090)` starts a metrics endpoint without authentication/TLS controls in this process. In common deployments this can bind broadly and leak internal telemetry, queue state, and performance characteristics useful for reconnaissance.

**Severity**: `medium`
**File**: `src/deriver/__main__.py`

## Solution

Bind metrics to localhost/private network only, place behind authenticated reverse proxy, and disable in untrusted environments by default.

## Changes

- `src/deriver/__main__.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prometheus metrics server now binds to the loopback interface to restrict local access.
  * Startup log message updated to display the complete metrics server address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->