### PR TITLE
fix: use configured VECTOR_STORE.DIMENSIONS instead of hardcoded 1536

### DIFF
--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -82,7 +82,7 @@ class _EmbeddingClient:
             response = await self.client.aio.models.embed_content(
                 model=self.model,
                 contents=query,
-                config={"output_dimensionality": 1536},
+                config={"output_dimensionality": settings.VECTOR_STORE.DIMENSIONS},
             )
             if not response.embeddings or not response.embeddings[0].values:
                 raise ValueError("No embedding returned from Gemini API")
@@ -116,7 +116,7 @@ class _EmbeddingClient:
                     response = await self.client.aio.models.embed_content(
                         model=self.model,
                         contents=batch,  # pyright: ignore[reportArgumentType]
-                        config={"output_dimensionality": 1536},
+                        config={"output_dimensionality": settings.VECTOR_STORE.DIMENSIONS},
                     )
                     if response.embeddings:
                         for emb in response.embeddings:
@@ -252,7 +252,7 @@ class _EmbeddingClient:
                     response = await self.client.aio.models.embed_content(
                         model=self.model,
                         contents=[item.text for item in batch],
-                        config={"output_dimensionality": 1536},
+                        config={"output_dimensionality": settings.VECTOR_STORE.DIMENSIONS},
                     )
                     if response.embeddings:
                         for item, embedding in zip(

--- a/src/models.py
+++ b/src/models.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import Mapped, MappedColumn, mapped_column, relationship
 from sqlalchemy.sql import func
 from typing_extensions import override
 
+from src.config import settings
 from src.utils.types import DocumentLevel, TaskType, VectorSyncState
 
 from .db import Base
@@ -278,7 +279,7 @@ class MessageEmbedding(Base):
         BigInteger, Identity(), primary_key=True, autoincrement=True
     )
     content: Mapped[str] = mapped_column(TEXT)
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(settings.VECTOR_STORE.DIMENSIONS), nullable=True)
     message_id: Mapped[str] = mapped_column(
         ForeignKey("messages.public_id", ondelete="CASCADE"), nullable=False, index=True
     )
@@ -386,7 +387,7 @@ class Document(Base):
     times_derived: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("1")
     )
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(settings.VECTOR_STORE.DIMENSIONS), nullable=True)
     source_ids: Mapped[list[str] | None] = mapped_column(
         JSONB, nullable=True, server_default=text("NULL")
     )


### PR DESCRIPTION
## Summary

- Replace hardcoded `Vector(1536)` in SQLAlchemy models (`Document`, `MessageEmbedding`) with `Vector(settings.VECTOR_STORE.DIMENSIONS)` so the dimension reads from config
- Replace hardcoded `"output_dimensionality": 1536` in Gemini embedding calls with the same config value
- This allows using embedding models with non-1536 dimensions (e.g. 768-dim nomic-embed-text) without patching source

## Context

When self-hosting Honcho with a local embedding model (e.g. nomic-embed-text-v1.5 via llama.cpp, which outputs 768 dimensions), the `VECTOR_STORE.DIMENSIONS` config setting is ignored because `src/models.py` hardcodes `Vector(1536)`. This causes pgvector to reject embeddings at query time with `ValueError: expected 1536 dimensions, not 768`.

The config setting already exists and defaults to 1536, so this is a no-op for existing deployments.

## Test plan

- [ ] Verify existing deployments with 1536-dim embeddings are unaffected (default config)
- [ ] Verify self-hosted setup with `VECTOR_STORE.DIMENSIONS = 768` works without source patching
- [ ] Verify no circular import issues (`src.config` imported in `src.models`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Embedding vector dimensions are now configurable through application settings instead of hardcoded values, providing greater flexibility for vector store configurations and system customization.
  * Updated database models and embedding services to consistently use configurable dimensions for improved system adaptability and configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->