### PR TITLE
feat: add Agno memory integration example

### DIFF
--- a/examples/agno/README.md
+++ b/examples/agno/README.md
@@ -1,0 +1,101 @@
+# Honcho Memory Integration for Agno
+
+Give your [Agno](https://docs.agno.com) agents persistent memory using [Honcho](https://honcho.dev).
+
+## Features
+
+- **Persistent Memory**: Every conversation turn is saved to Honcho and automatically injected into the agent's description on the next turn.
+- **Natural Language Recall**: The agent can query Honcho's Dialectic API to answer questions like "What are my hobbies?" or "What did we talk about last time?"
+- **Context Injection**: Conversation history is retrieved from Honcho and formatted for the LLM before every request via dynamic `description`.
+- **Zero Boilerplate**: A single `chat()` function handles context injection, agent creation, and memory persistence automatically.
+
+## Structure
+
+```
+agno/
+└── python/
+    ├── main.py
+    ├── pyproject.toml
+    └── tools/
+        ├── client.py
+        ├── save_memory.py
+        ├── query_memory.py
+        └── get_context.py
+```
+
+## Environment Variables
+
+Create a `.env` file in the `python/` directory:
+
+```env
+HONCHO_API_KEY=your-honcho-api-key
+HONCHO_WORKSPACE_ID=default
+OPENAI_API_KEY=your-openai-api-key
+```
+
+Get your Honcho API key at [honcho.dev](https://honcho.dev).
+
+## Installation
+
+```bash
+pip install agno honcho-ai python-dotenv openai
+```
+
+Or with uv:
+
+```bash
+uv add agno honcho-ai python-dotenv openai
+```
+
+## Quick Start
+
+```python
+from main import chat
+
+response = chat("alice", "I love hiking in the mountains", "session-1")
+print(response)
+```
+
+## Run the Demo
+
+```bash
+cd python
+python main.py
+```
+
+## How It Works
+
+### 1. Dynamic Description
+
+Before every LLM call, `chat()` fetches recent messages from Honcho and injects them into the agent's `description` string:
+
+```
+You are a helpful assistant with persistent memory powered by Honcho.
+
+## Conversation History
+User: I love hiking
+Assistant: That sounds wonderful! Do you have a favorite trail?
+```
+
+### 2. Memory Tools
+
+The `query_memory` tool is exposed to the LLM via Agno's `@tool` decorator. When the user asks "What do you remember about me?", the agent calls this tool to query Honcho's Dialectic API — a semantic memory layer that synthesizes observations about the user into a natural language answer.
+
+Because Agno tools are plain functions without run-context injection, `make_query_memory_tool(user_id)` is a factory that closes over the user ID at call time.
+
+### 3. Auto-Save
+
+The `chat()` function saves the user message before the agent runs and the assistant response after, keeping Honcho in sync with every turn.
+
+## Concept Mapping
+
+| Agno | Honcho |
+|---|---|
+| `user_id` | Peer (human) |
+| `"assistant"` | Peer (agent) |
+| `session_id` | Session |
+| Agent input | Message |
+
+## License
+
+AGPL-3.0-or-later

--- a/examples/agno/python/main.py
+++ b/examples/agno/python/main.py
@@ -1,0 +1,121 @@
+"""Agno + Honcho persistent memory integration.
+
+Demonstrates a conversational agent that remembers users across sessions.
+Honcho stores every message and builds a long-term representation of the user;
+the agent injects that context into its instructions on every turn and can
+query memory on demand via the ``query_memory`` tool.
+
+Usage:
+    python main.py
+
+Environment variables:
+    HONCHO_API_KEY      Required. Your Honcho API key from honcho.dev.
+    HONCHO_WORKSPACE_ID Optional. Workspace ID (default: "default").
+    OPENAI_API_KEY      Required. Your OpenAI API key.
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools import tool
+
+from tools.client import HonchoContext, get_client
+from tools.get_context import get_context
+from tools.save_memory import save_memory
+
+
+def make_query_memory_tool(user_id: str):
+    """Create a query_memory tool bound to a specific user.
+
+    Agno tools are plain functions decorated with ``@tool``. Because Agno
+    does not pass a run-context to tools, we use a factory to close over
+    the ``user_id`` at call time.
+
+    Args:
+        user_id: The user peer ID whose memory to query.
+
+    Returns:
+        An Agno-compatible tool function.
+    """
+
+    @tool
+    def query_memory(query: str) -> str:
+        """Query Honcho's Dialectic API to recall facts about the current user.
+
+        Use this when the user asks what you remember about them or their
+        past conversations.
+
+        Args:
+            query: Natural language question about the user.
+
+        Returns:
+            A natural language answer from Honcho's memory.
+        """
+        honcho = get_client()
+        peer = honcho.peer(user_id)
+        response = peer.chat(query=query)
+        return str(response) if response else "No relevant information found in memory."
+
+    return query_memory
+
+
+def chat(user_id: str, message: str, session_id: str) -> str:
+    """Run one conversation turn with persistent Honcho memory.
+
+    Builds a fresh agent with dynamic instructions derived from Honcho
+    context, saves the user message before the run, and persists the
+    assistant reply after.
+
+    Args:
+        user_id: Unique identifier for the user.
+        message: The user's input message.
+        session_id: Identifier for the current conversation session.
+
+    Returns:
+        The agent's response as a string.
+    """
+    ctx = HonchoContext(user_id=user_id, session_id=session_id)
+
+    base = (
+        "You are a helpful assistant with persistent memory powered by Honcho. "
+        "You remember users across conversations. "
+        "When a user asks what you remember about them, use the query_memory tool."
+    )
+    history = get_context(ctx, tokens=2000)
+    if history:
+        formatted = "\n".join(f"{m['role'].title()}: {m['content']}" for m in history)
+        description = f"{base}\n\n## Conversation History\n{formatted}"
+    else:
+        description = base
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        description=description,
+        tools=[make_query_memory_tool(user_id)],
+        markdown=False,
+    )
+
+    save_memory(user_id, message, "user", session_id)
+    run_response = agent.run(message)
+    response = (
+        run_response.content
+        if hasattr(run_response, "content")
+        else str(run_response)
+    )
+    save_memory(user_id, response, "assistant", session_id)
+
+    return response
+
+
+if __name__ == "__main__":
+    print("Agno HonchoMemoryAgent — type 'quit' to exit\n")
+    _user_id = "demo-user"
+    _session_id = "demo-session"
+
+    while True:
+        _user_input = input("You: ").strip()
+        if not _user_input:
+            continue
+        if _user_input.lower() in ("quit", "exit"):
+            break
+        _response = chat(_user_id, _user_input, _session_id)
+        print(f"Agent: {_response}\n")

--- a/examples/agno/python/pyproject.toml
+++ b/examples/agno/python/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "honcho-agno-example"
+version = "1.0.0"
+description = "Agno integration with Honcho for persistent memory"
+requires-python = ">=3.10"
+dependencies = [
+    "agno>=1.4.0",
+    "honcho-ai>=2.0.0",
+    "python-dotenv>=1.0.0",
+    "openai>=1.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/agno/python/pyproject.toml
+++ b/examples/agno/python/pyproject.toml
@@ -5,7 +5,7 @@ description = "Agno integration with Honcho for persistent memory"
 requires-python = ">=3.10"
 dependencies = [
     "agno>=1.4.0",
-    "honcho-ai>=2.0.0",
+    "honcho-ai>=2.1.0",
     "python-dotenv>=1.0.0",
     "openai>=1.0.0",
 ]

--- a/examples/agno/python/tools/client.py
+++ b/examples/agno/python/tools/client.py
@@ -1,0 +1,50 @@
+"""Honcho client initialization and context for Agno integration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+from dotenv import load_dotenv
+from honcho import Honcho
+
+load_dotenv()
+
+
+@dataclass
+class HonchoContext:
+    """Holds Honcho identity for a single conversation turn.
+
+    Attributes:
+        user_id: Unique identifier for the human peer.
+        session_id: Identifier for the current conversation session.
+        assistant_id: Peer ID for the assistant. Defaults to ``"assistant"``.
+    """
+
+    user_id: str
+    session_id: str
+    assistant_id: str = field(default="assistant")
+
+
+def get_client(workspace_id: str | None = None) -> Honcho:
+    """Initialize and return a Honcho client.
+
+    Args:
+        workspace_id: Optional workspace ID override. Falls back to
+            ``HONCHO_WORKSPACE_ID`` env var, then to ``"default"``.
+
+    Returns:
+        Configured Honcho client instance.
+
+    Raises:
+        ValueError: If ``HONCHO_API_KEY`` is not set.
+    """
+    api_key = os.getenv("HONCHO_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "HONCHO_API_KEY is required. Set it in your environment or .env file."
+        )
+
+    env_workspace = os.getenv("HONCHO_WORKSPACE_ID")
+    resolved_workspace = workspace_id or env_workspace or "default"
+    return Honcho(api_key=api_key, workspace_id=resolved_workspace)

--- a/examples/agno/python/tools/get_context.py
+++ b/examples/agno/python/tools/get_context.py
@@ -1,0 +1,30 @@
+"""Retrieve Honcho conversation context formatted for LLM injection."""
+
+from __future__ import annotations
+
+from .client import HonchoContext, get_client
+
+
+def get_context(
+    ctx: HonchoContext,
+    tokens: int = 2000,
+) -> list[dict[str, str]]:
+    """Retrieve conversation context ready for injection into an LLM prompt.
+
+    Args:
+        ctx: ``HonchoContext`` holding the user, session, and assistant IDs.
+        tokens: Maximum number of tokens to include. Defaults to ``2000``.
+
+    Returns:
+        A list of message dicts: ``[{"role": "user" | "assistant", "content": "..."}]``.
+        Returns an empty list if the session has no messages yet.
+    """
+    honcho = get_client()
+    user_peer = honcho.peer(ctx.user_id)
+    assistant_peer = honcho.peer(ctx.assistant_id)
+    session = honcho.session(ctx.session_id)
+
+    session.add_peers([user_peer, assistant_peer])
+
+    context = session.context(tokens=tokens)
+    return context.to_openai(assistant=ctx.assistant_id)

--- a/examples/agno/python/tools/query_memory.py
+++ b/examples/agno/python/tools/query_memory.py
@@ -1,0 +1,29 @@
+"""Query Honcho memory via the Dialectic API."""
+
+from .client import get_client
+
+
+def query_memory(user_id: str, query: str) -> str:
+    """Query what Honcho knows about a user using natural language.
+
+    Sends a question to Honcho's Dialectic API and returns an answer grounded
+    in the peer's long-term memory and stored observations.
+
+    Args:
+        user_id: The user peer ID to query memory for.
+        query: Natural language question, e.g. ``"What are my hobbies?"``
+
+    Returns:
+        A natural language answer drawn from Honcho's memory, or a fallback
+        message if no relevant information was found.
+    """
+    if not query:
+        raise ValueError("query must not be empty")
+
+    honcho = get_client()
+    peer = honcho.peer(user_id)
+    response = peer.chat(query=query)
+
+    if response:
+        return str(response)
+    return "No relevant information found in memory."

--- a/examples/agno/python/tools/query_memory.py
+++ b/examples/agno/python/tools/query_memory.py
@@ -16,13 +16,21 @@ def query_memory(user_id: str, query: str) -> str:
     Returns:
         A natural language answer drawn from Honcho's memory, or a fallback
         message if no relevant information was found.
-    """
-    if not query:
-        raise ValueError("query must not be empty")
 
-    honcho = get_client()
-    peer = honcho.peer(user_id)
-    response = peer.chat(query=query)
+    Raises:
+        ValueError: If query is empty or whitespace-only.
+        RuntimeError: If the Dialectic API call fails.
+    """
+    trimmed = query.strip()
+    if not trimmed:
+        raise ValueError("query must not be empty or whitespace")
+
+    try:
+        honcho = get_client()
+        peer = honcho.peer(user_id)
+        response = peer.chat(query=trimmed)
+    except Exception as exc:
+        raise RuntimeError("Failed to query Honcho memory") from exc
 
     if response:
         return str(response)

--- a/examples/agno/python/tools/save_memory.py
+++ b/examples/agno/python/tools/save_memory.py
@@ -1,0 +1,38 @@
+"""Save a conversation message to Honcho memory."""
+
+from .client import get_client
+
+
+def save_memory(
+    user_id: str,
+    content: str,
+    role: str,
+    session_id: str,
+    assistant_id: str = "assistant",
+) -> str:
+    """Save a single conversation turn to Honcho memory.
+
+    Args:
+        user_id: Unique identifier for the user peer.
+        content: Text content of the message to save.
+        role: Either ``"user"`` or ``"assistant"``.
+        session_id: Identifier for the conversation session.
+        assistant_id: Peer ID for the assistant. Defaults to ``"assistant"``.
+
+    Returns:
+        A confirmation string describing what was saved.
+    """
+    if not content:
+        raise ValueError("content must not be empty")
+
+    honcho = get_client()
+    user_peer = honcho.peer(user_id)
+    assistant_peer = honcho.peer(assistant_id)
+    session = honcho.session(session_id)
+
+    session.add_peers([user_peer, assistant_peer])
+
+    sender = assistant_peer if role == "assistant" else user_peer
+    session.add_messages([sender.message(content)])
+
+    return f"Saved {role} message to session '{session_id}' for user '{user_id}'."

--- a/examples/agno/python/tools/save_memory.py
+++ b/examples/agno/python/tools/save_memory.py
@@ -2,6 +2,8 @@
 
 from .client import get_client
 
+_VALID_ROLES = {"user", "assistant"}
+
 
 def save_memory(
     user_id: str,
@@ -21,9 +23,14 @@ def save_memory(
 
     Returns:
         A confirmation string describing what was saved.
+
+    Raises:
+        ValueError: If content is empty or role is not ``"user"`` or ``"assistant"``.
     """
     if not content:
         raise ValueError("content must not be empty")
+    if role not in _VALID_ROLES:
+        raise ValueError(f"role must be 'user' or 'assistant', got '{role}'")
 
     honcho = get_client()
     user_peer = honcho.peer(user_id)


### PR DESCRIPTION
## Summary

- Adds `examples/agno/python/` — a full Honcho memory integration for [Agno](https://docs.agno.com) agents
- Demonstrates persistent memory using `gpt-4.1-mini` via Agno's `Agent` class with dynamic `description` injection and a `@tool`-decorated function for natural language memory recall
- Follows the same pattern as the existing `examples/openai-agents/` example

## What's included

```
examples/agno/
├── README.md
└── python/
    ├── main.py
    ├── pyproject.toml
    └── tools/
        ├── client.py       # HonchoContext + get_client()
        ├── save_memory.py
        ├── get_context.py
        └── query_memory.py
```

## How it works

1. **Dynamic description** — Before every agent call, `chat()` fetches Honcho session context and injects conversation history into the agent's `description` string.
2. **Tool factory** — `make_query_memory_tool(user_id)` uses a closure to bind the user ID into an Agno `@tool`-decorated function, since Agno tools don't receive a run context.
3. **Auto-save** — `chat()` persists the user message before the agent runs and the assistant response after.

## Test plan

- [ ] Set `HONCHO_API_KEY` and `OPENAI_API_KEY` in `python/.env`
- [ ] `pip install agno honcho-ai python-dotenv openai`
- [ ] `cd python && python main.py`
- [ ] Tell the agent something about yourself, then ask "What do you remember about me?" in a new session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Examples**
  * Added Agno agent framework example demonstrating persistent conversation memory integration with Honcho, including natural-language memory querying and automatic context injection.

* **Documentation**
  * Included setup instructions, environment variable configuration, installation commands, quick-start usage snippets, and guidance for running the example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->