### PR TITLE
fix: re-add full MiniMax support to Honcho 2.x

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -207,6 +207,13 @@ class LLMSettings(HonchoSettings):
     OPENAI_COMPATIBLE_API_KEY: str | None = None
     GEMINI_API_KEY: str | None = None
     GROQ_API_KEY: str | None = None
+
+    # MiniMax Anthropic API compatibility endpoint
+    # Routes Anthropic-format requests through MiniMax to cleanly separate
+    # thinking blocks from content (avoids thinking tags polluting content)
+    MINIMAX_API_KEY: str | None = None
+    MINIMAX_BASE_URL: str | None = "https://api.minimaxi.com/anthropic"
+
     OPENAI_COMPATIBLE_BASE_URL: str | None = None
 
     # Separate vLLM endpoint (for local models)

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -284,6 +284,17 @@ if settings.LLM.GROQ_API_KEY:
     groq = AsyncGroq(api_key=settings.LLM.GROQ_API_KEY)
     CLIENTS["groq"] = groq
 
+# MiniMax Anthropic API compatibility endpoint
+# Routes Anthropic-format requests through MiniMax to cleanly separate
+# thinking blocks from content (avoids thinking tags polluting content)
+if settings.LLM.MINIMAX_API_KEY:
+    minimax = AsyncAnthropic(
+        api_key=settings.LLM.MINIMAX_API_KEY,
+        base_url=settings.LLM.MINIMAX_BASE_URL,
+        timeout=600.0,
+    )
+    CLIENTS["minimax"] = minimax
+
 SELECTED_PROVIDERS = [
     ("Summary", settings.SUMMARY.PROVIDER),
     ("Deriver", settings.DERIVER.PROVIDER),

--- a/src/utils/clients.py
+++ b/src/utils/clients.py
@@ -1813,8 +1813,25 @@ async def honcho_llm_call_inner(
             # If using response_model, parse the JSON response
             if response_model:
                 try:
-                    # Add back the opening brace that we prefilled
-                    json_content = "{" + text_content
+                    # MiniMax may wrap JSON in a markdown code fence (```json ... ```).
+                    # Strip fence markers to get clean JSON.
+                    cleaned = text_content.strip()
+                    if cleaned.startswith("```"):
+                        # Remove opening fence line (```json or ```)
+                        lines = cleaned.splitlines()
+                        if lines[0].strip().lstrip("`").startswith("json"):
+                            lines = lines[1:]
+                        # Remove closing fence if present
+                        if lines and lines[-1].strip().startswith("```"):
+                            lines = lines[:-1]
+                        cleaned = "\n".join(lines).strip()
+
+                    # Determine if we need to prepend '{' (model consumed the prefill)
+                    # or if the model started with '{' directly (did not consume prefill)
+                    if cleaned.startswith("{"):
+                        json_content = cleaned
+                    else:
+                        json_content = "{" + cleaned
                     parsed_json = json.loads(json_content)
                     parsed_content = response_model.model_validate(parsed_json)
 

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -34,7 +34,7 @@ class GetOrCreateResult(Generic[T]):
             await self.on_commit()
 
 
-SupportedProviders = Literal["anthropic", "openai", "google", "groq", "custom", "vllm"]
+SupportedProviders = Literal["anthropic", "openai", "google", "groq", "custom", "vllm", "minimax"]
 TaskType = Literal[
     "webhook", "summary", "representation", "dream", "deletion", "reconciler"
 ]


### PR DESCRIPTION
## Summary
- Re-add full MiniMax provider support
- Add 'minimax' back to SupportedProviders enum
- Strip markdown code fences from MiniMax JSON responses

## Test plan
- [ ] Verify MiniMax provider works in dialectic calls
- [ ] Verify JSON parsing handles markdown code fences correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MiniMax as a supported LLM provider with configurable API credentials and endpoint settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->