### PR TITLE
fix(json): extract structured payloads from noisy model output

### DIFF
--- a/src/utils/json_parser.py
+++ b/src/utils/json_parser.py
@@ -8,6 +8,135 @@ from json_repair import repair_json
 logger = logging.getLogger(__name__)
 # logging.getLogger("sqlalchemy.engine.Engine").disabled = True
 
+_JSON_FENCE_RE = re.compile(
+    r"```(?P<lang>[a-zA-Z0-9_+-]*)\s*(?P<body>.*?)```", re.IGNORECASE | re.DOTALL
+)
+_THINK_TAG_RE = re.compile(r"<think>.*?</think>", re.IGNORECASE | re.DOTALL)
+
+
+def _strip_reasoning_wrappers(text: str) -> str:
+    """Remove common reasoning/prose wrappers before JSON extraction."""
+    return _THINK_TAG_RE.sub("", text.strip()).strip()
+
+
+def _fenced_candidates(text: str) -> list[str]:
+    candidates: list[str] = []
+    for match in _JSON_FENCE_RE.finditer(text):
+        body = match.group("body").strip()
+        if not body:
+            continue
+        lang = (match.group("lang") or "").strip().lower()
+        priority = 0 if lang == "json" else 1
+        candidates.append((priority, body))
+    candidates.sort(key=lambda item: item[0])
+    return [body for _, body in candidates]
+
+
+def _collect_balanced_json_candidates(text: str) -> list[str]:
+    """Return all balanced JSON object/array substrings, in encounter order."""
+    candidates: list[str] = []
+    start = None
+    stack: list[str] = []
+    in_string = False
+    escape = False
+
+    for i, char in enumerate(text):
+        if start is None:
+            if char not in "[{":
+                continue
+            start = i
+            stack.append("}" if char == "{" else "]")
+            continue
+
+        if escape:
+            escape = False
+            continue
+
+        if char == "\\":
+            escape = True
+            continue
+
+        if char == '"':
+            in_string = not in_string
+            continue
+
+        if in_string:
+            continue
+
+        if char == "{":
+            stack.append("}")
+        elif char == "[":
+            stack.append("]")
+        elif stack and char == stack[-1]:
+            stack.pop()
+            if not stack and start is not None:
+                candidates.append(text[start : i + 1].strip())
+                start = None
+
+    return candidates
+
+
+def _score_json_candidate(candidate: str) -> tuple[int, int, int]:
+    """Rank candidates toward likely payloads instead of debug/schema debris."""
+    try:
+        payload = json.loads(candidate)
+    except json.JSONDecodeError:
+        return (-10, 0, len(candidate))
+
+    if isinstance(payload, dict):
+        keys = set(payload)
+        schema_keys = {"explicit", "deductive", "inductive", "observations", "facts"}
+        has_schema_signal = int(bool(keys & schema_keys))
+        return (2 if has_schema_signal else 0, len(keys), len(candidate))
+    if isinstance(payload, list):
+        return (1, len(payload), len(candidate))
+    return (0, 0, len(candidate))
+
+
+def _best_valid_json_candidate(candidates: list[str]) -> str | None:
+    valid_candidates: list[str] = []
+    for candidate in candidates:
+        try:
+            json.loads(candidate)
+            valid_candidates.append(candidate)
+        except json.JSONDecodeError:
+            continue
+    if not valid_candidates:
+        return None
+    return max(
+        enumerate(valid_candidates), key=lambda item: (_score_json_candidate(item[1]), item[0])
+    )[1]
+
+
+def extract_json_payload(text: str) -> str:
+    """Extract the most likely JSON payload from noisy model output."""
+    raw = text.strip()
+    if not raw:
+        return ""
+
+    direct_raw_valid = _best_valid_json_candidate([raw])
+    if direct_raw_valid:
+        return direct_raw_valid
+
+    cleaned = _strip_reasoning_wrappers(raw)
+    if not cleaned:
+        return ""
+
+    direct_valid = _best_valid_json_candidate([cleaned])
+    if direct_valid:
+        return direct_valid
+
+    fenced_valid = _best_valid_json_candidate(_fenced_candidates(cleaned))
+    if fenced_valid:
+        return fenced_valid
+
+    balanced_candidates = _collect_balanced_json_candidates(cleaned)
+    balanced_valid = _best_valid_json_candidate(balanced_candidates)
+    if balanced_valid:
+        return balanced_valid
+
+    return balanced_candidates[-1] if balanced_candidates else cleaned
+
 
 def comprehensive_json_repair(json_str: str) -> str:
     """Comprehensively repair malformed JSON with multiple strategies"""
@@ -354,7 +483,7 @@ def simple_bracket_repair(json_str: str) -> str:
 
 def validate_and_repair_json(json_str: str) -> str:
     """Main function with comprehensive repair strategies"""
-    json_str = json_str.strip()
+    json_str = extract_json_payload(json_str).strip()
 
     # Try parsing with repair library
     good_json = repair_json(json_str)

--- a/tests/utils/test_json_parser.py
+++ b/tests/utils/test_json_parser.py
@@ -1,0 +1,45 @@
+import json
+
+from src.utils.json_parser import extract_json_payload, validate_and_repair_json
+
+
+def test_extract_json_payload_strips_think_tags_and_prose():
+    raw = '<think>hidden reasoning</think>\nHere you go:\n{"explicit":[{"content":"I live in Berlin"}]}'
+    extracted = extract_json_payload(raw)
+    assert json.loads(extracted) == {"explicit": [{"content": "I live in Berlin"}]}
+
+
+def test_validate_and_repair_json_extracts_fenced_json():
+    raw = '```json\n{"explicit":[{"content":"I use Cubase"}]}\n```\nextra prose'
+    repaired = validate_and_repair_json(raw)
+    assert json.loads(repaired) == {"explicit": [{"content": "I use Cubase"}]}
+
+
+def test_validate_and_repair_json_extracts_top_level_array():
+    raw = 'analysis first\n["I live in Berlin", {"text":"I use Cubase"}]'
+    repaired = validate_and_repair_json(raw)
+    assert json.loads(repaired) == ["I live in Berlin", {"text": "I use Cubase"}]
+
+
+def test_extract_json_payload_prefers_json_fence_over_earlier_non_json_fence():
+    raw = '```text\nnot json\n```\n```json\n{"explicit":[{"content":"I live in Berlin"}]}\n```'
+    extracted = extract_json_payload(raw)
+    assert json.loads(extracted) == {"explicit": [{"content": "I live in Berlin"}]}
+
+
+def test_extract_json_payload_prefers_payload_over_earlier_schema_object():
+    raw = 'Schema: {"type":"object"}\nActual: {"explicit":[{"content":"I use Cubase"}]}'
+    extracted = extract_json_payload(raw)
+    assert json.loads(extracted) == {"explicit": [{"content": "I use Cubase"}]}
+
+
+def test_extract_json_payload_preserves_literal_think_text_inside_valid_json():
+    raw = '{"content":"literal <think> tag","explicit":[]}'
+    extracted = extract_json_payload(raw)
+    assert json.loads(extracted) == {"content": "literal <think> tag", "explicit": []}
+
+
+def test_extract_json_payload_prefers_later_array_payload_over_earlier_schema_dict():
+    raw = 'Schema: {"type":"object"}\nActual: [{"content":"I use Cubase"}]'
+    extracted = extract_json_payload(raw)
+    assert json.loads(extracted) == [{"content": "I use Cubase"}]


### PR DESCRIPTION
## Summary
- strip reasoning wrappers before repair without corrupting already-valid JSON
- prefer tagged JSON fences over generic fenced blocks
- collect and rank balanced JSON candidates instead of trusting the first blob that looks vaguely object-shaped
- add regression tests for fenced JSON preference, schema-vs-payload selection, and literal `<think>` text inside valid JSON

## Test Plan
- `set -a && source /Users/nikolaymohr/honcho/.env && set +a && uv run pytest tests/utils/test_json_parser.py -q`

## Why
OpenAI-compatible providers keep wrapping structured responses in junk. The old path was too trusting and regularly grabbed the wrong payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JSON payload extraction with enhanced handling of noisy input, fenced code blocks, and embedded JSON structures for increased parsing robustness.

* **Tests**
  * Added comprehensive test coverage for JSON extraction and validation scenarios, including edge cases and various formatting styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->