### PR TITLE
Route GPT-5 tool calls through OpenAI Responses

### DIFF
--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -370,6 +370,244 @@ def convert_tools_for_provider(
         return tools
 
 
+def _should_use_openai_responses_api(
+    model: str,
+    *,
+    tools: list[dict[str, Any]] | None,
+    reasoning_effort: ReasoningEffortType,
+    verbosity: VerbosityType,
+    response_model: type[BaseModel] | None,
+    json_mode: bool,
+    stream: bool,
+) -> bool:
+    if stream:
+        return False
+    if "gpt-5" not in model:
+        return False
+    return bool(tools or reasoning_effort or verbosity or response_model or json_mode)
+
+
+def _openai_message_content_to_string(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+        if parts:
+            return "\n".join(parts)
+        return json.dumps(content)
+    if content is None:
+        return ""
+    return str(content)
+
+
+def _convert_openai_messages_to_responses_input(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    input_items: list[dict[str, Any]] = []
+    for msg in messages:
+        role = str(msg.get("role", "") or "").strip()
+        if role == "tool":
+            input_items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": str(msg.get("tool_call_id", "") or "").strip(),
+                    "output": _openai_message_content_to_string(msg.get("content")),
+                    "id": str(msg.get("tool_call_id", "") or "").strip(),
+                }
+            )
+            continue
+
+        content = _openai_message_content_to_string(msg.get("content"))
+        if role in {"system", "developer", "user", "assistant"} and content:
+            input_items.append({"role": role, "content": content})
+
+        tool_calls = msg.get("tool_calls")
+        if role == "assistant" and isinstance(tool_calls, list):
+            for tool_call in tool_calls:
+                if not isinstance(tool_call, dict):
+                    continue
+                function = tool_call.get("function", {})
+                if not isinstance(function, dict):
+                    continue
+                call_id = str(tool_call.get("id", "") or "").strip()
+                name = str(function.get("name", "") or "").strip()
+                arguments = function.get("arguments")
+                if not name or arguments is None:
+                    continue
+                input_items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": call_id,
+                        "id": call_id,
+                        "name": name,
+                        "arguments": str(arguments),
+                    }
+                )
+    return input_items
+
+
+def _convert_openai_tools_to_responses_tools(
+    tools: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    converted: list[dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        if tool.get("type") != "function":
+            continue
+        function = tool.get("function", {})
+        if not isinstance(function, dict):
+            continue
+        name = str(function.get("name", "") or "").strip()
+        if not name:
+            continue
+        converted.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": function.get("description"),
+                "parameters": function.get("parameters") or {},
+            }
+        )
+    return converted
+
+
+def _convert_openai_tool_choice_to_responses(
+    tool_choice: str | dict[str, Any] | None,
+) -> str | dict[str, Any] | None:
+    if tool_choice is None:
+        return None
+    if isinstance(tool_choice, str):
+        return tool_choice
+    if "name" in tool_choice:
+        return {"type": "function", "name": tool_choice["name"]}
+    function = tool_choice.get("function")
+    if isinstance(function, dict) and "name" in function:
+        return {"type": "function", "name": function["name"]}
+    return tool_choice
+
+
+def _extract_openai_responses_tool_calls(response: Any) -> list[dict[str, Any]]:
+    tool_calls: list[dict[str, Any]] = []
+    for item in getattr(response, "output", []) or []:
+        if getattr(item, "type", None) != "function_call":
+            continue
+        arguments = getattr(item, "arguments", "") or ""
+        try:
+            parsed_arguments = json.loads(arguments) if arguments else {}
+        except json.JSONDecodeError:
+            parsed_arguments = {}
+        tool_calls.append(
+            {
+                "id": getattr(item, "call_id", "") or getattr(item, "id", ""),
+                "name": getattr(item, "name", ""),
+                "input": parsed_arguments,
+            }
+        )
+    return tool_calls
+
+
+def _extract_openai_responses_reasoning_content(response: Any) -> str | None:
+    parts: list[str] = []
+    for item in getattr(response, "output", []) or []:
+        if getattr(item, "type", None) != "reasoning":
+            continue
+        summaries = getattr(item, "summary", None) or []
+        for summary in summaries:
+            text = getattr(summary, "text", None)
+            if text:
+                parts.append(text)
+    return "\n".join(parts) if parts else None
+
+
+def _responses_text_format(
+    response_model: type[BaseModel] | None,
+    json_mode: bool,
+) -> dict[str, Any] | None:
+    if response_model is not None:
+        return {
+            "format": {
+                "type": "json_schema",
+                "name": response_model.__name__,
+                "schema": response_model.model_json_schema(),
+                "strict": True,
+            }
+        }
+    if json_mode:
+        return {"format": {"type": "json_object"}}
+    return None
+
+
+async def _call_openai_responses_api(
+    client: AsyncOpenAI,
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    max_tokens: int,
+    response_model: type[BaseModel] | None,
+    json_mode: bool,
+    temperature: float | None,
+    stop_seqs: list[str] | None,
+    reasoning_effort: ReasoningEffortType,
+    verbosity: VerbosityType,
+    tools: list[dict[str, Any]] | None,
+    tool_choice: str | dict[str, Any] | None,
+) -> "HonchoLLMCallResponse[Any]":
+    if stop_seqs:
+        logger.warning("OpenAI Responses API path ignores stop sequences")
+    input_items = _convert_openai_messages_to_responses_input(messages)
+    response_text = _responses_text_format(response_model, json_mode)
+    if response_text is not None and verbosity:
+        response_text["verbosity"] = verbosity
+    elif verbosity:
+        response_text = {"verbosity": verbosity}
+
+    create_params: dict[str, Any] = {
+        "model": model,
+        "input": input_items,
+        "max_output_tokens": max_tokens,
+    }
+    if temperature is not None and "gpt-5" not in model:
+        create_params["temperature"] = temperature
+    if reasoning_effort:
+        create_params["reasoning"] = {"effort": reasoning_effort}
+    if response_text is not None:
+        create_params["text"] = response_text
+    if tools:
+        create_params["tools"] = _convert_openai_tools_to_responses_tools(tools)
+        converted_tool_choice = _convert_openai_tool_choice_to_responses(tool_choice)
+        if converted_tool_choice is not None:
+            create_params["tool_choice"] = converted_tool_choice
+
+    response = await client.responses.create(**create_params)
+    usage = getattr(response, "usage", None)
+    tool_calls = _extract_openai_responses_tool_calls(response)
+    content_text = getattr(response, "output_text", "") or ""
+
+    parsed_content: Any = content_text
+    if response_model is not None:
+        parsed_json = json.loads(content_text)
+        parsed_content = response_model.model_validate(parsed_json)
+
+    cache_creation, cache_read = extract_openai_cache_tokens(usage)
+    finish_reason = getattr(response, "status", None)
+    return HonchoLLMCallResponse(
+        content=parsed_content,
+        input_tokens=getattr(usage, "input_tokens", 0) or 0,
+        output_tokens=getattr(usage, "output_tokens", 0) or 0,
+        cache_creation_input_tokens=cache_creation,
+        cache_read_input_tokens=cache_read,
+        finish_reasons=[finish_reason] if finish_reason else [],
+        tool_calls_made=tool_calls,
+        thinking_content=_extract_openai_responses_reasoning_content(response),
+    )
+
+
 def extract_openai_reasoning_content(response: Any) -> str | None:
     """
     Extract reasoning/thinking content from an OpenAI ChatCompletion response.
@@ -454,6 +692,12 @@ def extract_openai_cache_tokens(usage: Any) -> tuple[int, int]:
     # OpenAI native: usage.prompt_tokens_details.cached_tokens
     if hasattr(usage, "prompt_tokens_details") and usage.prompt_tokens_details:
         details = usage.prompt_tokens_details
+        if hasattr(details, "cached_tokens") and details.cached_tokens:
+            cache_read = details.cached_tokens
+
+    # OpenAI Responses API: usage.input_tokens_details.cached_tokens
+    if cache_read == 0 and hasattr(usage, "input_tokens_details") and usage.input_tokens_details:
+        details = usage.input_tokens_details
         if hasattr(details, "cached_tokens") and details.cached_tokens:
             cache_read = details.cached_tokens
 
@@ -1871,6 +2115,30 @@ async def honcho_llm_call_inner(
                         )
                     else:
                         processed_messages.append(msg)
+
+            if _should_use_openai_responses_api(
+                model,
+                tools=tools,
+                reasoning_effort=reasoning_effort,
+                verbosity=verbosity,
+                response_model=response_model,
+                json_mode=json_mode,
+                stream=stream,
+            ):
+                return await _call_openai_responses_api(
+                    client,
+                    model=params["model"],
+                    messages=processed_messages,
+                    max_tokens=params["max_tokens"],
+                    response_model=response_model,
+                    json_mode=json_mode,
+                    temperature=temperature,
+                    stop_seqs=stop_seqs,
+                    reasoning_effort=reasoning_effort,
+                    verbosity=verbosity,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                )
 
             openai_params: dict[str, Any] = {
                 "model": params["model"],

--- a/tests/utils/test_clients.py
+++ b/tests/utils/test_clients.py
@@ -317,28 +317,21 @@ class TestOpenAIClient:
         from openai import AsyncOpenAI
 
         mock_client = AsyncMock(spec=AsyncOpenAI)
-        mock_response = ChatCompletion(
-            id="test-id",
-            object="chat.completion",
-            created=1234567890,
-            model="gpt-5-turbo",
-            choices=[
-                Choice(
-                    index=0,
-                    message=ChatCompletionMessage(
-                        role="assistant", content="GPT-5 response"
-                    ),
-                    finish_reason="stop",
-                )
-            ],
-            usage=CompletionUsage(
-                prompt_tokens=10, completion_tokens=5, total_tokens=15
+        mock_response = Mock(
+            output_text="GPT-5 response",
+            output=[],
+            usage=Mock(
+                input_tokens=10,
+                output_tokens=5,
+                input_tokens_details=Mock(cached_tokens=0),
             ),
+            status="completed",
         )
-        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        mock_client.responses.create = AsyncMock(return_value=mock_response)
+        mock_client.chat.completions.create = AsyncMock()
 
         with patch.dict(CLIENTS, {"openai": mock_client}):
-            _response = await honcho_llm_call_inner(
+            response = await honcho_llm_call_inner(
                 provider="openai",
                 model="gpt-5-turbo",
                 prompt="Hello",
@@ -347,14 +340,88 @@ class TestOpenAIClient:
                 verbosity="medium",
             )
 
-            # Verify GPT-5 specific parameters were used
-            mock_client.chat.completions.create.assert_called_once()
-            call_args = mock_client.chat.completions.create.call_args
+            assert response.content == "GPT-5 response"
+            mock_client.responses.create.assert_called_once()
+            mock_client.chat.completions.create.assert_not_called()
+            call_args = mock_client.responses.create.call_args
             kwargs = call_args.kwargs
-            assert "max_completion_tokens" in kwargs
-            assert kwargs["max_completion_tokens"] == 100
-            assert kwargs["reasoning_effort"] == "high"
-            assert kwargs["verbosity"] == "medium"
+            assert kwargs["max_output_tokens"] == 100
+            assert kwargs["reasoning"] == {"effort": "high"}
+            assert kwargs["text"] == {"verbosity": "medium"}
+
+    async def test_openai_gpt5_tools_use_responses_api(self):
+        """Test GPT-5 tool calls route through the Responses API."""
+        from openai import AsyncOpenAI
+
+        mock_client = AsyncMock(spec=AsyncOpenAI)
+        mock_response = Mock(
+            output_text="",
+            output=[
+                Mock(
+                    type="function_call",
+                    call_id="call-1",
+                    id="call-1",
+                    name="repo_context",
+                    arguments='{"repo": "rsi-agent-platform"}',
+                )
+            ],
+            usage=Mock(
+                input_tokens=20,
+                output_tokens=7,
+                input_tokens_details=Mock(cached_tokens=0),
+            ),
+            status="completed",
+        )
+        mock_client.responses.create = AsyncMock(return_value=mock_response)
+        mock_client.chat.completions.create = AsyncMock()
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "repo_context",
+                    "description": "Load repo context",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"repo": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+        with patch.dict(CLIENTS, {"openai": mock_client}):
+            response = await honcho_llm_call_inner(
+                provider="openai",
+                model="gpt-5-turbo",
+                prompt="Inspect the repository",
+                max_tokens=100,
+                tools=tools,
+                tool_choice="required",
+            )
+
+            mock_client.responses.create.assert_called_once()
+            mock_client.chat.completions.create.assert_not_called()
+            call_args = mock_client.responses.create.call_args
+            kwargs = call_args.kwargs
+            assert kwargs["tool_choice"] == "required"
+            assert kwargs["tools"] == [
+                {
+                    "type": "function",
+                    "name": "repo_context",
+                    "description": "Load repo context",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"repo": {"type": "string"}},
+                    },
+                }
+            ]
+            assert response.tool_calls_made == [
+                {
+                    "id": "call-1",
+                    "name": "repo_context",
+                    "input": {"repo": "rsi-agent-platform"},
+                }
+            ]
 
     async def test_openai_json_mode(self):
         """Test OpenAI with JSON mode"""


### PR DESCRIPTION
## Summary
- route GPT-5 non-streaming tool/reasoning/structured-output requests through the OpenAI Responses API
- normalize Responses output back into Honcho's existing response shape, including tool calls and cached token accounting
- add coverage for GPT-5 Responses parameter shaping and tool-call extraction

## Validation
- uv run python -m py_compile src/utils/clients.py
- mocked smoke check confirming GPT-5 + tools + reasoning hits `responses.create(...)` rather than `chat.completions.create(...)`

## Note
- The full `tests/utils/test_clients.py` suite is currently blocked locally by the repo's Postgres-dependent test harness in `tests/conftest.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Responses API execution path for GPT-5 models supporting advanced parameters including tools, reasoning capabilities, and structured response formatting.
  * Enhanced cache token usage tracking from Responses API responses.

* **Tests**
  * Updated test coverage to verify Responses API behavior and tool call processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->