### PR TITLE
fix: remove hardcoded stop_sequences override from Deriver model config

### DIFF
--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -125,11 +125,7 @@ async def process_representation_tasks_batch(
     # validation on settings means max_tokens will always be > 0
     base_model_config = _get_deriver_model_config()
     max_tokens = base_model_config.max_output_tokens or settings.LLM.DEFAULT_MAX_TOKENS
-    model_config = base_model_config.model_copy(
-        update={
-            "stop_sequences": ["   \n", "\n\n\n\n"],
-        }
-    )
+    model_config = base_model_config
 
     # Single LLM call
     llm_start = time.perf_counter()


### PR DESCRIPTION
## Problem

The Minimal Deriver in `src/deriver/deriver.py` copies the base model config and injects hardcoded `stop_sequences`:

```python
model_config = base_model_config.model_copy(
    update={
        "stop_sequences": ["   \n", "\n\n\n\n"],
    }
)
```

This results in a `stop` parameter being sent in the OpenAI chat completions request. Several OpenAI-compatible backends reject this parameter for certain models with:

```
Error code: 400 - Unsupported parameter: 'stop' is not supported with this model.
```

This causes the entire Deriver pipeline to fail with `RetryError` after exhausting all retry attempts. It also blocks Dream, since Dream triggers Deriver calls internally as part of its consolidation pipeline.

## Fix

Pass the base model config through without modification:

```python
model_config = base_model_config
```

The stop sequences are whitespace heuristics (`"   \n"` and `"\n\n\n\n"`) intended to cut off trailing output. They are redundant because the Deriver call already uses `json_mode=True` and `response_model=PromptRepresentation`, which structurally constrain the output to valid JSON parsed into a Pydantic model. Any trailing whitespace is discarded during parsing.

## Environment

- Honcho main branch (latest as of 2026-04-20)
- OpenAI-compatible proxy backend
- Models affected: gpt-5-mini, gpt-5.2 (likely any model where the backend does not support `stop`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed language model response termination behavior by using standard configuration instead of custom overrides, improving consistency in generated outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->