### PR TITLE
fix: make observer/observed optional in conclusions query endpoint

### DIFF
--- a/src/crud/document.py
+++ b/src/crud/document.py
@@ -278,20 +278,23 @@ async def fetch_documents_by_ids(
 async def _query_documents_pgvector(
     db: AsyncSession,
     workspace_name: str,
-    observer: str,
-    observed: str,
+    observer: str | None,
+    observed: str | None,
     embedding: list[float],
     filters: dict[str, Any] | None,
     max_distance: float | None,
     top_k: int,
 ) -> list[models.Document]:
     """pgvector similarity search — pure DB operation."""
+    stmt = select(models.Document).where(
+        models.Document.workspace_name == workspace_name
+    )
+    if observer is not None:
+        stmt = stmt.where(models.Document.observer == observer)
+    if observed is not None:
+        stmt = stmt.where(models.Document.observed == observed)
     stmt = (
-        select(models.Document)
-        .where(models.Document.workspace_name == workspace_name)
-        .where(models.Document.observer == observer)
-        .where(models.Document.observed == observed)
-        .where(models.Document.embedding.isnot(None))
+        stmt.where(models.Document.embedding.isnot(None))
         .where(models.Document.deleted_at.is_(None))
     )
 
@@ -314,8 +317,8 @@ async def query_documents(
     workspace_name: str,
     query: str,
     *,
-    observer: str,
-    observed: str,
+    observer: str | None = None,
+    observed: str | None = None,
     filters: dict[str, Any] | None = None,
     max_distance: float | None = None,
     top_k: int = 5,
@@ -332,8 +335,8 @@ async def query_documents(
         db: Database session, or None to let the function manage its own
         workspace_name: Name of the workspace
         query: Search query text
-        observer: Name of the observing peer
-        observed: Name of the observed peer
+        observer: Name of the observing peer. If None, results are not filtered by observer.
+        observed: Name of the observed peer. If None, results are not filtered by observed.
         filters: Optional filters to apply at vector store level (supports: level, session_name)
         max_distance: Maximum cosine distance for results
         top_k: Number of results to return

--- a/src/routers/conclusions.py
+++ b/src/routers/conclusions.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, schemas
 from src.dependencies import db
-from src.exceptions import ResourceNotFoundException, ValidationException
+from src.exceptions import ResourceNotFoundException
 from src.security import require_auth
 
 logger = logging.getLogger(__name__)
@@ -99,17 +99,16 @@ async def query_conclusions(
 ) -> list[schemas.Conclusion]:
     """
     Query Conclusions using semantic search. Use `top_k` to control the number of results returned.
+
+    If ``observer`` or ``observed`` is not provided in filters, results will not be
+    filtered by that field. Omitting both is allowed but will return conclusions across
+    all peer relationships in the workspace.
     """
     observer = None
     observed = None
     if body.filters:
         observer = body.filters.get("observer") or body.filters.get("observer_id")
         observed = body.filters.get("observed") or body.filters.get("observed_id")
-
-    if not observer or not observed:
-        raise ValidationException(
-            "observer and observed must be specified for semantic search"
-        )
 
     documents = await crud.query_documents(
         db,


### PR DESCRIPTION
## Summary

Previously, the conclusions query endpoint required both observer and observed to be specified, raising ValidationException if either was missing.

## Changes

- query_documents: observer/observed now optional (default None)  
- _query_documents_pgvector: conditionally applies WHERE clause only when param is not None
- query_conclusions router: removed ValidationException guard

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| Without filters | ValidationException | Returns results |
| SDK path | Works | Works (unchanged) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document and conclusion semantic search now supports optional peer filtering—users can omit `observer` and/or `observed` parameters to query across all peer relationships in the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->