### PR TITLE
fix(llm): robust JSON handling for OpenAI-compatible proxies

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -378,13 +378,13 @@ class OpenAIBackend:
         response_format: type[BaseModel],
     ) -> Any:
         structured_params = dict(params)
-        structured_params["response_format"] = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": response_format.__name__,
-                "schema": response_format.model_json_schema(),
-            },
-        }
+        # Use json_object instead of json_schema — OpenAI-compatible proxies
+        # (Ollama, vLLM, etc.) don't support json_schema and will reject it
+        # or ignore it, returning empty/malformed content. json_object is
+        # widely supported and the repair pipeline (extract_json_from_text
+        # + validate_and_repair_json + repair_response_model_json) handles
+        # markdown-wrapped output correctly.
+        structured_params["response_format"] = {"type": "json_object"}
         return await self._client.chat.completions.create(**structured_params)
 
     @staticmethod

--- a/src/llm/structured_output.py
+++ b/src/llm/structured_output.py
@@ -33,24 +33,48 @@ def repair_response_model_json(
         final = validate_and_repair_json(raw_content)
         repaired_data = json.loads(final)
 
-        if (
-            response_model is PromptRepresentation
-            and "deductive" in repaired_data
-            and isinstance(repaired_data["deductive"], list)
+        if response_model is PromptRepresentation and isinstance(
+            repaired_data, dict
         ):
-            for item in repaired_data["deductive"]:
-                if isinstance(item, dict):
-                    if "conclusion" not in item and "premises" in item:
-                        if item["premises"]:
-                            item["conclusion"] = (
-                                f"[Incomplete reasoning from premises: {item['premises'][0][:100]}...]"
-                            )
-                        else:
-                            item["conclusion"] = (
-                                "[Incomplete reasoning - conclusion missing]"
-                            )
-                    if "premises" not in item:
-                        item["premises"] = []
+            # Normalize explicit: string[] → [{"content": s}, ...]
+            explicit = repaired_data.get("explicit")
+            if isinstance(explicit, list):
+                normalized = []
+                for item in explicit:
+                    if isinstance(item, str):
+                        normalized.append({"content": item})
+                    elif isinstance(item, dict) and "content" in item:
+                        normalized.append(item)
+                    elif isinstance(item, dict) and "observation" in item:
+                        normalized.append({"content": item["observation"]})
+                repaired_data["explicit"] = normalized
+
+            # Normalize deductive items (existing logic + string handling)
+            deductive = repaired_data.get("deductive")
+            if isinstance(deductive, list):
+                normalized_ded = []
+                for item in deductive:
+                    if isinstance(item, str):
+                        normalized_ded.append(
+                            {"conclusion": item, "premises": []}
+                        )
+                    elif isinstance(item, dict):
+                        if (
+                            "conclusion" not in item
+                            and "premises" in item
+                        ):
+                            if item["premises"]:
+                                item["conclusion"] = (
+                                    f"[Incomplete reasoning from premises: {item['premises'][0][:100]}...]"
+                                )
+                            else:
+                                item["conclusion"] = (
+                                    "[Incomplete reasoning - conclusion missing]"
+                                )
+                        if "premises" not in item:
+                            item["premises"] = []
+                        normalized_ded.append(item)
+                repaired_data["deductive"] = normalized_ded
 
         final = json.dumps(repaired_data)
     except (json.JSONDecodeError, KeyError, TypeError, ValueError):

--- a/src/utils/json_parser.py
+++ b/src/utils/json_parser.py
@@ -352,8 +352,66 @@ def simple_bracket_repair(json_str: str) -> str:
     return repaired
 
 
+def extract_json_from_text(text: str) -> str:
+    """Extract JSON from text that may be wrapped in markdown code fences or prose.
+
+    Handles:
+      - ```json\n{...}\n```
+      - ```\n{...}\n```
+      - Bare JSON surrounded by prose
+    """
+    text = text.strip()
+
+    # Strategy 1: Extract from markdown code fence
+    fence_pattern = re.compile(r"```(?:json)?\s*\n?(.*?)\n?\s*```", re.DOTALL)
+    match = fence_pattern.search(text)
+    if match:
+        candidate = match.group(1).strip()
+        try:
+            json.loads(candidate)
+            return candidate
+        except json.JSONDecodeError:
+            pass  # fall through to next strategy
+
+    # Strategy 2: Find outermost { ... } or [ ... ]
+    for open_ch, close_ch in [("{", "}"), ("[", "]")]:
+        start = text.find(open_ch)
+        if start != -1:
+            depth = 0
+            in_string = False
+            escape_next = False
+            for i in range(start, len(text)):
+                ch = text[i]
+                if escape_next:
+                    escape_next = False
+                    continue
+                if ch == "\\":
+                    escape_next = True
+                    continue
+                if ch == '"' and not escape_next:
+                    in_string = not in_string
+                    continue
+                if in_string:
+                    continue
+                if ch == open_ch:
+                    depth += 1
+                elif ch == close_ch:
+                    depth -= 1
+                    if depth == 0:
+                        candidate = text[start : i + 1]
+                        try:
+                            json.loads(candidate)
+                            return candidate
+                        except json.JSONDecodeError:
+                            break  # try the other bracket type
+
+    # Nothing extractable — return as-is (caller will handle the failure)
+    return text
+
+
 def validate_and_repair_json(json_str: str) -> str:
     """Main function with comprehensive repair strategies"""
+    json_str = extract_json_from_text(json_str)
     json_str = json_str.strip()
 
     # Try parsing with repair library


### PR DESCRIPTION
## Problem

When using OpenAI-compatible proxies (Ollama, vLLM, Together, OpenRouter), the structured output pipeline fails silently — the deriver generates zero observations on every call.

Three failure modes:

1. **Proxies ignore `response_format=json_schema`** — `_create_structured_response` falls back to `json_schema` format, which most proxies don't support. They reject it or ignore it, returning empty/malformed content.

2. **Proxies return markdown-wrapped JSON** — Even with `response_format=json_object`, models like `gemma3:4b` on Ollama return `` ```json {...} ``` `` instead of bare JSON. `json.loads()` fails with "Expecting value: line 1 column 1".

3. **Proxies don't follow the exact Pydantic schema** — They return string arrays instead of object arrays (e.g. `"explicit": ["observation1", "observation2"]` instead of `"explicit": [{"content": "observation1"}]`), or use alternate field names like `"observation"` instead of `"content"`.

## Changes

- **`src/utils/json_parser.py`** — New `extract_json_from_text()` function that strips markdown code fences and extracts bare JSON from prose before validation. Called at the top of `validate_and_repair_json()`.

- **`src/llm/backends/openai.py`** — `_create_structured_response()` now uses `{"type": "json_object"}` instead of `json_schema` format. The repair pipeline handles any schema drift downstream.

- **`src/llm/structured_output.py`** — `repair_response_model_json()` now normalizes schema variants:
  - `explicit`: `string` → `{"content": s}`, `{"observation": x}` → `{"content": x}`
  - `deductive`: `string` → `{"conclusion": s, "premises": []}`

## Testing

Tested with `gemma3:4b-cloud` on Ollama (self-hosted). Before: deriver generates 0 observations on every call. After: deriver generates 4+ observations per message batch, stored successfully in pgvector.

```
╭──────────────── ⚡ PERFORMANCE ─────────────────╮
│   Observation Count    4    count              │
╰────────────────────────────────────────────────╯
```

## Impact

- Zero impact on OpenAI native users (their `chat.completions.parse()` already works)
- Enables self-hosted users on Ollama/vLLM/etc. to use the deriver
- Backward compatible — all normalization is additive to the repair pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON extraction from text containing surrounding content or markdown formatting for more reliable parsing.
  * Enhanced normalization and repair of structured response data to ensure consistent output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->