### PR TITLE
Support dedicated embedding endpoint config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -208,6 +208,10 @@ class LLMSettings(HonchoSettings):
     GEMINI_API_KEY: str | None = None
     GROQ_API_KEY: str | None = None
     OPENAI_COMPATIBLE_BASE_URL: str | None = None
+    # Optional dedicated embedding endpoint/key. Useful when chat traffic goes
+    # through one OpenAI-compatible provider but embeddings must use another.
+    EMBEDDING_API_KEY: str | None = None
+    EMBEDDING_BASE_URL: str | None = None
 
     # Separate vLLM endpoint (for local models)
     VLLM_API_KEY: str | None = None

--- a/src/config.py
+++ b/src/config.py
@@ -208,8 +208,9 @@ class LLMSettings(HonchoSettings):
     GEMINI_API_KEY: str | None = None
     GROQ_API_KEY: str | None = None
     OPENAI_COMPATIBLE_BASE_URL: str | None = None
-    # Optional dedicated embedding endpoint/key. Useful when chat traffic goes
-    # through one OpenAI-compatible provider but embeddings must use another.
+    # Optional dedicated embedding endpoint/key for the openrouter embedding
+    # path. Useful when chat traffic goes through one OpenAI-compatible provider
+    # but embeddings must use another.
     EMBEDDING_API_KEY: str | None = None
     EMBEDDING_BASE_URL: str | None = None
 

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -42,13 +42,17 @@ class _EmbeddingClient:
             self.max_batch_size: int = 100
         elif self.provider == "openrouter":
             if api_key is None:
-                api_key = settings.LLM.OPENAI_COMPATIBLE_API_KEY
+                api_key = (
+                    settings.LLM.EMBEDDING_API_KEY
+                    or settings.LLM.OPENAI_COMPATIBLE_API_KEY
+                )
             if not api_key:
                 raise ValueError(
                     "OpenRouter API key (LLM_OPENAI_COMPATIBLE_API_KEY) is required"
                 )
             base_url = (
-                settings.LLM.OPENAI_COMPATIBLE_BASE_URL
+                settings.LLM.EMBEDDING_BASE_URL
+                or settings.LLM.OPENAI_COMPATIBLE_BASE_URL
                 or "https://openrouter.ai/api/v1"
             )
             self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
@@ -381,7 +385,10 @@ class EmbeddingClient:
                     if provider == "gemini":
                         api_key = settings.LLM.GEMINI_API_KEY
                     elif provider == "openrouter":
-                        api_key = settings.LLM.OPENAI_COMPATIBLE_API_KEY
+                        api_key = (
+                            settings.LLM.EMBEDDING_API_KEY
+                            or settings.LLM.OPENAI_COMPATIBLE_API_KEY
+                        )
                     else:
                         api_key = settings.LLM.OPENAI_API_KEY
 

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -26,7 +26,12 @@ class _EmbeddingClient:
     Embedding client supporting OpenAI and Gemini with chunking and batching support.
     """
 
-    def __init__(self, api_key: str | None = None, provider: str | None = None):
+    def __init__(
+        self,
+        api_key: str | None = None,
+        provider: str | None = None,
+        base_url: str | None = None,
+    ):
         self.provider: str = provider or settings.LLM.EMBEDDING_PROVIDER
 
         if self.provider == "gemini":
@@ -48,10 +53,12 @@ class _EmbeddingClient:
                 )
             if not api_key:
                 raise ValueError(
-                    "OpenRouter API key (LLM_OPENAI_COMPATIBLE_API_KEY) is required"
+                    "OpenRouter API key (LLM_EMBEDDING_API_KEY or "
+                    "LLM_OPENAI_COMPATIBLE_API_KEY) is required"
                 )
             base_url = (
-                settings.LLM.EMBEDDING_BASE_URL
+                base_url
+                or settings.LLM.EMBEDDING_BASE_URL
                 or settings.LLM.OPENAI_COMPATIBLE_BASE_URL
                 or "https://openrouter.ai/api/v1"
             )
@@ -382,6 +389,7 @@ class EmbeddingClient:
             with self._lock:
                 if self._instance is None:
                     provider = settings.LLM.EMBEDDING_PROVIDER
+                    base_url: str | None = None
                     if provider == "gemini":
                         api_key = settings.LLM.GEMINI_API_KEY
                     elif provider == "openrouter":
@@ -389,11 +397,16 @@ class EmbeddingClient:
                             settings.LLM.EMBEDDING_API_KEY
                             or settings.LLM.OPENAI_COMPATIBLE_API_KEY
                         )
+                        base_url = (
+                            settings.LLM.EMBEDDING_BASE_URL
+                            or settings.LLM.OPENAI_COMPATIBLE_BASE_URL
+                            or "https://openrouter.ai/api/v1"
+                        )
                     else:
                         api_key = settings.LLM.OPENAI_API_KEY
 
                     self._instance = _EmbeddingClient(
-                        api_key=api_key, provider=provider
+                        api_key=api_key, provider=provider, base_url=base_url
                     )
                     logger.debug(
                         f"Initialized embedding client with provider: {provider}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,8 @@ _RUNTIME_MOCK_TEST_BLOCKLIST_PREFIXES = (
     "tests/bench/",
     "tests/alembic/",
     "tests/unified/",
+    # Pure unit test with no DB/cache/runtime dependencies.
+    "tests/test_embedding_client.py",
 )
 
 
@@ -721,7 +723,7 @@ def mock_honcho_llm_call(request: pytest.FixtureRequest):
 
 
 @pytest.fixture(autouse=True)
-def mock_tracked_db(db_engine: AsyncEngine, request: pytest.FixtureRequest):
+def mock_tracked_db(request: pytest.FixtureRequest):
     """Mock tracked_db to create fresh sessions per call.
 
     Using a session factory instead of a shared session avoids asyncio lock
@@ -730,6 +732,8 @@ def mock_tracked_db(db_engine: AsyncEngine, request: pytest.FixtureRequest):
     if not _requires_runtime_mocks(_get_nodeid(request)):
         yield
         return
+
+    db_engine: AsyncEngine = request.getfixturevalue("db_engine")
 
     from contextlib import asynccontextmanager
 

--- a/tests/test_embedding_client.py
+++ b/tests/test_embedding_client.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from src import embedding_client as embedding_module
 
 
@@ -44,7 +46,49 @@ def test_openrouter_embedding_client_prefers_dedicated_embedding_endpoint(monkey
     assert client.model == "openai/text-embedding-3-small"
 
 
-def test_embedding_client_wrapper_prefers_dedicated_embedding_api_key(monkeypatch):
+def test_openrouter_embedding_client_falls_back_to_compatible_endpoint(monkeypatch):
+    monkeypatch.setattr(
+        embedding_module.settings.LLM,
+        "OPENAI_COMPATIBLE_API_KEY",
+        "chat-key",
+    )
+    monkeypatch.setattr(
+        embedding_module.settings.LLM,
+        "OPENAI_COMPATIBLE_BASE_URL",
+        "https://chat.example/v1",
+    )
+    monkeypatch.setattr(embedding_module.settings.LLM, "EMBEDDING_API_KEY", None)
+    monkeypatch.setattr(embedding_module.settings.LLM, "EMBEDDING_BASE_URL", None)
+
+    captured: dict[str, str] = {}
+
+    class FakeAsyncOpenAI:
+        def __init__(self, *, api_key: str, base_url: str):
+            captured["api_key"] = api_key
+            captured["base_url"] = base_url
+
+    monkeypatch.setattr(embedding_module, "AsyncOpenAI", FakeAsyncOpenAI)
+
+    embedding_module._EmbeddingClient(provider="openrouter")
+
+    assert captured == {
+        "api_key": "chat-key",
+        "base_url": "https://chat.example/v1",
+    }
+
+
+def test_openrouter_embedding_client_error_mentions_both_supported_keys(monkeypatch):
+    monkeypatch.setattr(embedding_module.settings.LLM, "EMBEDDING_API_KEY", None)
+    monkeypatch.setattr(embedding_module.settings.LLM, "OPENAI_COMPATIBLE_API_KEY", None)
+
+    with pytest.raises(ValueError) as excinfo:
+        embedding_module._EmbeddingClient(provider="openrouter")
+
+    assert "LLM_EMBEDDING_API_KEY" in str(excinfo.value)
+    assert "LLM_OPENAI_COMPATIBLE_API_KEY" in str(excinfo.value)
+
+
+def test_embedding_client_wrapper_prefers_dedicated_embedding_endpoint(monkeypatch):
     monkeypatch.setattr(embedding_module.settings.LLM, "EMBEDDING_PROVIDER", "openrouter")
     monkeypatch.setattr(
         embedding_module.settings.LLM,
@@ -53,18 +97,37 @@ def test_embedding_client_wrapper_prefers_dedicated_embedding_api_key(monkeypatc
     )
     monkeypatch.setattr(
         embedding_module.settings.LLM,
+        "OPENAI_COMPATIBLE_BASE_URL",
+        "https://chat.example/v1",
+    )
+    monkeypatch.setattr(
+        embedding_module.settings.LLM,
         "EMBEDDING_API_KEY",
         "embed-key",
+    )
+    monkeypatch.setattr(
+        embedding_module.settings.LLM,
+        "EMBEDDING_BASE_URL",
+        "https://embed.example/v1",
     )
 
     captured: dict[str, str] = {}
     original_instance = embedding_module.EmbeddingClient._instance
+    original_wrapper_instance = embedding_module.EmbeddingClient._wrapper_instance
     embedding_module.EmbeddingClient._instance = None
+    embedding_module.EmbeddingClient._wrapper_instance = None
 
     class FakeEmbeddingClient:
-        def __init__(self, *, api_key: str | None = None, provider: str | None = None):
+        def __init__(
+            self,
+            *,
+            api_key: str | None = None,
+            provider: str | None = None,
+            base_url: str | None = None,
+        ):
             captured["api_key"] = api_key or ""
             captured["provider"] = provider or ""
+            captured["base_url"] = base_url or ""
             self.provider = provider or ""
             self.model = "fake-model"
             self.max_embedding_tokens = 1
@@ -77,8 +140,10 @@ def test_embedding_client_wrapper_prefers_dedicated_embedding_api_key(monkeypatc
         wrapper._get_client()
     finally:
         embedding_module.EmbeddingClient._instance = original_instance
+        embedding_module.EmbeddingClient._wrapper_instance = original_wrapper_instance
 
     assert captured == {
         "api_key": "embed-key",
         "provider": "openrouter",
+        "base_url": "https://embed.example/v1",
     }

--- a/tests/test_embedding_client.py
+++ b/tests/test_embedding_client.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+
+from src import embedding_client as embedding_module
+
+
+def test_openrouter_embedding_client_prefers_dedicated_embedding_endpoint(monkeypatch):
+    monkeypatch.setattr(
+        embedding_module.settings.LLM,
+        "OPENAI_COMPATIBLE_API_KEY",
+        "chat-key",
+    )
+    monkeypatch.setattr(
+        embedding_module.settings.LLM,
+        "OPENAI_COMPATIBLE_BASE_URL",
+        "https://chat.example/v1",
+    )
+    monkeypatch.setattr(
+        embedding_module.settings.LLM,
+        "EMBEDDING_API_KEY",
+        "embed-key",
+    )
+    monkeypatch.setattr(
+        embedding_module.settings.LLM,
+        "EMBEDDING_BASE_URL",
+        "https://embed.example/v1",
+    )
+
+    captured: dict[str, str] = {}
+
+    class FakeAsyncOpenAI:
+        def __init__(self, *, api_key: str, base_url: str):
+            captured["api_key"] = api_key
+            captured["base_url"] = base_url
+
+    monkeypatch.setattr(embedding_module, "AsyncOpenAI", FakeAsyncOpenAI)
+
+    client = embedding_module._EmbeddingClient(provider="openrouter")
+
+    assert captured == {
+        "api_key": "embed-key",
+        "base_url": "https://embed.example/v1",
+    }
+    assert client.provider == "openrouter"
+    assert client.model == "openai/text-embedding-3-small"
+
+
+def test_embedding_client_wrapper_prefers_dedicated_embedding_api_key(monkeypatch):
+    monkeypatch.setattr(embedding_module.settings.LLM, "EMBEDDING_PROVIDER", "openrouter")
+    monkeypatch.setattr(
+        embedding_module.settings.LLM,
+        "OPENAI_COMPATIBLE_API_KEY",
+        "chat-key",
+    )
+    monkeypatch.setattr(
+        embedding_module.settings.LLM,
+        "EMBEDDING_API_KEY",
+        "embed-key",
+    )
+
+    captured: dict[str, str] = {}
+    original_instance = embedding_module.EmbeddingClient._instance
+    embedding_module.EmbeddingClient._instance = None
+
+    class FakeEmbeddingClient:
+        def __init__(self, *, api_key: str | None = None, provider: str | None = None):
+            captured["api_key"] = api_key or ""
+            captured["provider"] = provider or ""
+            self.provider = provider or ""
+            self.model = "fake-model"
+            self.max_embedding_tokens = 1
+            self.encoding = SimpleNamespace()
+
+    monkeypatch.setattr(embedding_module, "_EmbeddingClient", FakeEmbeddingClient)
+
+    try:
+        wrapper = embedding_module.EmbeddingClient()
+        wrapper._get_client()
+    finally:
+        embedding_module.EmbeddingClient._instance = original_instance
+
+    assert captured == {
+        "api_key": "embed-key",
+        "provider": "openrouter",
+    }


### PR DESCRIPTION
## Summary

- add `LLM_EMBEDDING_API_KEY` and `LLM_EMBEDDING_BASE_URL` for the `openrouter` embedding path
- pass the resolved embedding base URL explicitly through the `EmbeddingClient` wrapper
- improve the missing-key error message to mention both supported embedding key settings
- add unit coverage for dedicated endpoint preference, fallback behavior, and missing-key errors
- make the `tracked_db` test fixture lazy so these pure unit tests do not force DB setup

## Motivation

A self-hosted Honcho deployment can route chat/reasoning traffic through one OpenAI-compatible provider while needing embeddings from another endpoint. Without separate embedding configuration, writes that depend on embeddings (for example, conclusion creation) can fail even though the primary LLM path is configured correctly.

## Test plan

- [x] Run the focused unit tests from the repo root:
  ```bash
  uv run pytest tests/test_embedding_client.py -q
  ```
- [x] Result: `4 passed`

## Notes

- dedicated embedding endpoint support is intentionally scoped to the `openrouter` embedding path
- the fixture change is included to keep the new tests unit-level rather than requiring database initialization
