### PR TITLE
fix: embed() sends string input instead of array, breaking OpenAI-compatible providers

### DIFF
--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -99,7 +99,7 @@ class _EmbeddingClient:
             return self._validate_embedding_dimensions(response.embeddings[0].values)
         else:  # openai
             response = await self.client.embeddings.create(
-                model=self.model, input=query
+                model=self.model, input=[query]
             )
             return self._validate_embedding_dimensions(response.data[0].embedding)
 

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -51,7 +51,7 @@ async def test_openai_embedding_client_uses_configured_model_and_dimensions(
 
     assert embedding == [0.1] * 8
     assert fake_embeddings.calls == [
-        {"model": "text-embedding-3-small", "input": "hello world"}
+        {"model": "text-embedding-3-small", "input": ["hello world"]}
     ]
 
 


### PR DESCRIPTION
**Problem**

The `embed()` method in `src/embedding_client.py` sends `input=query` as a plain string. Many OpenAI-compatible providers (vLLM, LiteLLM, Ollama, custom endpoints) only accept array format and reject plain strings with 400 Bad Request.

The batch methods (`batch_embed`, `simple_batch_embed`, `_process_batch`) already correctly use array input. The single `embed()` method is the only inconsistency.

**Fix**

Wrap the input in an array: `input=[query]`. This is consistent with the batch methods and the [OpenAI Embeddings API spec](https://platform.openai.com/docs/api-reference/embeddings/create), which accepts both formats.

**Testing**

Verified against OpenAI-compatible endpoints using the `openrouter` provider setting with a custom `LLM_OPENAI_COMPATIBLE_BASE_URL`. Before: 400 Bad Request. After: embeddings returned correctly. No impact on direct OpenAI or Gemini providers, which accept both formats.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding request formatting to restore compatibility and reliability with the embedding API, reducing potential failures.

* **Tests**
  * Updated tests to align with the adjusted embedding request format and ensure consistent validation of returned embeddings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->