### PR TITLE
feat: add Vercel AI SDK memory integration example

### DIFF
--- a/examples/vercel-ai/README.md
+++ b/examples/vercel-ai/README.md
@@ -1,0 +1,101 @@
+# Honcho Memory Integration for Vercel AI SDK
+
+Give your [Vercel AI SDK](https://sdk.vercel.ai) agents persistent memory using [Honcho](https://honcho.dev).
+
+## Features
+
+- **Persistent Memory**: Every conversation turn is saved to Honcho and automatically injected into the agent's system prompt on the next turn.
+- **Natural Language Recall**: The agent can query Honcho's Dialectic API to answer questions like "What are my hobbies?" or "What did we talk about last time?"
+- **Context Injection**: Conversation history is retrieved from Honcho and formatted as a dynamic `system` string passed to `generateText()`.
+- **Multi-Step Tool Calls**: `maxSteps: 5` allows the agent to call `query_memory` and continue responding in a single turn.
+
+## Structure
+
+```
+vercel-ai/
+├── README.md
+└── typescript/
+    ├── main.ts
+    ├── package.json
+    ├── tsconfig.json
+    └── tools/
+        ├── client.ts
+        ├── saveMemory.ts
+        ├── queryMemory.ts
+        └── getContext.ts
+```
+
+## Environment Variables
+
+Create a `.env` file in the `typescript/` directory:
+
+```env
+HONCHO_API_KEY=your-honcho-api-key
+HONCHO_WORKSPACE_ID=default
+OPENAI_API_KEY=your-openai-api-key
+```
+
+Get your Honcho API key at [honcho.dev](https://honcho.dev).
+
+## Installation
+
+```bash
+cd typescript
+bun install
+# or: npm install
+```
+
+## Quick Start
+
+```typescript
+import { chat } from './main.js';
+
+const response = await chat('alice', 'I love hiking in the mountains', 'session-1');
+console.log(response);
+```
+
+## Run the Demo
+
+```bash
+cd typescript
+bun run main.ts
+```
+
+## How It Works
+
+### 1. Dynamic System String
+
+Before every `generateText()` call, `chat()` fetches recent messages from Honcho and injects them into the `system` parameter:
+
+```
+You are a helpful assistant with persistent memory powered by Honcho.
+
+## Conversation History
+User: I love hiking
+Assistant: That sounds wonderful! Do you have a favorite trail?
+```
+
+### 2. Memory Tool Factory
+
+`makeQueryMemoryTool(ctx)` returns a Vercel AI `tool()` with a Zod schema, closing over the user context. When the model calls `query_memory`, the execute function queries Honcho's Dialectic API.
+
+### 3. Multi-Step Execution
+
+`maxSteps: 5` allows the model to call `query_memory` and then generate a natural language response in a single `chat()` call — no extra orchestration needed.
+
+### 4. Auto-Save
+
+The `chat()` function saves the user message before `generateText()` runs and the assistant response after, keeping Honcho in sync with every turn.
+
+## Concept Mapping
+
+| Vercel AI SDK | Honcho |
+|---|---|
+| `userId` | Peer (human) |
+| `"assistant"` | Peer (agent) |
+| `sessionId` | Session |
+| `system` string | Context injection |
+
+## License
+
+AGPL-3.0-or-later

--- a/examples/vercel-ai/typescript/main.ts
+++ b/examples/vercel-ai/typescript/main.ts
@@ -1,0 +1,87 @@
+/**
+ * Vercel AI SDK + Honcho persistent memory integration.
+ *
+ * Demonstrates a conversational agent that remembers users across sessions.
+ * Honcho stores every message and builds a long-term representation of the user;
+ * the agent injects that context into its system prompt on every turn and can
+ * query memory on demand via the ``query_memory`` tool.
+ *
+ * Usage:
+ *   bun run main.ts
+ *
+ * Environment variables:
+ *   HONCHO_API_KEY      Required. Your Honcho API key from honcho.dev.
+ *   HONCHO_WORKSPACE_ID Optional. Workspace ID (default: "default").
+ *   OPENAI_API_KEY      Required. Your OpenAI API key.
+ */
+
+import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import * as readline from "readline/promises";
+
+import { createContext } from "./tools/client.js";
+import type { HonchoContext } from "./tools/client.js";
+import { getContext } from "./tools/getContext.js";
+import { makeQueryMemoryTool } from "./tools/queryMemory.js";
+import { saveMemory } from "./tools/saveMemory.js";
+
+async function chat(
+  userId: string,
+  message: string,
+  sessionId: string
+): Promise<string> {
+  const ctx: HonchoContext = createContext(userId, sessionId);
+
+  const base =
+    "You are a helpful assistant with persistent memory powered by Honcho. " +
+    "You remember users across conversations. " +
+    "When a user asks what you remember about them, use the query_memory tool.";
+
+  const history = await getContext(ctx, 2000);
+  const system =
+    history.length > 0
+      ? `${base}\n\n## Conversation History\n${history
+          .map(
+            (m) =>
+              `${m.role.charAt(0).toUpperCase() + m.role.slice(1)}: ${m.content}`
+          )
+          .join("\n")}`
+      : base;
+
+  await saveMemory(userId, message, "user", sessionId);
+
+  const { text } = await generateText({
+    model: openai("gpt-4.1-mini"),
+    system,
+    prompt: message,
+    tools: { query_memory: makeQueryMemoryTool(ctx) },
+    maxSteps: 5,
+  });
+
+  await saveMemory(userId, text, "assistant", sessionId);
+  return text;
+}
+
+async function main() {
+  console.log("Vercel AI HonchoMemoryAgent — type 'quit' to exit\n");
+  const userId = "demo-user";
+  const sessionId = "demo-session";
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  while (true) {
+    const userInput = (await rl.question("You: ")).trim();
+    if (!userInput) continue;
+    if (["quit", "exit"].includes(userInput.toLowerCase())) {
+      rl.close();
+      break;
+    }
+    const response = await chat(userId, userInput, sessionId);
+    console.log(`Agent: ${response}\n`);
+  }
+}
+
+main().catch(console.error);

--- a/examples/vercel-ai/typescript/main.ts
+++ b/examples/vercel-ai/typescript/main.ts
@@ -25,7 +25,7 @@ import { getContext } from "./tools/getContext.js";
 import { makeQueryMemoryTool } from "./tools/queryMemory.js";
 import { saveMemory } from "./tools/saveMemory.js";
 
-async function chat(
+export async function chat(
   userId: string,
   message: string,
   sessionId: string
@@ -79,8 +79,12 @@ async function main() {
       rl.close();
       break;
     }
-    const response = await chat(userId, userInput, sessionId);
-    console.log(`Agent: ${response}\n`);
+    try {
+      const response = await chat(userId, userInput, sessionId);
+      console.log(`Agent: ${response}\n`);
+    } catch (err) {
+      console.error(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    }
   }
 }
 

--- a/examples/vercel-ai/typescript/package.json
+++ b/examples/vercel-ai/typescript/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "honcho-vercel-ai-example",
+  "version": "1.0.0",
+  "description": "Vercel AI SDK integration with Honcho for persistent memory",
+  "main": "main.ts",
+  "type": "module",
+  "scripts": {
+    "start": "bun run main.ts",
+    "dev": "bun --watch main.ts",
+    "typecheck": "bun run tsc --noEmit"
+  },
+  "license": "AGPL-3.0-or-later",
+  "dependencies": {
+    "@ai-sdk/openai": "^1.0.0",
+    "@honcho-ai/sdk": "^2.0.0",
+    "ai": "^4.0.0",
+    "dotenv": "^17.0.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/vercel-ai/typescript/tools/client.ts
+++ b/examples/vercel-ai/typescript/tools/client.ts
@@ -1,0 +1,24 @@
+import { Honcho } from "@honcho-ai/sdk";
+import * as dotenv from "dotenv";
+dotenv.config();
+
+export interface HonchoContext {
+  userId: string;
+  sessionId: string;
+  assistantId: string;
+}
+
+export function createContext(
+  userId: string,
+  sessionId: string,
+  assistantId = "assistant"
+): HonchoContext {
+  return { userId, sessionId, assistantId };
+}
+
+export function getClient(): Honcho {
+  const apiKey = process.env.HONCHO_API_KEY;
+  if (!apiKey) throw new Error("HONCHO_API_KEY is required.");
+  const workspaceId = process.env.HONCHO_WORKSPACE_ID ?? "default";
+  return new Honcho({ apiKey, workspaceId });
+}

--- a/examples/vercel-ai/typescript/tools/getContext.ts
+++ b/examples/vercel-ai/typescript/tools/getContext.ts
@@ -1,0 +1,15 @@
+import { getClient } from "./client.js";
+import type { HonchoContext } from "./client.js";
+
+export async function getContext(
+  ctx: HonchoContext,
+  tokens = 2000
+): Promise<Array<{ role: string; content: string }>> {
+  const honcho = getClient();
+  const userPeer = honcho.peer(ctx.userId);
+  const assistantPeer = honcho.peer(ctx.assistantId);
+  const session = honcho.session(ctx.sessionId);
+  await session.addPeers([userPeer, assistantPeer]);
+  const context = await session.context({ tokens });
+  return context.toOpenAI(ctx.assistantId);
+}

--- a/examples/vercel-ai/typescript/tools/queryMemory.ts
+++ b/examples/vercel-ai/typescript/tools/queryMemory.ts
@@ -1,0 +1,25 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { getClient } from "./client.js";
+import type { HonchoContext } from "./client.js";
+
+export function makeQueryMemoryTool(ctx: HonchoContext) {
+  return tool({
+    description:
+      "Query Honcho's Dialectic API to recall facts about the current user. " +
+      "Use this when the user asks what you remember about them.",
+    parameters: z.object({
+      query: z
+        .string()
+        .describe(
+          "Natural language question about the user, e.g. 'What are my hobbies?'"
+        ),
+    }),
+    execute: async ({ query }) => {
+      const honcho = getClient();
+      const peer = honcho.peer(ctx.userId);
+      const response = await peer.chat(query);
+      return response ?? "No relevant information found in memory.";
+    },
+  });
+}

--- a/examples/vercel-ai/typescript/tools/queryMemory.ts
+++ b/examples/vercel-ai/typescript/tools/queryMemory.ts
@@ -16,10 +16,14 @@ export function makeQueryMemoryTool(ctx: HonchoContext) {
         ),
     }),
     execute: async ({ query }) => {
-      const honcho = getClient();
-      const peer = honcho.peer(ctx.userId);
-      const response = await peer.chat(query);
-      return response ?? "No relevant information found in memory.";
+      try {
+        const honcho = getClient();
+        const peer = honcho.peer(ctx.userId);
+        const response = await peer.chat(query);
+        return response ?? "No relevant information found in memory.";
+      } catch (err) {
+        throw new Error(`Failed to query Honcho memory: ${err instanceof Error ? err.message : String(err)}`);
+      }
     },
   });
 }

--- a/examples/vercel-ai/typescript/tools/saveMemory.ts
+++ b/examples/vercel-ai/typescript/tools/saveMemory.ts
@@ -1,0 +1,17 @@
+import { getClient } from "./client.js";
+
+export async function saveMemory(
+  userId: string,
+  content: string,
+  role: "user" | "assistant",
+  sessionId: string,
+  assistantId = "assistant"
+): Promise<void> {
+  const honcho = getClient();
+  const userPeer = honcho.peer(userId);
+  const assistantPeer = honcho.peer(assistantId);
+  const session = honcho.session(sessionId);
+  await session.addPeers([userPeer, assistantPeer]);
+  const sender = role === "assistant" ? assistantPeer : userPeer;
+  await session.addMessages([sender.message(content)]);
+}

--- a/examples/vercel-ai/typescript/tsconfig.json
+++ b/examples/vercel-ai/typescript/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["*.ts", "tools/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds `examples/vercel-ai/typescript/` — a full Honcho memory integration for the [Vercel AI SDK](https://sdk.vercel.ai)
- Uses `generateText()` with a dynamic `system` string, a Zod-typed `tool()` factory for memory recall, and `maxSteps: 5` for multi-step tool calls
- Follows the same pattern as the existing `examples/openai-agents/` example

## What's included

```
examples/vercel-ai/
├── README.md
└── typescript/
    ├── main.ts
    ├── package.json
    ├── tsconfig.json
    └── tools/
        ├── client.ts
        ├── saveMemory.ts
        ├── getContext.ts
        └── queryMemory.ts   # makeQueryMemoryTool(ctx) → tool()
```

## How it works

1. **Dynamic system string** — Honcho session history is fetched and formatted into the `system` parameter of `generateText()` before every call.
2. **Tool factory** — `makeQueryMemoryTool(ctx)` returns a Vercel AI `tool()` with a Zod schema, closing over the user context. `execute` calls Honcho's Dialectic API.
3. **Multi-step** — `maxSteps: 5` allows the model to call `query_memory` and continue responding in a single `chat()` call.
4. **Auto-save** — `chat()` persists the user message before `generateText()` and the assistant response after.

## Test plan

- [ ] Set `HONCHO_API_KEY` and `OPENAI_API_KEY` in `typescript/.env`
- [ ] `cd typescript && bun install && bun run main.ts`
- [ ] Tell the agent something about yourself, start a new session, then ask "What do you remember about me?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive integration guide including setup instructions, environment configuration, and example project structure for Vercel AI SDK and Honcho.

* **New Features**
  * New example CLI application featuring persistent memory storage, context injection, and natural-language memory queries with configurable tool support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->