### PR TITLE
feat: add Smolagents memory integration example

### DIFF
--- a/examples/smolagents/README.md
+++ b/examples/smolagents/README.md
@@ -1,0 +1,99 @@
+# Honcho Memory Integration for Smolagents
+
+Give your [Smolagents](https://huggingface.co/docs/smolagents) agents persistent memory using [Honcho](https://honcho.dev).
+
+## Features
+
+- **Persistent Memory**: Every conversation turn is saved to Honcho and automatically injected into the agent's task string on the next turn.
+- **Natural Language Recall**: The agent can query Honcho's Dialectic API to answer questions like "What are my hobbies?" or "What did we talk about last time?"
+- **Context Injection**: Conversation history is retrieved from Honcho and prepended to the agent's input message so the model always has an up-to-date view.
+- **Zero Boilerplate**: A single `chat()` function handles context injection, agent creation, and memory persistence automatically.
+
+## Structure
+
+```
+smolagents/
+└── python/
+    ├── main.py
+    ├── pyproject.toml
+    └── tools/
+        ├── client.py
+        ├── save_memory.py
+        ├── query_memory.py
+        └── get_context.py
+```
+
+## Environment Variables
+
+Create a `.env` file in the `python/` directory:
+
+```env
+HONCHO_API_KEY=your-honcho-api-key
+HONCHO_WORKSPACE_ID=default
+OPENAI_API_KEY=your-openai-api-key
+```
+
+Get your Honcho API key at [honcho.dev](https://honcho.dev).
+
+## Installation
+
+```bash
+pip install "smolagents[litellm]" honcho-ai python-dotenv
+```
+
+Or with uv:
+
+```bash
+uv add "smolagents[litellm]" honcho-ai python-dotenv
+```
+
+## Quick Start
+
+```python
+from main import chat
+
+response = chat("alice", "I love hiking in the mountains", "session-1")
+print(response)
+```
+
+## Run the Demo
+
+```bash
+cd python
+python main.py
+```
+
+## How It Works
+
+### 1. Dynamic Context Injection
+
+Before every agent call, `chat()` fetches recent messages from Honcho and prepends them to the user message:
+
+```
+## Conversation History
+User: I love hiking
+Assistant: That sounds wonderful! Do you have a favorite trail?
+
+User: What trail would you recommend for beginners?
+```
+
+### 2. Memory Tools
+
+`QueryMemoryTool` subclasses `smolagents.Tool` and exposes Honcho's Dialectic API to the agent. When the user asks "What do you remember about me?", the agent calls `forward()` which queries Honcho's semantic memory layer.
+
+### 3. Auto-Save
+
+The `chat()` function saves the user message before the agent runs and the assistant response after, keeping Honcho in sync with every turn.
+
+## Concept Mapping
+
+| Smolagents | Honcho |
+|---|---|
+| `user_id` | Peer (human) |
+| `"assistant"` | Peer (agent) |
+| `session_id` | Session |
+| Agent task | Message |
+
+## License
+
+AGPL-3.0-or-later

--- a/examples/smolagents/python/main.py
+++ b/examples/smolagents/python/main.py
@@ -82,5 +82,8 @@ if __name__ == "__main__":
             continue
         if _user_input.lower() in ("quit", "exit"):
             break
-        _response = chat(_user_id, _user_input, _session_id)
-        print(f"Agent: {_response}\n")
+        try:
+            _response = chat(_user_id, _user_input, _session_id)
+            print(f"Agent: {_response}\n")
+        except Exception as exc:
+            print(f"Error: {exc}\n")

--- a/examples/smolagents/python/main.py
+++ b/examples/smolagents/python/main.py
@@ -1,0 +1,86 @@
+"""Smolagents + Honcho persistent memory integration.
+
+Demonstrates a conversational agent that remembers users across sessions.
+Honcho stores every message and builds a long-term representation of the user;
+the agent injects that context into its task string on every turn and can
+query memory on demand via the ``query_memory`` tool.
+
+Usage:
+    python main.py
+
+Environment variables:
+    HONCHO_API_KEY      Required. Your Honcho API key from honcho.dev.
+    HONCHO_WORKSPACE_ID Optional. Workspace ID (default: "default").
+    OPENAI_API_KEY      Required. Your OpenAI API key (used via LiteLLM).
+"""
+
+from smolagents import LiteLLMModel, ToolCallingAgent
+
+from tools.client import HonchoContext
+from tools.get_context import get_context
+from tools.query_memory import QueryMemoryTool
+from tools.save_memory import save_memory
+
+SYSTEM_PROMPT = (
+    "You are a helpful assistant with persistent memory powered by Honcho. "
+    "You remember users across conversations. "
+    "When a user asks what you remember about them, use the query_memory tool."
+)
+
+
+def chat(user_id: str, message: str, session_id: str) -> str:
+    """Run one conversation turn with persistent Honcho memory.
+
+    Fetches Honcho context and prepends it to the message so the agent
+    always has an up-to-date view of the session. Saves the user message
+    before the run and the assistant reply after.
+
+    Args:
+        user_id: Unique identifier for the user.
+        message: The user's input message.
+        session_id: Identifier for the current conversation session.
+
+    Returns:
+        The agent's response as a string.
+    """
+    ctx = HonchoContext(user_id=user_id, session_id=session_id)
+
+    # Build context prefix from Honcho history
+    history = get_context(ctx, tokens=2000)
+    if history:
+        formatted = "\n".join(f"{m['role'].title()}: {m['content']}" for m in history)
+        context_prefix = f"## Conversation History\n{formatted}\n\n"
+    else:
+        context_prefix = ""
+
+    model = LiteLLMModel(model_id="openai/gpt-4.1-mini")
+    agent = ToolCallingAgent(
+        tools=[QueryMemoryTool(user_id)],
+        model=model,
+        system_prompt=SYSTEM_PROMPT,
+    )
+
+    save_memory(user_id, message, "user", session_id)
+
+    # Prepend history so the agent has full context without relying on
+    # built-in memory (Smolagents manages its own short-term memory separately)
+    full_message = f"{context_prefix}User: {message}" if context_prefix else message
+    response = str(agent.run(full_message))
+
+    save_memory(user_id, response, "assistant", session_id)
+    return response
+
+
+if __name__ == "__main__":
+    print("Smolagents HonchoMemoryAgent — type 'quit' to exit\n")
+    _user_id = "demo-user"
+    _session_id = "demo-session"
+
+    while True:
+        _user_input = input("You: ").strip()
+        if not _user_input:
+            continue
+        if _user_input.lower() in ("quit", "exit"):
+            break
+        _response = chat(_user_id, _user_input, _session_id)
+        print(f"Agent: {_response}\n")

--- a/examples/smolagents/python/pyproject.toml
+++ b/examples/smolagents/python/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "honcho-smolagents-example"
+version = "1.0.0"
+description = "Smolagents integration with Honcho for persistent memory"
+requires-python = ">=3.10"
+dependencies = [
+    "smolagents[litellm]>=1.0.0",
+    "honcho-ai>=2.0.0",
+    "python-dotenv>=1.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/smolagents/python/tools/client.py
+++ b/examples/smolagents/python/tools/client.py
@@ -1,0 +1,50 @@
+"""Honcho client initialization and context for Smolagents integration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+from dotenv import load_dotenv
+from honcho import Honcho
+
+load_dotenv()
+
+
+@dataclass
+class HonchoContext:
+    """Holds Honcho identity for a single conversation turn.
+
+    Attributes:
+        user_id: Unique identifier for the human peer.
+        session_id: Identifier for the current conversation session.
+        assistant_id: Peer ID for the assistant. Defaults to ``"assistant"``.
+    """
+
+    user_id: str
+    session_id: str
+    assistant_id: str = field(default="assistant")
+
+
+def get_client(workspace_id: str | None = None) -> Honcho:
+    """Initialize and return a Honcho client.
+
+    Args:
+        workspace_id: Optional workspace ID override. Falls back to
+            ``HONCHO_WORKSPACE_ID`` env var, then to ``"default"``.
+
+    Returns:
+        Configured Honcho client instance.
+
+    Raises:
+        ValueError: If ``HONCHO_API_KEY`` is not set.
+    """
+    api_key = os.getenv("HONCHO_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "HONCHO_API_KEY is required. Set it in your environment or .env file."
+        )
+
+    env_workspace = os.getenv("HONCHO_WORKSPACE_ID")
+    resolved_workspace = workspace_id or env_workspace or "default"
+    return Honcho(api_key=api_key, workspace_id=resolved_workspace)

--- a/examples/smolagents/python/tools/get_context.py
+++ b/examples/smolagents/python/tools/get_context.py
@@ -1,0 +1,30 @@
+"""Retrieve Honcho conversation context formatted for LLM injection."""
+
+from __future__ import annotations
+
+from .client import HonchoContext, get_client
+
+
+def get_context(
+    ctx: HonchoContext,
+    tokens: int = 2000,
+) -> list[dict[str, str]]:
+    """Retrieve conversation context ready for injection into an LLM prompt.
+
+    Args:
+        ctx: ``HonchoContext`` holding the user, session, and assistant IDs.
+        tokens: Maximum number of tokens to include. Defaults to ``2000``.
+
+    Returns:
+        A list of message dicts: ``[{"role": "user" | "assistant", "content": "..."}]``.
+        Returns an empty list if the session has no messages yet.
+    """
+    honcho = get_client()
+    user_peer = honcho.peer(ctx.user_id)
+    assistant_peer = honcho.peer(ctx.assistant_id)
+    session = honcho.session(ctx.session_id)
+
+    session.add_peers([user_peer, assistant_peer])
+
+    context = session.context(tokens=tokens)
+    return context.to_openai(assistant=ctx.assistant_id)

--- a/examples/smolagents/python/tools/query_memory.py
+++ b/examples/smolagents/python/tools/query_memory.py
@@ -37,8 +37,20 @@ class QueryMemoryTool(Tool):
 
         Returns:
             A natural language answer from Honcho's memory.
+
+        Raises:
+            ValueError: If query is empty or whitespace-only.
+            RuntimeError: If the Dialectic API call fails.
         """
-        honcho = get_client()
-        peer = honcho.peer(self.user_id)
-        response = peer.chat(query=query)
+        trimmed = query.strip()
+        if not trimmed:
+            raise ValueError("query must not be empty or whitespace")
+
+        try:
+            honcho = get_client()
+            peer = honcho.peer(self.user_id)
+            response = peer.chat(query=trimmed)
+        except Exception as exc:
+            raise RuntimeError("Failed to query Honcho memory") from exc
+
         return str(response) if response else "No relevant information found in memory."

--- a/examples/smolagents/python/tools/query_memory.py
+++ b/examples/smolagents/python/tools/query_memory.py
@@ -1,0 +1,44 @@
+"""QueryMemoryTool — Honcho Dialectic API exposed as a Smolagents Tool."""
+
+from smolagents import Tool
+
+from .client import get_client
+
+
+class QueryMemoryTool(Tool):
+    """Query Honcho's Dialectic API to recall facts about the current user.
+
+    Subclasses ``smolagents.Tool`` so the agent can call it when the user
+    asks about their history, preferences, or past conversations.
+    """
+
+    name = "query_memory"
+    description = (
+        "Query Honcho's Dialectic API to recall facts about the current user. "
+        "Use this when the user asks what you remember about them or their past conversations."
+    )
+    inputs = {
+        "query": {
+            "type": "string",
+            "description": "Natural language question about the user, e.g. 'What are my hobbies?'",
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, user_id: str) -> None:
+        super().__init__()
+        self.user_id = user_id
+
+    def forward(self, query: str) -> str:
+        """Execute the memory query.
+
+        Args:
+            query: Natural language question about the user.
+
+        Returns:
+            A natural language answer from Honcho's memory.
+        """
+        honcho = get_client()
+        peer = honcho.peer(self.user_id)
+        response = peer.chat(query=query)
+        return str(response) if response else "No relevant information found in memory."

--- a/examples/smolagents/python/tools/save_memory.py
+++ b/examples/smolagents/python/tools/save_memory.py
@@ -1,0 +1,38 @@
+"""Save a conversation message to Honcho memory."""
+
+from .client import get_client
+
+
+def save_memory(
+    user_id: str,
+    content: str,
+    role: str,
+    session_id: str,
+    assistant_id: str = "assistant",
+) -> str:
+    """Save a single conversation turn to Honcho memory.
+
+    Args:
+        user_id: Unique identifier for the user peer.
+        content: Text content of the message to save.
+        role: Either ``"user"`` or ``"assistant"``.
+        session_id: Identifier for the conversation session.
+        assistant_id: Peer ID for the assistant. Defaults to ``"assistant"``.
+
+    Returns:
+        A confirmation string describing what was saved.
+    """
+    if not content:
+        raise ValueError("content must not be empty")
+
+    honcho = get_client()
+    user_peer = honcho.peer(user_id)
+    assistant_peer = honcho.peer(assistant_id)
+    session = honcho.session(session_id)
+
+    session.add_peers([user_peer, assistant_peer])
+
+    sender = assistant_peer if role == "assistant" else user_peer
+    session.add_messages([sender.message(content)])
+
+    return f"Saved {role} message to session '{session_id}' for user '{user_id}'."

--- a/examples/smolagents/python/tools/save_memory.py
+++ b/examples/smolagents/python/tools/save_memory.py
@@ -2,6 +2,8 @@
 
 from .client import get_client
 
+_VALID_ROLES = {"user", "assistant"}
+
 
 def save_memory(
     user_id: str,
@@ -24,6 +26,8 @@ def save_memory(
     """
     if not content:
         raise ValueError("content must not be empty")
+    if role not in _VALID_ROLES:
+        raise ValueError(f"role must be 'user' or 'assistant', got '{role}'")
 
     honcho = get_client()
     user_peer = honcho.peer(user_id)


### PR DESCRIPTION
## Summary

- Adds `examples/smolagents/python/` — a full Honcho memory integration for [Smolagents](https://huggingface.co/docs/smolagents) (HuggingFace)
- Demonstrates persistent memory using a `ToolCallingAgent` with `LiteLLMModel`, a `Tool` subclass for memory recall, and Honcho context injected into the task string
- Follows the same pattern as the existing `examples/openai-agents/` example

## What's included

```
examples/smolagents/
├── README.md
└── python/
    ├── main.py
    ├── pyproject.toml
    └── tools/
        ├── client.py
        ├── save_memory.py
        ├── get_context.py
        └── query_memory.py  # QueryMemoryTool(Tool) subclass
```

## How it works

1. **Context injection** — Honcho session history is prepended to the agent task string so the model always has recent context.
2. **Tool subclass** — `QueryMemoryTool` extends `smolagents.Tool`, implementing `forward()` to call Honcho's Dialectic API. The `user_id` is stored as an instance attribute.
3. **Auto-save** — `chat()` persists the user message before the agent runs and the assistant response after.

## Test plan

- [ ] Set `HONCHO_API_KEY` and `OPENAI_API_KEY` in `python/.env`
- [ ] `pip install "smolagents[litellm]" honcho-ai python-dotenv`
- [ ] `cd python && python main.py`
- [ ] Tell the agent something about yourself, then ask "What do you remember about me?" in a new session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive integration guide explaining Smolagents setup with persistent memory, including required project structure, environment variables, dependencies, and step-by-step usage examples.

* **New Features**
  * Added a complete working example demonstrating conversational AI with persistent memory capabilities, enabling automatic conversation history retrieval and natural-language semantic memory recall across separate user sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->