### PR TITLE
fix(models): make Vector dimension configurable via VECTOR_STORE_DIMENSIONS

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1,10 +1,14 @@
 import datetime
+import os
 from logging import getLogger
 from typing import Any, final
 
 from dotenv import load_dotenv
 from nanoid import generate as generate_nanoid
 from pgvector.sqlalchemy import Vector
+
+_VECTOR_DIMS = int(os.environ.get("VECTOR_STORE_DIMENSIONS", "768"))
+
 from sqlalchemy import (
     BigInteger,
     Boolean,
@@ -278,7 +282,7 @@ class MessageEmbedding(Base):
         BigInteger, Identity(), primary_key=True, autoincrement=True
     )
     content: Mapped[str] = mapped_column(TEXT)
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(_VECTOR_DIMS), nullable=True)
     message_id: Mapped[str] = mapped_column(
         ForeignKey("messages.public_id", ondelete="CASCADE"), nullable=False, index=True
     )
@@ -386,7 +390,7 @@ class Document(Base):
     times_derived: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("1")
     )
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(_VECTOR_DIMS), nullable=True)
     source_ids: Mapped[list[str] | None] = mapped_column(
         JSONB, nullable=True, server_default=text("NULL")
     )


### PR DESCRIPTION
## Problem

The `Vector(1536)` dimension is hardcoded in both `MessageEmbedding.embedding` and `Document.embedding` column definitions. Self-hosted deployments using smaller embedding models (e.g. `nomic-embed-text` at 768 dimensions) need a different dimension, but the hardcoded 1536 causes pgvector query failures:

```
(builtins.ValueError) expected 1536 dimensions, not 768
```

This happens even when the database schema has already been migrated to `vector(768)`, because SQLAlchemy generates query placeholders matching the model's declared dimension (1536) rather than the actual column dimension (768).

## Changes

- **`src/models.py`** — Replace `Vector(1536)` with `Vector(_VECTOR_DIMS)` where `_VECTOR_DIMS = int(os.environ.get("VECTOR_STORE_DIMENSIONS", "768"))`. This aligns with the existing `EMBEDDING_VECTOR_DIMENSIONS` env var convention and the `VECTOR_STORE_DIMENSIONS` config validation already present in `src/config.py`.

## Why default 768 instead of 1536?

The default matters less than the mechanism — users must set `VECTOR_STORE_DIMENSIONS` to match their embedding model regardless. However, 768 is a reasonable default because:
- `nomic-embed-text` (768d) is the most common self-hosted embedding model
- OpenAI `text-embedding-3-small` supports 1536d but also 512d and 768d via `dimensions` param
- Fresh installs with OpenAI embeddings would simply set `VECTOR_STORE_DIMENSIONS=1536`

## Testing

Self-hosted deployment with `nomic-embed-text:latest` (768d). Before: deriver observations fail to store with "expected 1536 dimensions, not 768". After: observations store successfully in pgvector.

Relates to #593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Embedding vector dimensions are now configurable via environment variables instead of using hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->