### PR TITLE
feat(embedding): add custom (OpenAI-compatible) embedding provider for local models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "scikit-learn>=1.6.0",
     "prometheus_client>=0.21.0",
     "cloudevents>=1.12.0",
+    "transformers>=5.5.4",
 ]
 [dependency-groups]
 dev = [

--- a/src/config.py
+++ b/src/config.py
@@ -219,6 +219,11 @@ class LLMSettings(HonchoSettings):
     CUSTOM_EMBEDDING_BASE_URL: str | None = None
     CUSTOM_EMBEDDING_API_KEY: str | None = None
     CUSTOM_EMBEDDING_MODEL: str | None = None
+    CUSTOM_EMBEDDING_MAX_TOKENS: Annotated[int, Field(default=4096, gt=0, le=8192)] = 4096
+    CUSTOM_EMBEDDING_MAX_TOKENS_PER_REQUEST: Annotated[
+        int, Field(default=32_000, gt=0, le=300_000)
+    ] = 32_000
+    CUSTOM_EMBEDDING_MAX_BATCH_SIZE: Annotated[int, Field(default=32, gt=0, le=256)] = 32
 
     # General LLM settings
     DEFAULT_MAX_TOKENS: Annotated[int, Field(default=1000, gt=0, le=100_000)] = 2500

--- a/src/config.py
+++ b/src/config.py
@@ -215,15 +215,52 @@ class LLMSettings(HonchoSettings):
 
     EMBEDDING_PROVIDER: Literal["openai", "gemini", "openrouter", "custom"] = "openai"
 
-    # Custom embedding provider (local vLLM, TEI, or any OpenAI-compatible endpoint)
+    # Custom embedding provider (local vLLM, TEI, or any OpenAI-compatible endpoint).
+    # The embedding client loads the model's real tokenizer (e.g. Qwen) via
+    # `transformers.AutoTokenizer.from_pretrained(CUSTOM_EMBEDDING_MODEL)` so
+    # token counts and chunking match what the self-hosted server will see.
     CUSTOM_EMBEDDING_BASE_URL: str | None = None
     CUSTOM_EMBEDDING_API_KEY: str | None = None
     CUSTOM_EMBEDDING_MODEL: str | None = None
-    CUSTOM_EMBEDDING_MAX_TOKENS: Annotated[int, Field(default=4096, gt=0, le=8192)] = 4096
+    CUSTOM_EMBEDDING_MAX_TOKENS: Annotated[
+        int,
+        Field(
+            default=4096,
+            gt=0,
+            le=8192,
+            description=(
+                "Client-side pre-check cap on a single input's token count "
+                "(measured with the model's real tokenizer). This is NOT "
+                "synced to the server — the server enforces its own limit "
+                "via `--max-model-len` (vLLM) or equivalent; set this <= "
+                "that value with some headroom."
+            ),
+        ),
+    ] = 4096
     CUSTOM_EMBEDDING_MAX_TOKENS_PER_REQUEST: Annotated[
-        int, Field(default=32_000, gt=0, le=300_000)
+        int,
+        Field(
+            default=32_000,
+            gt=0,
+            le=300_000,
+            description=(
+                "Client-side batching cap on total tokens packed into a "
+                "single HTTP request to the custom server."
+            ),
+        ),
     ] = 32_000
-    CUSTOM_EMBEDDING_MAX_BATCH_SIZE: Annotated[int, Field(default=32, gt=0, le=256)] = 32
+    CUSTOM_EMBEDDING_MAX_BATCH_SIZE: Annotated[
+        int,
+        Field(
+            default=32,
+            gt=0,
+            le=256,
+            description=(
+                "Client-side cap on number of inputs per request. Should "
+                "match the server's `--max-num-seqs` when possible."
+            ),
+        ),
+    ] = 32
 
     # General LLM settings
     DEFAULT_MAX_TOKENS: Annotated[int, Field(default=1000, gt=0, le=100_000)] = 2500

--- a/src/config.py
+++ b/src/config.py
@@ -213,7 +213,12 @@ class LLMSettings(HonchoSettings):
     VLLM_API_KEY: str | None = None
     VLLM_BASE_URL: str | None = None
 
-    EMBEDDING_PROVIDER: Literal["openai", "gemini", "openrouter"] = "openai"
+    EMBEDDING_PROVIDER: Literal["openai", "gemini", "openrouter", "custom"] = "openai"
+
+    # Custom embedding provider (local vLLM, TEI, or any OpenAI-compatible endpoint)
+    CUSTOM_EMBEDDING_BASE_URL: str | None = None
+    CUSTOM_EMBEDDING_API_KEY: str | None = None
+    CUSTOM_EMBEDDING_MODEL: str | None = None
 
     # General LLM settings
     DEFAULT_MAX_TOKENS: Annotated[int, Field(default=1000, gt=0, le=100_000)] = 2500

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -61,8 +61,8 @@ class _EmbeddingClient:
             base_url = settings.LLM.CUSTOM_EMBEDDING_BASE_URL or "http://localhost:8081/v1"
             self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
             self.model = settings.LLM.CUSTOM_EMBEDDING_MODEL or "Qwen/Qwen3-Embedding-8B"
-            self.max_embedding_tokens = settings.MAX_EMBEDDING_TOKENS
-            self.max_batch_size = 256
+            self.max_embedding_tokens = settings.LLM.CUSTOM_EMBEDDING_MAX_TOKENS
+            self.max_batch_size = settings.LLM.CUSTOM_EMBEDDING_MAX_BATCH_SIZE
         else:  # openai
             if api_key is None:
                 api_key = settings.LLM.OPENAI_API_KEY
@@ -75,7 +75,9 @@ class _EmbeddingClient:
 
         self.encoding: tiktoken.Encoding = tiktoken.get_encoding("o200k_base")
         self.max_embedding_tokens_per_request: int = (
-            settings.MAX_EMBEDDING_TOKENS_PER_REQUEST
+            settings.LLM.CUSTOM_EMBEDDING_MAX_TOKENS_PER_REQUEST
+            if self.provider == "custom"
+            else settings.MAX_EMBEDDING_TOKENS_PER_REQUEST
         )
 
     async def embed(self, query: str) -> list[float]:
@@ -164,7 +166,7 @@ class _EmbeddingClient:
         # 1. Prepare chunks for all texts if needed
         text_chunks = self._prepare_chunks(id_resource_dict)
 
-        # 2. Create batches that fit API limits (max 2048 embeddings per request, max 300,000 tokens per request)
+        # 2. Create batches that fit the provider's count + token limits
         batches = self._create_batches(text_chunks)
 
         # 3. Process all batches concurrently

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -2,8 +2,9 @@ import asyncio
 import logging
 import threading
 from collections import defaultdict
-from typing import NamedTuple
+from typing import Any, Callable, NamedTuple
 
+import httpx
 import tiktoken
 from google import genai
 from openai import AsyncOpenAI
@@ -11,6 +12,15 @@ from openai import AsyncOpenAI
 from .config import settings
 
 logger = logging.getLogger(__name__)
+
+# Lazy sentinel: the `custom` provider needs a HuggingFace tokenizer (e.g. Qwen
+# for Qwen3-Embedding-8B) so that pre-checks and chunk boundaries match what
+# the self-hosted server will actually see. `transformers` stays optional so
+# non-custom deployments don't pay for it.
+try:
+    from transformers import AutoTokenizer as _AutoTokenizer
+except ImportError:  # pragma: no cover
+    _AutoTokenizer = None  # type: ignore[assignment]
 
 
 class BatchItem(NamedTuple):
@@ -59,7 +69,21 @@ class _EmbeddingClient:
             if api_key is None:
                 api_key = settings.LLM.CUSTOM_EMBEDDING_API_KEY or "dummy"
             base_url = settings.LLM.CUSTOM_EMBEDDING_BASE_URL or "http://localhost:8081/v1"
-            self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+            # Bound the connection pool and fail fast on stalls. The upstream
+            # AsyncOpenAI default pool (100 conns, ~10 min timeout) will starve
+            # the deriver if the self-hosted server hangs.
+            http_client = httpx.AsyncClient(
+                timeout=httpx.Timeout(30.0, connect=5.0),
+                limits=httpx.Limits(
+                    max_connections=16, max_keepalive_connections=8
+                ),
+            )
+            self.client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                http_client=http_client,
+                max_retries=0,
+            )
             self.model = settings.LLM.CUSTOM_EMBEDDING_MODEL or "Qwen/Qwen3-Embedding-8B"
             self.max_embedding_tokens = settings.LLM.CUSTOM_EMBEDDING_MAX_TOKENS
             self.max_batch_size = settings.LLM.CUSTOM_EMBEDDING_MAX_BATCH_SIZE
@@ -80,8 +104,68 @@ class _EmbeddingClient:
             else settings.MAX_EMBEDDING_TOKENS_PER_REQUEST
         )
 
+        # For `custom` provider, load the real model tokenizer so token counts
+        # and chunk boundaries match what the self-hosted server will see.
+        # tiktoken's o200k_base tokenizer (OpenAI GPT-4o) produces dramatically
+        # different token counts for CJK text vs Qwen's BPE, which would make
+        # pre-checks and `_chunk_text_with_tokens` send oversize requests that
+        # the server rejects.
+        self._accurate_tokenizer: Any = None
+        if self.provider == "custom":
+            if _AutoTokenizer is None:
+                raise ImportError(
+                    "The 'custom' embedding provider requires the 'transformers' "
+                    "package to load the self-hosted model's tokenizer. Install "
+                    "with: uv pip install transformers"
+                )
+            try:
+                self._accurate_tokenizer = _AutoTokenizer.from_pretrained(self.model)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to load tokenizer for custom embedding model "
+                    f"{self.model!r}: {e}. Ensure the model is reachable via "
+                    "HuggingFace Hub or set HF_HUB_OFFLINE / HF_HOME to a cache "
+                    "that contains it."
+                ) from e
+            logger.info(
+                "Custom embedding provider configured: model=%s, "
+                "max_tokens=%d (client-side pre-check only — server enforces "
+                "its own --max-model-len), max_batch_size=%d, "
+                "max_tokens_per_request=%d",
+                self.model,
+                self.max_embedding_tokens,
+                self.max_batch_size,
+                self.max_embedding_tokens_per_request,
+            )
+
+    def _count_tokens(self, text: str) -> int:
+        """Accurate token count for the active provider.
+
+        Falls back to tiktoken o200k_base for non-custom providers (matches
+        OpenAI's billing model and is a reasonable estimate for Gemini).
+        """
+        if self._accurate_tokenizer is not None:
+            return len(
+                self._accurate_tokenizer.encode(text, add_special_tokens=False)
+            )
+        return len(self.encoding.encode(text))
+
+    def _tokenize(self, text: str) -> list[int]:
+        """Return the provider-accurate token id list for *text*."""
+        if self._accurate_tokenizer is not None:
+            return self._accurate_tokenizer.encode(text, add_special_tokens=False)
+        return self.encoding.encode(text)
+
+    def _detokenize(self, token_ids: list[int]) -> str:
+        """Inverse of _tokenize for the active provider."""
+        if self._accurate_tokenizer is not None:
+            return self._accurate_tokenizer.decode(
+                token_ids, skip_special_tokens=True
+            )
+        return self.encoding.decode(token_ids)
+
     async def embed(self, query: str) -> list[float]:
-        token_count = len(self.encoding.encode(query))
+        token_count = self._count_tokens(query)
 
         if token_count > self.max_embedding_tokens:
             raise ValueError(
@@ -183,22 +267,48 @@ class _EmbeddingClient:
         """
         Chunk texts that exceed token limits.
 
+        For the `custom` provider, ignores the caller-supplied `encoded_tokens`
+        (which come from Honcho's global tiktoken encoder) and re-encodes with
+        the real model tokenizer so chunks actually fit the server's
+        `--max-model-len`. Other providers reuse the caller's tokens.
+
+        Overlapping chunks are de-duplicated by exact text match so the 20%
+        overlap (see `_chunk_text_with_tokens`) doesn't produce redundant
+        vector rows when two windows happen to land on identical content.
+
         Args:
             id_resource_dict: Maps text IDs to (text, encoded_tokens) tuples
 
         Returns:
             Maps text IDs to lists of (chunk_text, token_count) tuples
         """
-        return {
-            text_id: (
-                _chunk_text_with_tokens(
-                    text, encoded_tokens, self.max_embedding_tokens, self.encoding
+        prepared: dict[str, list[tuple[str, int]]] = {}
+        for text_id, (text, caller_encoded_tokens) in id_resource_dict.items():
+            if self._accurate_tokenizer is not None:
+                tokens = self._tokenize(text)
+            else:
+                tokens = caller_encoded_tokens
+
+            if len(tokens) > self.max_embedding_tokens:
+                raw_chunks = _chunk_text_with_tokens(
+                    text,
+                    tokens,
+                    self.max_embedding_tokens,
+                    self._detokenize,
                 )
-                if len(encoded_tokens) > self.max_embedding_tokens
-                else [(text, len(encoded_tokens))]
-            )
-            for text_id, (text, encoded_tokens) in id_resource_dict.items()
-        }
+            else:
+                raw_chunks = [(text, len(tokens))]
+
+            seen: set[str] = set()
+            deduped: list[tuple[str, int]] = []
+            for chunk_text, count in raw_chunks:
+                if chunk_text in seen:
+                    continue
+                seen.add(chunk_text)
+                deduped.append((chunk_text, count))
+            prepared[text_id] = deduped
+
+        return prepared
 
     def _create_batches(
         self, text_chunks: dict[str, list[tuple[str, int]]]
@@ -328,7 +438,7 @@ def _chunk_text_with_tokens(
     text: str,
     encoded_tokens: list[int],
     max_tokens: int,
-    encoding: tiktoken.Encoding,
+    decode_fn: Callable[[list[int]], str],
 ) -> list[tuple[str, int]]:
     """
     Split text into chunks that fit within token limits, with 20% overlap.
@@ -337,7 +447,9 @@ def _chunk_text_with_tokens(
         text: Original text to chunk
         encoded_tokens: Pre-encoded tokens for the text
         max_tokens: Maximum tokens per chunk
-        encoding: Tiktoken encoding model
+        decode_fn: Callable turning a token id list back into text — the
+            caller supplies one matching its own tokenizer (tiktoken for
+            OpenAI/Gemini, the model's tokenizer for `custom`)
 
     Returns:
         List of (chunk_text, token_count) tuples
@@ -351,7 +463,7 @@ def _chunk_text_with_tokens(
 
     return [
         (
-            encoding.decode(encoded_tokens[i : i + max_tokens]),
+            decode_fn(encoded_tokens[i : i + max_tokens]),
             min(max_tokens, len(encoded_tokens) - i),
         )
         for i in range(0, len(encoded_tokens), step_size)

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -55,6 +55,14 @@ class _EmbeddingClient:
             self.model = "openai/text-embedding-3-small"
             self.max_embedding_tokens = settings.MAX_EMBEDDING_TOKENS
             self.max_batch_size = 2048  # Same as OpenAI
+        elif self.provider == "custom":
+            if api_key is None:
+                api_key = settings.LLM.CUSTOM_EMBEDDING_API_KEY or "dummy"
+            base_url = settings.LLM.CUSTOM_EMBEDDING_BASE_URL or "http://localhost:8081/v1"
+            self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+            self.model = settings.LLM.CUSTOM_EMBEDDING_MODEL or "Qwen/Qwen3-Embedding-8B"
+            self.max_embedding_tokens = settings.MAX_EMBEDDING_TOKENS
+            self.max_batch_size = 256
         else:  # openai
             if api_key is None:
                 api_key = settings.LLM.OPENAI_API_KEY
@@ -382,6 +390,8 @@ class EmbeddingClient:
                         api_key = settings.LLM.GEMINI_API_KEY
                     elif provider == "openrouter":
                         api_key = settings.LLM.OPENAI_COMPATIBLE_API_KEY
+                    elif provider == "custom":
+                        api_key = settings.LLM.CUSTOM_EMBEDDING_API_KEY
                     else:
                         api_key = settings.LLM.OPENAI_API_KEY
 

--- a/src/main.py
+++ b/src/main.py
@@ -120,10 +120,60 @@ if SENTRY_ENABLED:
     )
 
 
+async def _assert_pgvector_dim_consistency() -> None:
+    """Fail fast if the pgvector column dim doesn't match settings.VECTOR_STORE.DIMENSIONS.
+
+    The ORM in src/models.py declares `Vector(1536)` statically but
+    VectorStoreSettings.DIMENSIONS is user-configurable. If the two drift
+    (e.g. someone sets VECTOR_STORE_DIMENSIONS=1024 but never re-ran a
+    corresponding migration), every embedding write would fail with a
+    pgvector dim mismatch — at message-insert time, not at startup. Surface
+    the mismatch immediately so it's caught before accepting traffic.
+    """
+    from sqlalchemy import text
+
+    expected = settings.VECTOR_STORE.DIMENSIONS
+    try:
+        async with engine.connect() as conn:
+            # pgvector stores dim in pg_attribute.atttypmod. Check the two
+            # tables that carry the embedding column in Honcho's schema.
+            row = await conn.execute(
+                text(
+                    "SELECT c.relname AS tbl, a.atttypmod AS dim "
+                    "FROM pg_attribute a "
+                    "JOIN pg_class c ON a.attrelid = c.oid "
+                    "WHERE a.attname = 'embedding' "
+                    "  AND c.relkind = 'r' "
+                    "  AND c.relname IN ('message_embeddings', 'documents')"
+                )
+            )
+            rows = list(row)
+    except Exception as e:
+        logger.warning(
+            "Could not verify pgvector dim consistency at startup "
+            "(DB unreachable or schema missing): %s",
+            e,
+        )
+        return
+
+    mismatches = [(tbl, dim) for tbl, dim in rows if dim != expected]
+    if mismatches:
+        detail = ", ".join(f"{tbl}.embedding={dim}" for tbl, dim in mismatches)
+        raise RuntimeError(
+            f"pgvector dim mismatch: settings.VECTOR_STORE.DIMENSIONS={expected} "
+            f"but schema has {detail}. Either restore DIMENSIONS to match the "
+            "current schema or run an alembic migration that widens the "
+            "column; Honcho refuses to start with a mismatched schema because "
+            "every embedding write would fail at runtime."
+        )
+
+
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     # Initialize CloudEvents telemetry
     await initialize_telemetry_async()
+
+    await _assert_pgvector_dim_consistency()
 
     try:
         await init_cache()

--- a/uv.lock
+++ b/uv.lock
@@ -1142,6 +1142,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.48.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1281,6 +1290,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/43/724d307b34e353da0abd476e02f72f735cdd2bc86082dee1b32ea0bfee1d/hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144", size = 3800935, upload-time = "2026-03-31T22:39:49.618Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d2/8bee5996b699262edb87dbb54118d287c0e1b2fc78af7cdc41857ba5e3c4/hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f", size = 3558942, upload-time = "2026-03-31T22:39:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a1/e993d09cbe251196fb60812b09a58901c468127b7259d2bf0f68bf6088eb/hf_xet-1.4.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21644b404bb0100fe3857892f752c4d09642586fd988e61501c95bbf44b393a3", size = 4207657, upload-time = "2026-03-31T22:39:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/9eb6d21e5c34c63e5e399803a6932fa983cabdf47c0ecbcfe7ea97684b8c/hf_xet-1.4.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:987f09cfe418237812896a6736b81b1af02a3a6dcb4b4944425c4c4fca7a7cf8", size = 3986765, upload-time = "2026-03-31T22:39:37.936Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/8ad6f16fdb82f5f7284a34b5ec48645bd575bdcd2f6f0d1644775909c486/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:60cf7fc43a99da0a853345cf86d23738c03983ee5249613a6305d3e57a5dca74", size = 4188162, upload-time = "2026-03-31T22:39:58.382Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c4/39d6e136cbeea9ca5a23aad4b33024319222adbdc059ebcda5fc7d9d5ff4/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2815a49a7a59f3e2edf0cf113ae88e8cb2ca2a221bf353fb60c609584f4884d4", size = 4424525, upload-time = "2026-03-31T22:40:00.225Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/adc32dae6bdbc367853118b9878139ac869419a4ae7ba07185dc31251b76/hf_xet-1.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:42ee323265f1e6a81b0e11094564fb7f7e0ec75b5105ffd91ae63f403a11931b", size = 3671610, upload-time = "2026-03-31T22:40:10.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/19/25d897dcc3f81953e0c2cde9ec186c7a0fee413eb0c9a7a9130d87d94d3a/hf_xet-1.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:27c976ba60079fb8217f485b9c5c7fcd21c90b0367753805f87cb9f3cdc4418a", size = 3528529, upload-time = "2026-03-31T22:40:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/36/3e8f85ca9fe09b8de2b2e10c63b3b3353d7dda88a0b3d426dffbe7b8313b/hf_xet-1.4.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5251d5ece3a81815bae9abab41cf7ddb7bcb8f56411bce0827f4a3071c92fdc6", size = 3801019, upload-time = "2026-03-31T22:39:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9c/defb6cb1de28bccb7bd8d95f6e60f72a3d3fa4cb3d0329c26fb9a488bfe7/hf_xet-1.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1feb0f3abeacee143367c326a128a2e2b60868ec12a36c225afb1d6c5a05e6d2", size = 3558746, upload-time = "2026-03-31T22:39:54.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bd/8d001191893178ff8e826e46ad5299446e62b93cd164e17b0ffea08832ec/hf_xet-1.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b301fc150290ca90b4fccd079829b84bb4786747584ae08b94b4577d82fb791", size = 4207692, upload-time = "2026-03-31T22:39:46.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/6790b402803250e9936435613d3a78b9aaeee7973439f0918848dde58309/hf_xet-1.4.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d972fbe95ddc0d3c0fc49b31a8a69f47db35c1e3699bf316421705741aab6653", size = 3986281, upload-time = "2026-03-31T22:39:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/51/56/ea62552fe53db652a9099eda600b032d75554d0e86c12a73824bfedef88b/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c5b48db1ee344a805a1b9bd2cda9b6b65fe77ed3787bd6e87ad5521141d317cd", size = 4187414, upload-time = "2026-03-31T22:40:04.951Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f5/bc1456d4638061bea997e6d2db60a1a613d7b200e0755965ec312dc1ef79/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:22bdc1f5fb8b15bf2831440b91d1c9bbceeb7e10c81a12e8d75889996a5c9da8", size = 4424368, upload-time = "2026-03-31T22:40:06.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/76/ab597bae87e1f06d18d3ecb8ed7f0d3c9a37037fc32ce76233d369273c64/hf_xet-1.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0392c79b7cf48418cd61478c1a925246cf10639f4cd9d94368d8ca1e8df9ea07", size = 3672280, upload-time = "2026-03-31T22:40:16.401Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/2e462d34e23a09a74d73785dbed71cc5dbad82a72eee2ad60a72a554155d/hf_xet-1.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:681c92a07796325778a79d76c67011764ecc9042a8c3579332b61b63ae512075", size = 3528945, upload-time = "2026-03-31T22:40:14.995Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+]
+
+[[package]]
 name = "honcho"
 version = "3.0.6"
 source = { virtual = "." }
@@ -1316,6 +1357,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tenacity" },
     { name = "tiktoken" },
+    { name = "transformers" },
     { name = "turbopuffer" },
     { name = "typing-extensions" },
 ]
@@ -1372,6 +1414,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.30" },
     { name = "tenacity", specifier = ">=9.1.2" },
     { name = "tiktoken", specifier = ">=0.9.0" },
+    { name = "transformers", specifier = ">=5.5.4" },
     { name = "turbopuffer", specifier = ">=1.8.1" },
     { name = "typing-extensions", specifier = ">=4.11.0" },
 ]
@@ -1489,6 +1532,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/89/e7aa12d8a6b9259bed10671abb25ae6fa437c0f88a86ecbf59617bae7759/huggingface_hub-1.11.0.tar.gz", hash = "sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278", size = 761749, upload-time = "2026-04-16T13:07:39.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/02/4f3f8997d1ea7fe0146b343e5e14bd065fa87af790d07e5576d31b31cc18/huggingface_hub-1.11.0-py3-none-any.whl", hash = "sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab", size = 645499, upload-time = "2026-04-16T13:07:37.716Z" },
 ]
 
 [[package]]
@@ -3779,6 +3842,32 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6a/4d08d89a6fcbe905c5ae68b8b34f0791850882fc19782d0d02c65abbdf3b/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4729811a6640d019a4b7ba8638ee2fd21fa5ca8c7e7bdf0fed62068fcaac737", size = 492430, upload-time = "2025-11-19T15:18:11.884Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/29/59ed8152b30f72c42d00d241e58eaca558ae9dbfa5695206e2e0f54c7063/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12f49080303fa6bb424b362149a12949dfbbf1e06811a88f2307276b0c131afd", size = 503977, upload-time = "2025-11-19T15:18:17.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/4811bfec67fa260e791369b16dab105e4bae82686120554cc484064e22b4/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0071bffba4150c2f46cae1432d31995d77acfd9f8db598b5d1a2ce67e8440ad2", size = 623890, upload-time = "2025-11-19T15:18:22.666Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5b/632a58724221ef03d78ab65062e82a1010e1bef8e8e0b9d7c6d7b8044841/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:473b32699f4200e69801bf5abf93f1a4ecd432a70984df164fc22ccf39c4a6f3", size = 531885, upload-time = "2025-11-19T15:18:27.146Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4245,6 +4334,36 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+    { url = "https://files.pythonhosted.org/packages/84/04/655b79dbcc9b3ac5f1479f18e931a344af67e5b7d3b251d2dcdcd7558592/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:753d47ebd4542742ef9261d9da92cd545b2cacbb48349a1225466745bb866ec4", size = 3282301, upload-time = "2026-01-05T10:40:34.858Z" },
+    { url = "https://files.pythonhosted.org/packages/46/cd/e4851401f3d8f6f45d8480262ab6a5c8cb9c4302a790a35aa14eeed6d2fd/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e10bf9113d209be7cd046d40fbabbaf3278ff6d18eb4da4c500443185dc1896c", size = 3161308, upload-time = "2026-01-05T10:40:40.737Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6e/55553992a89982cd12d4a66dddb5e02126c58677ea3931efcbe601d419db/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64d94e84f6660764e64e7e0b22baa72f6cd942279fdbb21d46abd70d179f0195", size = 3718964, upload-time = "2026-01-05T10:40:46.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/b1c87148aa15e099243ec9f0cf9d0e970cc2234c3257d558c25a2c5304e6/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f01a9c019878532f98927d2bacb79bbb404b43d3437455522a00a30718cdedb5", size = 3373542, upload-time = "2026-01-05T10:40:52.803Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4308,6 +4427,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/1e/1e244ab2ab50a863e6b52cc55761910567fa532b69a6740f6e99c5fdbd98/transformers-5.5.4.tar.gz", hash = "sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e", size = 8227649, upload-time = "2026-04-13T16:55:55.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/fb/162a66789c65e5afa3b051309240c26bf37fbc8fea285b4546ae747995a2/transformers-5.5.4-py3-none-any.whl", hash = "sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167", size = 10236696, upload-time = "2026-04-13T16:55:51.497Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a `custom` embedding provider that points Honcho at any OpenAI-compatible `/v1/embeddings` endpoint — enabling self-hosted models served via **vLLM** or **Text Embeddings Inference (TEI)** without reaching out to OpenAI/Gemini/OpenRouter.

Motivation: on-prem deployments with local GPUs (tested on DGX Spark with Qwen3-Embedding-8B served by vLLM at 1536 dims via Matryoshka truncation) need to drive Honcho's embedding client entirely on-device, including in air-gapped setups.

## Changes

1. **New provider branch in `_EmbeddingClient`** (`src/embedding_client.py`)
   - `provider == "custom"` picks `AsyncOpenAI(base_url=LLM_CUSTOM_EMBEDDING_BASE_URL)` (defaulting to `http://localhost:8081/v1`) and the configured `LLM_CUSTOM_EMBEDDING_MODEL` (e.g. `Qwen/Qwen3-Embedding-8B`).
   - Separate, configurable batch/token limits so operators can match a local server's constraints without changing OpenAI-path defaults.

2. **New settings in `LLMSettings`** (`src/config.py`)
   - `CUSTOM_EMBEDDING_BASE_URL`, `CUSTOM_EMBEDDING_API_KEY`, `CUSTOM_EMBEDDING_MODEL`
   - `CUSTOM_EMBEDDING_MAX_TOKENS` (default 4096)
   - `CUSTOM_EMBEDDING_MAX_TOKENS_PER_REQUEST` (default 32_000)
   - `CUSTOM_EMBEDDING_MAX_BATCH_SIZE` (default 32)

3. **No schema change** — relies on the existing `Vector(1536)` pgvector column. Server-side truncation (e.g. `--pooler-config dimensions=1536` on vLLM) keeps the contract.

## Usage

```bash
# .env
LLM_EMBEDDING_PROVIDER=custom
LLM_CUSTOM_EMBEDDING_BASE_URL=http://localhost:8081/v1
LLM_CUSTOM_EMBEDDING_MODEL=Qwen/Qwen3-Embedding-8B
LLM_CUSTOM_EMBEDDING_API_KEY=dummy
```

## Testing

- Verified end-to-end against vLLM 0.19 serving `Qwen/Qwen3-Embedding-8B` with `--pooler-config '{"task":"embed","pooling_type":"LAST","dimensions":1536}'` (Matryoshka). Messages posted to `/v3/workspaces/{w}/sessions/{s}/messages` were successfully processed by the deriver and persisted into `message_embeddings` with `vector_dims = 1536`.
- Existing OpenAI / Gemini / OpenRouter paths unchanged.

## Notes to maintainers

- Happy to split into 2 PRs (provider branch + tuning knobs) if preferred.
- Second commit message has a `local:` prefix — can reword to `feat(embedding):` before merge.