### PR TITLE
fix(docker): remove api-specific healthcheck from shared image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,4 @@ USER app
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
-
 CMD ["fastapi", "run", "--host", "0.0.0.0", "src/main.py"]


### PR DESCRIPTION
## Summary

Removes the `HEALTHCHECK` directive from the shared `Dockerfile`.

## Motivation

The `HEALTHCHECK` probes `http://localhost:8000/health` — an endpoint that only the `honcho-api` service exposes. The `honcho-deriver` service reuses the same image but is a background queue worker with no HTTP server. Because the probe can never succeed, Docker permanently marks every deriver container as **unhealthy**.

The fix is to remove the `HEALTHCHECK` from the shared image. Service-level health checks belong in each service's own runtime configuration:
- In **Docker Compose**, the `healthcheck` key can be set per service in `docker-compose.yml`
- In **Kubernetes**, the API Deployment gets its own `readinessProbe` / `livenessProbe`; the deriver Deployment intentionally has none

## Test plan

- [ ] Build the image: `docker build -t honcho:latest .`
- [ ] Run the deriver container: `docker run honcho:latest /app/.venv/bin/python -m src.deriver`
- [ ] Verify container status is `Up` (not `Up (unhealthy)`) via `docker ps`

Closes #521

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automated container health monitoring. The application continues to operate normally on the exposed port with unchanged startup and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->