### PR TITLE
fix: add namespace, model, and provider to langfuse metadata so we ca…

### DIFF
--- a/src/llm/api.py
+++ b/src/llm/api.py
@@ -31,6 +31,7 @@ from .runtime import (
     effective_temperature,
     plan_attempt,
     resolve_runtime_model_config,
+    update_current_langfuse_observation,
 )
 from .tool_loop import execute_tool_loop
 from .types import (
@@ -193,13 +194,19 @@ async def honcho_llm_call(
     current_attempt.set(1)
 
     def _get_attempt_plan() -> AttemptPlan:
-        return plan_attempt(
+        plan = plan_attempt(
             runtime_model_config=runtime_model_config,
             attempt=current_attempt.get(),
             retry_attempts=retry_attempts,
             call_thinking_budget_tokens=thinking_budget_tokens,
             call_reasoning_effort=reasoning_effort,
         )
+        update_current_langfuse_observation(
+            plan.provider,
+            plan.model,
+            name=track_name,
+        )
+        return plan
 
     async def _call_with_provider_selection() -> (
         HonchoLLMCallResponse[Any] | AsyncIterator[HonchoLLMCallStreamChunk]

--- a/src/llm/runtime.py
+++ b/src/llm/runtime.py
@@ -21,6 +21,7 @@ from src.config import (
     ModelConfig,
     ModelTransport,
     resolve_model_config,
+    settings,
 )
 
 from .registry import backend_for_provider, client_for_model_config
@@ -30,6 +31,33 @@ logger = logging.getLogger(__name__)
 
 # ContextVar tracking the current retry attempt for provider switching.
 current_attempt: ContextVar[int] = ContextVar("current_attempt", default=0)
+
+
+def update_current_langfuse_observation(
+    provider: ModelTransport,
+    model: str,
+    *,
+    name: str | None = None,
+) -> None:
+    """Best-effort annotation of the current Langfuse span with LLM routing."""
+    if not settings.LANGFUSE_PUBLIC_KEY:
+        return
+
+    try:
+        from langfuse import get_client
+
+        update_kwargs: dict[str, Any] = {
+            "metadata": {
+                "namespace": settings.NAMESPACE,
+                "provider": provider,
+                "model": model,
+            }
+        }
+        if name is not None:
+            update_kwargs["name"] = name
+        get_client().update_current_span(**update_kwargs)
+    except Exception as exc:  # pragma: no cover - best-effort telemetry
+        logger.debug("Failed to update Langfuse span metadata: %s", exc)
 
 
 @dataclass(frozen=True)
@@ -204,4 +232,5 @@ __all__ = [
     "resolve_backend_for_plan",
     "resolve_runtime_model_config",
     "select_model_config_for_attempt",
+    "update_current_langfuse_observation",
 ]

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -33,6 +33,43 @@ from src.utils.types import SupportedProviders, set_current_iteration
 
 logger = logging.getLogger(__name__)
 
+
+def _update_langfuse_metadata(
+    provider: str, model: str, *, name: str | None = None
+) -> None:
+    """
+    Attach ``namespace``, ``provider``, and ``model`` to the current Langfuse
+    observation, optionally renaming it to a more specific top-level label.
+
+    Uses ``langfuse.get_client().update_current_span(...)``, which annotates the
+    currently-active ``@observe``-decorated span via OpenTelemetry context, so
+    the metadata lands on the current top-level span itself rather than any child.
+
+    No-op when Langfuse is not configured. Any failure is swallowed and logged
+    at debug level so observability issues never break LLM execution.
+    """
+    if not settings.LANGFUSE_PUBLIC_KEY:
+        return
+    try:
+        from langfuse import get_client
+
+        update_kwargs: dict[str, Any] = {
+            "metadata": {
+                "namespace": settings.NAMESPACE,
+                "provider": provider,
+                "model": model,
+            }
+        }
+        if name is not None:
+            update_kwargs["name"] = name
+
+        get_client().update_current_span(
+            **update_kwargs,
+        )
+    except Exception as exc:  # pragma: no cover - best-effort telemetry
+        logger.debug("Failed to update Langfuse span metadata: %s", exc)
+
+
 # Gemini finish reasons that indicate the response was blocked by safety or policy
 # filters. When these occur, the response typically has no usable text content and
 # retrying with a backup provider is appropriate.
@@ -738,6 +775,7 @@ async def _execute_tool_loop(
             conversation_messages: list[dict[str, Any]] = conversation_messages,
         ) -> HonchoLLMCallResponse[Any]:
             # Use shared provider selection helper
+            # (also tags the current Langfuse LLM Call span as a side effect).
             provider, model, thinking_budget, gpt5_reasoning_effort, gpt5_verbosity = (
                 get_provider_and_model()
             )
@@ -812,6 +850,11 @@ async def _execute_tool_loop(
                 continue
 
             if stream_final:
+                # Tag the current Langfuse "LLM Call" span before handing back
+                # the async generator — the generator body runs after this
+                # function returns (and after the @observe span would close),
+                # so metadata must be set here.
+                _update_langfuse_metadata(llm_settings.PROVIDER, llm_settings.MODEL)
                 # Stream the final response with metadata from tool execution
                 stream = _stream_final_response(
                     llm_settings=llm_settings,
@@ -946,6 +989,9 @@ async def _execute_tool_loop(
 
     # If streaming the final response, use the streaming helper with metadata
     if stream_final:
+        # Tag the current Langfuse "LLM Call" span before handing back
+        # the async generator — see note in the non-max branch above.
+        _update_langfuse_metadata(llm_settings.PROVIDER, llm_settings.MODEL)
         stream = _stream_final_response(
             llm_settings=llm_settings,
             prompt=prompt,
@@ -975,6 +1021,7 @@ async def _execute_tool_loop(
 
     async def _final_call() -> HonchoLLMCallResponse[Any]:
         # Use shared provider selection helper for backup failover support
+        # (also tags the current Langfuse LLM Call span as a side effect).
         provider, model, thinking_budget, gpt5_reasoning_effort, gpt5_verbosity = (
             get_provider_and_model()
         )
@@ -1357,6 +1404,13 @@ async def honcho_llm_call(
         """
         Get the provider and model to use based on current attempt.
 
+        Side effect: tags the current Langfuse observation with
+        ``namespace``/``provider``/``model`` metadata and, when ``track_name``
+        is provided, renames it to that higher-level operation label so every path through
+        ``honcho_llm_call`` — non-tool calls, tool-loop iterations, the final
+        synthesis call, and retry/backup-failover attempts — annotates the
+        outer ``@observe`` span itself (not a child).
+
         Returns:
             Tuple of (provider, model, thinking_budget, reasoning_effort, verbosity)
         """
@@ -1406,6 +1460,8 @@ async def honcho_llm_call(
             thinking_budget = thinking_budget_tokens
             gpt5_reasoning_effort = reasoning_effort
             gpt5_verbosity = verbosity
+
+        _update_langfuse_metadata(provider, model, name=track_name)
 
         return provider, model, thinking_budget, gpt5_reasoning_effort, gpt5_verbosity
 

--- a/tests/utils/test_clients.py
+++ b/tests/utils/test_clients.py
@@ -1175,6 +1175,43 @@ class TestMainLLMCallFunction:
 
             assert response.content == "No retry response"
 
+    async def test_track_name_updates_langfuse_span_name(self):
+        """track_name should rename the top-level Langfuse span."""
+
+        mock_llm_client = AsyncMock(spec=AsyncAnthropic)
+        mock_response = Mock()
+        mock_response.content = [TextBlock(text="Named response", type="text")]
+        mock_response.usage = Usage(input_tokens=5, output_tokens=5)
+        mock_response.stop_reason = "stop"
+        mock_llm_client.messages.create = AsyncMock(return_value=mock_response)
+
+        mock_langfuse_client = Mock()
+
+        with (
+            patch.dict(CLIENTS, {"anthropic": mock_llm_client}),
+            patch.object(settings, "LANGFUSE_PUBLIC_KEY", "test-public-key"),
+            patch("langfuse.get_client", return_value=mock_langfuse_client),
+        ):
+            settings.DIALECTIC.LEVELS["medium"].PROVIDER = "anthropic"
+            settings.DIALECTIC.LEVELS["medium"].MODEL = "claude-4-sonnet"
+            response = await honcho_llm_call(
+                llm_settings=settings.DIALECTIC.LEVELS["medium"],
+                prompt="Hello",
+                max_tokens=100,
+                enable_retry=False,
+                track_name="Dialectic Agent",
+            )
+
+            assert response.content == "Named response"
+            mock_langfuse_client.update_current_span.assert_called_once_with(
+                name="Dialectic Agent",
+                metadata={
+                    "namespace": settings.NAMESPACE,
+                    "provider": "anthropic",
+                    "model": "claude-4-sonnet",
+                },
+            )
+
 
 class TestEdgeCases:
     """Tests for edge cases and boundary conditions"""

--- a/tests/utils/test_clients.py
+++ b/tests/utils/test_clients.py
@@ -23,7 +23,12 @@ from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.completion_usage import CompletionUsage
 from pydantic import BaseModel, Field
 
-from src.config import ConfiguredModelSettings, ModelConfig, ResolvedFallbackConfig
+from src.config import (
+    ConfiguredModelSettings,
+    ModelConfig,
+    ResolvedFallbackConfig,
+    settings,
+)
 from src.exceptions import LLMError, ValidationException
 from src.llm import (
     CLIENTS,
@@ -904,6 +909,44 @@ class TestMainLLMCallFunction:
             )
 
             assert response.content == "No retry response"
+
+    async def test_track_name_updates_langfuse_span_name(self):
+        """track_name should rename the top-level Langfuse span."""
+
+        mock_llm_client = AsyncMock(spec=AsyncAnthropic)
+        mock_response = Mock()
+        mock_response.content = [TextBlock(text="Named response", type="text")]
+        mock_response.usage = Usage(input_tokens=5, output_tokens=5)
+        mock_response.stop_reason = "stop"
+        mock_llm_client.messages.create = AsyncMock(return_value=mock_response)
+
+        mock_langfuse_client = Mock()
+
+        with (
+            patch.dict(CLIENTS, {"anthropic": mock_llm_client}),
+            patch.object(settings, "LANGFUSE_PUBLIC_KEY", "test-public-key"),
+            patch("langfuse.get_client", return_value=mock_langfuse_client),
+        ):
+            response = await honcho_llm_call(
+                model_config=ConfiguredModelSettings(
+                    model="claude-4-sonnet",
+                    transport="anthropic",
+                ),
+                prompt="Hello",
+                max_tokens=100,
+                enable_retry=False,
+                track_name="Dialectic Agent",
+            )
+
+            assert response.content == "Named response"
+            mock_langfuse_client.update_current_span.assert_called_once_with(
+                name="Dialectic Agent",
+                metadata={
+                    "namespace": settings.NAMESPACE,
+                    "provider": "anthropic",
+                    "model": "claude-4-sonnet",
+                },
+            )
 
 
 class TestEdgeCases:


### PR DESCRIPTION
…n filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Langfuse span name tracking with metadata validation.

* **New Features**
  * Improved LLM call tracking with automatic Langfuse span updates capturing provider, model, and custom naming information per attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->