### PR TITLE
fix(deriver): normalize PromptRepresentation inputs safely

### DIFF
--- a/src/utils/representation.py
+++ b/src/utils/representation.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from src import models
 from src.utils.formatting import parse_datetime_iso
@@ -118,13 +118,79 @@ class PromptRepresentation(BaseModel):
         default_factory=list,
     )
 
+    @classmethod
+    def _extract_explicit_container(cls, value: Any, *, depth: int = 0) -> Any:
+        if depth > 3:
+            return value
+        if value is None or isinstance(value, list):
+            return value
+        if not isinstance(value, dict):
+            return value
+        if "explicit" in value:
+            return value.get("explicit")
+        for alias in ("observations", "facts", "items", "data", "result", "output"):
+            if alias in value:
+                return cls._extract_explicit_container(value.get(alias), depth=depth + 1)
+        return value
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_top_level_shape(cls, value: Any) -> Any:
+        """Normalize noisy provider outputs into the expected top-level shape."""
+        if value is None:
+            return {"explicit": []}
+
+        if isinstance(value, list):
+            return {"explicit": value}
+
+        if not isinstance(value, dict):
+            return value
+
+        extracted = cls._extract_explicit_container(value)
+        if isinstance(extracted, dict) and not any(
+            key in extracted for key in ("content", "text", "fact", "observation")
+        ):
+            raise ValueError(f"Unsupported PromptRepresentation shape: {sorted(value.keys())}")
+        return {"explicit": extracted}
+
     @field_validator("explicit", mode="before")
     @classmethod
-    def convert_none_to_empty_list(cls, v: Any) -> Any:
-        """Convert None to empty list - handles LLMs returning null instead of []."""
+    def normalize_explicit_items(cls, v: Any) -> Any:
+        """Normalize provider drift into explicit observation items."""
         if v is None:
             return []
-        return v
+
+        if not isinstance(v, list):
+            v = [v]
+
+        normalized: list[dict[str, str]] = []
+        for item in v:
+            content: str | None = None
+
+            if isinstance(item, str):
+                content = item
+            elif isinstance(item, ExplicitObservationBase):
+                content = item.content
+            elif isinstance(item, dict):
+                for key in ("content", "text", "fact", "observation"):
+                    value = item.get(key)
+                    if isinstance(value, str) and value.strip():
+                        content = value
+                        break
+
+            if not content:
+                continue
+
+            content = content.strip()
+            if not content:
+                continue
+
+            if len(content) > 2000:
+                content = content[:2000].rstrip()
+
+            normalized.append({"content": content})
+
+        return normalized
 
 
 class ExplicitObservation(ExplicitObservationBase, ObservationMetadata):

--- a/tests/deriver/test_representation_crud.py
+++ b/tests/deriver/test_representation_crud.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from src.utils.representation import (
     DeductiveObservation,
     ExplicitObservation,
@@ -106,3 +108,25 @@ def test_prompt_representation_conversion():
     # (they would be created directly by the Dreamer via the create_observations tool)
     assert len(rep.deductive) == 0
     assert rep.explicit[0].created_at == timestamp
+
+
+def test_prompt_representation_normalizes_top_level_array_and_alias_keys():
+    arr = PromptRepresentation.model_validate(["I live in Berlin", {"text": "I use Cubase"}])
+    assert [item.content for item in arr.explicit] == ["I live in Berlin", "I use Cubase"]
+
+    aliased = PromptRepresentation.model_validate({"observations": ["I am a musician"]})
+    assert [item.content for item in aliased.explicit] == ["I am a musician"]
+
+    nested = PromptRepresentation.model_validate({"result": {"observations": ["I work remotely"]}})
+    assert [item.content for item in nested.explicit] == ["I work remotely"]
+
+
+def test_prompt_representation_truncates_overlong_content():
+    prompt_rep = PromptRepresentation.model_validate({"explicit": [{"content": "x" * 5000}]})
+    assert len(prompt_rep.explicit) == 1
+    assert len(prompt_rep.explicit[0].content) == 2000
+
+
+def test_prompt_representation_rejects_unknown_top_level_dict_shape():
+    with pytest.raises(Exception):
+        PromptRepresentation.model_validate({"metadata": {"foo": "bar"}})


### PR DESCRIPTION
## Summary
- normalize top-level arrays and common alias wrappers into `explicit` observations
- recursively unwrap nested alias containers like `result -> observations`
- preserve compatibility with string/list item drift while rejecting unknown top-level wrapper shapes
- truncate overlong content and add focused regression tests

## Test Plan
- `set -a && source /Users/nikolaymohr/honcho/.env && set +a && uv run pytest tests/deriver/test_representation_crud.py -q`

## Why
Self-hosted OpenAI-compatible backends keep returning almost-correct shapes. Dropping usable observations because the model said `observations` or nested the payload one level too deep is pointless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input data handling to accept and normalize various formats (arrays, nested objects, null values) more robustly.
  * Enhanced validation to properly extract and clean observation data from supported structures.
  * Added content truncation (2000 character limit) to ensure data integrity.

* **Tests**
  * Added comprehensive test coverage for input normalization, content truncation, and validation error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->