### PR TITLE
feat(mcp): read HONCHO_API_URL env var to support self-hosted Honcho instances

### DIFF
--- a/mcp/.dev.vars.example
+++ b/mcp/.dev.vars.example
@@ -1,0 +1,4 @@
+# Uncomment and point at a self-hosted Honcho to bypass the managed API.
+# wrangler dev reads this file automatically when it exists as `.dev.vars`.
+# For deployed Workers, use: wrangler secret put HONCHO_API_URL
+# HONCHO_API_URL=http://127.0.0.1:28000

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -12,6 +12,7 @@ dist/
 .env
 .env.local
 .env.production
+.dev.vars
 
 # IDE files
 .vscode/

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -69,6 +69,28 @@ Built on:
 - **[@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk)** — `McpServer` for tool registration
 - **[@honcho-ai/sdk](https://www.npmjs.com/package/@honcho-ai/sdk)** v2 — Honcho TypeScript SDK
 
+## Self-Hosted Honcho
+
+If you run Honcho yourself (for privacy, latency, or offline use), deploy the
+MCP Worker alongside your instance and set `HONCHO_API_URL` in its
+environment.
+
+**Local dev (`bun run dev`):** create `mcp/.dev.vars`:
+
+```
+HONCHO_API_URL=http://127.0.0.1:28000
+```
+
+**Deployed Worker:**
+
+```bash
+wrangler secret put HONCHO_API_URL
+# paste your URL when prompted
+```
+
+When `HONCHO_API_URL` is unset the Worker routes to `https://api.honcho.dev`,
+so this change is backward-compatible.
+
 ## Development
 
 ### Setup

--- a/mcp/src/config.ts
+++ b/mcp/src/config.ts
@@ -8,11 +8,21 @@ export interface HonchoConfig {
   workspaceId: string;
 }
 
+export interface Env {
+  HONCHO_API_URL?: string;
+}
+
 /**
- * Parse configuration from request headers.
+ * Parse configuration from request headers and Worker env bindings.
  * Throws on missing required fields so callers get clear errors.
+ *
+ * The Honcho API URL is read from the `HONCHO_API_URL` env var when set,
+ * allowing operators to run this Worker alongside a self-hosted Honcho
+ * instance (see the "Self-Hosted Honcho" section in README.md). It is
+ * intentionally not exposed as a request header: routing public requests
+ * to an internal URL would be a latency and security regression.
  */
-export function parseConfig(request: Request): HonchoConfig {
+export function parseConfig(request: Request, env: Env = {}): HonchoConfig {
   const authHeader = request.headers.get("Authorization");
   const trimmedAuthHeader = authHeader?.trim();
   if (!trimmedAuthHeader?.startsWith("Bearer ")) {
@@ -37,7 +47,7 @@ export function parseConfig(request: Request): HonchoConfig {
     apiKey,
     userName,
     assistantName: request.headers.get("X-Honcho-Assistant-Name")?.trim() || "Assistant",
-    baseUrl: "https://api.honcho.dev",
+    baseUrl: env.HONCHO_API_URL?.trim() || "https://api.honcho.dev",
     workspaceId: request.headers.get("X-Honcho-Workspace-ID")?.trim() || "default",
   };
 }

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,5 +1,5 @@
 import { createMcpHandler } from "agents/mcp";
-import { parseConfig, createClient } from "./config.js";
+import { parseConfig, createClient, type Env } from "./config.js";
 import { createServer } from "./server.js";
 
 const CORS_ORIGIN = "*";
@@ -16,7 +16,7 @@ const CORS_HEADERS = {
 export default {
   async fetch(
     request: Request,
-    env: unknown,
+    env: Env,
     executionCtx: ExecutionContext,
   ): Promise<Response> {
     if (request.method === "OPTIONS") {
@@ -25,7 +25,7 @@ export default {
 
     let config;
     try {
-      config = parseConfig(request);
+      config = parseConfig(request, env);
     } catch (e) {
       const message =
         e instanceof Error ? e.message : "Invalid request";


### PR DESCRIPTION
## Summary

- Read the Honcho API URL from the Worker's `HONCHO_API_URL` env binding,
  falling back to `https://api.honcho.dev` when unset.
- Document the self-hosted workflow (`.dev.vars` locally, `wrangler secret`
  for deployed Workers) in `mcp/README.md`.
- Add `mcp/.dev.vars.example` so the convention is discoverable.

## Motivation

Closes #508. Prior PRs #540 and #503 tried to solve the same problem with an
`X-Honcho-Base-URL` request header; both were declined because exposing the
upstream URL as a header is a latency/security regression for the hosted
Worker. This PR uses the env-var mechanism suggested by @ajspig in #540:

> The MCP server is a thin stateless proxy, so if you're self-hosting
> Honcho, the natural path is to run the MCP server locally alongside it
> and point it at your instance via environment variables (e.g.
> HONCHO_API_URL).

## Changes

| File | Change |
| --- | --- |
| `mcp/src/config.ts` | Accept `Env` binding; read `HONCHO_API_URL` with fallback |
| `mcp/src/index.ts` | Pass `env` to `parseConfig` |
| `mcp/.dev.vars.example` | Document the local-dev convention |
| `mcp/README.md` | Add "Self-Hosted Honcho" section |

## Backwards compatibility

No breaking change. `HONCHO_API_URL` is optional. Unset → identical behavior
to `main` today.

## Test plan

- [x] `bun run tsc --noEmit` passes
- [x] Local handshake (JSON-RPC initialize) against a self-hosted Honcho at
      `http://127.0.0.1:28000` succeeds with `HONCHO_API_URL` set
- [x] Same handshake against `api.honcho.dev` succeeds with `HONCHO_API_URL` unset (no regression)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom Honcho API endpoint via the `HONCHO_API_URL` environment variable, allowing the Worker to integrate with self-hosted Honcho instances while maintaining backward compatibility with the default endpoint.

* **Documentation**
  * Added setup instructions for deploying the MCP Worker with a self-hosted Honcho instance, including guidance for local development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->