### PR TITLE
Feat/sqlite local dev 405

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "scikit-learn>=1.6.0",
     "prometheus_client>=0.21.0",
     "cloudevents>=1.12.0",
+    "aiosqlite>=0.19.0",
 ]
 [dependency-groups]
 dev = [

--- a/src/config.py
+++ b/src/config.py
@@ -173,6 +173,14 @@ class DBSettings(HonchoSettings):
     SQL_DEBUG: bool = False
     TRACING: bool = False
 
+    @model_validator(mode="after")
+    def _sqlite_defaults(self) -> "DBSettings":
+        """Auto-configure pool and schema when using SQLite."""
+        if self.CONNECTION_URI.startswith("sqlite"):
+            object.__setattr__(self, "POOL_CLASS", "null")
+            object.__setattr__(self, "SCHEMA", "")
+        return self
+
 
 class AuthSettings(HonchoSettings):
     model_config = SettingsConfigDict(env_prefix="AUTH_", extra="ignore")  # pyright: ignore
@@ -686,3 +694,8 @@ class AppSettings(HonchoSettings):
 
 # Create a single global instance of the settings
 settings: AppSettings = AppSettings()
+
+
+def is_sqlite() -> bool:
+    """Return True when the configured database is SQLite."""
+    return settings.DB.CONNECTION_URI.startswith("sqlite")

--- a/src/crud/deriver.py
+++ b/src/crud/deriver.py
@@ -87,8 +87,8 @@ def _build_queue_status_query(
     observed: str | None = None,
 ) -> Select[Any]:
     """Build SQL query for queue status with validation and aggregation."""
-    observer_name_expr = models.QueueItem.payload["observer"].astext
-    observed_name_expr = models.QueueItem.payload["observed"].astext
+    observer_name_expr = models.QueueItem.payload["observer"].as_string()
+    observed_name_expr = models.QueueItem.payload["observed"].as_string()
 
     # Define conditions for cleaner window functions
     is_completed = models.QueueItem.processed

--- a/src/crud/document.py
+++ b/src/crud/document.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql import Select
 from sqlalchemy.sql.functions import func
 
 from src import models, schemas
-from src.config import settings
+from src.config import is_sqlite, settings
 from src.crud.collection import get_or_create_collection
 from src.crud.peer import get_peer
 from src.crud.session import get_session
@@ -193,6 +193,8 @@ async def query_documents_most_derived(
 
 def _uses_pgvector() -> bool:
     """Check whether queries should go through pgvector (DB-only) path."""
+    if is_sqlite():
+        return False
     return (
         settings.VECTOR_STORE.TYPE == "pgvector" or not settings.VECTOR_STORE.MIGRATED
     )

--- a/src/crud/message.py
+++ b/src/crud/message.py
@@ -251,44 +251,47 @@ async def create_messages(
         workspace_name=workspace_name,
     )
 
-    _session_lock = await _acquire_session_lock(db, workspace_name, session_name)
-
-    # Get the last sequence number on a session - uses (workspace_name, session_name, seq_in_session) index
-    last_seq = (
-        await db.scalar(
-            select(models.Message.seq_in_session)
-            .where(
-                models.Message.workspace_name == workspace_name,
-                models.Message.session_name == session_name,
-            )
-            .order_by(models.Message.seq_in_session.desc())
-            .limit(1)
-        )
-        or 0
-    )
-
-    # Create list of message objects (this will trigger the before_insert event)
-    message_objects: list[models.Message] = []
-    for offset, message in enumerate(messages, start=1):
-        message_seq_in_session = last_seq + offset
-        message_obj = models.Message(
-            session_name=session_name,
-            peer_name=message.peer_name,
-            content=message.content,
-            h_metadata=message.metadata or {},
-            workspace_name=workspace_name,
-            public_id=generate_nanoid(),
-            token_count=len(message.encoded_message),
-            created_at=message.created_at,  # Use provided created_at if available
-            seq_in_session=message_seq_in_session,
-        )
-        message_objects.append(message_obj)
-
-    db.add_all(message_objects)
-
     # Commit here to release the advisory lock before generating embeddings.
-    # For SQLite, also release the asyncio.Lock acquired above.
+    # For SQLite, also release the asyncio.Lock acquired below.
+    # The try/finally starts before the acquire so the lock is always released
+    # even if an intermediate DB query or object construction raises.
+    _session_lock = None
     try:
+        _session_lock = await _acquire_session_lock(db, workspace_name, session_name)
+
+        # Get the last sequence number on a session - uses (workspace_name, session_name, seq_in_session) index
+        last_seq = (
+            await db.scalar(
+                select(models.Message.seq_in_session)
+                .where(
+                    models.Message.workspace_name == workspace_name,
+                    models.Message.session_name == session_name,
+                )
+                .order_by(models.Message.seq_in_session.desc())
+                .limit(1)
+            )
+            or 0
+        )
+
+        # Create list of message objects (this will trigger the before_insert event)
+        message_objects: list[models.Message] = []
+        for offset, message in enumerate(messages, start=1):
+            message_seq_in_session = last_seq + offset
+            message_obj = models.Message(
+                session_name=session_name,
+                peer_name=message.peer_name,
+                content=message.content,
+                h_metadata=message.metadata or {},
+                workspace_name=workspace_name,
+                public_id=generate_nanoid(),
+                token_count=len(message.encoded_message),
+                created_at=message.created_at,  # Use provided created_at if available
+                seq_in_session=message_seq_in_session,
+            )
+            message_objects.append(message_obj)
+
+        db.add_all(message_objects)
+
         await db.commit()
     finally:
         if _session_lock is not None:

--- a/src/crud/message.py
+++ b/src/crud/message.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Sequence
 from datetime import datetime
 from logging import getLogger
@@ -8,7 +9,7 @@ from sqlalchemy import ColumnElement, Select, and_, func, or_, select, text, upd
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import models, schemas
-from src.config import settings
+from src.config import is_sqlite, settings
 from src.dependencies import tracked_db
 from src.embedding_client import embedding_client
 from src.utils.filter import apply_filter
@@ -18,6 +19,40 @@ from src.vector_store import VectorRecord, get_external_vector_store, upsert_wit
 from .session import get_or_create_session
 
 logger = getLogger(__name__)
+
+# Per-session asyncio locks used as a fallback for SQLite (single-process only).
+# PostgreSQL uses pg_advisory_xact_lock which is cross-process safe.
+_sqlite_session_locks: dict[tuple[str, str], asyncio.Lock] = {}
+_sqlite_locks_mutex = asyncio.Lock()
+
+
+async def _acquire_session_lock(
+    db: AsyncSession, workspace_name: str, session_name: str
+) -> asyncio.Lock | None:
+    """Acquire a write lock for the given session.
+
+    On PostgreSQL: uses a transaction-scoped advisory lock (auto-released on commit).
+    On SQLite: uses an asyncio.Lock (must be explicitly released by the caller).
+
+    Returns the acquired asyncio.Lock (SQLite) or None (PostgreSQL, lock is implicit).
+    """
+    if is_sqlite():
+        async with _sqlite_locks_mutex:
+            key = (workspace_name, session_name)
+            if key not in _sqlite_session_locks:
+                _sqlite_session_locks[key] = asyncio.Lock()
+            lock = _sqlite_session_locks[key]
+        await lock.acquire()
+        return lock
+
+    await db.execute(text("SET LOCAL lock_timeout = '5s'"))
+    await db.execute(
+        text(
+            "SELECT pg_advisory_xact_lock(hashtext(:workspace_name), hashtext(:session_name))"
+        ),
+        {"workspace_name": workspace_name, "session_name": session_name},
+    )
+    return None
 
 
 def _deduplicate_messages(
@@ -216,13 +251,7 @@ async def create_messages(
         workspace_name=workspace_name,
     )
 
-    await db.execute(text("SET LOCAL lock_timeout = '5s'"))
-    await db.execute(
-        text(
-            "SELECT pg_advisory_xact_lock(hashtext(:workspace_name), hashtext(:session_name))"
-        ),
-        {"workspace_name": workspace_name, "session_name": session_name},
-    )
+    _session_lock = await _acquire_session_lock(db, workspace_name, session_name)
 
     # Get the last sequence number on a session - uses (workspace_name, session_name, seq_in_session) index
     last_seq = (
@@ -257,8 +286,13 @@ async def create_messages(
 
     db.add_all(message_objects)
 
-    # Commit here to release the advisory lock before generating embeddings
-    await db.commit()
+    # Commit here to release the advisory lock before generating embeddings.
+    # For SQLite, also release the asyncio.Lock acquired above.
+    try:
+        await db.commit()
+    finally:
+        if _session_lock is not None:
+            _session_lock.release()
     try:
         if settings.EMBED_MESSAGES:
             encoded_message_lookup = {

--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -11,7 +11,7 @@ from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import make_transient_to_detached
-from sqlalchemy.types import BigInteger, Boolean
+from sqlalchemy.types import BigInteger
 
 from src import models, schemas
 from src.cache.client import (

--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -987,9 +987,7 @@ async def _get_or_add_peers_to_session(
             models.SessionPeer.peer_name.notin_(
                 peer_names.keys()
             ),  # Exclude peers being updated
-            models.SessionPeer.configuration["observe_others"].astext.cast(
-                Boolean
-            ),  # Only observers
+            models.SessionPeer.configuration["observe_others"].as_boolean(),  # Only observers
         )
         result = await db.execute(existing_observers_stmt)
         existing_observer_count = result.scalar() or 0
@@ -1135,9 +1133,7 @@ async def set_peer_config(
                 models.SessionPeer.left_at.is_(None),  # Only active peers
                 models.SessionPeer.peer_name
                 != peer_name,  # Exclude the peer being updated
-                models.SessionPeer.configuration["observe_others"].astext.cast(
-                    Boolean
-                ),  # Only observers
+                models.SessionPeer.configuration["observe_others"].as_boolean(),  # Only observers
             )
             result = await db.execute(existing_observers_stmt)
             observer_count = result.scalar() or 0

--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -6,7 +6,7 @@ from typing import cast as typing_cast
 from cashews import NOT_NONE
 from nanoid import generate as generate_nanoid
 from sqlalchemy import Select, and_, case, cast, delete, func, insert, select, update
-from sqlalchemy.dialects.postgresql import insert as pg_insert
+from src.db_types import upsert_insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -1000,7 +1000,7 @@ async def _get_or_add_peers_to_session(
             raise ObserverException(session_name, total_observers)
 
     # Use upsert to handle both new peers and rejoining peers
-    stmt = pg_insert(models.SessionPeer).values(
+    stmt = upsert_insert(models.SessionPeer).values(
         [
             {
                 "session_name": session_name,

--- a/src/db.py
+++ b/src/db.py
@@ -5,9 +5,9 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.pool import NullPool
 
-from src.config import settings
+from src.config import is_sqlite, settings
 
-connect_args = {"prepare_threshold": None}
+connect_args = {"check_same_thread": False} if is_sqlite() else {"prepare_threshold": None}
 
 # Context variable to store request context
 request_context: contextvars.ContextVar[str | None] = contextvars.ContextVar(
@@ -54,7 +54,7 @@ convention = {
     "pk": "pk_%(table_name)s",  # Primary key
 }
 
-table_schema = settings.DB.SCHEMA
+table_schema = settings.DB.SCHEMA or None  # empty string (SQLite) → None
 # Note: column_0_N_name expands to include all columns in multi-column constraints
 # e.g., "workspace_id_tenant_id" for a composite constraint on both columns
 meta = MetaData(naming_convention=convention)
@@ -63,7 +63,16 @@ Base = declarative_base(metadata=meta)
 
 
 async def init_db():
-    """Initialize the database using Alembic migrations"""
+    """Initialize the database.
+
+    For SQLite: creates all tables directly via SQLAlchemy metadata (no Alembic).
+    For PostgreSQL: installs the pgvector extension and runs Alembic migrations.
+    """
+    if is_sqlite():
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        return
+
     from alembic import command
     from alembic.config import Config
 

--- a/src/db_types.py
+++ b/src/db_types.py
@@ -1,0 +1,107 @@
+"""Cross-dialect SQLAlchemy type helpers for SQLite compatibility.
+
+These utilities allow the same model definitions to work on both
+PostgreSQL (production) and SQLite (local development).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import JSON, CheckConstraint, Index, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import TypeDecorator, TypeEngine
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Dialect
+
+
+class JSONBCompat(TypeDecorator[Any]):
+    """Use JSONB on PostgreSQL, JSON on SQLite and other dialects."""
+
+    impl: TypeEngine[Any] | type[TypeEngine[Any]] = JSON
+    cache_ok: bool | None = True
+
+    def load_dialect_impl(self, dialect: Dialect) -> Any:
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(JSONB())
+        return dialect.type_descriptor(JSON())
+
+
+class VectorType(TypeDecorator[Any]):
+    """Use pgvector Vector on PostgreSQL, JSON-serialized TEXT on SQLite.
+
+    On SQLite the embedding is stored as a JSON text string and is never
+    used for cosine-distance queries — vector search is routed through the
+    external vector store (e.g. lancedb) when running in SQLite mode.
+    """
+
+    impl: TypeEngine[Any] | type[TypeEngine[Any]] = Text
+    cache_ok: bool | None = True
+
+    def __init__(self, dimensions: int = 1536) -> None:
+        super().__init__()
+        self.dimensions: int = dimensions
+
+    def load_dialect_impl(self, dialect: Dialect) -> Any:
+        if dialect.name == "postgresql":
+            from pgvector.sqlalchemy import Vector  # type: ignore[import-untyped]
+
+            return dialect.type_descriptor(Vector(self.dimensions))  # pyright: ignore[reportUnknownVariableType]
+        return dialect.type_descriptor(Text())
+
+    def process_bind_param(self, value: Any, dialect: Dialect) -> Any:
+        if dialect.name != "postgresql" and value is not None:
+            return json.dumps(value)
+        return value
+
+    def process_result_value(self, value: Any, dialect: Dialect) -> Any:
+        if dialect.name != "postgresql" and value is not None:
+            return json.loads(value)
+        return value
+
+
+def pg_check(sqltext: str, name: str) -> CheckConstraint | None:
+    """Return a CheckConstraint only when NOT running SQLite.
+
+    Use with ``*filter(None, [...])`` unpacking in ``__table_args__`` to
+    cleanly drop the constraint on SQLite without changing model structure.
+    """
+    from src.config import is_sqlite
+
+    if is_sqlite():
+        return None
+    return CheckConstraint(sqltext, name=name)
+
+
+def pg_only_index(name: str, *args: Any, **kwargs: Any) -> Index | None:
+    """Return an Index only when NOT running SQLite.
+
+    Use with ``*filter(None, [...])`` unpacking in ``__table_args__``.
+    Needed for indexes whose column expressions are PostgreSQL-specific SQL
+    (e.g. ``to_tsvector(...)``). Indexes that use only ``postgresql_``-prefixed
+    kwargs don't need this — SQLAlchemy already ignores those on other dialects.
+    """
+    from src.config import is_sqlite
+
+    if is_sqlite():
+        return None
+    return Index(name, *args, **kwargs)
+
+
+def upsert_insert(model: Any) -> Any:
+    """Return a dialect-appropriate Insert that supports on_conflict_do_update.
+
+    PostgreSQL uses ``sqlalchemy.dialects.postgresql.insert``;
+    SQLite uses ``sqlalchemy.dialects.sqlite.insert`` (requires SQLite >= 3.24).
+    """
+    from src.config import is_sqlite
+
+    if is_sqlite():
+        from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+        return sqlite_insert(model)
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    return pg_insert(model)

--- a/src/db_types.py
+++ b/src/db_types.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import JSON, CheckConstraint, Index, Text
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.expression import FunctionElement
 from sqlalchemy.types import TypeDecorator, TypeEngine
 
 if TYPE_CHECKING:
@@ -130,6 +132,32 @@ def pg_only_index(name: str, *args: Any, **kwargs: Any) -> Index | None:
     if is_sqlite():
         return None
     return Index(name, *args, **kwargs)
+
+
+class _EmptyJsonObject(FunctionElement):  # type: ignore[type-arg]
+    """Dialect-aware server default for JSONBCompat columns."""
+
+    inherit_cache = True
+
+
+@compiles(_EmptyJsonObject)  # type: ignore[misc]
+def _emit_empty_json(element: Any, compiler: Any, **kw: Any) -> str:
+    return "'{}'"
+
+
+@compiles(_EmptyJsonObject, "postgresql")  # type: ignore[misc]
+def _emit_empty_jsonb(element: Any, compiler: Any, **kw: Any) -> str:
+    return "'{}'::jsonb"
+
+
+def empty_json_default() -> _EmptyJsonObject:
+    """Return ``'{}'::jsonb`` on PostgreSQL and ``'{}'`` on SQLite.
+
+    Use as ``server_default=empty_json_default()`` on JSONBCompat columns so
+    that Alembic autogenerate sees the same string as existing migrations on
+    PostgreSQL while SQLite CREATE TABLE gets valid syntax.
+    """
+    return _EmptyJsonObject()
 
 
 def upsert_insert(model: Any) -> Any:

--- a/src/db_types.py
+++ b/src/db_types.py
@@ -18,10 +18,33 @@ if TYPE_CHECKING:
 
 
 class JSONBCompat(TypeDecorator[Any]):
-    """Use JSONB on PostgreSQL, JSON on SQLite and other dialects."""
+    """Use JSONB on PostgreSQL, JSON on SQLite and other dialects.
+
+    Overrides the Comparator to ensure JSON-specific operators (``contains``
+    via ``@>``, subscript ``__getitem__``, and ``.astext``) are forwarded
+    through SQLAlchemy's JSON type rather than falling back to the base
+    ``ColumnOperators`` implementations (which would generate LIKE etc.).
+    """
 
     impl: TypeEngine[Any] | type[TypeEngine[Any]] = JSON
     cache_ok: bool | None = True
+
+    class Comparator(TypeDecorator.Comparator[Any]):  # type: ignore[type-arg]
+        def contains(self, other: Any, **kwargs: Any) -> Any:
+            # Use JSON's contains (→ @> on PostgreSQL, json_extract on SQLite)
+            # instead of base ColumnOperators.contains which generates LIKE.
+            from sqlalchemy import JSON as SaJSON, type_coerce
+
+            return type_coerce(self.expr, SaJSON()).contains(other, **kwargs)
+
+        def __getitem__(self, index: Any) -> Any:
+            # Delegate to the generic JSON type's subscript so that the
+            # returned element has .astext (and other JSON accessor attrs).
+            from sqlalchemy import JSON as SaJSON, type_coerce
+
+            return type_coerce(self.expr, SaJSON())[index]
+
+    comparator_factory = Comparator
 
     def load_dialect_impl(self, dialect: Dialect) -> Any:
         if dialect.name == "postgresql":
@@ -35,6 +58,11 @@ class VectorType(TypeDecorator[Any]):
     On SQLite the embedding is stored as a JSON text string and is never
     used for cosine-distance queries — vector search is routed through the
     external vector store (e.g. lancedb) when running in SQLite mode.
+
+    Overrides the Comparator to forward ``cosine_distance`` to the real
+    pgvector ``Vector`` type so that query expressions like
+    ``column.cosine_distance(vec)`` work even though the mapped column type
+    is ``VectorType`` rather than the raw pgvector ``Vector``.
     """
 
     impl: TypeEngine[Any] | type[TypeEngine[Any]] = Text
@@ -43,6 +71,20 @@ class VectorType(TypeDecorator[Any]):
     def __init__(self, dimensions: int = 1536) -> None:
         super().__init__()
         self.dimensions: int = dimensions
+
+    class Comparator(TypeDecorator.Comparator[Any]):  # type: ignore[type-arg]
+        def cosine_distance(self, other: Any) -> Any:
+            # type_coerce tells SQLAlchemy to treat this expression as a real
+            # pgvector Vector without wrapping it in extra SQL, then delegate
+            # to pgvector's .cosine_distance() for the <=> operator.
+            from pgvector.sqlalchemy import Vector  # type: ignore[import-untyped]
+            from sqlalchemy import type_coerce
+
+            return type_coerce(
+                self.expr, Vector(self.type.dimensions)  # pyright: ignore[reportUnknownVariableType]
+            ).cosine_distance(other)
+
+    comparator_factory = Comparator
 
     def load_dialect_impl(self, dialect: Dialect) -> Any:
         if dialect.name == "postgresql":

--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 from nanoid import generate as generate_nanoid
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sqlalchemy import and_, delete, or_, select, update
-from sqlalchemy.dialects.postgresql import insert
+from src.db_types import upsert_insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func
@@ -342,7 +342,7 @@ class QueueManager:
         values = [{"work_unit_key": key} for key in work_unit_keys]
 
         stmt = (
-            insert(models.ActiveQueueSession)
+            upsert_insert(models.ActiveQueueSession)
             .values(values)
             .on_conflict_do_nothing()
             .returning(

--- a/src/models.py
+++ b/src/models.py
@@ -24,7 +24,7 @@ from sqlalchemy.orm import Mapped, MappedColumn, mapped_column, relationship
 from sqlalchemy.sql import func
 from typing_extensions import override
 
-from src.db_types import JSONBCompat, VectorType, pg_check, pg_only_index
+from src.db_types import JSONBCompat, VectorType, empty_json_default, pg_check, pg_only_index
 from src.utils.types import DocumentLevel, TaskType, VectorSyncState
 
 from .db import Base
@@ -57,14 +57,14 @@ session_peers_table = Table(
         JSONBCompat,
         default=dict,
         nullable=False,
-        server_default=text("'{}'"),
+        server_default=empty_json_default(),
     ),
     Column(
         "internal_metadata",
         JSONBCompat,
         default=dict,
         nullable=False,
-        server_default=text("'{}'"),
+        server_default=empty_json_default(),
     ),
     Column(
         "joined_at",
@@ -99,13 +99,13 @@ class Workspace(Base):
         DateTime(timezone=True), server_default=func.now(), index=True
     )
     h_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "metadata", JSONBCompat, default=dict, server_default=text("'{}'")
+        "metadata", JSONBCompat, default=dict, server_default=empty_json_default()
     )
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
+        "internal_metadata", JSONBCompat, default=dict, server_default=empty_json_default()
     )
     configuration: Mapped[dict[str, Any]] = mapped_column(
-        JSONBCompat, default=dict, server_default=text("'{}'")
+        JSONBCompat, default=dict, server_default=empty_json_default()
     )
 
     sessions = relationship(
@@ -129,10 +129,10 @@ class Peer(Base):
     id: Mapped[str] = mapped_column(TEXT, default=generate_nanoid, primary_key=True)
     name: Mapped[str] = mapped_column(TEXT, nullable=False)
     h_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "metadata", JSONBCompat, default=dict, server_default=text("'{}'")
+        "metadata", JSONBCompat, default=dict, server_default=empty_json_default()
     )
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
+        "internal_metadata", JSONBCompat, default=dict, server_default=empty_json_default()
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), index=True
@@ -141,7 +141,7 @@ class Peer(Base):
         ForeignKey("workspaces.name"), nullable=False, index=True
     )
     configuration: Mapped[dict[str, Any]] = mapped_column(
-        JSONBCompat, default=dict, server_default=text("'{}'")
+        JSONBCompat, default=dict, server_default=empty_json_default()
     )
 
     workspace = relationship("Workspace", back_populates="peers")
@@ -167,10 +167,10 @@ class Session(Base):
     name: Mapped[str] = mapped_column(TEXT)
     is_active: Mapped[bool] = mapped_column(default=True, server_default=text("true"))
     h_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "metadata", JSONBCompat, default=dict, server_default=text("'{}'")
+        "metadata", JSONBCompat, default=dict, server_default=empty_json_default()
     )
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
+        "internal_metadata", JSONBCompat, default=dict, server_default=empty_json_default()
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), index=True
@@ -179,7 +179,7 @@ class Session(Base):
         ForeignKey("workspaces.name"), nullable=False, index=True
     )
     configuration: Mapped[dict[str, Any]] = mapped_column(
-        JSONBCompat, default=dict, server_default=text("'{}'")
+        JSONBCompat, default=dict, server_default=empty_json_default()
     )
 
     workspace = relationship("Workspace", back_populates="sessions")
@@ -215,10 +215,10 @@ class Message(Base):
     session_name: Mapped[str] = mapped_column(TEXT, nullable=False)
     content: Mapped[str] = mapped_column(TEXT)
     h_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "metadata", JSONBCompat, default=dict, server_default=text("'{}'")
+        "metadata", JSONBCompat, default=dict, server_default=empty_json_default()
     )
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
+        "internal_metadata", JSONBCompat, default=dict, server_default=empty_json_default()
     )
     token_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     seq_in_session: Mapped[int] = mapped_column(BigInteger, nullable=False)
@@ -341,10 +341,10 @@ class Collection(Base):
         DateTime(timezone=True), server_default=func.now(), index=True
     )
     h_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "metadata", JSONBCompat, default=dict, server_default=text("'{}'")
+        "metadata", JSONBCompat, default=dict, server_default=empty_json_default()
     )
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
+        "internal_metadata", JSONBCompat, default=dict, server_default=empty_json_default()
     )
     documents = relationship(
         "Document", back_populates="collection", cascade="all, delete, delete-orphan"
@@ -379,7 +379,7 @@ class Document(Base):
     __tablename__: str = "documents"
     id: Mapped[str] = mapped_column(TEXT, default=generate_nanoid, primary_key=True)
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
+        "internal_metadata", JSONBCompat, default=dict, server_default=empty_json_default()
     )
     content: Mapped[str] = mapped_column(TEXT)
     level: Mapped[DocumentLevel] = mapped_column(

--- a/src/models.py
+++ b/src/models.py
@@ -4,7 +4,6 @@ from typing import Any, final
 
 from dotenv import load_dotenv
 from nanoid import generate as generate_nanoid
-from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     BigInteger,
     Boolean,
@@ -17,14 +16,15 @@ from sqlalchemy import (
     Index,
     Integer,
     Table,
+    TEXT,
     UniqueConstraint,
     text,
 )
-from sqlalchemy.dialects.postgresql import JSONB, TEXT
 from sqlalchemy.orm import Mapped, MappedColumn, mapped_column, relationship
 from sqlalchemy.sql import func
 from typing_extensions import override
 
+from src.db_types import JSONBCompat, VectorType, pg_check, pg_only_index
 from src.utils.types import DocumentLevel, TaskType, VectorSyncState
 
 from .db import Base
@@ -54,17 +54,17 @@ session_peers_table = Table(
     Column("peer_name", TEXT, primary_key=True, nullable=False),
     Column(
         "configuration",
-        JSONB,
+        JSONBCompat,
         default=dict,
         nullable=False,
-        server_default=text("'{}'::jsonb"),
+        server_default=text("'{}'"),
     ),
     Column(
         "internal_metadata",
-        JSONB,
+        JSONBCompat,
         default=dict,
         nullable=False,
-        server_default=text("'{}'::jsonb"),
+        server_default=text("'{}'"),
     ),
     Column(
         "joined_at",
@@ -99,13 +99,13 @@ class Workspace(Base):
         DateTime(timezone=True), server_default=func.now(), index=True
     )
     h_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
+        "metadata", JSONBCompat, default=dict, server_default=text("'{}'")
     )
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
+        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
     )
     configuration: Mapped[dict[str, Any]] = mapped_column(
-        JSONB, default=dict, server_default=text("'{}'::jsonb")
+        JSONBCompat, default=dict, server_default=text("'{}'")
     )
 
     sessions = relationship(
@@ -119,7 +119,7 @@ class Workspace(Base):
     __table_args__ = (
         CheckConstraint("length(id) = 21", name="id_length"),
         CheckConstraint("length(name) <= 512", name="name_length"),
-        CheckConstraint("id ~ '^[A-Za-z0-9_-]+$'", name="id_format"),
+        *filter(None, [pg_check("id ~ '^[A-Za-z0-9_-]+$'", name="id_format")]),
     )
 
 
@@ -129,10 +129,10 @@ class Peer(Base):
     id: Mapped[str] = mapped_column(TEXT, default=generate_nanoid, primary_key=True)
     name: Mapped[str] = mapped_column(TEXT, nullable=False)
     h_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
+        "metadata", JSONBCompat, default=dict, server_default=text("'{}'")
     )
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
+        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), index=True
@@ -141,7 +141,7 @@ class Peer(Base):
         ForeignKey("workspaces.name"), nullable=False, index=True
     )
     configuration: Mapped[dict[str, Any]] = mapped_column(
-        JSONB, default=dict, server_default=text("'{}'::jsonb")
+        JSONBCompat, default=dict, server_default=text("'{}'")
     )
 
     workspace = relationship("Workspace", back_populates="peers")
@@ -153,7 +153,7 @@ class Peer(Base):
         UniqueConstraint("name", "workspace_name"),
         CheckConstraint("length(id) = 21", name="id_length"),
         CheckConstraint("length(name) <= 512", name="name_length"),
-        CheckConstraint("id ~ '^[A-Za-z0-9_-]+$'", name="id_format"),
+        *filter(None, [pg_check("id ~ '^[A-Za-z0-9_-]+$'", name="id_format")]),
     )
 
     def __repr__(self) -> str:
@@ -167,10 +167,10 @@ class Session(Base):
     name: Mapped[str] = mapped_column(TEXT)
     is_active: Mapped[bool] = mapped_column(default=True, server_default=text("true"))
     h_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
+        "metadata", JSONBCompat, default=dict, server_default=text("'{}'")
     )
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
+        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), index=True
@@ -179,7 +179,7 @@ class Session(Base):
         ForeignKey("workspaces.name"), nullable=False, index=True
     )
     configuration: Mapped[dict[str, Any]] = mapped_column(
-        JSONB, default=dict, server_default=text("'{}'::jsonb")
+        JSONBCompat, default=dict, server_default=text("'{}'")
     )
 
     workspace = relationship("Workspace", back_populates="sessions")
@@ -192,7 +192,7 @@ class Session(Base):
         UniqueConstraint("name", "workspace_name"),
         CheckConstraint("length(name) <= 512", name="name_length"),
         CheckConstraint("length(id) = 21", name="id_length"),
-        CheckConstraint("id ~ '^[A-Za-z0-9_-]+$'", name="id_format"),
+        *filter(None, [pg_check("id ~ '^[A-Za-z0-9_-]+$'", name="id_format")]),
     )
 
     def __repr__(self) -> str:
@@ -215,10 +215,10 @@ class Message(Base):
     session_name: Mapped[str] = mapped_column(TEXT, nullable=False)
     content: Mapped[str] = mapped_column(TEXT)
     h_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
+        "metadata", JSONBCompat, default=dict, server_default=text("'{}'")
     )
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
+        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
     )
     token_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     seq_in_session: Mapped[int] = mapped_column(BigInteger, nullable=False)
@@ -234,7 +234,7 @@ class Message(Base):
 
     __table_args__ = (
         CheckConstraint("length(public_id) = 21", name="public_id_length"),
-        CheckConstraint("public_id ~ '^[A-Za-z0-9_-]+$'", name="public_id_format"),
+        *filter(None, [pg_check("public_id ~ '^[A-Za-z0-9_-]+$'", name="public_id_format")]),
         CheckConstraint("length(content) <= 65535", name="content_length"),
         # Composite foreign key constraint for sessions
         ForeignKeyConstraint(
@@ -257,12 +257,14 @@ class Message(Base):
             "session_name",
             "seq_in_session",
         ),
-        # Full text search index on content column
-        Index(
-            "ix_messages_content_gin",
-            text("to_tsvector('english', content)"),
-            postgresql_using="gin",
-        ),
+        # Full text search index on content column (PostgreSQL only)
+        *filter(None, [
+            pg_only_index(
+                "ix_messages_content_gin",
+                text("to_tsvector('english', content)"),
+                postgresql_using="gin",
+            )
+        ]),
     )
 
     @override
@@ -278,7 +280,7 @@ class MessageEmbedding(Base):
         BigInteger, Identity(), primary_key=True, autoincrement=True
     )
     content: Mapped[str] = mapped_column(TEXT)
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(VectorType(1536), nullable=True)
     message_id: Mapped[str] = mapped_column(
         ForeignKey("messages.public_id", ondelete="CASCADE"), nullable=False, index=True
     )
@@ -339,10 +341,10 @@ class Collection(Base):
         DateTime(timezone=True), server_default=func.now(), index=True
     )
     h_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
+        "metadata", JSONBCompat, default=dict, server_default=text("'{}'")
     )
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
+        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
     )
     documents = relationship(
         "Document", back_populates="collection", cascade="all, delete, delete-orphan"
@@ -358,7 +360,7 @@ class Collection(Base):
             "workspace_name",
         ),
         CheckConstraint("length(id) = 21", name="id_length"),
-        CheckConstraint("id ~ '^[A-Za-z0-9_-]+$'", name="id_format"),
+        *filter(None, [pg_check("id ~ '^[A-Za-z0-9_-]+$'", name="id_format")]),
         # Composite foreign key constraint for observer peer
         ForeignKeyConstraint(
             ["observer", "workspace_name"],
@@ -377,7 +379,7 @@ class Document(Base):
     __tablename__: str = "documents"
     id: Mapped[str] = mapped_column(TEXT, default=generate_nanoid, primary_key=True)
     internal_metadata: Mapped[dict[str, Any]] = mapped_column(
-        "internal_metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
+        "internal_metadata", JSONBCompat, default=dict, server_default=text("'{}'")
     )
     content: Mapped[str] = mapped_column(TEXT)
     level: Mapped[DocumentLevel] = mapped_column(
@@ -386,9 +388,9 @@ class Document(Base):
     times_derived: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("1")
     )
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(VectorType(1536), nullable=True)
     source_ids: Mapped[list[str] | None] = mapped_column(
-        JSONB, nullable=True, server_default=text("NULL")
+        JSONBCompat, nullable=True, server_default=text("NULL")
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), index=True
@@ -420,7 +422,7 @@ class Document(Base):
     __table_args__ = (
         CheckConstraint("length(id) = 21", name="id_length"),
         CheckConstraint("length(content) <= 65535", name="content_length"),
-        CheckConstraint("id ~ '^[A-Za-z0-9_-]+$'", name="id_format"),
+        *filter(None, [pg_check("id ~ '^[A-Za-z0-9_-]+$'", name="id_format")]),
         # Composite foreign key constraint for collections
         ForeignKeyConstraint(
             ["observer", "observed", "workspace_name"],
@@ -482,7 +484,7 @@ class QueueItem(Base):
     work_unit_key: Mapped[str] = mapped_column(TEXT, nullable=False)
 
     task_type: Mapped[TaskType] = mapped_column(TEXT, nullable=False)
-    payload: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSONBCompat, nullable=False)
     processed: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default=text("false"), index=True
     )

--- a/src/utils/filter.py
+++ b/src/utils/filter.py
@@ -337,7 +337,7 @@ def _build_comparison_condition(
     if op_value == "*":
         return None
 
-    field_accessor = column[field_name].astext
+    field_accessor = column[field_name].as_string()
 
     # Mapping of operators to their SQLAlchemy methods
     if operator in NUMERIC_OPERATORS:

--- a/src/utils/search.py
+++ b/src/utils/search.py
@@ -12,7 +12,7 @@ from sqlalchemy import Select, and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import models
-from src.config import settings
+from src.config import is_sqlite, settings
 from src.dependencies import tracked_db
 from src.embedding_client import embedding_client
 from src.exceptions import ValidationException
@@ -26,6 +26,8 @@ T = TypeVar("T")
 
 def _uses_pgvector_message_search() -> bool:
     """Return True when semantic message search can stay entirely in Postgres."""
+    if is_sqlite():
+        return False
     return (
         settings.VECTOR_STORE.TYPE == "pgvector" or not settings.VECTOR_STORE.MIGRATED
     )
@@ -268,7 +270,7 @@ async def _fulltext_search(
     # Escape ILIKE pattern characters to treat user input literally
     escaped_query = escape_ilike_pattern(query)
 
-    if has_special_chars:
+    if is_sqlite() or has_special_chars:
         # For queries with special characters, use exact string matching (ILIKE)
         search_condition = models.Message.content.ilike(
             f"%{escaped_query}%", escape=ILIKE_ESCAPE_CHAR

--- a/tests/test_sqlite_json_ops.py
+++ b/tests/test_sqlite_json_ops.py
@@ -53,9 +53,9 @@ async def sqlite_engine():
         name: t.schema for name, t in Base.metadata.tables.items()
     }
 
-    settings.DB.CONNECTION_URI = SQLITE_URL
     engine = create_async_engine(SQLITE_URL, echo=False)
     try:
+        settings.DB.CONNECTION_URI = SQLITE_URL
         async with engine.begin() as conn:
             Base.metadata.schema = None
             for table in Base.metadata.tables.values():

--- a/tests/test_sqlite_json_ops.py
+++ b/tests/test_sqlite_json_ops.py
@@ -46,29 +46,27 @@ SQLITE_URL = "sqlite+aiosqlite:///:memory:"
 @pytest_asyncio.fixture(scope="module")
 async def sqlite_engine():
     """Create an async SQLite engine with all tables."""
-    # Tell is_sqlite() to return True so the app takes SQLite code paths
+    # Save originals before any mutations so teardown always restores cleanly.
     original_uri = settings.DB.CONNECTION_URI
+    original_schema = Base.metadata.schema
+    original_table_schemas = {
+        name: t.schema for name, t in Base.metadata.tables.items()
+    }
+
     settings.DB.CONNECTION_URI = SQLITE_URL
+    Base.metadata.schema = None
+    for table in Base.metadata.tables.values():
+        table.schema = None
 
     engine = create_async_engine(SQLITE_URL, echo=False)
-    async with engine.begin() as conn:
-        # SQLite doesn't need schema prefixes
-        original_schema = Base.metadata.schema
-        original_table_schemas = {
-            name: t.schema for name, t in Base.metadata.tables.items()
-        }
-        Base.metadata.schema = None
-        for table in Base.metadata.tables.values():
-            table.schema = None
-        await conn.run_sync(Base.metadata.create_all)
-
     try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
         yield engine
     finally:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
         await engine.dispose()
-        # Restore original schema + URI
         Base.metadata.schema = original_schema
         for name, table in Base.metadata.tables.items():
             table.schema = original_table_schemas[name]
@@ -98,12 +96,12 @@ async def sqlite_session(sqlite_engine: AsyncEngine) -> AsyncGenerator[AsyncSess
 async def sqlite_cache():
     original_enabled = settings.CACHE.ENABLED
     original_url = settings.CACHE.URL
+    original_disable = ControlMixin._disable  # pyright: ignore[reportPrivateUsage]
+
     fake_redis = FakeAsyncRedis(decode_responses=True)
 
     def fake_from_url(*_a: Any, **_kw: Any):
         return fake_redis
-
-    original_disable = ControlMixin._disable  # pyright: ignore[reportPrivateUsage]
 
     @property  # type: ignore
     def patched_disable(self):  # pyright: ignore
@@ -114,13 +112,11 @@ async def sqlite_cache():
 
     redis_patch = patch("redis.asyncio.from_url", fake_from_url)
     redis_patch.start()
-    ControlMixin._disable = patched_disable  # pyright: ignore
-
-    settings.CACHE.ENABLED = True
-    settings.CACHE.URL = "redis://fake:6379/0"
-    cache.setup("redis://fake:6379/0", pickle_type=PicklerType.SQLALCHEMY, enable=True)
-
     try:
+        ControlMixin._disable = patched_disable  # pyright: ignore
+        settings.CACHE.ENABLED = True
+        settings.CACHE.URL = "redis://fake:6379/0"
+        cache.setup("redis://fake:6379/0", pickle_type=PicklerType.SQLALCHEMY, enable=True)
         yield fake_redis
     finally:
         redis_patch.stop()
@@ -138,6 +134,8 @@ def sqlite_client(
     sqlite_session: AsyncSession,
     sqlite_cache: FakeAsyncRedis,  # noqa: ARG001
 ) -> TestClient:
+    previous_handler = app.exception_handlers.get(HonchoException)
+
     @app.exception_handler(HonchoException)
     async def _handler(_: Request, exc: HonchoException) -> JSONResponse:  # pyright: ignore
         return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
@@ -149,6 +147,10 @@ def sqlite_client(
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.pop(get_db, None)
+    if previous_handler is None:
+        app.exception_handlers.pop(HonchoException, None)
+    else:
+        app.exception_handlers[HonchoException] = previous_handler
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sqlite_json_ops.py
+++ b/tests/test_sqlite_json_ops.py
@@ -1,0 +1,279 @@
+"""
+Focused pytest tests for the three SQLite JSON operator fixes.
+
+Runs with a pure in-memory SQLite database — no PostgreSQL, no Redis needed.
+
+Tests:
+  1. filter.py  — column[field].as_string()     (metadata filter queries)
+  2. session.py — config["observe_others"].as_boolean() (peer observer count)
+  3. deriver.py — payload["observer"].as_string()       (queue status)
+"""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from cashews.backends.interface import ControlMixin
+from cashews.picklers import PicklerType
+from fakeredis import FakeAsyncRedis
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from src import models  # noqa: F401 — ensures all models are registered
+from src.cache.client import cache
+from src.config import settings
+from src.db import Base
+from src.dependencies import get_db
+from src.exceptions import HonchoException
+from src.main import app
+
+# ---------------------------------------------------------------------------
+# SQLite engine / session fixtures (no PostgreSQL, no CREATE EXTENSION)
+# ---------------------------------------------------------------------------
+
+SQLITE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest_asyncio.fixture(scope="module")
+async def sqlite_engine():
+    """Create an async SQLite engine with all tables."""
+    # Tell is_sqlite() to return True so the app takes SQLite code paths
+    original_uri = settings.DB.CONNECTION_URI
+    settings.DB.CONNECTION_URI = SQLITE_URL
+
+    engine = create_async_engine(SQLITE_URL, echo=False)
+    async with engine.begin() as conn:
+        # SQLite doesn't need schema prefixes
+        original_schema = Base.metadata.schema
+        Base.metadata.schema = None
+        for table in Base.metadata.tables.values():
+            table.schema = None
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        yield engine
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+        # Restore original schema + URI
+        Base.metadata.schema = original_schema
+        settings.DB.CONNECTION_URI = original_uri
+
+
+@pytest_asyncio.fixture(scope="function")
+async def sqlite_session(sqlite_engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
+    """Provide a rollback-isolated session per test."""
+    Session = async_sessionmaker(bind=sqlite_engine, expire_on_commit=False)
+    async with Session() as session:
+        try:
+            yield session
+        finally:
+            await session.rollback()
+    # Clear all rows between tests
+    async with sqlite_engine.begin() as conn:
+        for table in reversed(Base.metadata.sorted_tables):
+            await conn.execute(table.delete())
+
+
+# ---------------------------------------------------------------------------
+# Cache fixture (fakeredis, same pattern as main conftest)
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture(scope="module")
+async def sqlite_cache():
+    original_enabled = settings.CACHE.ENABLED
+    original_url = settings.CACHE.URL
+    fake_redis = FakeAsyncRedis(decode_responses=True)
+
+    def fake_from_url(*_a: Any, **_kw: Any):
+        return fake_redis
+
+    original_disable = ControlMixin._disable  # pyright: ignore[reportPrivateUsage]
+
+    @property  # type: ignore
+    def patched_disable(self):  # pyright: ignore
+        try:
+            return original_disable.fget(self)  # pyright: ignore[reportOptionalCall]
+        except LookupError:
+            return set()  # pyright: ignore
+
+    redis_patch = patch("redis.asyncio.from_url", fake_from_url)
+    redis_patch.start()
+    ControlMixin._disable = patched_disable  # pyright: ignore
+
+    settings.CACHE.ENABLED = True
+    settings.CACHE.URL = "redis://fake:6379/0"
+    cache.setup("redis://fake:6379/0", pickle_type=PicklerType.SQLALCHEMY, enable=True)
+
+    try:
+        yield fake_redis
+    finally:
+        redis_patch.stop()
+        ControlMixin._disable = original_disable  # pyright: ignore
+        settings.CACHE.ENABLED = original_enabled
+        settings.CACHE.URL = original_url
+
+
+# ---------------------------------------------------------------------------
+# TestClient fixture wired to SQLite
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="function")
+def sqlite_client(
+    sqlite_session: AsyncSession,
+    sqlite_cache: FakeAsyncRedis,  # noqa: ARG001
+) -> TestClient:
+    @app.exception_handler(HonchoException)
+    async def _handler(_: Request, exc: HonchoException) -> JSONResponse:  # pyright: ignore
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield sqlite_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.pop(get_db, None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_workspace(client: TestClient, name: str = "ws-sqlite-test") -> str:
+    r = client.post("/v3/workspaces", json={"name": name})
+    assert r.status_code in (200, 201), f"workspace create: {r.status_code} {r.text}"
+    return r.json()["name"]
+
+
+def make_peer(client: TestClient, ws: str, name: str) -> str:
+    r = client.post(f"/v3/workspaces/{ws}/peers", json={"name": name})
+    assert r.status_code in (200, 201), f"peer create: {r.status_code} {r.text}"
+    return r.json()["name"]
+
+
+def make_session(client: TestClient, ws: str, name: str = "sess") -> str:
+    r = client.post(f"/v3/workspaces/{ws}/sessions", json={"name": name})
+    assert r.status_code in (200, 201), f"session create: {r.status_code} {r.text}"
+    return r.json()["name"]
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — filter.py: column[field].as_string()
+# ---------------------------------------------------------------------------
+
+def test_metadata_filter_as_string(sqlite_client: TestClient):
+    """
+    List messages with a metadata equality filter.
+    Before the fix: as_string() didn't exist on JSONBCompat comparator,
+    or astext generated wrong SQL on SQLite.
+    """
+    ws = make_workspace(sqlite_client, "ws-filter")
+    peer = make_peer(sqlite_client, ws, "p1")
+    sess = make_session(sqlite_client, ws, "s1")
+
+    # Add peer to session
+    r = sqlite_client.put(
+        f"/v3/workspaces/{ws}/sessions/{sess}/peers",
+        json=[{"peer_name": peer, "observe_others": False}],
+    )
+    assert r.status_code in (200, 201, 204)
+
+    # Create a message with metadata
+    r = sqlite_client.post(
+        f"/v3/workspaces/{ws}/sessions/{sess}/messages",
+        json=[{"content": "hello", "peer_name": peer, "metadata": {"topic": "sqlite"}}],
+    )
+    assert r.status_code in (200, 201), f"create message: {r.text}"
+
+    # List with metadata filter — exercises as_string() in filter.py
+    r = sqlite_client.post(
+        f"/v3/workspaces/{ws}/sessions/{sess}/messages/list",
+        json={"filters": {"topic": {"$eq": "sqlite"}}},
+    )
+    assert r.status_code == 200, f"filter query failed: {r.status_code} {r.text}"
+    items = r.json().get("items", [])
+    assert len(items) == 1, f"expected 1 result, got {len(items)}"
+    assert items[0]["metadata"]["topic"] == "sqlite"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — session.py: config["observe_others"].as_boolean()
+# ---------------------------------------------------------------------------
+
+def test_observe_others_as_boolean(sqlite_client: TestClient):
+    """
+    Update a peer's observe_others config inside a session.
+    The observer-count check in session.py uses as_boolean() on a JSON field —
+    before the fix this generated wrong SQL on SQLite.
+    """
+    ws = make_workspace(sqlite_client, "ws-obs")
+    observer = make_peer(sqlite_client, ws, "observer")
+    target = make_peer(sqlite_client, ws, "target")
+    sess = make_session(sqlite_client, ws, "s2")
+
+    # Add both peers; observer watches others
+    r = sqlite_client.put(
+        f"/v3/workspaces/{ws}/sessions/{sess}/peers",
+        json=[
+            {"peer_name": observer, "observe_others": True},
+            {"peer_name": target, "observe_others": False},
+        ],
+    )
+    assert r.status_code in (200, 201, 204), f"add peers: {r.text}"
+
+    # Update target's config — this triggers the observer-count query (as_boolean path)
+    r = sqlite_client.put(
+        f"/v3/workspaces/{ws}/sessions/{sess}/peers/{target}/config",
+        json={"observe_others": True},
+    )
+    assert r.status_code in (200, 204), f"set_peer_config failed: {r.status_code} {r.text}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — deriver.py: payload["observer"].as_string()
+# ---------------------------------------------------------------------------
+
+def test_queue_status_as_string(sqlite_client: TestClient):
+    """
+    Fetch the workspace queue status (plain + filtered by observer).
+    _build_queue_status_query uses as_string() on QueueItem.payload JSON fields —
+    before the fix astext generated wrong SQL on SQLite.
+    """
+    ws = make_workspace(sqlite_client, "ws-queue")
+    peer = make_peer(sqlite_client, ws, "qpeer")
+    sess = make_session(sqlite_client, ws, "s3")
+
+    r = sqlite_client.put(
+        f"/v3/workspaces/{ws}/sessions/{sess}/peers",
+        json=[{"peer_name": peer, "observe_others": True}],
+    )
+    assert r.status_code in (200, 201, 204)
+
+    # Create a message to enqueue a deriver task
+    r = sqlite_client.post(
+        f"/v3/workspaces/{ws}/sessions/{sess}/messages",
+        json=[{"content": "queue trigger", "peer_name": peer}],
+    )
+    assert r.status_code in (200, 201), f"create message: {r.text}"
+
+    # Plain queue status — exercises as_string() in SELECT expressions
+    r = sqlite_client.get(f"/v3/workspaces/{ws}/queue/status")
+    assert r.status_code == 200, f"queue/status failed: {r.status_code} {r.text}"
+
+    # Filtered queue status — exercises as_string() in WHERE clause too
+    r = sqlite_client.get(
+        f"/v3/workspaces/{ws}/queue/status",
+        params={"observer_id": peer},
+    )
+    assert r.status_code == 200, f"queue/status?observer_id failed: {r.status_code} {r.text}"

--- a/tests/test_sqlite_json_ops.py
+++ b/tests/test_sqlite_json_ops.py
@@ -54,13 +54,12 @@ async def sqlite_engine():
     }
 
     settings.DB.CONNECTION_URI = SQLITE_URL
-    Base.metadata.schema = None
-    for table in Base.metadata.tables.values():
-        table.schema = None
-
     engine = create_async_engine(SQLITE_URL, echo=False)
     try:
         async with engine.begin() as conn:
+            Base.metadata.schema = None
+            for table in Base.metadata.tables.values():
+                table.schema = None
             await conn.run_sync(Base.metadata.create_all)
         yield engine
     finally:

--- a/tests/test_sqlite_json_ops.py
+++ b/tests/test_sqlite_json_ops.py
@@ -11,7 +11,7 @@ Tests:
 
 from collections.abc import AsyncGenerator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
@@ -54,6 +54,9 @@ async def sqlite_engine():
     async with engine.begin() as conn:
         # SQLite doesn't need schema prefixes
         original_schema = Base.metadata.schema
+        original_table_schemas = {
+            name: t.schema for name, t in Base.metadata.tables.items()
+        }
         Base.metadata.schema = None
         for table in Base.metadata.tables.values():
             table.schema = None
@@ -67,6 +70,8 @@ async def sqlite_engine():
         await engine.dispose()
         # Restore original schema + URI
         Base.metadata.schema = original_schema
+        for name, table in Base.metadata.tables.items():
+            table.schema = original_table_schemas[name]
         settings.DB.CONNECTION_URI = original_uri
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -157,6 +157,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1285,6 +1294,7 @@ name = "honcho"
 version = "3.0.5"
 source = { virtual = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "alembic" },
     { name = "cashews", extra = ["redis"] },
     { name = "cloudevents" },
@@ -1342,6 +1352,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "cashews", extras = ["redis"], specifier = "==7.4.4" },
     { name = "cloudevents", specifier = ">=1.12.0" },


### PR DESCRIPTION
## What this fixes

The SQLite support added in #405 broke on queries that use JSON field accessors. The `JSONBCompat` custom `TypeDecorator` wasn't forwarding JSON-specific operators to the underlying `JSON`/`JSONB` type, so SQLAlchemy fell back to wrong SQL on SQLite (e.g. `LIKE` instead of `json_extract`).

**Three code paths were affected:**

| File | Old code | Fixed code |
|------|----------|------------|
| `src/crud/deriver.py` | `.astext` on queue payload fields | `.as_string()` |
| `src/crud/session.py` | `.astext.cast(Boolean)` on `observe_others` config | `.as_boolean()` |
| `src/utils/filter.py` | `.astext` on metadata filter fields | `.as_string()` |

## What changed

- **`src/db_types.py`** — Added `Comparator` subclasses to `JSONBCompat` and `VectorType` so that `__getitem__`, `as_string()`, `as_boolean()`, `contains()`, and `cosine_distance()` properly delegate to the underlying `JSON`/pgvector types instead of falling back to base `ColumnOperators`
- **`src/crud/deriver.py`** — `.astext` → `.as_string()` (queue status query)
- **`src/crud/session.py`** — `.astext.cast(Boolean)` → `.as_boolean()` (observer count queries)
- **`src/utils/filter.py`** — `.astext` → `.as_string()` (metadata filter queries)

## Tests

Added `tests/test_sqlite_json_ops.py` with 3 focused tests that run against a real in-memory SQLite database (no PostgreSQL required):

- `test_metadata_filter_as_string` — list messages with a metadata equality filter
- `test_observe_others_as_boolean` — update peer config with `observe_others` inside a session
- `test_queue_status_as_string` — fetch workspace queue status plain + filtered by observer

## How to test locally

```bash
DB_CONNECTION_URI=sqlite+aiosqlite:///./honcho_test.db \
LLM_ANTHROPIC_API_KEY=<your-key> \
uv run fastapi dev src/main.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Official SQLite runtime support for embeddings and JSON-backed fields.

* **Bug Fixes**
  * Disabled Postgres-only similarity and full-text paths on SQLite; search now falls back to safe string matching.
  * Fixed JSON extraction/comparison behavior and adjusted session/message locking so operations work correctly on SQLite.
  * Database initialization now follows a SQLite-specific path.

* **Tests**
  * Added end-to-end SQLite integration tests for JSON ops, session behavior, and queue/status endpoints.

* **Chores**
  * Added async SQLite runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->