### PR TITLE
fix(api): allow optional observer and observed parameters for cross-peer search

### DIFF
--- a/src/crud/document.py
+++ b/src/crud/document.py
@@ -278,8 +278,8 @@ async def fetch_documents_by_ids(
 async def _query_documents_pgvector(
     db: AsyncSession,
     workspace_name: str,
-    observer: str,
-    observed: str,
+    observer: str | None,
+    observed: str | None,
     embedding: list[float],
     filters: dict[str, Any] | None,
     max_distance: float | None,
@@ -289,11 +289,14 @@ async def _query_documents_pgvector(
     stmt = (
         select(models.Document)
         .where(models.Document.workspace_name == workspace_name)
-        .where(models.Document.observer == observer)
-        .where(models.Document.observed == observed)
         .where(models.Document.embedding.isnot(None))
         .where(models.Document.deleted_at.is_(None))
     )
+
+    if observer:
+        stmt = stmt.where(models.Document.observer == observer)
+    if observed:
+        stmt = stmt.where(models.Document.observed == observed)
 
     if max_distance is not None:
         stmt = stmt.where(
@@ -314,8 +317,8 @@ async def query_documents(
     workspace_name: str,
     query: str,
     *,
-    observer: str,
-    observed: str,
+    observer: str | None = None,
+    observed: str | None = None,
     filters: dict[str, Any] | None = None,
     max_distance: float | None = None,
     top_k: int = 5,
@@ -378,6 +381,11 @@ async def query_documents(
             for doc in docs:
                 managed_db.expunge(doc)
             return docs
+
+    if not observer or not observed:
+        raise ValidationException(
+            "observer and observed must be specified for semantic search on external vector stores"
+        )
 
     # External vector store — network call first, DB only for the ID fetch
     document_ids = await query_external_vector_document_ids(

--- a/src/routers/conclusions.py
+++ b/src/routers/conclusions.py
@@ -6,6 +6,7 @@ from fastapi_pagination.ext.sqlalchemy import apaginate
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, schemas
+from src.crud.document import _uses_pgvector
 from src.dependencies import db
 from src.exceptions import ResourceNotFoundException, ValidationException
 from src.security import require_auth
@@ -106,10 +107,11 @@ async def query_conclusions(
         observer = body.filters.get("observer") or body.filters.get("observer_id")
         observed = body.filters.get("observed") or body.filters.get("observed_id")
 
-    if not observer or not observed:
-        raise ValidationException(
-            "observer and observed must be specified for semantic search"
-        )
+    if not _uses_pgvector():
+        if not observer or not observed:
+            raise ValidationException(
+                "observer and observed must be specified for semantic search on external vector stores"
+            )
 
     documents = await crud.query_documents(
         db,


### PR DESCRIPTION
Fixes #520 

What changed?
We adopted the minimum viable approach recommended by the maintainers by updating the /conclusions/query endpoint and the underlying DB query logic. 

Specifically:

We modified src/crud/document.py to accept optional observer and observed parameters, ensuring the SQL constraints are dynamically bypassed when they are omitted.
We updated src/routers/conclusions.py to route the ValidationException inside a _uses_pgvector() guard logic.
We added explicitly targeted guardrails across these paths to raise a clear validation error ensuring the users of external vector stores (like LanceDB/Turbopuffer) receive a helpful message instead of a silent failure, as namespaces currently require specific scoping there.

Why was this prioritized?

I prioritized this contribution because the current constraint was creating unnecessary friction for developers wanting to query global, workspace-level insights. Fixing this improves the overall developer experience and REST API utility, without blocking future optimizations for external storage solutions. It's a quick win for the community's usability.

What problem does it solve for Honcho?

Previously, the endpoint demanded precise (workspace, observer, observed) scopes for fetching semantic conclusions. If a user simply wanted to search across all peer conversations/facts within a workspace, it would fail. By making the parameters optional when operating on standard DB infrastructure (pgvector), Honcho allows for much broader semantic searches and ad-hoc analytics without breaking security or backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made observer and observed parameters optional for document searches, enabling more flexible query capabilities.

* **Bug Fixes**
  * Fixed semantic search validation to properly handle external vector store configurations, ensuring appropriate error handling when required parameters are missing in specific search scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->