### PR TITLE
feat(embeddings): add local HTTP embedding provider support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -88,6 +88,9 @@ LLM_OPENAI_COMPATIBLE_API_KEY=your-api-key-here
 # Embedding provider — defaults to openai (requires LLM_OPENAI_API_KEY).
 # Set to openrouter to route embeddings through your custom endpoint instead.
 LLM_EMBEDDING_PROVIDER=openrouter
+# LLM_EMBEDDING_BASE_URL=http://127.0.0.1:8100  # For local provider only
+# LLM_EMBEDDING_MODEL=mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ
+# LLM_EMBEDDING_API_KEY=***
 # LLM_DEFAULT_MAX_TOKENS=2500
 # LLM_MAX_TOOL_OUTPUT_CHARS=10000
 # LLM_MAX_MESSAGE_CONTENT_CHARS=2000

--- a/src/config.py
+++ b/src/config.py
@@ -213,7 +213,10 @@ class LLMSettings(HonchoSettings):
     VLLM_API_KEY: str | None = None
     VLLM_BASE_URL: str | None = None
 
-    EMBEDDING_PROVIDER: Literal["openai", "gemini", "openrouter"] = "openai"
+    EMBEDDING_PROVIDER: Literal["openai", "gemini", "openrouter", "local"] = "openai"
+    EMBEDDING_MODEL: str | None = None
+    EMBEDDING_BASE_URL: str | None = None
+    EMBEDDING_API_KEY: str | None = None
 
     # General LLM settings
     DEFAULT_MAX_TOKENS: Annotated[int, Field(default=1000, gt=0, le=100_000)] = 2500

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -4,6 +4,7 @@ import threading
 from collections import defaultdict
 from typing import NamedTuple
 
+import httpx
 import tiktoken
 from google import genai
 from openai import AsyncOpenAI
@@ -23,11 +24,14 @@ class BatchItem(NamedTuple):
 
 class _EmbeddingClient:
     """
-    Embedding client supporting OpenAI and Gemini with chunking and batching support.
+    Embedding client supporting local endpoints, OpenAI, Gemini,
+    and OpenRouter with chunking and batching support.
     """
 
     def __init__(self, api_key: str | None = None, provider: str | None = None):
         self.provider: str = provider or settings.LLM.EMBEDDING_PROVIDER
+        self.base_url: str | None = None
+        self.api_key: str | None = None
 
         if self.provider == "gemini":
             if api_key is None:
@@ -35,7 +39,7 @@ class _EmbeddingClient:
             if not api_key:
                 raise ValueError("Gemini API key is required")
             self.client: genai.Client | AsyncOpenAI = genai.Client(api_key=api_key)
-            self.model: str = "gemini-embedding-001"
+            self.model: str = settings.LLM.EMBEDDING_MODEL or "gemini-embedding-001"
             # Gemini has a 2048 token limit
             self.max_embedding_tokens: int = min(settings.MAX_EMBEDDING_TOKENS, 2048)
             # Gemini batch size is not documented, using conservative estimate
@@ -47,21 +51,30 @@ class _EmbeddingClient:
                 raise ValueError(
                     "OpenRouter API key (LLM_OPENAI_COMPATIBLE_API_KEY) is required"
                 )
-            base_url = (
-                settings.LLM.OPENAI_COMPATIBLE_BASE_URL
-                or "https://openrouter.ai/api/v1"
-            )
+            base_url = settings.LLM.OPENAI_COMPATIBLE_BASE_URL or "https://openrouter.ai/api/v1"
             self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-            self.model = "openai/text-embedding-3-small"
+            self.model = settings.LLM.EMBEDDING_MODEL or "openai/text-embedding-3-small"
             self.max_embedding_tokens = settings.MAX_EMBEDDING_TOKENS
             self.max_batch_size = 2048  # Same as OpenAI
+        elif self.provider == "local":
+            base_url = settings.LLM.EMBEDDING_BASE_URL
+            if not base_url:
+                raise ValueError("LLM_EMBEDDING_BASE_URL is required for local embeddings")
+            if api_key is None:
+                api_key = settings.LLM.EMBEDDING_API_KEY
+            self.client = None
+            self.base_url = base_url.rstrip("/")
+            self.api_key = api_key
+            self.model = settings.LLM.EMBEDDING_MODEL or "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ"
+            self.max_embedding_tokens = settings.MAX_EMBEDDING_TOKENS
+            self.max_batch_size = 1024
         else:  # openai
             if api_key is None:
                 api_key = settings.LLM.OPENAI_API_KEY
             if not api_key:
                 raise ValueError("OpenAI API key is required")
             self.client = AsyncOpenAI(api_key=api_key)
-            self.model = "text-embedding-3-small"
+            self.model = settings.LLM.EMBEDDING_MODEL or "text-embedding-3-small"
             self.max_embedding_tokens = settings.MAX_EMBEDDING_TOKENS
             self.max_batch_size = 2048  # OpenAI batch limit
 
@@ -87,11 +100,11 @@ class _EmbeddingClient:
             if not response.embeddings or not response.embeddings[0].values:
                 raise ValueError("No embedding returned from Gemini API")
             return response.embeddings[0].values
-        else:  # openai
-            response = await self.client.embeddings.create(
-                model=self.model, input=query
-            )
-            return response.data[0].embedding
+        if self.provider == "local":
+            return await self._embed_local_single(query)
+
+        response = await self.client.embeddings.create(model=self.model, input=query)
+        return response.data[0].embedding
 
     async def simple_batch_embed(self, texts: list[str]) -> list[list[float]]:
         """
@@ -122,6 +135,8 @@ class _EmbeddingClient:
                         for emb in response.embeddings:
                             if emb.values:
                                 embeddings.append(emb.values)
+                elif self.provider == "local":
+                    embeddings.extend(await self._embed_local_batch(batch))
                 else:  # openai
                     response = await self.client.embeddings.create(
                         input=batch,
@@ -137,6 +152,44 @@ class _EmbeddingClient:
                 raise
 
         return embeddings
+
+    async def _embed_local_single(self, text: str) -> list[float]:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                f"{self.base_url}/embed",
+                json={"text": text, "model": self.model},
+                headers=self._local_headers(),
+            )
+            response.raise_for_status()
+            data = response.json()
+        embedding = data.get("embedding")
+        if not isinstance(embedding, list):
+            raise ValueError("No embedding returned from local embedding server")
+        return embedding
+
+    async def _embed_local_batch(self, texts: list[str]) -> list[list[float]]:
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            response = await client.post(
+                f"{self.base_url}/embed_batch",
+                json={"texts": texts, "model": self.model},
+                headers=self._local_headers(),
+            )
+            response.raise_for_status()
+            data = response.json()
+        embeddings = data.get("embeddings")
+        if not isinstance(embeddings, list):
+            raise ValueError("No embeddings returned from local embedding server")
+        if len(embeddings) != len(texts):
+            raise ValueError(
+                "Local embedding server returned mismatched embedding count "
+                f"(expected {len(texts)}, got {len(embeddings)})"
+            )
+        return embeddings
+
+    def _local_headers(self) -> dict[str, str]:
+        if not self.api_key:
+            return {}
+        return {"Authorization": f"Bearer {self.api_key}"}
 
     async def batch_embed(
         self, id_resource_dict: dict[str, tuple[str, list[int]]]
@@ -262,6 +315,10 @@ class _EmbeddingClient:
                                 result[item.text_id][item.chunk_index] = (
                                     embedding.values
                                 )
+                elif self.provider == "local":
+                    embeddings = await self._embed_local_batch([item.text for item in batch])
+                    for item, embedding in zip(batch, embeddings, strict=True):
+                        result[item.text_id][item.chunk_index] = embedding
                 else:  # openai / openrouter
                     response = await self.client.embeddings.create(
                         model=self.model, input=[item.text for item in batch]
@@ -382,6 +439,8 @@ class EmbeddingClient:
                         api_key = settings.LLM.GEMINI_API_KEY
                     elif provider == "openrouter":
                         api_key = settings.LLM.OPENAI_COMPATIBLE_API_KEY
+                    elif provider == "local":
+                        api_key = settings.LLM.EMBEDDING_API_KEY
                     else:
                         api_key = settings.LLM.OPENAI_API_KEY
 

--- a/tests/test_embedding_client_local.py
+++ b/tests/test_embedding_client_local.py
@@ -1,0 +1,207 @@
+import pytest
+
+from src.embedding_client import _EmbeddingClient
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    def __init__(self, calls: list[dict], **kwargs):
+        self.calls = calls
+        self.kwargs = kwargs
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def post(self, url: str, *, json: dict, headers: dict[str, str]):
+        self.calls.append({"url": url, "json": json, "headers": headers})
+        if url.endswith("/embed"):
+            return _FakeResponse({"embedding": [0.0, 0.5]})
+        if url.endswith("/embed_batch"):
+            texts = json["texts"]
+            return _FakeResponse(
+                {
+                    "embeddings": [
+                        [float(i), float(i) + 0.5] for i, _ in enumerate(texts)
+                    ]
+                }
+            )
+        raise AssertionError(f"Unexpected URL: {url}")
+
+
+@pytest.mark.asyncio
+async def test_local_provider_uses_local_embedding_endpoint(monkeypatch: pytest.MonkeyPatch):
+    calls: list[dict] = []
+
+    def fake_async_client(**kwargs):
+        return _FakeAsyncClient(calls, **kwargs)
+
+    monkeypatch.setattr("src.embedding_client.httpx.AsyncClient", fake_async_client)
+    monkeypatch.setattr("src.embedding_client.settings.LLM.EMBEDDING_PROVIDER", "local")
+    monkeypatch.setattr(
+        "src.embedding_client.settings.LLM.EMBEDDING_BASE_URL",
+        "http://127.0.0.1:8100",
+    )
+    monkeypatch.setattr(
+        "src.embedding_client.settings.LLM.EMBEDDING_MODEL",
+        "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ",
+    )
+    monkeypatch.setattr("src.embedding_client.settings.LLM.EMBEDDING_API_KEY", "local")
+
+    client = _EmbeddingClient(provider="local")
+
+    embedding = await client.embed("안녕하세요")
+    batch = await client.simple_batch_embed(["하나", "둘"])
+
+    assert client.model == "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ"
+    assert client.base_url == "http://127.0.0.1:8100"
+    assert embedding == [0.0, 0.5]
+    assert batch == [[0.0, 0.5], [1.0, 1.5]]
+    assert calls == [
+        {
+            "url": "http://127.0.0.1:8100/embed",
+            "json": {
+                "text": "안녕하세요",
+                "model": "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ",
+            },
+            "headers": {"Authorization": "Bearer local"},
+        },
+        {
+            "url": "http://127.0.0.1:8100/embed_batch",
+            "json": {
+                "texts": ["하나", "둘"],
+                "model": "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ",
+            },
+            "headers": {"Authorization": "Bearer local"},
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_local_provider_omits_auth_header_without_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[dict] = []
+
+    def fake_async_client(**kwargs):
+        return _FakeAsyncClient(calls, **kwargs)
+
+    monkeypatch.setattr("src.embedding_client.httpx.AsyncClient", fake_async_client)
+    monkeypatch.setattr("src.embedding_client.settings.LLM.EMBEDDING_PROVIDER", "local")
+    monkeypatch.setattr(
+        "src.embedding_client.settings.LLM.EMBEDDING_BASE_URL",
+        "http://127.0.0.1:8100",
+    )
+    monkeypatch.setattr(
+        "src.embedding_client.settings.LLM.EMBEDDING_MODEL",
+        "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ",
+    )
+    monkeypatch.setattr("src.embedding_client.settings.LLM.EMBEDDING_API_KEY", None)
+
+    client = _EmbeddingClient(provider="local")
+
+    embedding = await client.embed("안녕하세요")
+
+    assert embedding == [0.0, 0.5]
+    assert calls == [
+        {
+            "url": "http://127.0.0.1:8100/embed",
+            "json": {
+                "text": "안녕하세요",
+                "model": "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ",
+            },
+            "headers": {},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_local_provider_batch_raises_on_mismatched_embedding_count(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class _MismatchedBatchClient(_FakeAsyncClient):
+        async def post(self, url: str, *, json: dict, headers: dict[str, str]):
+            self.calls.append({"url": url, "json": json, "headers": headers})
+            if url.endswith("/embed_batch"):
+                return _FakeResponse({"embeddings": [[0.0, 0.5]]})
+            return await super().post(url, json=json, headers=headers)
+
+    def fake_async_client(**kwargs):
+        return _MismatchedBatchClient([], **kwargs)
+
+    monkeypatch.setattr("src.embedding_client.httpx.AsyncClient", fake_async_client)
+    monkeypatch.setattr("src.embedding_client.settings.LLM.EMBEDDING_PROVIDER", "local")
+    monkeypatch.setattr(
+        "src.embedding_client.settings.LLM.EMBEDDING_BASE_URL",
+        "http://127.0.0.1:8100",
+    )
+    monkeypatch.setattr(
+        "src.embedding_client.settings.LLM.EMBEDDING_MODEL",
+        "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ",
+    )
+    monkeypatch.setattr("src.embedding_client.settings.LLM.EMBEDDING_API_KEY", None)
+
+    client = _EmbeddingClient(provider="local")
+
+    with pytest.raises(ValueError, match="expected 2, got 1"):
+        await client.simple_batch_embed(["하나", "둘"])
+
+
+def test_local_provider_requires_base_url(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("src.embedding_client.settings.LLM.EMBEDDING_PROVIDER", "local")
+    monkeypatch.setattr("src.embedding_client.settings.LLM.EMBEDDING_BASE_URL", None)
+
+    with pytest.raises(ValueError, match="LLM_EMBEDDING_BASE_URL is required"):
+        _EmbeddingClient(provider="local")
+
+
+def test_openrouter_uses_openai_compatible_base_url(monkeypatch: pytest.MonkeyPatch):
+    created: dict = {}
+
+    class _FakeEmbeddingsAPI:
+        async def create(self, *, model: str, input_text: str | list[str]):
+            _ = (model, input_text)
+            return type(
+                "EmbeddingResponse",
+                (),
+                {"data": [type("EmbeddingItem", (), {"embedding": [0.0, 0.5]})]},
+            )
+
+    class _FakeAsyncOpenAI:
+        def __init__(self, *, api_key: str, base_url: str):
+            created["api_key"] = api_key
+            created["base_url"] = base_url
+            self.embeddings = _FakeEmbeddingsAPI()
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr("src.embedding_client.settings.LLM.EMBEDDING_PROVIDER", "openrouter")
+    monkeypatch.setattr("src.embedding_client.settings.LLM.OPENAI_COMPATIBLE_API_KEY", "router-key")
+    monkeypatch.setattr(
+        "src.embedding_client.settings.LLM.OPENAI_COMPATIBLE_BASE_URL",
+        "https://openrouter.ai/api/v1",
+    )
+    monkeypatch.setattr(
+        "src.embedding_client.settings.LLM.EMBEDDING_BASE_URL",
+        "http://127.0.0.1:8100",
+    )
+    monkeypatch.setattr(
+        "src.embedding_client.settings.LLM.EMBEDDING_MODEL",
+        "custom-embed-model",
+    )
+
+    client = _EmbeddingClient(provider="openrouter")
+
+    assert created["base_url"] == "https://openrouter.ai/api/v1"
+    assert client.model == "custom-embed-model"


### PR DESCRIPTION
# **Release v[X.X.X]**

This pull request fixes #518

## **Description**

This PR adds opt-in support for a `local` embedding provider so Honcho can use self-hosted/local HTTP embedding services without requiring an OpenAI-compatible `/v1/embeddings` shim.

### What this PR adds

- `LLM_EMBEDDING_PROVIDER=local`
- `LLM_EMBEDDING_BASE_URL`
- `LLM_EMBEDDING_MODEL`
- `LLM_EMBEDDING_API_KEY`

### Behavior

When `LLM_EMBEDDING_PROVIDER=local` is selected, the embedding client calls native local HTTP endpoints:

- `POST {base_url}/embed`
- `POST {base_url}/embed_batch`

This PR also allows `LLM_EMBEDDING_MODEL` to override the default embedding model for existing providers where applicable.

### Why

This makes it easier to use Honcho with lightweight local/self-hosted embedding servers, such as MLX-based embedding services, without introducing a compatibility wrapper layer.

### Scope of this PR

This PR is intentionally limited to:
- provider/config plumbing
- embedding client support
- tests
- env-template documentation

This PR does **not** include:
- configurable pgvector dimension migration strategy
- document persistence fallback semantics when embedding generation fails

Those are better handled as follow-up discussions/PRs because they affect schema/runtime policy more directly.

---

### **Additional context**

Files included in this PR:

- `src/config.py`
- `src/embedding_client.py`
- `tests/test_embedding_client_local.py`
- `.env.template`

Validation performed:
- added targeted tests for the local provider path
- validated syntax with `python -m py_compile` on touched Python files
- earlier local end-to-end verification was done against a running local embedding server

Note: I intentionally kept this PR small and additive.
I excluded:
- configurable vector dimensions / pgvector migration concerns
- persistence fallback behavior when embeddings fail

because both seem better discussed separately from basic local-provider support.

## **Changelog**

### **Added**
- Added `local` embedding provider support
- Added `LLM_EMBEDDING_BASE_URL`
- Added `LLM_EMBEDDING_MODEL`
- Added `LLM_EMBEDDING_API_KEY`
- Added tests for local embedding provider behavior

### **Changed**
- Allowed embedding model override for supported providers
- Updated `.env.template` to document local embedding configuration

### **Deprecated**

### **Removed**

### **Fixed**
- Improved support for self-hosted embedding backends that are not OpenAI-compatible

### **Security**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a local embedding provider and configurable embedding overrides: model, base URL, and API key.

* **Documentation**
  * Environment template updated with commented placeholders for embedding configuration.

* **Bug Fixes**
  * Improved validation and error handling for local embedding configuration and mismatched batch responses.

* **Tests**
  * Added unit tests covering local and OpenRouter-compatible embedding flows, request formatting, headers, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->