### PR TITLE
docs(skills): add local development Claude Code skill

### DIFF
--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -18,13 +18,9 @@ This skill guides you through setting up and running Honcho locally for developm
 
 ### Prerequisites
 
-- [uv](https://docs.astral.sh/uv/) — Python package manager (handles Python version automatically)
-  ```bash
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-  # or: brew install uv
-  ```
-- **Git**
-- **Docker** with Compose v2 (for Docker setup) — use `docker compose`, not `docker-compose`
+- Python 3.10 or higher
+- [uv](https://docs.astral.sh/uv/) 0.5.0 or higher
+- Docker with Compose v2 (recommended for the database) — use `docker compose` not `docker-compose`
 
 ### Install Dependencies
 
@@ -34,13 +30,17 @@ cd honcho
 uv sync
 ```
 
-Activate the virtual environment (optional — `uv run` handles this automatically):
+Activate the virtual environment:
 
 ```bash
-source .venv/bin/activate        # Unix/macOS
-# .venv\Scripts\activate         # Windows CMD
-# .venv\Scripts\activate.ps1     # Windows PowerShell
+# Unix/macOS
+source .venv/bin/activate
+
+# Windows (Command Prompt): .venv\Scripts\activate
+# Windows (PowerShell):     .venv\Scripts\activate.ps1
 ```
+
+> **Note:** All commands in this guide use `uv run`, which automatically uses the virtual environment — explicit activation is optional.
 
 ### Configure Environment Variables
 
@@ -48,246 +48,280 @@ source .venv/bin/activate        # Unix/macOS
 cp .env.template .env
 ```
 
-#### LLM Setup (required — server will not start without this)
+Open `.env` and set the required values:
 
-Honcho uses LLMs for memory extraction, summarization, dialectic chat, and dreaming. Any OpenAI-compatible endpoint works — OpenRouter, Together, Fireworks, Ollama, vLLM, or a direct vendor API. Models must support tool calling.
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DB_CONNECTION_URI` | Yes | PostgreSQL connection string — must use `postgresql+psycopg` prefix |
+| `LLM_OPENAI_COMPATIBLE_BASE_URL` | Yes (default) | Base URL for an OpenAI-compatible endpoint (OpenRouter, Together, Fireworks, local vLLM, etc.) |
+| `LLM_OPENAI_COMPATIBLE_API_KEY` | Yes (default) | API key for the OpenAI-compatible endpoint above |
+| `LLM_ANTHROPIC_API_KEY` | Alternative | Direct Anthropic key — set `DERIVER_PROVIDER=anthropic` etc. to use |
+| `LLM_OPENAI_API_KEY` | Alternative | Direct OpenAI key — set `DERIVER_PROVIDER=openai` etc. to use |
+| `LLM_GEMINI_API_KEY` | Alternative | Direct Gemini key — set `DERIVER_PROVIDER=google` etc. to use |
+| `LLM_GROQ_API_KEY` | Alternative | Direct Groq key — set `DERIVER_PROVIDER=groq` etc. to use |
+| `DERIVER_PROVIDER` | No | LLM provider for the deriver — valid values: `custom`, `anthropic`, `openai`, `google`, `groq` |
+| `DERIVER_MODEL` | No | Model name for the deriver (e.g. `gpt-4o`, `claude-3-5-sonnet-20241022`) |
+| `SUMMARY_PROVIDER` | No | LLM provider for summarization — same valid values as `DERIVER_PROVIDER` |
+| `LLM_EMBEDDING_PROVIDER` | No | Provider for embeddings — defaults to `custom` (OpenAI-compatible); valid values: `custom`, `anthropic`, `openai`, `google`, `groq` |
+| `THINKING_BUDGET_TOKENS` | No | Token budget for extended thinking (Anthropic models only) |
+| `AUTH_USE_AUTH` | No | Defaults to `false`. If set to `true`, every request requires a valid auth token and `AUTH_JWT_SECRET` must also be set |
+| `AUTH_JWT_SECRET` | Conditional | Required when `AUTH_USE_AUTH=true` — JWT signing secret for auth tokens |
+| `SENTRY_ENABLED` | No | Set to `false` for local development |
 
-**Quick start (recommended):**
+> **Important:** Honcho defaults to an OpenAI-compatible endpoint. Set `LLM_OPENAI_COMPATIBLE_BASE_URL` and `LLM_OPENAI_COMPATIBLE_API_KEY` to use OpenRouter, Together, Fireworks, or any compatible provider. To use a direct vendor key instead, set the matching `LLM_*_API_KEY` and point `DERIVER_PROVIDER` (and other role providers) at it.
 
-1. Get a key from [openrouter.ai](https://openrouter.ai) (or any OpenAI-compatible provider)
-2. Edit your `.env`:
+Minimal local development `.env` (OpenAI-compatible example):
 
-```bash
+```env
+DB_CONNECTION_URI=postgresql+psycopg://postgres:postgres@localhost:5432/postgres
 LLM_OPENAI_COMPATIBLE_BASE_URL=https://openrouter.ai/api/v1
-LLM_OPENAI_COMPATIBLE_API_KEY=your-api-key-here
-LLM_EMBEDDING_PROVIDER=openrouter
-
-DERIVER_PROVIDER=custom
-DERIVER_MODEL=google/gemini-2.5-flash
-
-SUMMARY_PROVIDER=custom
-SUMMARY_MODEL=google/gemini-2.5-flash
-
-DREAM_PROVIDER=custom
-DREAM_MODEL=google/gemini-2.5-flash
-DREAM_DEDUCTION_MODEL=google/gemini-2.5-flash
-DREAM_INDUCTION_MODEL=google/gemini-2.5-flash
-
-DIALECTIC_LEVELS__minimal__PROVIDER=custom
-DIALECTIC_LEVELS__minimal__MODEL=google/gemini-2.5-flash
-DIALECTIC_LEVELS__low__PROVIDER=custom
-DIALECTIC_LEVELS__low__MODEL=google/gemini-2.5-flash
-DIALECTIC_LEVELS__medium__PROVIDER=custom
-DIALECTIC_LEVELS__medium__MODEL=google/gemini-2.5-flash
-DIALECTIC_LEVELS__high__PROVIDER=custom
-DIALECTIC_LEVELS__high__MODEL=google/gemini-2.5-flash
-DIALECTIC_LEVELS__max__PROVIDER=custom
-DIALECTIC_LEVELS__max__MODEL=google/gemini-2.5-flash
+LLM_OPENAI_COMPATIBLE_API_KEY=your-key-here
+SENTRY_ENABLED=false
 ```
 
-> **Tip:** Use find-and-replace to swap all `your-model-here` with your chosen model in one step.
+> **Docker full-stack note:** If you run `docker compose up` (full stack), replace `localhost` with `database` in `DB_CONNECTION_URI` — containers resolve the database by service name, not localhost.
 
-**Alternative — direct vendor keys:**
+### Set Up the Database
+
+Using Docker (recommended):
+
 ```bash
-# Uncomment only the key you want to use
-# LLM_GEMINI_API_KEY=your-key
-# LLM_ANTHROPIC_API_KEY=your-key
-# LLM_OPENAI_API_KEY=your-key
-# LLM_GROQ_API_KEY=your-key
+cp docker-compose.yml.example docker-compose.yml
+docker compose up -d database
 ```
-Then set `DERIVER_PROVIDER=google` (or `anthropic`, `openai`, `groq`) and use the corresponding model name format.
 
-#### Key environment variables reference
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DB_CONNECTION_URI` | `postgresql+psycopg://postgres:postgres@localhost:5432/postgres` | Must use `postgresql+psycopg` prefix |
-| `LLM_OPENAI_COMPATIBLE_BASE_URL` | — | Base URL for OpenAI-compatible endpoint |
-| `LLM_OPENAI_COMPATIBLE_API_KEY` | — | API key for your endpoint |
-| `LLM_EMBEDDING_PROVIDER` | `openrouter` | Routes embeddings through your custom endpoint |
-| `DERIVER_PROVIDER` | `custom` | LLM provider for the background worker |
-| `DERIVER_MODEL` | — | Model name for the deriver |
-| `AUTH_USE_AUTH` | `false` | Set to `true` in production; requires `AUTH_JWT_SECRET` |
+Or use [Supabase](https://supabase.com) as an alternative — set `DB_CONNECTION_URI` to your Supabase connection string.
 
 ---
 
 ## Phase 2: Running Honcho
 
-### Option A: Docker (Recommended)
+### Run Database Migrations
 
-Docker Compose handles the database, Redis cache, API server, and deriver worker.
+Always run migrations before starting the server for the first time or after pulling new changes:
 
-```bash
-cp docker-compose.yml.example docker-compose.yml
-docker compose up -d --build
-```
-
-The first build takes a few minutes. This starts four services:
-- **api** — HTTP server on `localhost:8000`
-- **deriver** — background worker (no HTTP port)
-- **database** — PostgreSQL with pgvector on `localhost:5432`
-- **redis** — cache on `localhost:6379`
-
-Migrations run automatically on startup.
-
-Verify everything is running:
-```bash
-docker compose ps
-curl http://localhost:8000/health
-# {"status":"ok"}
-```
-
-### Option B: Manual Setup
-
-**1. Start PostgreSQL and Redis:**
-```bash
-docker run --name honcho-db \
-  -e POSTGRES_USER=postgres \
-  -e POSTGRES_PASSWORD=postgres \
-  -p 5432:5432 \
-  -d pgvector/pgvector:pg15
-
-docker run --name honcho-redis \
-  -p 6379:6379 \
-  -d redis:alpine
-```
-
-Or use [Supabase](https://supabase.com) (free, enable pgvector in SQL editor: `CREATE EXTENSION IF NOT EXISTS vector;`).
-
-**2. Run migrations:**
 ```bash
 uv run alembic upgrade head
 ```
 
-**3. Start the API server:**
+### Start the API Server
+
 ```bash
 uv run fastapi dev src/main.py
 ```
 
-**4. Start the deriver** (separate terminal — required for memory processing):
+The API will be available at `http://localhost:8000`. The interactive docs are at `http://localhost:8000/docs`.
+
+### Start the Deriver (Background Worker)
+
+The deriver processes messages asynchronously and builds user representations. Run it in a **separate terminal**:
+
 ```bash
 uv run python -m src.deriver
 ```
 
----
+> **Note:** Both the API server and the deriver must be running for Honcho's memory and reasoning features to work. The API accepts messages; the deriver processes them in the background.
 
-## Phase 3: Verifying Your Setup
+To verify the deriver is working, send a message via the API and watch the deriver terminal for log output showing it picked up the task. If the deriver log is silent, check that a valid LLM API key is set in `.env`.
+
+### Verify Your Setup
+
+With both the API server and deriver running, confirm everything is working:
 
 ```bash
-# Health check
 curl http://localhost:8000/health
-# {"status":"ok"}
-
-# Smoke test — confirms database + migrations
-curl -s -X POST http://localhost:8000/v3/workspaces \
-  -H "Content-Type: application/json" \
-  -d '{"name": "test"}' | python3 -m json.tool
-# Should return a workspace object with an id
 ```
 
-Interactive API docs: `http://localhost:8000/docs`
+Expected response: `{"status":"ok"}`. If the interactive docs are also loading at `http://localhost:8000/docs`, the server is fully up. If `/health` returns an error or times out, check the terminal where you ran `uv run fastapi dev src/main.py` for startup errors.
+
+### Run Everything with Docker
+
+If you prefer to run the full stack via Docker:
+
+```bash
+cp .env.template .env
+cp docker-compose.yml.example docker-compose.yml
+docker compose up
+```
+
+> **Note:** The API container automatically runs database migrations on startup via `docker/entrypoint.sh`. You do not need to run `alembic upgrade head` manually when using Docker.
+
+### Clean Up
+
+Stop the API server and deriver with `Ctrl+C` in each terminal.
+
+Stop Docker containers:
+
+```bash
+docker compose down
+```
+
+Deactivate the virtual environment:
+
+```bash
+deactivate
+```
 
 ---
 
-## Phase 4: Development Tasks
+## Phase 3: Development Tasks
 
-### Running Tests
+### Run Tests
 
 ```bash
 uv run pytest
 ```
 
 Run a specific test file:
+
 ```bash
-uv run pytest tests/test_users.py -v
+uv run pytest tests/test_<filename>.py
 ```
 
-### Creating a New Migration
+Run with verbose output:
 
 ```bash
-uv run alembic revision --autogenerate -m "describe your change"
+uv run pytest -v
 ```
 
-Review the generated file in `migrations/versions/` before applying:
+### Create a New Migration
+
+After modifying a SQLAlchemy model in `src/`:
+
 ```bash
+uv run alembic revision --autogenerate -m "description of your change"
 uv run alembic upgrade head
 ```
 
-Check current migration status:
-```bash
-uv run alembic current
-```
+Review the generated migration file in `migrations/versions/` before applying it.
 
-### Setting Up Pre-commit Hooks
+### Set Up Pre-commit Hooks
 
 ```bash
-uv run pre-commit install
+uv run pre-commit install --hook-type pre-commit --hook-type commit-msg --hook-type pre-push
 ```
 
-Hooks run automatically on `git commit`. To run manually:
+Run hooks manually against all files:
+
 ```bash
 uv run pre-commit run --all-files
 ```
 
+Hooks enforce formatting, linting, type checking, and conventional commit messages.
+
 ### Code Standards
 
-- **Formatter:** Black (`uv run black .`)
-- **Types:** Type hints required on all new functions
-- **Docstrings:** Google style
-- **Commits:** Conventional commits (`feat:`, `fix:`, `docs:`, `chore:`)
+Follow these conventions when contributing:
+
+- Format code: `uv run ruff format .`
+- Lint code: `uv run ruff check .`
+- Type check: `uv run basedpyright` (a strict fork of pyright — stricter than standard mypy)
+- Use type hints on all function signatures
+- Write Google-style docstrings
+- Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `test:`, `refactor:`
 
 ---
 
-## Troubleshooting
+## Phase 4: Troubleshooting
 
-### Server fails to start — "LLM provider not configured"
+### ModuleNotFoundError at startup
 
-The server requires at least one LLM provider. Set `LLM_OPENAI_COMPATIBLE_BASE_URL` and `LLM_OPENAI_COMPATIBLE_API_KEY`, then set `DERIVER_MODEL`, `SUMMARY_MODEL`, `DREAM_MODEL`, and all `DIALECTIC_LEVELS__*__MODEL` values. See [LLM Setup](#llm-setup) above.
+**Symptom:** `ModuleNotFoundError: No module named 'honcho'` or similar import errors
+
+**Fix:**
+
+```bash
+uv sync --reinstall
+```
+
+This reinstalls all dependencies from scratch, which resolves corrupted or incomplete installs.
 
 ### Database connection error
 
-```
-sqlalchemy.exc.OperationalError: connection refused
+**Symptom:** `sqlalchemy.exc.OperationalError` or `could not connect to server`
+
+**Fix:**
+1. Confirm Docker is running: `docker compose up -d database`
+2. Check `DB_CONNECTION_URI` in `.env` — must use `postgresql+psycopg` (not `postgresql+psycopg2`)
+3. Verify the database is healthy: `docker compose ps`
+
+### Missing LLM API key
+
+**Symptom:** `DERIVER_PROVIDER not set` or model-related errors at startup or when the deriver runs
+
+**Fix:**
+Honcho defaults to an OpenAI-compatible endpoint. Add these to `.env`:
+
+```env
+LLM_OPENAI_COMPATIBLE_BASE_URL=https://openrouter.ai/api/v1
+LLM_OPENAI_COMPATIBLE_API_KEY=your-key-here
 ```
 
-- Confirm PostgreSQL is running: `docker compose ps` or `brew services list | grep postgresql`
-- Confirm `DB_CONNECTION_URI` uses the `postgresql+psycopg` prefix (not `postgresql://`)
-- Default DB name is `postgres` (not `honcho`)
+To use a direct vendor key instead, set the matching key and point the role providers at it:
 
-### Migrations not applied
-
+```env
+LLM_ANTHROPIC_API_KEY=your-key-here
+DERIVER_PROVIDER=anthropic
+SUMMARY_PROVIDER=anthropic
 ```
-sqlalchemy.exc.ProgrammingError: relation "..." does not exist
-```
-
-Run: `uv run alembic upgrade head`
 
 ### Deriver not processing messages
 
-Check logs:
+**Symptom:** Messages are stored but representations never update; `peer.chat()` returns empty or generic answers
+
+**Fix:**
+1. Confirm the deriver is running in a separate terminal: `uv run python -m src.deriver`
+2. Confirm a valid LLM API key is set — the deriver calls the LLM to build representations
+3. Check deriver logs for errors
+
+### Migration errors
+
+**Symptom:** `alembic.util.exc.CommandError` or `relation does not exist`
+
+**Fix:**
+
 ```bash
-docker compose logs deriver --tail 20
+uv run alembic upgrade head
 ```
 
-- Confirm `DERIVER_PROVIDER` and `DERIVER_MODEL` are set in `.env`
-- Without the deriver, messages are stored but no memory extraction occurs
-- Look for "polling" or "processing" in the logs to confirm it's running
+If you have conflicts or a dirty migration state:
+
+> **Warning:** `alembic downgrade base` drops all tables and deletes all data. Only use this in a local development database.
+
+```bash
+uv run alembic downgrade base
+uv run alembic upgrade head
+```
 
 ### Port already in use
 
+**Symptom:** `ERROR: [Errno 48] Address already in use` (macOS) or `ERROR: [Errno 98] Address already in use` (Linux) on port 8000
+
+**Fix:**
+
+Unix/macOS:
+
 ```bash
-lsof -i :8000   # find what's using port 8000
-kill -9 <PID>
+lsof -ti:8000 | xargs kill -9
 ```
 
-### Docker build fails
+Windows (Command Prompt):
 
-```bash
-docker compose down --volumes
-docker compose up -d --build
+```cmd
+for /f "tokens=5" %a in ('netstat -aon ^| findstr :8000') do taskkill /F /PID %a
 ```
 
-If BuildKit errors occur, ensure Docker Desktop is up to date.
+Windows (PowerShell):
+
+```powershell
+Get-NetTCPConnection -LocalPort 8000 | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
+```
+
+Then restart the server:
+
+```bash
+uv run fastapi dev src/main.py
+```
 
 ---
 
@@ -295,23 +329,20 @@ If BuildKit errors occur, ensure Docker Desktop is up to date.
 
 | Task | Command |
 |------|---------|
-| Start all services (Docker) | `docker compose up -d --build` |
-| Stop all services | `docker compose down` |
-| Start API server (manual) | `uv run fastapi dev src/main.py` |
-| Start deriver (manual) | `uv run python -m src.deriver` |
+| Install dependencies | `uv sync` |
 | Run migrations | `uv run alembic upgrade head` |
-| New migration | `uv run alembic revision --autogenerate -m "description"` |
+| Start API server | `uv run fastapi dev src/main.py` |
+| Start deriver | `uv run python -m src.deriver` |
 | Run tests | `uv run pytest` |
-| Check health | `curl http://localhost:8000/health` |
-| View API docs | `http://localhost:8000/docs` |
-| View logs (Docker) | `docker compose logs api --tail 50` |
-| Check container status | `docker compose ps` |
+| Format code | `uv run ruff format .` |
+| New migration | `uv run alembic revision --autogenerate -m "description"` |
+| Run all pre-commit hooks | `uv run pre-commit run --all-files` |
 
 ---
 
 ## Resources
 
 - [Honcho Documentation](https://docs.honcho.dev)
-- [Configuration Guide](https://docs.honcho.dev/contributing/configuration)
-- [API Reference](https://docs.honcho.dev/api-reference/introduction)
-- [Discord Community](https://discord.gg/honcho)
+- [Contributing Guide](../../../CONTRIBUTING.md)
+- [API Reference](https://docs.honcho.dev/v3/api-reference/introduction)
+- [Discord Community](https://discord.com/invite/honcho)

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -65,6 +65,14 @@ Open `.env` and set the required values:
 
 > **Important:** Honcho requires exactly one LLM API key to function — you do not need all of them. The default provider is Gemini (`LLM_GEMINI_API_KEY`). If you see errors about missing model configuration, an LLM key is the most likely cause.
 
+Minimal local development `.env` (Gemini example):
+
+```env
+DB_CONNECTION_URI=postgresql+psycopg://user:password@localhost:5432/honcho
+LLM_GEMINI_API_KEY=your-gemini-key-here
+SENTRY_ENABLED=false
+```
+
 ### Set Up the Database
 
 Using Docker (recommended):

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -20,7 +20,7 @@ This skill guides you through setting up and running Honcho locally for developm
 
 - Python 3.9 or higher
 - [uv](https://docs.astral.sh/uv/) 0.4.9 or higher
-- Docker (recommended for the database)
+- Docker with Compose v2 (recommended for the database) — use `docker compose` not `docker-compose`
 
 ### Install Dependencies
 
@@ -61,9 +61,10 @@ Open `.env` and set the required values:
 | `AUTH_JWT_SECRET` | Conditional | Required when `AUTH_USE_AUTH=true` — JWT signing secret for auth tokens |
 | `LLM_PROVIDER` | No | Override the default provider — valid values: `google`, `anthropic`, `openai`, `groq` |
 | `LLM_OPENAI_COMPATIBLE_API_KEY` | Optional | API key for OpenAI-compatible endpoints (e.g. vLLM, local models) |
+| `LLM_OPENAI_COMPATIBLE_BASE_URL` | Optional | Base URL for the OpenAI-compatible endpoint — required when `LLM_OPENAI_COMPATIBLE_API_KEY` is set |
 | `SENTRY_ENABLED` | No | Set to `false` for local development |
 
-> **Important:** Honcho requires exactly one LLM API key to function — you do not need all of them. The default provider is Gemini (`LLM_GEMINI_API_KEY`). If you see errors about missing model configuration, an LLM key is the most likely cause.
+> **Important:** Honcho requires at least one LLM API key. You can set multiple keys, but only the provider matching `LLM_PROVIDER` will be used (default: `google`/Gemini). If you see errors about missing model configuration, an LLM key is the most likely cause.
 
 Minimal local development `.env` (Gemini example):
 

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -42,14 +42,14 @@ Open `.env` and set the required values:
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DB_CONNECTION_URI` | Yes | PostgreSQL connection string — must use `postgresql+psycopg` prefix |
-| `LLM_GEMINI_API_KEY` | Yes (default) | Honcho uses Gemini by default — get a key at [aistudio.google.com](https://aistudio.google.com) |
-| `LLM_ANTHROPIC_API_KEY` | Alternative | Use instead of Gemini if preferred |
-| `LLM_OPENAI_API_KEY` | Alternative | Use instead of Gemini if preferred |
-| `LLM_GROQ_API_KEY` | Alternative | Use instead of Gemini if preferred |
+| `LLM_GEMINI_API_KEY` | One required (default) | Honcho uses Gemini by default — get a key at [aistudio.google.com](https://aistudio.google.com) |
+| `LLM_ANTHROPIC_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
+| `LLM_OPENAI_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
+| `LLM_GROQ_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
 | `AUTH_USE_AUTH` | No | Set to `false` for local development |
 | `SENTRY_ENABLED` | No | Set to `false` for local development |
 
-> **Important:** Honcho requires at least one LLM API key to function. The default is Gemini (`LLM_GEMINI_API_KEY`). If you see errors about missing model configuration, this is the most likely cause.
+> **Important:** Honcho requires exactly one LLM API key to function — you do not need all of them. The default provider is Gemini (`LLM_GEMINI_API_KEY`). If you see errors about missing model configuration, an LLM key is the most likely cause.
 
 ### Set Up the Database
 
@@ -217,7 +217,7 @@ uv run alembic upgrade head
 
 ### Port already in use
 
-**Symptom:** `ERROR: [Errno 48] Address already in use` on port 8000
+**Symptom:** `ERROR: [Errno 48] Address already in use` (macOS) or `ERROR: [Errno 98] Address already in use` (Linux) on port 8000
 
 **Fix:**
 

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -1,0 +1,243 @@
+# Local Honcho Development
+
+## What This Skill Does
+
+This skill guides you through setting up and running Honcho locally for development. Use it when you need to get the server running, run the deriver, execute migrations, run tests, or troubleshoot common setup issues.
+
+**Trigger phrases:**
+- "Help me set up Honcho locally"
+- "How do I run the deriver?"
+- "My database connection isn't working"
+- "How do I run the tests?"
+- "How do I create a migration?"
+- "How do I install pre-commit hooks?"
+
+---
+
+## Phase 1: Environment Setup
+
+### Prerequisites
+
+- Python 3.9 or higher
+- [uv](https://docs.astral.sh/uv/) 0.4.9 or higher
+- Docker (recommended for the database)
+
+### Install Dependencies
+
+```bash
+git clone https://github.com/plastic-labs/honcho.git
+cd honcho
+uv sync
+source .venv/bin/activate
+```
+
+### Configure Environment Variables
+
+```bash
+cp .env.template .env
+```
+
+Open `.env` and set the required values:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DB_CONNECTION_URI` | Yes | PostgreSQL connection string — must use `postgresql+psycopg` prefix |
+| `LLM_GEMINI_API_KEY` | Yes (default) | Honcho uses Gemini by default — get a key at [aistudio.google.com](https://aistudio.google.com) |
+| `LLM_ANTHROPIC_API_KEY` | Alternative | Use instead of Gemini if preferred |
+| `LLM_OPENAI_API_KEY` | Alternative | Use instead of Gemini if preferred |
+| `LLM_GROQ_API_KEY` | Alternative | Use instead of Gemini if preferred |
+| `AUTH_USE_AUTH` | No | Set to `false` for local development |
+| `SENTRY_ENABLED` | No | Set to `false` for local development |
+
+> **Important:** Honcho requires at least one LLM API key to function. The default is Gemini (`LLM_GEMINI_API_KEY`). If you see errors about missing model configuration, this is the most likely cause.
+
+### Set Up the Database
+
+Using Docker (recommended):
+
+```bash
+cp docker-compose.yml.example docker-compose.yml
+docker compose up -d database
+```
+
+Or use [Supabase](https://supabase.com) as an alternative — set `DB_CONNECTION_URI` to your Supabase connection string.
+
+---
+
+## Phase 2: Running Honcho
+
+### Run Database Migrations
+
+Always run migrations before starting the server for the first time or after pulling new changes:
+
+```bash
+uv run alembic upgrade head
+```
+
+### Start the API Server
+
+```bash
+uv run fastapi dev src/main.py
+```
+
+The API will be available at `http://localhost:8000`. The interactive docs are at `http://localhost:8000/docs`.
+
+### Start the Deriver (Background Worker)
+
+The deriver processes messages asynchronously and builds user representations. Run it in a **separate terminal**:
+
+```bash
+uv run python -m src.deriver
+```
+
+> **Note:** Both the API server and the deriver must be running for Honcho's memory and reasoning features to work. The API accepts messages; the deriver processes them in the background.
+
+### Run Everything with Docker
+
+If you prefer to run the full stack via Docker:
+
+```bash
+cp .env.template .env
+cp docker-compose.yml.example docker-compose.yml
+docker compose up
+```
+
+---
+
+## Phase 3: Development Tasks
+
+### Run Tests
+
+```bash
+uv run pytest
+```
+
+Run a specific test file:
+
+```bash
+uv run pytest tests/test_<filename>.py
+```
+
+Run with verbose output:
+
+```bash
+uv run pytest -v
+```
+
+### Create a New Migration
+
+After modifying a SQLAlchemy model in `src/`:
+
+```bash
+uv run alembic revision --autogenerate -m "description of your change"
+uv run alembic upgrade head
+```
+
+Review the generated migration file in `migrations/versions/` before applying it.
+
+### Set Up Pre-commit Hooks
+
+```bash
+uv add --dev pre-commit
+uv run pre-commit install --hook-type pre-commit --hook-type commit-msg --hook-type pre-push
+```
+
+Run hooks manually against all files:
+
+```bash
+uv run pre-commit run --all-files
+```
+
+Hooks enforce PEP 8, Black formatting, type hints, and conventional commit messages.
+
+### Code Standards
+
+Follow these conventions when contributing:
+
+- Format with [Black](https://black.readthedocs.io/) (`uv run black .`)
+- Use type hints on all function signatures
+- Write Google-style docstrings
+- Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `test:`, `refactor:`
+
+---
+
+## Phase 4: Troubleshooting
+
+### Database connection error
+
+**Symptom:** `sqlalchemy.exc.OperationalError` or `could not connect to server`
+
+**Fix:**
+1. Confirm Docker is running: `docker compose up -d database`
+2. Check `DB_CONNECTION_URI` in `.env` — must use `postgresql+psycopg` (not `postgresql+psycopg2`)
+3. Verify the database is healthy: `docker compose ps`
+
+### Missing LLM API key
+
+**Symptom:** `KeyError: LLM_GEMINI_API_KEY` or model-related errors at startup or when the deriver runs
+
+**Fix:**
+Honcho defaults to Gemini. Add your key to `.env`:
+```
+LLM_GEMINI_API_KEY=your-key-here
+```
+Get a free Gemini key at [aistudio.google.com](https://aistudio.google.com).
+
+If you prefer a different provider, set the corresponding key and update `LLM_PROVIDER` in `.env` if that setting is present.
+
+### Deriver not processing messages
+
+**Symptom:** Messages are stored but representations never update; `peer.chat()` returns empty or generic answers
+
+**Fix:**
+1. Confirm the deriver is running in a separate terminal: `uv run python -m src.deriver`
+2. Confirm a valid LLM API key is set — the deriver calls the LLM to build representations
+3. Check deriver logs for errors
+
+### Migration errors
+
+**Symptom:** `alembic.util.exc.CommandError` or `relation does not exist`
+
+**Fix:**
+```bash
+uv run alembic upgrade head
+```
+If you have conflicts or a dirty migration state:
+```bash
+uv run alembic downgrade base
+uv run alembic upgrade head
+```
+
+### Port already in use
+
+**Symptom:** `ERROR: [Errno 48] Address already in use` on port 8000
+
+**Fix:**
+```bash
+lsof -ti:8000 | xargs kill -9
+uv run fastapi dev src/main.py
+```
+
+---
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Install dependencies | `uv sync` |
+| Run migrations | `uv run alembic upgrade head` |
+| Start API server | `uv run fastapi dev src/main.py` |
+| Start deriver | `uv run python -m src.deriver` |
+| Run tests | `uv run pytest` |
+| Format code | `uv run black .` |
+| New migration | `uv run alembic revision --autogenerate -m "description"` |
+| Run all pre-commit hooks | `uv run pre-commit run --all-files` |
+
+---
+
+## Resources
+
+- [Honcho Documentation](https://docs.honcho.dev)
+- [Contributing Guide](../../CONTRIBUTING.md)
+- [API Reference](https://docs.honcho.dev/v3/api-reference/introduction)
+- [Discord Community](https://discord.com/invite/honcho)

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -28,8 +28,19 @@ This skill guides you through setting up and running Honcho locally for developm
 git clone https://github.com/plastic-labs/honcho.git
 cd honcho
 uv sync
-source .venv/bin/activate
 ```
+
+Activate the virtual environment:
+
+```bash
+# Unix/macOS
+source .venv/bin/activate
+
+# Windows (Command Prompt): .venv\Scripts\activate
+# Windows (PowerShell):     .venv\Scripts\activate.ps1
+```
+
+> **Note:** All commands in this guide use `uv run`, which automatically uses the virtual environment — explicit activation is optional.
 
 ### Configure Environment Variables
 
@@ -46,7 +57,8 @@ Open `.env` and set the required values:
 | `LLM_ANTHROPIC_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
 | `LLM_OPENAI_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
 | `LLM_GROQ_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
-| `AUTH_USE_AUTH` | No | Set to `false` for local development |
+| `AUTH_USE_AUTH` | No | Set to `false` for local development — defaults to `true`, which requires a valid token on every request |
+| `LLM_PROVIDER` | No | Override the default provider — valid values: `gemini`, `anthropic`, `openai`, `groq` |
 | `SENTRY_ENABLED` | No | Set to `false` for local development |
 
 > **Important:** Honcho requires exactly one LLM API key to function — you do not need all of them. The default provider is Gemini (`LLM_GEMINI_API_KEY`). If you see errors about missing model configuration, an LLM key is the most likely cause.
@@ -91,6 +103,8 @@ uv run python -m src.deriver
 ```
 
 > **Note:** Both the API server and the deriver must be running for Honcho's memory and reasoning features to work. The API accepts messages; the deriver processes them in the background.
+
+To verify the deriver is working, send a message via the API and watch the deriver terminal for log output showing it picked up the task. If the deriver log is silent, check that a valid LLM API key is set in `.env`.
 
 ### Run Everything with Docker
 
@@ -138,7 +152,6 @@ Review the generated migration file in `migrations/versions/` before applying it
 ### Set Up Pre-commit Hooks
 
 ```bash
-uv add --dev pre-commit
 uv run pre-commit install --hook-type pre-commit --hook-type commit-msg --hook-type pre-push
 ```
 
@@ -156,7 +169,7 @@ Follow these conventions when contributing:
 
 - Format code: `uv run ruff format src/`
 - Lint code: `uv run ruff check src/`
-- Type check: `uv run basedpyright`
+- Type check: `uv run basedpyright` (a strict fork of pyright — stricter than standard mypy)
 - Use type hints on all function signatures
 - Write Google-style docstrings
 - Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `test:`, `refactor:`
@@ -187,7 +200,7 @@ LLM_GEMINI_API_KEY=your-key-here
 
 Get a free Gemini key at [aistudio.google.com](https://aistudio.google.com).
 
-If you prefer a different provider, set the corresponding key and update `LLM_PROVIDER` in `.env` if that setting is present.
+If you prefer a different provider, set the corresponding key and set `LLM_PROVIDER` in `.env` to the matching value (`anthropic`, `openai`, or `groq`).
 
 ### Deriver not processing messages
 
@@ -210,6 +223,8 @@ uv run alembic upgrade head
 
 If you have conflicts or a dirty migration state:
 
+> **Warning:** `alembic downgrade base` drops all tables and deletes all data. Only use this in a local development database.
+
 ```bash
 uv run alembic downgrade base
 uv run alembic upgrade head
@@ -221,8 +236,27 @@ uv run alembic upgrade head
 
 **Fix:**
 
+Unix/macOS:
+
 ```bash
 lsof -ti:8000 | xargs kill -9
+```
+
+Windows (Command Prompt):
+
+```cmd
+for /f "tokens=5" %a in ('netstat -aon ^| findstr :8000') do taskkill /F /PID %a
+```
+
+Windows (PowerShell):
+
+```powershell
+Get-NetTCPConnection -LocalPort 8000 | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
+```
+
+Then restart the server:
+
+```bash
 uv run fastapi dev src/main.py
 ```
 

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -18,9 +18,13 @@ This skill guides you through setting up and running Honcho locally for developm
 
 ### Prerequisites
 
-- Python 3.10 or higher
-- [uv](https://docs.astral.sh/uv/) 0.4.9 or higher
-- Docker with Compose v2 (recommended for the database) — use `docker compose` not `docker-compose`
+- [uv](https://docs.astral.sh/uv/) — Python package manager (handles Python version automatically)
+  ```bash
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # or: brew install uv
+  ```
+- **Git**
+- **Docker** with Compose v2 (for Docker setup) — use `docker compose`, not `docker-compose`
 
 ### Install Dependencies
 
@@ -30,17 +34,13 @@ cd honcho
 uv sync
 ```
 
-Activate the virtual environment:
+Activate the virtual environment (optional — `uv run` handles this automatically):
 
 ```bash
-# Unix/macOS
-source .venv/bin/activate
-
-# Windows (Command Prompt): .venv\Scripts\activate
-# Windows (PowerShell):     .venv\Scripts\activate.ps1
+source .venv/bin/activate        # Unix/macOS
+# .venv\Scripts\activate         # Windows CMD
+# .venv\Scripts\activate.ps1     # Windows PowerShell
 ```
-
-> **Note:** All commands in this guide use `uv run`, which automatically uses the virtual environment — explicit activation is optional.
 
 ### Configure Environment Variables
 
@@ -48,268 +48,242 @@ source .venv/bin/activate
 cp .env.template .env
 ```
 
-Open `.env` and set the required values:
+#### LLM Setup (required — server will not start without this)
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `DB_CONNECTION_URI` | Yes | PostgreSQL connection string — must use `postgresql+psycopg` prefix |
-| `LLM_GEMINI_API_KEY` | One required (default) | Honcho uses Gemini by default — get a key at [aistudio.google.com](https://aistudio.google.com) |
-| `LLM_ANTHROPIC_API_KEY` | One required (alternative) | Use instead of Gemini — get a key at [console.anthropic.com](https://console.anthropic.com) |
-| `LLM_OPENAI_API_KEY` | One required (alternative) | Use instead of Gemini — get a key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
-| `LLM_GROQ_API_KEY` | One required (alternative) | Use instead of Gemini — get a key at [console.groq.com/keys](https://console.groq.com/keys) |
-| `AUTH_USE_AUTH` | No | Defaults to `false`. If set to `true`, every request requires a valid auth token and `AUTH_JWT_SECRET` must also be set |
-| `AUTH_JWT_SECRET` | Conditional | Required when `AUTH_USE_AUTH=true` — JWT signing secret for auth tokens |
-| `LLM_PROVIDER` | No | Override the default provider — valid values: `google`, `anthropic`, `openai`, `groq` |
-| `LLM_OPENAI_COMPATIBLE_API_KEY` | Optional | API key for OpenAI-compatible endpoints (e.g. vLLM, local models) |
-| `LLM_OPENAI_COMPATIBLE_BASE_URL` | Optional | Base URL for the OpenAI-compatible endpoint — required when `LLM_OPENAI_COMPATIBLE_API_KEY` is set |
-| `SENTRY_ENABLED` | No | Set to `false` for local development |
+Honcho uses LLMs for memory extraction, summarization, dialectic chat, and dreaming. Any OpenAI-compatible endpoint works — OpenRouter, Together, Fireworks, Ollama, vLLM, or a direct vendor API. Models must support tool calling.
 
-> **Important:** Honcho requires at least one LLM API key. You can set multiple keys, but only the provider matching `LLM_PROVIDER` will be used (default: `google`/Gemini). If you see errors about missing model configuration, an LLM key is the most likely cause.
+**Quick start (recommended):**
 
-Minimal local development `.env` (Gemini example):
-
-```env
-DB_CONNECTION_URI=postgresql+psycopg://user:password@localhost:5432/honcho
-LLM_GEMINI_API_KEY=your-gemini-key-here
-SENTRY_ENABLED=false
-```
-
-### Set Up the Database
-
-Using Docker (recommended):
+1. Get a key from [openrouter.ai](https://openrouter.ai) (or any OpenAI-compatible provider)
+2. Edit your `.env`:
 
 ```bash
-cp docker-compose.yml.example docker-compose.yml
-docker compose up -d database
+LLM_OPENAI_COMPATIBLE_BASE_URL=https://openrouter.ai/api/v1
+LLM_OPENAI_COMPATIBLE_API_KEY=your-api-key-here
+LLM_EMBEDDING_PROVIDER=openrouter
+
+DERIVER_PROVIDER=custom
+DERIVER_MODEL=google/gemini-2.5-flash
+
+SUMMARY_PROVIDER=custom
+SUMMARY_MODEL=google/gemini-2.5-flash
+
+DREAM_PROVIDER=custom
+DREAM_MODEL=google/gemini-2.5-flash
+DREAM_DEDUCTION_MODEL=google/gemini-2.5-flash
+DREAM_INDUCTION_MODEL=google/gemini-2.5-flash
+
+DIALECTIC_LEVELS__minimal__PROVIDER=custom
+DIALECTIC_LEVELS__minimal__MODEL=google/gemini-2.5-flash
+DIALECTIC_LEVELS__low__PROVIDER=custom
+DIALECTIC_LEVELS__low__MODEL=google/gemini-2.5-flash
+DIALECTIC_LEVELS__medium__PROVIDER=custom
+DIALECTIC_LEVELS__medium__MODEL=google/gemini-2.5-flash
+DIALECTIC_LEVELS__high__PROVIDER=custom
+DIALECTIC_LEVELS__high__MODEL=google/gemini-2.5-flash
+DIALECTIC_LEVELS__max__PROVIDER=custom
+DIALECTIC_LEVELS__max__MODEL=google/gemini-2.5-flash
 ```
 
-Or use [Supabase](https://supabase.com) as an alternative — set `DB_CONNECTION_URI` to your Supabase connection string.
+> **Tip:** Use find-and-replace to swap all `your-model-here` with your chosen model in one step.
+
+**Alternative — direct vendor keys:**
+```bash
+# Uncomment only the key you want to use
+# LLM_GEMINI_API_KEY=your-key
+# LLM_ANTHROPIC_API_KEY=your-key
+# LLM_OPENAI_API_KEY=your-key
+# LLM_GROQ_API_KEY=your-key
+```
+Then set `DERIVER_PROVIDER=google` (or `anthropic`, `openai`, `groq`) and use the corresponding model name format.
+
+#### Key environment variables reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DB_CONNECTION_URI` | `postgresql+psycopg://postgres:postgres@localhost:5432/postgres` | Must use `postgresql+psycopg` prefix |
+| `LLM_OPENAI_COMPATIBLE_BASE_URL` | — | Base URL for OpenAI-compatible endpoint |
+| `LLM_OPENAI_COMPATIBLE_API_KEY` | — | API key for your endpoint |
+| `LLM_EMBEDDING_PROVIDER` | `openrouter` | Routes embeddings through your custom endpoint |
+| `DERIVER_PROVIDER` | `custom` | LLM provider for the background worker |
+| `DERIVER_MODEL` | — | Model name for the deriver |
+| `AUTH_USE_AUTH` | `false` | Set to `true` in production; requires `AUTH_JWT_SECRET` |
 
 ---
 
 ## Phase 2: Running Honcho
 
-### Run Database Migrations
+### Option A: Docker (Recommended)
 
-Always run migrations before starting the server for the first time or after pulling new changes:
+Docker Compose handles the database, Redis cache, API server, and deriver worker.
 
+```bash
+cp docker-compose.yml.example docker-compose.yml
+docker compose up -d --build
+```
+
+The first build takes a few minutes. This starts four services:
+- **api** — HTTP server on `localhost:8000`
+- **deriver** — background worker (no HTTP port)
+- **database** — PostgreSQL with pgvector on `localhost:5432`
+- **redis** — cache on `localhost:6379`
+
+Migrations run automatically on startup.
+
+Verify everything is running:
+```bash
+docker compose ps
+curl http://localhost:8000/health
+# {"status":"ok"}
+```
+
+### Option B: Manual Setup
+
+**1. Start PostgreSQL with pgvector:**
+```bash
+docker run --name honcho-db \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -p 5432:5432 \
+  -d pgvector/pgvector:pg15
+```
+
+Or use [Supabase](https://supabase.com) (free, enable pgvector in SQL editor: `CREATE EXTENSION IF NOT EXISTS vector;`).
+
+**2. Run migrations:**
 ```bash
 uv run alembic upgrade head
 ```
 
-### Start the API Server
-
+**3. Start the API server:**
 ```bash
 uv run fastapi dev src/main.py
 ```
 
-The API will be available at `http://localhost:8000`. The interactive docs are at `http://localhost:8000/docs`.
-
-### Start the Deriver (Background Worker)
-
-The deriver processes messages asynchronously and builds user representations. Run it in a **separate terminal**:
-
+**4. Start the deriver** (separate terminal — required for memory processing):
 ```bash
 uv run python -m src.deriver
 ```
 
-> **Note:** Both the API server and the deriver must be running for Honcho's memory and reasoning features to work. The API accepts messages; the deriver processes them in the background.
+---
 
-To verify the deriver is working, send a message via the API and watch the deriver terminal for log output showing it picked up the task. If the deriver log is silent, check that a valid LLM API key is set in `.env`.
-
-### Verify Your Setup
-
-With both the API server and deriver running, confirm everything is working:
+## Phase 3: Verifying Your Setup
 
 ```bash
-curl http://localhost:8000/docs
+# Health check
+curl http://localhost:8000/health
+# {"status":"ok"}
+
+# Smoke test — confirms database + migrations
+curl -s -X POST http://localhost:8000/v3/workspaces \
+  -H "Content-Type: application/json" \
+  -d '{"name": "test"}' | python3 -m json.tool
+# Should return a workspace object with an id
 ```
 
-If the interactive docs page loads, the API server is running correctly. You can also confirm the server started without errors by checking the terminal where you ran `uv run fastapi dev src/main.py`.
-
-### Run Everything with Docker
-
-If you prefer to run the full stack via Docker:
-
-```bash
-cp .env.template .env
-cp docker-compose.yml.example docker-compose.yml
-docker compose up
-```
-
-> **Note:** The API container automatically runs database migrations on startup via `docker/entrypoint.sh`. You do not need to run `alembic upgrade head` manually when using Docker.
-
-### Clean Up
-
-Stop the API server and deriver with `Ctrl+C` in each terminal.
-
-Stop Docker containers:
-
-```bash
-docker compose down
-```
-
-Deactivate the virtual environment:
-
-```bash
-deactivate
-```
+Interactive API docs: `http://localhost:8000/docs`
 
 ---
 
-## Phase 3: Development Tasks
+## Phase 4: Development Tasks
 
-### Run Tests
+### Running Tests
 
 ```bash
 uv run pytest
 ```
 
 Run a specific test file:
-
 ```bash
-uv run pytest tests/test_<filename>.py
+uv run pytest tests/test_users.py -v
 ```
 
-Run with verbose output:
+### Creating a New Migration
 
 ```bash
-uv run pytest -v
+uv run alembic revision --autogenerate -m "describe your change"
 ```
 
-### Create a New Migration
-
-After modifying a SQLAlchemy model in `src/`:
-
+Review the generated file in `migrations/versions/` before applying:
 ```bash
-uv run alembic revision --autogenerate -m "description of your change"
 uv run alembic upgrade head
 ```
 
-Review the generated migration file in `migrations/versions/` before applying it.
-
-### Set Up Pre-commit Hooks
-
+Check current migration status:
 ```bash
-uv run pre-commit install --hook-type pre-commit --hook-type commit-msg --hook-type pre-push
+uv run alembic current
 ```
 
-Run hooks manually against all files:
+### Setting Up Pre-commit Hooks
 
+```bash
+uv run pre-commit install
+```
+
+Hooks run automatically on `git commit`. To run manually:
 ```bash
 uv run pre-commit run --all-files
 ```
 
-Hooks enforce formatting, linting, type checking, and conventional commit messages.
-
 ### Code Standards
 
-Follow these conventions when contributing:
-
-- Format code: `uv run ruff format .`
-- Lint code: `uv run ruff check .`
-- Type check: `uv run basedpyright` (a strict fork of pyright — stricter than standard mypy)
-- Use type hints on all function signatures
-- Write Google-style docstrings
-- Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `test:`, `refactor:`
+- **Formatter:** Black (`uv run black .`)
+- **Types:** Type hints required on all new functions
+- **Docstrings:** Google style
+- **Commits:** Conventional commits (`feat:`, `fix:`, `docs:`, `chore:`)
 
 ---
 
-## Phase 4: Troubleshooting
+## Troubleshooting
 
-### ModuleNotFoundError at startup
+### Server fails to start — "LLM provider not configured"
 
-**Symptom:** `ModuleNotFoundError: No module named 'honcho'` or similar import errors
-
-**Fix:**
-
-```bash
-uv sync --reinstall
-```
-
-This reinstalls all dependencies from scratch, which resolves corrupted or incomplete installs.
+The server requires at least one LLM provider. Set `LLM_OPENAI_COMPATIBLE_BASE_URL` and `LLM_OPENAI_COMPATIBLE_API_KEY`, then set `DERIVER_MODEL`, `SUMMARY_MODEL`, `DREAM_MODEL`, and all `DIALECTIC_LEVELS__*__MODEL` values. See [LLM Setup](#llm-setup) above.
 
 ### Database connection error
 
-**Symptom:** `sqlalchemy.exc.OperationalError` or `could not connect to server`
-
-**Fix:**
-1. Confirm Docker is running: `docker compose up -d database`
-2. Check `DB_CONNECTION_URI` in `.env` — must use `postgresql+psycopg` (not `postgresql+psycopg2`)
-3. Verify the database is healthy: `docker compose ps`
-
-### Missing LLM API key
-
-**Symptom:** `KeyError: LLM_GEMINI_API_KEY` or model-related errors at startup or when the deriver runs
-
-**Fix:**
-Honcho defaults to Gemini. Add your key to `.env`:
-
-```env
-LLM_GEMINI_API_KEY=your-key-here
+```
+sqlalchemy.exc.OperationalError: connection refused
 ```
 
-Get a free Gemini key at [aistudio.google.com](https://aistudio.google.com).
+- Confirm PostgreSQL is running: `docker compose ps` or `brew services list | grep postgresql`
+- Confirm `DB_CONNECTION_URI` uses the `postgresql+psycopg` prefix (not `postgresql://`)
+- Default DB name is `postgres` (not `honcho`)
 
-If you prefer a different provider, set the corresponding key and set `LLM_PROVIDER` in `.env` to the matching value (`anthropic`, `openai`, `groq`, or `google` for Gemini).
+### Migrations not applied
+
+```
+sqlalchemy.exc.ProgrammingError: relation "..." does not exist
+```
+
+Run: `uv run alembic upgrade head`
 
 ### Deriver not processing messages
 
-**Symptom:** Messages are stored but representations never update; `peer.chat()` returns empty or generic answers
-
-**Fix:**
-1. Confirm the deriver is running in a separate terminal: `uv run python -m src.deriver`
-2. Confirm a valid LLM API key is set — the deriver calls the LLM to build representations
-3. Check deriver logs for errors
-
-### Migration errors
-
-**Symptom:** `alembic.util.exc.CommandError` or `relation does not exist`
-
-**Fix:**
-
+Check logs:
 ```bash
-uv run alembic upgrade head
+docker compose logs deriver --tail 20
 ```
 
-If you have conflicts or a dirty migration state:
-
-> **Warning:** `alembic downgrade base` drops all tables and deletes all data. Only use this in a local development database.
-
-```bash
-uv run alembic downgrade base
-uv run alembic upgrade head
-```
+- Confirm `DERIVER_PROVIDER` and `DERIVER_MODEL` are set in `.env`
+- Without the deriver, messages are stored but no memory extraction occurs
+- Look for "polling" or "processing" in the logs to confirm it's running
 
 ### Port already in use
 
-**Symptom:** `ERROR: [Errno 48] Address already in use` (macOS) or `ERROR: [Errno 98] Address already in use` (Linux) on port 8000
+```bash
+lsof -i :8000   # find what's using port 8000
+kill -9 <PID>
+```
 
-**Fix:**
-
-Unix/macOS:
+### Docker build fails
 
 ```bash
-lsof -ti:8000 | xargs kill -9
+docker compose down --volumes
+docker compose up -d --build
 ```
 
-Windows (Command Prompt):
-
-```cmd
-for /f "tokens=5" %a in ('netstat -aon ^| findstr :8000') do taskkill /F /PID %a
-```
-
-Windows (PowerShell):
-
-```powershell
-Get-NetTCPConnection -LocalPort 8000 | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
-```
-
-Then restart the server:
-
-```bash
-uv run fastapi dev src/main.py
-```
+If BuildKit errors occur, ensure Docker Desktop is up to date.
 
 ---
 
@@ -317,20 +291,23 @@ uv run fastapi dev src/main.py
 
 | Task | Command |
 |------|---------|
-| Install dependencies | `uv sync` |
+| Start all services (Docker) | `docker compose up -d --build` |
+| Stop all services | `docker compose down` |
+| Start API server (manual) | `uv run fastapi dev src/main.py` |
+| Start deriver (manual) | `uv run python -m src.deriver` |
 | Run migrations | `uv run alembic upgrade head` |
-| Start API server | `uv run fastapi dev src/main.py` |
-| Start deriver | `uv run python -m src.deriver` |
-| Run tests | `uv run pytest` |
-| Format code | `uv run ruff format .` |
 | New migration | `uv run alembic revision --autogenerate -m "description"` |
-| Run all pre-commit hooks | `uv run pre-commit run --all-files` |
+| Run tests | `uv run pytest` |
+| Check health | `curl http://localhost:8000/health` |
+| View API docs | `http://localhost:8000/docs` |
+| View logs (Docker) | `docker compose logs api --tail 50` |
+| Check container status | `docker compose ps` |
 
 ---
 
 ## Resources
 
 - [Honcho Documentation](https://docs.honcho.dev)
-- [Contributing Guide](../../../CONTRIBUTING.md)
-- [API Reference](https://docs.honcho.dev/v3/api-reference/introduction)
-- [Discord Community](https://discord.com/invite/honcho)
+- [Configuration Guide](https://docs.honcho.dev/contributing/configuration)
+- [API Reference](https://docs.honcho.dev/api-reference/introduction)
+- [Discord Community](https://discord.gg/honcho)

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -57,8 +57,10 @@ Open `.env` and set the required values:
 | `LLM_ANTHROPIC_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
 | `LLM_OPENAI_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
 | `LLM_GROQ_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
-| `AUTH_USE_AUTH` | No | Set to `false` for local development — defaults to `true`, which requires a valid token on every request |
-| `LLM_PROVIDER` | No | Override the default provider — valid values: `gemini`, `anthropic`, `openai`, `groq` |
+| `AUTH_USE_AUTH` | No | Defaults to `false`. If set to `true`, every request requires a valid auth token and `AUTH_JWT_SECRET` must also be set |
+| `AUTH_JWT_SECRET` | Conditional | Required when `AUTH_USE_AUTH=true` — JWT signing secret for auth tokens |
+| `LLM_PROVIDER` | No | Override the default provider — valid values: `google`, `anthropic`, `openai`, `groq` |
+| `LLM_OPENAI_COMPATIBLE_API_KEY` | Optional | API key for OpenAI-compatible endpoints (e.g. vLLM, local models) |
 | `SENTRY_ENABLED` | No | Set to `false` for local development |
 
 > **Important:** Honcho requires exactly one LLM API key to function — you do not need all of them. The default provider is Gemini (`LLM_GEMINI_API_KEY`). If you see errors about missing model configuration, an LLM key is the most likely cause.
@@ -127,6 +129,8 @@ cp docker-compose.yml.example docker-compose.yml
 docker compose up
 ```
 
+> **Note:** The API container automatically runs database migrations on startup via `docker/entrypoint.sh`. You do not need to run `alembic upgrade head` manually when using Docker.
+
 ### Clean Up
 
 Stop the API server and deriver with `Ctrl+C` in each terminal.
@@ -194,8 +198,8 @@ Hooks enforce formatting, linting, type checking, and conventional commit messag
 
 Follow these conventions when contributing:
 
-- Format code: `uv run ruff format src/`
-- Lint code: `uv run ruff check src/`
+- Format code: `uv run ruff format .`
+- Lint code: `uv run ruff check .`
 - Type check: `uv run basedpyright` (a strict fork of pyright — stricter than standard mypy)
 - Use type hints on all function signatures
 - Write Google-style docstrings
@@ -239,7 +243,7 @@ LLM_GEMINI_API_KEY=your-key-here
 
 Get a free Gemini key at [aistudio.google.com](https://aistudio.google.com).
 
-If you prefer a different provider, set the corresponding key and set `LLM_PROVIDER` in `.env` to the matching value (`anthropic`, `openai`, or `groq`).
+If you prefer a different provider, set the corresponding key and set `LLM_PROVIDER` in `.env` to the matching value (`anthropic`, `openai`, `groq`, or `google` for Gemini).
 
 ### Deriver not processing messages
 
@@ -310,7 +314,7 @@ uv run fastapi dev src/main.py
 | Start API server | `uv run fastapi dev src/main.py` |
 | Start deriver | `uv run python -m src.deriver` |
 | Run tests | `uv run pytest` |
-| Format code | `uv run ruff format src/` |
+| Format code | `uv run ruff format .` |
 | New migration | `uv run alembic revision --autogenerate -m "description"` |
 | Run all pre-commit hooks | `uv run pre-commit run --all-files` |
 

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -148,13 +148,15 @@ Run hooks manually against all files:
 uv run pre-commit run --all-files
 ```
 
-Hooks enforce PEP 8, Black formatting, type hints, and conventional commit messages.
+Hooks enforce formatting, linting, type checking, and conventional commit messages.
 
 ### Code Standards
 
 Follow these conventions when contributing:
 
-- Format with [Black](https://black.readthedocs.io/) (`uv run black .`)
+- Format code: `uv run ruff format src/`
+- Lint code: `uv run ruff check src/`
+- Type check: `uv run basedpyright`
 - Use type hints on all function signatures
 - Write Google-style docstrings
 - Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `test:`, `refactor:`
@@ -178,9 +180,11 @@ Follow these conventions when contributing:
 
 **Fix:**
 Honcho defaults to Gemini. Add your key to `.env`:
-```
+
+```bash
 LLM_GEMINI_API_KEY=your-key-here
 ```
+
 Get a free Gemini key at [aistudio.google.com](https://aistudio.google.com).
 
 If you prefer a different provider, set the corresponding key and update `LLM_PROVIDER` in `.env` if that setting is present.
@@ -199,10 +203,13 @@ If you prefer a different provider, set the corresponding key and update `LLM_PR
 **Symptom:** `alembic.util.exc.CommandError` or `relation does not exist`
 
 **Fix:**
+
 ```bash
 uv run alembic upgrade head
 ```
+
 If you have conflicts or a dirty migration state:
+
 ```bash
 uv run alembic downgrade base
 uv run alembic upgrade head
@@ -229,7 +236,7 @@ uv run fastapi dev src/main.py
 | Start API server | `uv run fastapi dev src/main.py` |
 | Start deriver | `uv run python -m src.deriver` |
 | Run tests | `uv run pytest` |
-| Format code | `uv run black .` |
+| Format code | `uv run ruff format src/` |
 | New migration | `uv run alembic revision --autogenerate -m "description"` |
 | Run all pre-commit hooks | `uv run pre-commit run --all-files` |
 
@@ -238,6 +245,6 @@ uv run fastapi dev src/main.py
 ## Resources
 
 - [Honcho Documentation](https://docs.honcho.dev)
-- [Contributing Guide](../../CONTRIBUTING.md)
+- [Contributing Guide](../../../CONTRIBUTING.md)
 - [API Reference](https://docs.honcho.dev/v3/api-reference/introduction)
 - [Discord Community](https://discord.com/invite/honcho)

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -106,6 +106,17 @@ uv run python -m src.deriver
 
 To verify the deriver is working, send a message via the API and watch the deriver terminal for log output showing it picked up the task. If the deriver log is silent, check that a valid LLM API key is set in `.env`.
 
+### Verify Your Setup
+
+With both the API server and deriver running, confirm everything is working:
+
+```bash
+curl http://localhost:8000/health
+# Expected: {"status":"OK"}
+```
+
+If the health check fails, confirm the API server started without errors and the database migrations ran successfully.
+
 ### Run Everything with Docker
 
 If you prefer to run the full stack via Docker:
@@ -114,6 +125,22 @@ If you prefer to run the full stack via Docker:
 cp .env.template .env
 cp docker-compose.yml.example docker-compose.yml
 docker compose up
+```
+
+### Clean Up
+
+Stop the API server and deriver with `Ctrl+C` in each terminal.
+
+Stop Docker containers:
+
+```bash
+docker compose down
+```
+
+Deactivate the virtual environment:
+
+```bash
+deactivate
 ```
 
 ---
@@ -177,6 +204,18 @@ Follow these conventions when contributing:
 ---
 
 ## Phase 4: Troubleshooting
+
+### ModuleNotFoundError at startup
+
+**Symptom:** `ModuleNotFoundError: No module named 'honcho'` or similar import errors
+
+**Fix:**
+
+```bash
+uv sync --reinstall
+```
+
+This reinstalls all dependencies from scratch, which resolves corrupted or incomplete installs.
 
 ### Database connection error
 

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -139,13 +139,17 @@ curl http://localhost:8000/health
 
 ### Option B: Manual Setup
 
-**1. Start PostgreSQL with pgvector:**
+**1. Start PostgreSQL and Redis:**
 ```bash
 docker run --name honcho-db \
   -e POSTGRES_USER=postgres \
   -e POSTGRES_PASSWORD=postgres \
   -p 5432:5432 \
   -d pgvector/pgvector:pg15
+
+docker run --name honcho-redis \
+  -p 6379:6379 \
+  -d redis:alpine
 ```
 
 Or use [Supabase](https://supabase.com) (free, enable pgvector in SQL editor: `CREATE EXTENSION IF NOT EXISTS vector;`).

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -246,7 +246,7 @@ This reinstalls all dependencies from scratch, which resolves corrupted or incom
 **Fix:**
 Honcho defaults to Gemini. Add your key to `.env`:
 
-```bash
+```env
 LLM_GEMINI_API_KEY=your-key-here
 ```
 

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -18,7 +18,7 @@ This skill guides you through setting up and running Honcho locally for developm
 
 ### Prerequisites
 
-- Python 3.9 or higher
+- Python 3.10 or higher
 - [uv](https://docs.astral.sh/uv/) 0.4.9 or higher
 - Docker with Compose v2 (recommended for the database) — use `docker compose` not `docker-compose`
 
@@ -54,9 +54,9 @@ Open `.env` and set the required values:
 |----------|----------|-------------|
 | `DB_CONNECTION_URI` | Yes | PostgreSQL connection string — must use `postgresql+psycopg` prefix |
 | `LLM_GEMINI_API_KEY` | One required (default) | Honcho uses Gemini by default — get a key at [aistudio.google.com](https://aistudio.google.com) |
-| `LLM_ANTHROPIC_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
-| `LLM_OPENAI_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
-| `LLM_GROQ_API_KEY` | One required (alternative) | Use instead of Gemini if preferred |
+| `LLM_ANTHROPIC_API_KEY` | One required (alternative) | Use instead of Gemini — get a key at [console.anthropic.com](https://console.anthropic.com) |
+| `LLM_OPENAI_API_KEY` | One required (alternative) | Use instead of Gemini — get a key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
+| `LLM_GROQ_API_KEY` | One required (alternative) | Use instead of Gemini — get a key at [console.groq.com/keys](https://console.groq.com/keys) |
 | `AUTH_USE_AUTH` | No | Defaults to `false`. If set to `true`, every request requires a valid auth token and `AUTH_JWT_SECRET` must also be set |
 | `AUTH_JWT_SECRET` | Conditional | Required when `AUTH_USE_AUTH=true` — JWT signing secret for auth tokens |
 | `LLM_PROVIDER` | No | Override the default provider — valid values: `google`, `anthropic`, `openai`, `groq` |
@@ -122,11 +122,10 @@ To verify the deriver is working, send a message via the API and watch the deriv
 With both the API server and deriver running, confirm everything is working:
 
 ```bash
-curl http://localhost:8000/health
-# Expected: {"status":"OK"}
+curl http://localhost:8000/docs
 ```
 
-If the health check fails, confirm the API server started without errors and the database migrations ran successfully.
+If the interactive docs page loads, the API server is running correctly. You can also confirm the server started without errors by checking the terminal where you ran `uv run fastapi dev src/main.py`.
 
 ### Run Everything with Docker
 

--- a/.claude/skills/local-development/SKILL.md
+++ b/.claude/skills/local-development/SKILL.md
@@ -220,6 +220,7 @@ uv run alembic upgrade head
 **Symptom:** `ERROR: [Errno 48] Address already in use` on port 8000
 
 **Fix:**
+
 ```bash
 lsof -ti:8000 | xargs kill -9
 uv run fastapi dev src/main.py

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,3 +1,18 @@
+# ⚠️  SECURITY NOTE
+# This file is a starting point for local development only.
+# All services are bound to 127.0.0.1 (localhost) to prevent exposure
+# to external networks. Do NOT remove the 127.0.0.1: prefix on port
+# bindings when deploying to any shared or public-facing environment.
+#
+# Before production use:
+#   - Change POSTGRES_PASSWORD and POSTGRES_USER to strong credentials
+#     and update DB_CONNECTION_URI in api/deriver environment blocks accordingly
+#   - Remove POSTGRES_HOST_AUTH_METHOD=trust (use password auth instead)
+#   - Set a strong Grafana admin password (GF_SECURITY_ADMIN_PASSWORD)
+#     and disable anonymous access (GF_AUTH_ANONYMOUS_ENABLED=false)
+#   - Add Redis authentication (requirepass) or remove Redis port exposure
+#   - Consider removing Prometheus/Grafana ports entirely if not needed
+
 services:
   api:
     image: honcho:latest
@@ -11,13 +26,13 @@ services:
       redis:
         condition: service_healthy
     ports:
-      - 8000:8000
+      - 127.0.0.1:8000:8000
     volumes:
       - .:/app
       - venv:/app/.venv
     environment:
-      - DB_CONNECTION_URI=postgresql+psycopg://postgres:postgres@database:5432/postgres
-      - CACHE_URL=redis://redis:6379/0?suppress=true
+      - DB_CONNECTION_URI=${DB_CONNECTION_URI:-postgresql+psycopg://postgres:postgres@database:5432/postgres}
+      - CACHE_URL=${CACHE_URL:-redis://redis:6379/0?suppress=true}
     env_file:
       - path: .env
         required: false
@@ -35,17 +50,17 @@ services:
       - .:/app
       - venv:/app/.venv
     environment:
-      - DB_CONNECTION_URI=postgresql+psycopg://postgres:postgres@database:5432/postgres
-      - CACHE_URL=redis://redis:6379/0?suppress=true
+      - DB_CONNECTION_URI=${DB_CONNECTION_URI:-postgresql+psycopg://postgres:postgres@database:5432/postgres}
+      - CACHE_URL=${CACHE_URL:-redis://redis:6379/0?suppress=true}
       - METRICS_ENABLED=true
     env_file:
       - path: .env
         required: false
   database:
     image: pgvector/pgvector:pg15
-    restart: always
+    restart: unless-stopped
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     command: ["postgres", "-c", "max_connections=800"]
     environment:
       - POSTGRES_DB=postgres
@@ -63,11 +78,11 @@ services:
       retries: 5
   redis:
     image: redis:8.2
-    restart: always
+    restart: unless-stopped
     ports:
-      - 6379:6379
+      - 127.0.0.1:6379:6379
     volumes:
-      - ./redis-data:/data
+      - redis-data:/data
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping"]
       interval: 5s
@@ -76,7 +91,7 @@ services:
   prometheus:
     image: prom/prometheus:v3.2.1
     ports:
-      - 9090:9090
+      - 127.0.0.1:9090:9090
     volumes:
       - ./docker/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
@@ -86,14 +101,14 @@ services:
   grafana:
     image: grafana/grafana:11.4.0
     ports:
-      - 3000:3000
+      - 127.0.0.1:3000:3000
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
     volumes:
-      - ./grafana-data:/var/lib/grafana
+      - grafana-data:/var/lib/grafana
       - ./docker/grafana-datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml:ro
     depends_on:
       prometheus:
@@ -101,4 +116,6 @@ services:
 volumes:
   pgdata:
   venv:
+  redis-data:
   prometheus-data:
+  grafana-data:


### PR DESCRIPTION
Closes #407

## What This Skill Does

Activates when a developer asks questions like "Help me set up Honcho locally", "How do I run the deriver?", "My database connection isn't working", etc. Guides them through setup, configuration, running services, and troubleshooting.

## Changes in this update (rebased on main after #510 merged)

- **Default LLM provider** — switched from Gemini to OpenAI-compatible endpoint (OpenRouter, Together, Fireworks, etc.). `DERIVER_PROVIDER=custom` routes through `LLM_OPENAI_COMPATIBLE_BASE_URL/API_KEY`. Direct vendor keys (`LLM_GEMINI_API_KEY` etc.) documented as alternatives.
- **New env vars** — `LLM_OPENAI_COMPATIBLE_BASE_URL`, `LLM_OPENAI_COMPATIBLE_API_KEY`, `LLM_EMBEDDING_PROVIDER`, `DERIVER_PROVIDER/MODEL`, `SUMMARY_PROVIDER/MODEL`, `DREAM_PROVIDER/MODEL`, `DIALECTIC_LEVELS__*__PROVIDER/MODEL` — all documented with a ready-to-copy quick start block
- **DB name** — updated from `honcho` to `postgres` throughout
- **uv** — no version pin, just install uv (matches current prereqs)
- **Redis** — added to Docker service list and to manual setup (`docker run redis:alpine`)
- **Health endpoint** — updated to `/health` → `{"status":"ok"}`
- **Docker** — documents that it builds from source, no pre-built image
- **Troubleshooting** — updated error messages to match new config (deriver provider not set, DB name, etc.)

## Verified

Walked through the full skill with Claude Code on a clean environment — triggered with "Help me set up Honcho locally", ran through Docker path, verified health check and smoke test pass.

@ajspig — let me know if anything needs adjusting.