### PR TITLE
feat: add Vertex AI support for Anthropic and Google providers

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -214,6 +214,7 @@ class LLMSettings(HonchoSettings):
     VLLM_BASE_URL: str | None = None
 
     EMBEDDING_PROVIDER: Literal["openai", "gemini", "openrouter"] = "openai"
+    EMBEDDING_MODEL: str | None = None
 
     # General LLM settings
     DEFAULT_MAX_TOKENS: Annotated[int, Field(default=1000, gt=0, le=100_000)] = 2500

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import threading
 from collections import defaultdict
 from typing import NamedTuple
@@ -32,10 +33,13 @@ class _EmbeddingClient:
         if self.provider == "gemini":
             if api_key is None:
                 api_key = settings.LLM.GEMINI_API_KEY
-            if not api_key:
+            if not api_key and os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").lower() == "true":
+                self.client: genai.Client | AsyncOpenAI = genai.Client(vertexai=True)
+            elif not api_key:
                 raise ValueError("Gemini API key is required")
-            self.client: genai.Client | AsyncOpenAI = genai.Client(api_key=api_key)
-            self.model: str = "gemini-embedding-001"
+            else:
+                self.client = genai.Client(api_key=api_key)
+            self.model: str = settings.LLM.EMBEDDING_MODEL or "gemini-embedding-001"
             # Gemini has a 2048 token limit
             self.max_embedding_tokens: int = min(settings.MAX_EMBEDDING_TOKENS, 2048)
             # Gemini batch size is not documented, using conservative estimate

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -33,12 +33,12 @@ class _EmbeddingClient:
         if self.provider == "gemini":
             if api_key is None:
                 api_key = settings.LLM.GEMINI_API_KEY
-            if not api_key and os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").lower() == "true":
-                self.client: genai.Client | AsyncOpenAI = genai.Client(vertexai=True)
-            elif not api_key:
-                raise ValueError("Gemini API key is required")
+            if api_key:
+                self.client: genai.Client | AsyncOpenAI = genai.Client(api_key=api_key)
+            elif os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").lower() == "true":
+                self.client = genai.Client(vertexai=True)
             else:
-                self.client = genai.Client(api_key=api_key)
+                raise ValueError("Gemini API key is required")
             self.model: str = settings.LLM.EMBEDDING_MODEL or "gemini-embedding-001"
             # Gemini has a 2048 token limit
             self.max_embedding_tokens: int = min(settings.MAX_EMBEDDING_TOKENS, 2048)

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -7,6 +7,10 @@ from dataclasses import dataclass
 from typing import Any, Generic, Literal, TypeVar, cast, overload
 
 from anthropic import AsyncAnthropic
+try:
+    from anthropic import AsyncAnthropicVertex
+except ImportError:
+    AsyncAnthropicVertex = type(None)
 from anthropic.types import TextBlock, ThinkingBlock, ToolUseBlock
 from anthropic.types.message import Message as AnthropicMessage
 from anthropic.types.usage import Usage
@@ -1691,7 +1695,7 @@ async def honcho_llm_call_inner(
     non_system_messages: list[dict[str, Any]] = []
 
     match client:
-        case AsyncAnthropic():
+        case AsyncAnthropic() | AsyncAnthropicVertex():
             # Anthropic requires system messages to be passed as a top-level parameter
             # Extract system messages and non-system messages
             for msg in params["messages"]:
@@ -2379,7 +2383,7 @@ async def handle_streaming_response(
         HonchoLLMCallStreamChunk: Individual chunks of the streaming response
     """
     match client:
-        case AsyncAnthropic():
+        case AsyncAnthropic() | AsyncAnthropicVertex():
             # Anthropic requires system messages as a top-level parameter
             messages = params["messages"]
             system_content = "\n\n".join(

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -257,11 +257,11 @@ if settings.LLM.ANTHROPIC_API_KEY:
         timeout=600.0,  # 10 minutes timeout for long-running operations
     )
     CLIENTS["anthropic"] = anthropic
-elif os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID"):
+elif os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID") and os.environ.get("ANTHROPIC_VERTEX_REGION"):
     from anthropic import AsyncAnthropicVertex
     anthropic = AsyncAnthropicVertex(
         project_id=os.environ["ANTHROPIC_VERTEX_PROJECT_ID"],
-        region=os.environ.get("ANTHROPIC_VERTEX_REGION", "global"),
+        region=os.environ["ANTHROPIC_VERTEX_REGION"],
         timeout=600.0,
     )
     CLIENTS["anthropic"] = anthropic

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from collections.abc import AsyncIterator, Callable
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -256,6 +257,14 @@ if settings.LLM.ANTHROPIC_API_KEY:
         timeout=600.0,  # 10 minutes timeout for long-running operations
     )
     CLIENTS["anthropic"] = anthropic
+elif os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID"):
+    from anthropic import AsyncAnthropicVertex
+    anthropic = AsyncAnthropicVertex(
+        project_id=os.environ["ANTHROPIC_VERTEX_PROJECT_ID"],
+        region=os.environ.get("ANTHROPIC_VERTEX_REGION", "global"),
+        timeout=600.0,
+    )
+    CLIENTS["anthropic"] = anthropic
 
 if settings.LLM.OPENAI_API_KEY:
     openai_client = AsyncOpenAI(
@@ -278,6 +287,9 @@ if settings.LLM.VLLM_API_KEY and settings.LLM.VLLM_BASE_URL:
 
 if settings.LLM.GEMINI_API_KEY:
     google = genai.client.Client(api_key=settings.LLM.GEMINI_API_KEY)
+    CLIENTS["google"] = google
+elif os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").lower() == "true":
+    google = genai.client.Client(vertexai=True)
     CLIENTS["google"] = google
 
 if settings.LLM.GROQ_API_KEY:

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -10,7 +10,7 @@ from anthropic import AsyncAnthropic
 try:
     from anthropic import AsyncAnthropicVertex
 except ImportError:
-    AsyncAnthropicVertex = type(None)
+    AsyncAnthropicVertex = type("_Unavailable", (), {})
 from anthropic.types import TextBlock, ThinkingBlock, ToolUseBlock
 from anthropic.types.message import Message as AnthropicMessage
 from anthropic.types.usage import Usage

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -9,8 +9,10 @@ from typing import Any, Generic, Literal, TypeVar, cast, overload
 from anthropic import AsyncAnthropic
 try:
     from anthropic import AsyncAnthropicVertex
+    _HAS_ANTHROPIC_VERTEX = True
 except ImportError:
     AsyncAnthropicVertex = type("_Unavailable", (), {})
+    _HAS_ANTHROPIC_VERTEX = False
 from anthropic.types import TextBlock, ThinkingBlock, ToolUseBlock
 from anthropic.types.message import Message as AnthropicMessage
 from anthropic.types.usage import Usage
@@ -262,7 +264,11 @@ if settings.LLM.ANTHROPIC_API_KEY:
     )
     CLIENTS["anthropic"] = anthropic
 elif os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID") and os.environ.get("CLOUD_ML_REGION"):
-    from anthropic import AsyncAnthropicVertex
+    if not _HAS_ANTHROPIC_VERTEX:
+        raise ImportError(
+            "Vertex AI env vars are set but AsyncAnthropicVertex is not available. "
+            "Install or upgrade the anthropic SDK."
+        )
     # SDK reads ANTHROPIC_VERTEX_PROJECT_ID and CLOUD_ML_REGION from env
     anthropic = AsyncAnthropicVertex(timeout=600.0)
     CLIENTS["anthropic"] = anthropic

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -257,13 +257,10 @@ if settings.LLM.ANTHROPIC_API_KEY:
         timeout=600.0,  # 10 minutes timeout for long-running operations
     )
     CLIENTS["anthropic"] = anthropic
-elif os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID") and os.environ.get("ANTHROPIC_VERTEX_REGION"):
+elif os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID") and os.environ.get("CLOUD_ML_REGION"):
     from anthropic import AsyncAnthropicVertex
-    anthropic = AsyncAnthropicVertex(
-        project_id=os.environ["ANTHROPIC_VERTEX_PROJECT_ID"],
-        region=os.environ["ANTHROPIC_VERTEX_REGION"],
-        timeout=600.0,
-    )
+    # SDK reads ANTHROPIC_VERTEX_PROJECT_ID and CLOUD_ML_REGION from env
+    anthropic = AsyncAnthropicVertex(timeout=600.0)
     CLIENTS["anthropic"] = anthropic
 
 if settings.LLM.OPENAI_API_KEY:


### PR DESCRIPTION
Vertex AI support for self-hosted Honcho -- use GCP service accounts instead of direct API keys.

## What changed

**`src/utils/clients.py`** -- when `ANTHROPIC_VERTEX_PROJECT_ID` and `ANTHROPIC_VERTEX_REGION` are both set, initializes an `AsyncAnthropicVertex` client. When `GOOGLE_GENAI_USE_VERTEXAI=true` is set, initializes `genai.Client(vertexai=True)`. Both only kick in when no direct API key is configured.

**`src/embedding_client.py`** -- same Vertex AI fallback for the Gemini embedding client. Also makes the embedding model name configurable via `LLM_EMBEDDING_MODEL`.

**`src/config.py`** -- adds `EMBEDDING_MODEL` field (optional, defaults to `gemini-embedding-001`).

## Why

If you're self-hosting on GCP and already have Vertex AI access through a service account, you shouldn't need to go get separate API keys from Anthropic and Google. This wires up the existing Vertex AI auth path.

## Tested with

- Claude haiku-4-5, sonnet-4-6, opus-4-6 via `AnthropicVertex`
- Gemini 2.5 Flash generation via Vertex AI
- Gemini embeddings (`gemini-embedding-2-preview`) via Vertex AI

Existing behavior is unaffected -- the Vertex paths only activate when env vars are set and no API key exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New configurable embedding model setting to explicitly override the default embedding model.
  * Optional Google Vertex AI backend for Gemini-style embeddings with automatic selection when configured.
  * Optional Anthropic Vertex AI backend for Anthropic-style embeddings with automatic selection when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->