### PR TITLE
fix: omit stop for gpt-5 reasoning models

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -304,7 +304,7 @@ class OpenAIBackend:
         if thinking_effort:
             params["reasoning_effort"] = thinking_effort
 
-        if stop:
+        if stop and not _uses_max_completion_tokens(model):
             params["stop"] = stop
         if tools:
             params["tools"] = self._convert_tools(tools)

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -64,6 +64,48 @@ async def test_openai_backend_uses_gpt5_params_and_extracts_reasoning() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openai_backend_omits_stop_for_gpt5_reasoning_models() -> None:
+    client = Mock()
+    client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        content="Hello from GPT-5",
+                        tool_calls=[],
+                        reasoning_details=[],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                prompt_tokens_details=None,
+            ),
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    await backend.complete(
+        model="gpt-5.4-mini",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        stop=["\n\n\n\n"],
+        thinking_effort="low",
+    )
+
+    await_args = client.chat.completions.create.await_args
+    if await_args is None:
+        raise AssertionError("Expected OpenAI create call")
+    call = await_args.kwargs
+    assert call["model"] == "gpt-5.4-mini"
+    assert call["max_completion_tokens"] == 100
+    assert call["reasoning_effort"] == "low"
+    assert "stop" not in call
+
+
+@pytest.mark.asyncio
 async def test_openai_backend_passes_thinking_effort_through_for_non_gpt5_models() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- omit the `stop` parameter for GPT-5/o-series reasoning models in the OpenAI backend
- add a regression test proving GPT-5.4-mini requests do not send `stop`

## Why
GPT-5.4-mini rejects `stop` with `400 unsupported_parameter`, which blocks deriver queue processing when stop sequences are set upstream.

## Test Plan
- uv run pytest tests/llm/test_backends/test_openai.py::test_openai_backend_omits_stop_for_gpt5_reasoning_models tests/llm/test_backends/test_openai.py::test_openai_backend_uses_gpt5_params_and_extracts_reasoning -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenAI backend to properly handle request parameters for GPT-5 reasoning models that use `max_completion_tokens`.

* **Tests**
  * Added test coverage to verify GPT-5 reasoning models correctly omit incompatible parameters while maintaining required settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->