### PR TITLE
feat: support ANTHROPIC_BASE_URL for custom Anthropic-compatible endpoints

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -203,6 +203,7 @@ class LLMSettings(HonchoSettings):
 
     # API Keys for LLM providers
     ANTHROPIC_API_KEY: str | None = None
+    ANTHROPIC_BASE_URL: str | None = None
     OPENAI_API_KEY: str | None = None
     OPENAI_COMPATIBLE_API_KEY: str | None = None
     GEMINI_API_KEY: str | None = None
@@ -214,6 +215,7 @@ class LLMSettings(HonchoSettings):
     VLLM_BASE_URL: str | None = None
 
     EMBEDDING_PROVIDER: Literal["openai", "gemini", "openrouter"] = "openai"
+    EMBEDDING_MODEL: str = "text-embedding-3-small"
 
     # General LLM settings
     DEFAULT_MAX_TOKENS: Annotated[int, Field(default=1000, gt=0, le=100_000)] = 2500

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -52,7 +52,7 @@ class _EmbeddingClient:
                 or "https://openrouter.ai/api/v1"
             )
             self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-            self.model = "openai/text-embedding-3-small"
+            self.model = settings.LLM.EMBEDDING_MODEL or "openai/text-embedding-3-small"
             self.max_embedding_tokens = settings.MAX_EMBEDDING_TOKENS
             self.max_batch_size = 2048  # Same as OpenAI
         else:  # openai
@@ -61,7 +61,7 @@ class _EmbeddingClient:
             if not api_key:
                 raise ValueError("OpenAI API key is required")
             self.client = AsyncOpenAI(api_key=api_key)
-            self.model = "text-embedding-3-small"
+            self.model = settings.LLM.EMBEDDING_MODEL or "text-embedding-3-small"
             self.max_embedding_tokens = settings.MAX_EMBEDDING_TOKENS
             self.max_batch_size = 2048  # OpenAI batch limit
 

--- a/src/models.py
+++ b/src/models.py
@@ -27,6 +27,7 @@ from typing_extensions import override
 
 from src.utils.types import DocumentLevel, TaskType, VectorSyncState
 
+from .config import settings
 from .db import Base
 
 load_dotenv(override=True)
@@ -278,7 +279,7 @@ class MessageEmbedding(Base):
         BigInteger, Identity(), primary_key=True, autoincrement=True
     )
     content: Mapped[str] = mapped_column(TEXT)
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(settings.VECTOR_STORE.DIMENSIONS), nullable=True)
     message_id: Mapped[str] = mapped_column(
         ForeignKey("messages.public_id", ondelete="CASCADE"), nullable=False, index=True
     )
@@ -386,7 +387,7 @@ class Document(Base):
     times_derived: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("1")
     )
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(settings.VECTOR_STORE.DIMENSIONS), nullable=True)
     source_ids: Mapped[list[str] | None] = mapped_column(
         JSONB, nullable=True, server_default=text("NULL")
     )

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -251,10 +251,13 @@ CLIENTS: dict[
 ] = {}
 
 if settings.LLM.ANTHROPIC_API_KEY:
-    anthropic = AsyncAnthropic(
-        api_key=settings.LLM.ANTHROPIC_API_KEY,
-        timeout=600.0,  # 10 minutes timeout for long-running operations
-    )
+    anthropic_kwargs: dict[str, Any] = {
+        "api_key": settings.LLM.ANTHROPIC_API_KEY,
+        "timeout": 600.0,  # 10 minutes timeout for long-running operations
+    }
+    if settings.LLM.ANTHROPIC_BASE_URL:
+        anthropic_kwargs["base_url"] = settings.LLM.ANTHROPIC_BASE_URL
+    anthropic = AsyncAnthropic(**anthropic_kwargs)
     CLIENTS["anthropic"] = anthropic
 
 if settings.LLM.OPENAI_API_KEY:


### PR DESCRIPTION
This PR adds support for configuring a custom \"base_url\" for the Anthropic client, enabling the use of Anthropic-compatible endpoints (e.g., Kimi, OpenRouter, etc.).

Changes:
- Added \"ANTHROPIC_BASE_URL\" to LLMSettings
- Passed \"base_url\" to AsyncAnthropic when configured

Testing:
- Verified basic Messages API, tool calling, JSON mode, and forced-tool structured output against a custom Anthropic-compatible endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom Anthropic API base URL for flexible deployments and proxies.
  * Added a configurable embedding model setting (default: text-embedding-3-small) so you can choose which embedding model to use.
  * Made the vector dimension for stored embeddings configurable via settings, allowing different vector sizes per deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->