### PR TITLE
fix(models): use VECTOR_STORE_DIMENSIONS env var for pgvector column dimensions

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from logging import getLogger
 from typing import Any, final
 
@@ -278,7 +279,9 @@ class MessageEmbedding(Base):
         BigInteger, Identity(), primary_key=True, autoincrement=True
     )
     content: Mapped[str] = mapped_column(TEXT)
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(
+        Vector(int(os.environ.get("VECTOR_STORE_DIMENSIONS", "768")))
+    , nullable=True)
     message_id: Mapped[str] = mapped_column(
         ForeignKey("messages.public_id", ondelete="CASCADE"), nullable=False, index=True
     )
@@ -386,7 +389,9 @@ class Document(Base):
     times_derived: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("1")
     )
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(
+        Vector(int(os.environ.get("VECTOR_STORE_DIMENSIONS", "768")))
+    , nullable=True)
     source_ids: Mapped[list[str] | None] = mapped_column(
         JSONB, nullable=True, server_default=text("NULL")
     )


### PR DESCRIPTION
## Problem

`Vector(1536)` is hardcoded in `MessageEmbedding.embedding` and `Document.embedding` columns in `src/models.py`. This ignores the `VECTOR_STORE_DIMENSIONS` environment variable, causing dimension mismatch errors for any self-hosted user running non-OpenAI embedding models:

- nomic-embed-text → 768 dims
- nomic-embed-text-v2-moe → 768 dims
- Gemini embedding-001 → 3072 dims

Error pattern:
```
sqlalchemy.exc.StatementError: expected 1536 dimensions, not 768
```

## Fix

Read `VECTOR_STORE_DIMENSIONS` at model definition time, defaulting to 768 (the most common dimension for open embedding models) when unset.

```python
# Before
embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)

# After
embedding: MappedColumn[Any] = mapped_column(
    Vector(int(os.environ.get("VECTOR_STORE_DIMENSIONS", "768")))
, nullable=True)
```

Applied to both `MessageEmbedding` and `Document` models.

## Testing

- Self-hosted Honcho with Ollama (`nomic-embed-text`, 768 dims) — previously crashed on startup, now starts and processes conclusions correctly.
- `VECTOR_STORE_DIMENSIONS=1536` reproduces the original behavior for OpenAI embedding users.

## Notes

- This also relates to the `EMBEDDING.VECTOR_DIMENSIONS must remain 1536` validation added in `src/config.py` — that guard is useful for fresh installs but prevents existing users who already have non-1536 data from upgrading. A separate PR could add an escape hatch (e.g. `VECTOR_STORE_DIMENSIONS_OVERRIDE=true`).
- The migration files also contain hardcoded `Vector(1536)` but those are less impactful since they only run on fresh DB creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedding vector dimensions are now configurable through environment variables, enabling deployment flexibility based on specific system requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->