### PR TITLE
feat: add Mastra memory integration example

### DIFF
--- a/examples/mastra/README.md
+++ b/examples/mastra/README.md
@@ -1,0 +1,97 @@
+# Honcho Memory Integration for Mastra
+
+Give your [Mastra](https://mastra.ai) agents persistent memory using [Honcho](https://honcho.dev).
+
+## Features
+
+- **Persistent Memory**: Every conversation turn is saved to Honcho and automatically injected into the agent's instructions on the next turn.
+- **Natural Language Recall**: The agent can query Honcho's Dialectic API to answer questions like "What are my hobbies?" or "What did we talk about last time?"
+- **Context Injection**: Conversation history is retrieved from Honcho and formatted into the `instructions` string passed to `new Agent()` on every turn.
+- **Zero Boilerplate**: A single `chat()` function handles context injection, agent creation, and memory persistence automatically.
+
+## Structure
+
+```
+mastra/
+├── README.md
+└── typescript/
+    ├── main.ts
+    ├── package.json
+    ├── tsconfig.json
+    └── tools/
+        ├── client.ts
+        ├── saveMemory.ts
+        ├── queryMemory.ts
+        └── getContext.ts
+```
+
+## Environment Variables
+
+Create a `.env` file in the `typescript/` directory:
+
+```env
+HONCHO_API_KEY=your-honcho-api-key
+HONCHO_WORKSPACE_ID=default
+OPENAI_API_KEY=your-openai-api-key
+```
+
+Get your Honcho API key at [honcho.dev](https://honcho.dev).
+
+## Installation
+
+```bash
+cd typescript
+bun install
+# or: npm install
+```
+
+## Quick Start
+
+```typescript
+import { chat } from './main.js';
+
+const response = await chat('alice', 'I love hiking in the mountains', 'session-1');
+console.log(response);
+```
+
+## Run the Demo
+
+```bash
+cd typescript
+bun run main.ts
+```
+
+## How It Works
+
+### 1. Dynamic Instructions
+
+`buildInstructions(ctx)` fetches recent messages from Honcho and passes them as the `instructions` string to `new Agent()` before every `generate()` call:
+
+```
+You are a helpful assistant with persistent memory powered by Honcho.
+
+## Conversation History
+User: I love hiking
+Assistant: That sounds wonderful! Do you have a favorite trail?
+```
+
+### 2. Memory Tool Factory
+
+`makeQueryMemoryTool(ctx)` returns a Mastra `createTool()` instance, closing over the user context. When the model calls `query_memory`, the execute function queries Honcho's Dialectic API for long-term user facts.
+
+### 3. Auto-Save
+
+The `chat()` function saves the user message before `agent.generate()` runs and the assistant response after, keeping Honcho in sync with every turn.
+
+## Concept Mapping
+
+| Mastra | Honcho |
+|---|---|
+| `userId` | Peer (human) |
+| `"assistant"` | Peer (agent) |
+| `sessionId` | Session |
+| `instructions` string | Context injection |
+
+## License
+
+AGPL-3.0-or-later

--- a/examples/mastra/typescript/main.ts
+++ b/examples/mastra/typescript/main.ts
@@ -1,0 +1,94 @@
+/**
+ * Mastra + Honcho persistent memory integration.
+ *
+ * Demonstrates a conversational agent that remembers users across sessions.
+ * Honcho stores every message and builds a long-term representation of the user;
+ * the agent injects that context into its instructions on every turn and can
+ * query memory on demand via the ``query_memory`` tool.
+ *
+ * Usage:
+ *   bun run main.ts
+ *
+ * Environment variables:
+ *   HONCHO_API_KEY      Required. Your Honcho API key from honcho.dev.
+ *   HONCHO_WORKSPACE_ID Optional. Workspace ID (default: "default").
+ *   OPENAI_API_KEY      Required. Your OpenAI API key.
+ */
+
+import { Agent } from "@mastra/core/agent";
+import { openai } from "@ai-sdk/openai";
+import * as readline from "readline/promises";
+
+import { createContext } from "./tools/client.js";
+import type { HonchoContext } from "./tools/client.js";
+import { getContext } from "./tools/getContext.js";
+import { makeQueryMemoryTool } from "./tools/queryMemory.js";
+import { saveMemory } from "./tools/saveMemory.js";
+
+async function buildInstructions(ctx: HonchoContext): Promise<string> {
+  const base =
+    "You are a helpful assistant with persistent memory powered by Honcho. " +
+    "You remember users across conversations. " +
+    "When a user asks what you remember about them, use the query_memory tool.";
+
+  const history = await getContext(ctx, 2000);
+  if (history.length === 0) return base;
+
+  const formatted = history
+    .map(
+      (m) =>
+        `${m.role.charAt(0).toUpperCase() + m.role.slice(1)}: ${m.content}`
+    )
+    .join("\n");
+
+  return `${base}\n\n## Conversation History\n${formatted}`;
+}
+
+async function chat(
+  userId: string,
+  message: string,
+  sessionId: string
+): Promise<string> {
+  const ctx: HonchoContext = createContext(userId, sessionId);
+
+  await saveMemory(userId, message, "user", sessionId);
+
+  const instructions = await buildInstructions(ctx);
+
+  const agent = new Agent({
+    name: "HonchoMemoryAgent",
+    instructions,
+    model: openai("gpt-4.1-mini"),
+    tools: { query_memory: makeQueryMemoryTool(ctx) },
+  });
+
+  const result = await agent.generate(message);
+  const response = result.text;
+
+  await saveMemory(userId, response, "assistant", sessionId);
+  return response;
+}
+
+async function main() {
+  console.log("Mastra HonchoMemoryAgent — type 'quit' to exit\n");
+  const userId = "demo-user";
+  const sessionId = "demo-session";
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  while (true) {
+    const userInput = (await rl.question("You: ")).trim();
+    if (!userInput) continue;
+    if (["quit", "exit"].includes(userInput.toLowerCase())) {
+      rl.close();
+      break;
+    }
+    const response = await chat(userId, userInput, sessionId);
+    console.log(`Agent: ${response}\n`);
+  }
+}
+
+main().catch(console.error);

--- a/examples/mastra/typescript/main.ts
+++ b/examples/mastra/typescript/main.ts
@@ -44,7 +44,7 @@ async function buildInstructions(ctx: HonchoContext): Promise<string> {
   return `${base}\n\n## Conversation History\n${formatted}`;
 }
 
-async function chat(
+export async function chat(
   userId: string,
   message: string,
   sessionId: string
@@ -86,8 +86,12 @@ async function main() {
       rl.close();
       break;
     }
-    const response = await chat(userId, userInput, sessionId);
-    console.log(`Agent: ${response}\n`);
+    try {
+      const response = await chat(userId, userInput, sessionId);
+      console.log(`Agent: ${response}\n`);
+    } catch (err) {
+      console.error(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    }
   }
 }
 

--- a/examples/mastra/typescript/package.json
+++ b/examples/mastra/typescript/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "honcho-mastra-example",
+  "version": "1.0.0",
+  "description": "Mastra integration with Honcho for persistent memory",
+  "main": "main.ts",
+  "type": "module",
+  "scripts": {
+    "start": "bun run main.ts",
+    "dev": "bun --watch main.ts",
+    "typecheck": "bun run tsc --noEmit"
+  },
+  "license": "AGPL-3.0-or-later",
+  "dependencies": {
+    "@ai-sdk/openai": "^1.0.0",
+    "@honcho-ai/sdk": "^2.0.0",
+    "@mastra/core": "^0.10.0",
+    "dotenv": "^17.0.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/mastra/typescript/tools/client.ts
+++ b/examples/mastra/typescript/tools/client.ts
@@ -1,0 +1,24 @@
+import { Honcho } from "@honcho-ai/sdk";
+import * as dotenv from "dotenv";
+dotenv.config();
+
+export interface HonchoContext {
+  userId: string;
+  sessionId: string;
+  assistantId: string;
+}
+
+export function createContext(
+  userId: string,
+  sessionId: string,
+  assistantId = "assistant"
+): HonchoContext {
+  return { userId, sessionId, assistantId };
+}
+
+export function getClient(): Honcho {
+  const apiKey = process.env.HONCHO_API_KEY;
+  if (!apiKey) throw new Error("HONCHO_API_KEY is required.");
+  const workspaceId = process.env.HONCHO_WORKSPACE_ID ?? "default";
+  return new Honcho({ apiKey, workspaceId });
+}

--- a/examples/mastra/typescript/tools/getContext.ts
+++ b/examples/mastra/typescript/tools/getContext.ts
@@ -1,0 +1,15 @@
+import { getClient } from "./client.js";
+import type { HonchoContext } from "./client.js";
+
+export async function getContext(
+  ctx: HonchoContext,
+  tokens = 2000
+): Promise<Array<{ role: string; content: string }>> {
+  const honcho = getClient();
+  const userPeer = honcho.peer(ctx.userId);
+  const assistantPeer = honcho.peer(ctx.assistantId);
+  const session = honcho.session(ctx.sessionId);
+  await session.addPeers([userPeer, assistantPeer]);
+  const context = await session.context({ tokens });
+  return context.toOpenAI(ctx.assistantId);
+}

--- a/examples/mastra/typescript/tools/queryMemory.ts
+++ b/examples/mastra/typescript/tools/queryMemory.ts
@@ -15,10 +15,14 @@ export function makeQueryMemoryTool(ctx: HonchoContext) {
         .describe("Natural language question about the user"),
     }),
     execute: async ({ context: { query } }) => {
-      const honcho = getClient();
-      const peer = honcho.peer(ctx.userId);
-      const response = await peer.chat(query);
-      return { result: response ?? "No relevant information found in memory." };
+      try {
+        const honcho = getClient();
+        const peer = honcho.peer(ctx.userId);
+        const response = await peer.chat(query);
+        return { result: response ?? "No relevant information found in memory." };
+      } catch (err) {
+        throw new Error(`Failed to query Honcho memory: ${err instanceof Error ? err.message : String(err)}`);
+      }
     },
   });
 }

--- a/examples/mastra/typescript/tools/queryMemory.ts
+++ b/examples/mastra/typescript/tools/queryMemory.ts
@@ -1,0 +1,24 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+import { getClient } from "./client.js";
+import type { HonchoContext } from "./client.js";
+
+export function makeQueryMemoryTool(ctx: HonchoContext) {
+  return createTool({
+    id: "query_memory",
+    description:
+      "Query Honcho's Dialectic API to recall facts about the current user. " +
+      "Use this when the user asks what you remember about them.",
+    inputSchema: z.object({
+      query: z
+        .string()
+        .describe("Natural language question about the user"),
+    }),
+    execute: async ({ context: { query } }) => {
+      const honcho = getClient();
+      const peer = honcho.peer(ctx.userId);
+      const response = await peer.chat(query);
+      return { result: response ?? "No relevant information found in memory." };
+    },
+  });
+}

--- a/examples/mastra/typescript/tools/saveMemory.ts
+++ b/examples/mastra/typescript/tools/saveMemory.ts
@@ -1,0 +1,17 @@
+import { getClient } from "./client.js";
+
+export async function saveMemory(
+  userId: string,
+  content: string,
+  role: "user" | "assistant",
+  sessionId: string,
+  assistantId = "assistant"
+): Promise<void> {
+  const honcho = getClient();
+  const userPeer = honcho.peer(userId);
+  const assistantPeer = honcho.peer(assistantId);
+  const session = honcho.session(sessionId);
+  await session.addPeers([userPeer, assistantPeer]);
+  const sender = role === "assistant" ? assistantPeer : userPeer;
+  await session.addMessages([sender.message(content)]);
+}

--- a/examples/mastra/typescript/tsconfig.json
+++ b/examples/mastra/typescript/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["*.ts", "tools/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds `examples/mastra/typescript/` — a full Honcho memory integration for [Mastra](https://mastra.ai) agents
- Uses `new Agent({ instructions, tools })` with dynamic instructions built from Honcho context, and `createTool()` for memory recall
- Follows the same pattern as the existing `examples/openai-agents/` example

## What's included

```
examples/mastra/
├── README.md
└── typescript/
    ├── main.ts
    ├── package.json
    ├── tsconfig.json
    └── tools/
        ├── client.ts
        ├── saveMemory.ts
        ├── getContext.ts
        └── queryMemory.ts   # makeQueryMemoryTool(ctx) → createTool()
```

## How it works

1. **Dynamic instructions** — `buildInstructions(ctx)` fetches Honcho session history and passes it as the `instructions` string to `new Agent()` before every `generate()` call.
2. **Tool factory** — `makeQueryMemoryTool(ctx)` returns a Mastra `createTool()` with a Zod schema, closing over the user context. `execute` calls Honcho's Dialectic API.
3. **Auto-save** — `chat()` persists the user message before `agent.generate()` and the assistant response after.

## Test plan

- [ ] Set `HONCHO_API_KEY` and `OPENAI_API_KEY` in `typescript/.env`
- [ ] `cd typescript && bun install && bun run main.ts`
- [ ] Tell the agent something about yourself, start a new session, then ask "What do you remember about me?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)