### PR TITLE
fix(surprisal): use correct filter format for level observations

### DIFF
--- a/src/dreamer/surprisal.py
+++ b/src/dreamer/surprisal.py
@@ -261,7 +261,7 @@ async def _fetch_recent_observations(
         workspace_name=workspace_name,
         observer=observer,
         observed=observed,
-        filters={"level": levels} if levels else None,
+        filters={"level": {"in": levels}} if levels else None,
         limit=limit,
     )
 


### PR DESCRIPTION
## Problem

The Surprisal module in `src/dreamer/surprisal.py` passes a bare list to the `filters` parameter of `get_all_documents()`:

```python
filters={"level": levels}
```

However, `apply_filter()` in `src/utils/filter.py` expects operator-based syntax with an explicit `"in"` key for list membership checks:

```python
filters={"level": {"in": levels}}
```

Without the `"in"` operator wrapper, the filter doesn't match any recognized operator pattern and is silently ignored. This causes `_fetch_level_observations()` to return 0 results, making the entire Surprisal phase of the Dream cycle a no-op — no high-surprisal observations are ever identified.

## Fix

One-line change on line 264 of `src/dreamer/surprisal.py`:

```diff
- filters={"level": levels} if levels else None,
+ filters={"level": {"in": levels}} if levels else None,
```

## Verification

After this fix, `_fetch_level_observations()` correctly filters by observation level, allowing the Surprisal computation to identify and surface high-surprisal observations during the Dream cycle.

Fixes #559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved level filtering accuracy in the recent sampling strategy to properly handle multiple level values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->