### PR TITLE
fix(clients): harden structured-output fallback paths

### DIFF
--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -33,17 +33,25 @@ Analyze messages from {peer_id} to extract **explicit atomic facts** about them.
    - Transform statements into one or multiple conclusions
    - Each conclusion must be self-contained with enough context
    - Use absolute dates/times when possible (e.g. "June 26, 2025" not "yesterday")
+   - Do NOT add facts from general knowledge or unstated implications
 
 RULES:
 - Properly attribute observations to the correct subject: if it is about {peer_id}, say so. If {peer_id} is referencing someone or something else, make that clear.
 - Observations should make sense on their own. Each observation will be used in the future to better understand {peer_id}.
 - Extract ALL observations from {peer_id} messages, using others as context.
 - Contextualize each observation sufficiently (e.g. "Ann is nervous about the job interview at the pharmacy" not just "Ann is nervous")
+- Return ONLY valid JSON.
+- The top-level response MUST be a single JSON object with exactly one key: "explicit".
+- The value of "explicit" MUST be an array of objects shaped like {{"content": "..."}}.
+- Do NOT include markdown fences.
+- Do NOT include explanatory prose.
+- Do NOT include analysis, thoughts, summaries, or any keys besides "explicit".
+- If there are no explicit facts, return {{"explicit": []}}.
 
 EXAMPLES:
 - EXPLICIT: "I just had my 25th birthday last Saturday" → "{peer_id} is 25 years old", "{peer_id}'s birthday is June 21st"
-- EXPLICIT: "I took my dog for a walk in NYC" → "{peer_id} has a dog", "{peer_id} lives in NYC"
-- EXPLICIT: "{peer_id} attended college" + general knowledge → "{peer_id} completed high school or equivalent"
+- EXPLICIT: "I took my dog for a walk in NYC" → "{peer_id} has a dog", "{peer_id} was in NYC"
+- NOT EXPLICIT: Do not add facts from general knowledge like "Berlin is in Germany" or "Cubase is a DAW" unless the user said them.
 
 Messages to analyze:
 <messages>

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -33,6 +33,13 @@ from src.utils.types import SupportedProviders, set_current_iteration
 
 logger = logging.getLogger(__name__)
 
+
+def _should_retry_with_structured_fallback(exc: Exception) -> bool:
+    """Only fallback for parse/schema drift, not generic provider failures."""
+    if isinstance(exc, (ValidationError, ValueError, json.JSONDecodeError, TypeError, AttributeError)):
+        return True
+    return False
+
 # Gemini finish reasons that indicate the response was blocked by safety or policy
 # filters. When these occur, the response typically has no usable text content and
 # retrying with a backup provider is appropriate.
@@ -1989,51 +1996,118 @@ async def honcho_llm_call_inner(
                 )
             elif response_model:
                 openai_params["response_format"] = response_model
-                response: ChatCompletion = await client.chat.completions.parse(  # pyright: ignore
-                    **openai_params
-                )
-                # Extract the parsed object for structured output
-                parsed_content = response.choices[0].message.parsed
-                if parsed_content is None:
-                    raise ValueError("No parsed content in structured response")
-
-                usage = response.usage
-                finish_reason = response.choices[0].finish_reason
-
-                # Validate that parsed content matches the response model
-                if not isinstance(parsed_content, response_model):
-                    raise ValueError(
-                        f"Parsed content does not match the response model: {parsed_content} != {response_model}"
+                try:
+                    response: ChatCompletion = await client.chat.completions.parse(  # pyright: ignore
+                        **openai_params
                     )
+                    # Extract the parsed object for structured output
+                    parsed_content = response.choices[0].message.parsed
+                    if parsed_content is None:
+                        raise ValueError("No parsed content in structured response")
 
-                # Extract tool calls if present (though unlikely with structured output)
-                parsed_tool_calls: list[dict[str, Any]] = []
-                if (
-                    hasattr(response.choices[0].message, "tool_calls")
-                    and response.choices[0].message.tool_calls
-                ):
-                    for tool_call in response.choices[0].message.tool_calls:
-                        parsed_tool_calls.append(
-                            {
-                                "id": tool_call.id,
-                                "name": tool_call.function.name,
-                                "input": json.loads(tool_call.function.arguments)
-                                if tool_call.function.arguments
-                                else {},
-                            }
+                    usage = response.usage
+                    finish_reason = response.choices[0].finish_reason
+
+                    # Validate that parsed content matches the response model
+                    if not isinstance(parsed_content, response_model):
+                        raise ValueError(
+                            f"Parsed content does not match the response model: {parsed_content} != {response_model}"
                         )
 
-                cache_creation, cache_read = extract_openai_cache_tokens(usage)
-                return HonchoLLMCallResponse(
-                    content=parsed_content,
-                    input_tokens=usage.prompt_tokens if usage else 0,
-                    output_tokens=usage.completion_tokens if usage else 0,
-                    cache_creation_input_tokens=cache_creation,
-                    cache_read_input_tokens=cache_read,
-                    finish_reasons=[finish_reason] if finish_reason else [],
-                    tool_calls_made=parsed_tool_calls,
-                    thinking_content=extract_openai_reasoning_content(response),
-                )
+                    # Extract tool calls if present (though unlikely with structured output)
+                    parsed_tool_calls: list[dict[str, Any]] = []
+                    if (
+                        hasattr(response.choices[0].message, "tool_calls")
+                        and response.choices[0].message.tool_calls
+                    ):
+                        for tool_call in response.choices[0].message.tool_calls:
+                            parsed_tool_calls.append(
+                                {
+                                    "id": tool_call.id,
+                                    "name": tool_call.function.name,
+                                    "input": json.loads(tool_call.function.arguments)
+                                    if tool_call.function.arguments
+                                    else {},
+                                }
+                            )
+
+                    cache_creation, cache_read = extract_openai_cache_tokens(usage)
+                    return HonchoLLMCallResponse(
+                        content=parsed_content,
+                        input_tokens=usage.prompt_tokens if usage else 0,
+                        output_tokens=usage.completion_tokens if usage else 0,
+                        cache_creation_input_tokens=cache_creation,
+                        cache_read_input_tokens=cache_read,
+                        finish_reasons=[finish_reason] if finish_reason else [],
+                        tool_calls_made=parsed_tool_calls,
+                        thinking_content=extract_openai_reasoning_content(response),
+                    )
+                except Exception as parse_exc:
+                    if not _should_retry_with_structured_fallback(parse_exc):
+                        raise
+                    logger.warning(
+                        "Structured parse failed for %s/%s; retrying with JSON repair fallback: %s",
+                        provider,
+                        model,
+                        parse_exc,
+                    )
+                    fallback_params = dict(openai_params)
+                    is_minimax_prompt_representation = (
+                        provider == "custom"
+                        and response_model is PromptRepresentation
+                        and "minimax" in (settings.LLM.OPENAI_COMPATIBLE_BASE_URL or "").lower()
+                    )
+                    if is_minimax_prompt_representation:
+                        fallback_params.pop("response_format", None)
+                        fallback_messages = list(fallback_params.get("messages") or [])
+                        fallback_messages.insert(
+                            0,
+                            {
+                                "role": "system",
+                                "content": (
+                                    "Return only a single JSON object with key explicit. "
+                                    'The value must be an array of {"content": "..."} objects. '
+                                    "Do not output reasoning, <think> tags, markdown, or any other keys."
+                                ),
+                            },
+                        )
+                        fallback_params["messages"] = fallback_messages
+                        if "max_tokens" in fallback_params:
+                            fallback_params["max_tokens"] = max(
+                                int(fallback_params["max_tokens"]), 2000
+                            )
+                        if "max_completion_tokens" in fallback_params:
+                            fallback_params["max_completion_tokens"] = max(
+                                int(fallback_params["max_completion_tokens"]), 2000
+                            )
+                    else:
+                        fallback_params["response_format"] = {"type": "json_object"}
+                    fallback_response: ChatCompletion = await client.chat.completions.create(  # pyright: ignore
+                        **fallback_params
+                    )
+                    fallback_usage = fallback_response.usage
+                    fallback_finish_reason = fallback_response.choices[0].finish_reason
+                    fallback_raw = fallback_response.choices[0].message.content or ""
+                    repaired_json = validate_and_repair_json(fallback_raw)
+                    parsed_content = response_model.model_validate_json(repaired_json)
+
+                    cache_creation, cache_read = extract_openai_cache_tokens(
+                        fallback_usage
+                    )
+                    return HonchoLLMCallResponse(
+                        content=parsed_content,
+                        input_tokens=fallback_usage.prompt_tokens if fallback_usage else 0,
+                        output_tokens=fallback_usage.completion_tokens if fallback_usage else 0,
+                        cache_creation_input_tokens=cache_creation,
+                        cache_read_input_tokens=cache_read,
+                        finish_reasons=[fallback_finish_reason]
+                        if fallback_finish_reason
+                        else [],
+                        tool_calls_made=[],
+                        thinking_content=extract_openai_reasoning_content(
+                            fallback_response
+                        ),
+                    )
             else:
                 response: ChatCompletion = await client.chat.completions.create(  # pyright: ignore
                     **openai_params

--- a/tests/utils/test_clients.py
+++ b/tests/utils/test_clients.py
@@ -35,6 +35,7 @@ from src.utils.clients import (
     honcho_llm_call,
     honcho_llm_call_inner,
 )
+from src.utils.representation import PromptRepresentation
 
 
 class SampleTestModel(BaseModel):
@@ -519,6 +520,104 @@ class TestOpenAIClient:
             assert chunks[2].content == ""
             assert chunks[2].is_done is True
             assert chunks[2].finish_reasons == ["stop"]
+
+    async def test_openai_response_model_parse_runtime_error_does_not_fallback(self):
+        from openai import AsyncOpenAI
+
+        mock_client = AsyncMock(spec=AsyncOpenAI)
+        mock_client.chat.completions.parse = AsyncMock(side_effect=RuntimeError("provider exploded"))
+        mock_client.chat.completions.create = AsyncMock()
+
+        with patch.dict(CLIENTS, {"openai": mock_client}):
+            with pytest.raises(RuntimeError, match="provider exploded"):
+                await honcho_llm_call_inner(
+                    provider="openai",
+                    model="gpt-4",
+                    prompt="Generate a person",
+                    max_tokens=100,
+                    response_model=SampleTestModel,
+                )
+
+        mock_client.chat.completions.create.assert_not_called()
+
+    async def test_openai_response_model_validation_error_uses_json_fallback(self):
+        from openai import AsyncOpenAI
+
+        mock_client = AsyncMock(spec=AsyncOpenAI)
+        mock_client.chat.completions.parse = AsyncMock(side_effect=ValueError("No parsed content in structured response"))
+        fallback_response = ChatCompletion(
+            id="test-id",
+            object="chat.completion",
+            created=1234567890,
+            model="gpt-4",
+            choices=[
+                Choice(
+                    index=0,
+                    finish_reason="stop",
+                    message=ChatCompletionMessage(
+                        role="assistant",
+                        content='{"name":"Jane","age":31,"active":true}',
+                    ),
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=fallback_response)
+
+        with patch.dict(CLIENTS, {"openai": mock_client}):
+            response = await honcho_llm_call_inner(
+                provider="openai",
+                model="gpt-4",
+                prompt="Generate a person",
+                max_tokens=100,
+                response_model=SampleTestModel,
+            )
+
+        assert isinstance(response.content, SampleTestModel)
+        assert response.content.name == "Jane"
+        mock_client.chat.completions.create.assert_called_once()
+
+    async def test_custom_minimax_prompt_representation_fallback_drops_response_format(self):
+        from openai import AsyncOpenAI
+
+        mock_client = AsyncMock(spec=AsyncOpenAI)
+        mock_client.chat.completions.parse = AsyncMock(side_effect=ValueError("No parsed content in structured response"))
+        fallback_response = ChatCompletion(
+            id="test-id",
+            object="chat.completion",
+            created=1234567890,
+            model="MiniMax-M2.7",
+            choices=[
+                Choice(
+                    index=0,
+                    finish_reason="stop",
+                    message=ChatCompletionMessage(
+                        role="assistant",
+                        content='{"explicit":[{"content":"I live in Berlin"}]}',
+                    ),
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=fallback_response)
+
+        with (
+            patch.dict(CLIENTS, {"custom": mock_client}),
+            patch.object(settings.LLM, "OPENAI_COMPATIBLE_BASE_URL", "https://api.minimax.io/v1"),
+        ):
+            response = await honcho_llm_call_inner(
+                provider="custom",
+                model="MiniMax-M2.7",
+                prompt="Generate observations",
+                max_tokens=100,
+                response_model=PromptRepresentation,
+            )
+
+        assert isinstance(response.content, PromptRepresentation)
+        create_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert "response_format" not in create_kwargs
+        assert create_kwargs["messages"][0]["role"] == "system"
+        assert "Return only a single JSON object with key explicit" in create_kwargs["messages"][0]["content"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- tighten the deriver prompt to require exact JSON output and forbid unstated general-knowledge leakage
- add structured-output fallback after parse/schema drift for OpenAI-compatible providers
- scope the MiniMax custom-provider fallback to `PromptRepresentation` instead of every response model
- avoid retrying generic provider/runtime failures through the structured fallback path
- add tests covering validation fallback, non-fallback runtime errors, and the MiniMax prompt-representation branch

## Test Plan
- `set -a && source /Users/nikolaymohr/honcho/.env && set +a && uv run pytest tests/utils/test_clients.py -q`

## Why
The current structured-output path is too brittle for messy OpenAI-compatible providers. This makes fallback behavior explicit instead of magical and reduces the odds of deriver batches dying on parse drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added fallback retry mechanism to gracefully handle structured output parsing failures, improving system resilience.
  * Stricter fact extraction now recognizes only explicitly stated information, avoiding inferred facts.

* **Improvements**
  * Enhanced output formatting constraints for consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->