### PR TITLE
fix(deriver): normalize PromptRepresentation.explicit string shapes

### DIFF
--- a/src/utils/representation.py
+++ b/src/utils/representation.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -120,10 +120,45 @@ class PromptRepresentation(BaseModel):
 
     @field_validator("explicit", mode="before")
     @classmethod
-    def convert_none_to_empty_list(cls, v: Any) -> Any:
-        """Convert None to empty list - handles LLMs returning null instead of []."""
+    def normalize_explicit(cls, v: Any) -> Any:
+        """Normalize loose shapes emitted by OpenAI-compatible providers.
+
+        Some structured-output backends occasionally emit ``explicit`` as a
+        bare string or a list of strings instead of the declared list of
+        ``{"content": str}`` objects. When that happens the whole deriver
+        batch currently falls through to the empty-fallback representation,
+        dropping otherwise usable observations (see issue #524).
+
+        This validator coerces the following shapes into the declared one:
+
+        - ``None`` -> ``[]`` (preserves prior behavior)
+        - ``"User works remotely"`` -> ``[{"content": "User works remotely"}]``
+        - ``["A", "B"]`` -> ``[{"content": "A"}, {"content": "B"}]``
+        - ``["A", {"content": "B"}]`` -> mixed strings and dicts coexist
+        - blank/whitespace-only strings are dropped
+
+        Anything that is neither ``None``, ``str``, nor ``list`` is passed
+        through unchanged so Pydantic raises its normal validation error.
+        """
         if v is None:
             return []
+        if isinstance(v, str):
+            stripped = v.strip()
+            return [{"content": stripped}] if stripped else []
+        if isinstance(v, list):
+            normalized: list[Any] = []
+            for item in cast(list[Any], v):
+                if item is None:
+                    continue
+                if isinstance(item, str):
+                    stripped = item.strip()
+                    if stripped:
+                        normalized.append({"content": stripped})
+                    continue
+                # dicts, ExplicitObservationBase instances, etc. pass through
+                # to normal Pydantic validation.
+                normalized.append(item)
+            return normalized
         return v
 
 

--- a/tests/deriver/test_representation_crud.py
+++ b/tests/deriver/test_representation_crud.py
@@ -106,3 +106,64 @@ def test_prompt_representation_conversion():
     # (they would be created directly by the Dreamer via the create_observations tool)
     assert len(rep.deductive) == 0
     assert rep.explicit[0].created_at == timestamp
+
+
+def test_prompt_representation_accepts_string_explicit():
+    """Issue #524: accept ``explicit`` emitted as a bare string."""
+    pr = PromptRepresentation.model_validate({"explicit": "User works remotely"})
+    assert [e.content for e in pr.explicit] == ["User works remotely"]
+
+
+def test_prompt_representation_accepts_list_of_strings_explicit():
+    """Issue #524: accept ``explicit`` emitted as a list of strings."""
+    pr = PromptRepresentation.model_validate(
+        {"explicit": ["User prefers Korean communication", "User likes coffee"]}
+    )
+    assert [e.content for e in pr.explicit] == [
+        "User prefers Korean communication",
+        "User likes coffee",
+    ]
+
+
+def test_prompt_representation_accepts_mixed_list_explicit():
+    """Issue #524: a list mixing strings and proper dicts is normalized."""
+    pr = PromptRepresentation.model_validate(
+        {
+            "explicit": [
+                "User works remotely",
+                {"content": "User likes coffee"},
+            ]
+        }
+    )
+    assert [e.content for e in pr.explicit] == [
+        "User works remotely",
+        "User likes coffee",
+    ]
+
+
+def test_prompt_representation_drops_blank_string_items():
+    """Issue #524: blank and whitespace-only string items are filtered out."""
+    pr = PromptRepresentation.model_validate(
+        {"explicit": ["  ", "", "User works remotely", "   "]}
+    )
+    assert [e.content for e in pr.explicit] == ["User works remotely"]
+
+
+def test_prompt_representation_bare_blank_string_explicit():
+    """Issue #524: a single bare blank string yields an empty list."""
+    pr = PromptRepresentation.model_validate({"explicit": "   "})
+    assert pr.explicit == []
+
+
+def test_prompt_representation_none_explicit_still_allowed():
+    """Existing behavior: ``None`` continues to coerce to an empty list."""
+    pr = PromptRepresentation.model_validate({"explicit": None})
+    assert pr.explicit == []
+
+
+def test_prompt_representation_proper_dicts_explicit_pass_through():
+    """Existing behavior: a well-formed dict list still validates unchanged."""
+    pr = PromptRepresentation.model_validate(
+        {"explicit": [{"content": "A"}, {"content": "B"}]}
+    )
+    assert [e.content for e in pr.explicit] == ["A", "B"]


### PR DESCRIPTION
## Summary

Closes #524.

Some OpenAI-compatible structured-output backends occasionally emit `PromptRepresentation.explicit` as a bare string or a list of strings instead of the declared `list[{"content": str}]`. Today that causes Pydantic validation to fail and the entire deriver batch falls through to the empty-fallback representation, silently dropping otherwise usable observations.

This PR extends the existing before-validator on `PromptRepresentation.explicit` (in `src/utils/representation.py`) to coerce the loose shapes called out in the issue:

| Input | Normalized to |
| --- | --- |
| `"User works remotely"` | `[{"content": "User works remotely"}]` |
| `["A", "B"]` | `[{"content": "A"}, {"content": "B"}]` |
| `["A", {"content": "B"}]` | mixed strings and dicts coexist |
| `"  "` / `""` in a list | dropped |
| `None` | `[]` (preserved) |

Anything that is neither `None`, `str`, nor `list` still passes through to normal Pydantic validation, so genuinely malformed input continues to raise.

## Why this, why now

Issue #524 is tightly scoped by its author ("not about vector dimensions, embedding provider config, queue flushing, token accounting, or broad JSON repair policy changes"), and the failure mode is concrete and user-visible: self-hosted Honcho users on OpenAI-compatible providers lose a whole batch of observations whenever the model drifts into a string-valued emission. The fix is a narrow Pydantic normalization at the validator boundary — it doesn't widen the declared schema and doesn't touch any other code path.

## What changed

- `src/utils/representation.py` — renamed `convert_none_to_empty_list` to `normalize_explicit` and extended it with the string / list-of-string / mixed-list / blank-string rules described above. `None -> []` behavior is preserved. Adds `cast` to the `typing` import to satisfy `basedpyright`.
- `tests/deriver/test_representation_crud.py` — adds seven unit tests covering each new variant plus a pass-through test for already well-formed dict input, and a test confirming the existing `None -> []` behavior still holds.

## Out of scope (intentionally)

Per the issue, this PR does **not** touch: vector dimensions, embedding provider configuration, queue flushing / backlog claiming, token usage accounting, or broad JSON repair policy changes. All of those deserve their own discussions.

## Test plan

- [x] `uv run pytest tests/deriver/test_representation_crud.py` — 10 passed (3 pre-existing + 7 new)
- [x] `uv run pytest tests/deriver/test_representation_crud.py tests/integration/test_representation.py` — 19 passed
- [x] `uv run ruff check src/utils/representation.py tests/deriver/test_representation_crud.py` — clean
- [x] `uv run ruff format --check src/utils/representation.py tests/deriver/test_representation_crud.py` — already formatted
- [x] `uv run basedpyright src/utils/representation.py tests/deriver/test_representation_crud.py` — 0 errors, 0 warnings

By Gamaliel — coworking with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced input flexibility: the explicit field now accepts bare strings and lists of mixed strings and dictionaries, with automatic normalization and filtering of blank entries.

* **Tests**
  * Added comprehensive test coverage for expanded input handling and normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->