### PR TITLE
feat: export LLM traces for all call sites, not just deriver

### DIFF
--- a/src/dreamer/specialists.py
+++ b/src/dreamer/specialists.py
@@ -219,6 +219,7 @@ If you update it, send the full deduplicated list and remove stale entries.
             messages=messages,
             track_name=f"Dreamer/{self.name}",
             iteration_callback=iteration_callback,
+            trace_name=f"dreamer_{self.name}",
         )
 
         # Log metrics

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -1499,9 +1499,9 @@ async def honcho_llm_call(
         result: (
             HonchoLLMCallResponse[Any] | AsyncIterator[HonchoLLMCallStreamChunk]
         ) = await decorated()
-        if trace_name and isinstance(result, HonchoLLMCallResponse):
+        if isinstance(result, HonchoLLMCallResponse):
             log_reasoning_trace(
-                task_type=trace_name,
+                task_type=trace_name or "untagged",
                 llm_settings=llm_settings,
                 prompt=prompt,
                 response=result,
@@ -1549,9 +1549,9 @@ async def honcho_llm_call(
         stream_final=stream_final_only,
         iteration_callback=iteration_callback,
     )
-    if trace_name and isinstance(result, HonchoLLMCallResponse):
+    if isinstance(result, HonchoLLMCallResponse):
         log_reasoning_trace(
-            task_type=trace_name,
+            task_type=trace_name or "untagged",
             llm_settings=llm_settings,
             prompt=prompt,
             response=result,

--- a/src/utils/summarizer.py
+++ b/src/utils/summarizer.py
@@ -215,6 +215,7 @@ async def create_short_summary(
         llm_settings=settings.SUMMARY,
         prompt=prompt,
         max_tokens=settings.SUMMARY.MAX_TOKENS_SHORT,
+        trace_name="short_summary",
     )
 
 
@@ -240,6 +241,7 @@ async def create_long_summary(
         llm_settings=settings.SUMMARY,
         prompt=prompt,
         max_tokens=settings.SUMMARY.MAX_TOKENS_LONG,
+        trace_name="long_summary",
     )
 
 


### PR DESCRIPTION
[Summary]
- Remove the trace_name guard in honcho_llm_call so that all LLM generation calls are logged to the JSONL traces file when REASONING_TRACES_FILE is set, not just the ones that explicitly opt in
- Add trace_name tags to the three call sites that were previously untraced: summarizer (short_summary, long_summary) and dreamer specialists (dreamer_deduction, dreamer_induction)
- Calls without an explicit trace_name are logged with task_type: "untagged" as a fallback

[Motivation]
Previously, only the minimal deriver and dialectic chat paths emitted traces. This meant there was no visibility into LLM inputs/outputs for summarization or dream cycle calls which makes it harder to debug memory quality, audit model behavior, or benchmark across the full pipeline. With this change, setting a single env var captures every generative LLM call with its module-level tag, input/output pairs, token counts, and tool call history. 

This PR will ensure that we have a standardized way to get the traces data we need for training models, benchmarking (also affects excadrill), and doing downstream analysis for different modules. This can enable easy benchmarking for things like the summary, dreamer, etc as per the wishlist.

[Traced call sites]
| Module | task_type tag |
  |--------|----------------|
  | Deriver | `minimal_deriver` |
  | Dialectic | `dialectic_chat` |
  | Dreamer (deduction) | `dreamer_deduction` |
  | Dreamer (induction) | `dreamer_induction` |
  | Summarizer (short) | `short_summary` |
  | Summarizer (long) | `long_summary` |

[Test plan]
- Set REASONING_TRACES_FILE=traces.jsonl and run the server with message ingestion + dialectic queries
- Verify JSONL contains entries for all six task_type values
- Verify each entry has both input (prompt/messages + tokens) and output (content + tokens) fields
- Verify unset REASONING_TRACES_FILE produces no trace file (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal tracing and logging infrastructure to improve system diagnostics and monitoring capabilities across core components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->