### PR TITLE
feat(embedding): forward dimensions to OpenAI embeddings.create

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,6 +18,10 @@ LOG_LEVEL=INFO
 # EMBEDDING_VECTOR_DIMENSIONS=1536
 # EMBEDDING_MAX_INPUT_TOKENS=8192
 # EMBEDDING_MAX_TOKENS_PER_REQUEST=300000
+# Forward `dimensions` on OpenAI embeddings.create requests so MRL-capable
+# models return EMBEDDING_VECTOR_DIMENSIONS-sized vectors. Set to false for
+# providers that reject the field (e.g. text-embedding-ada-002).
+# EMBEDDING_SEND_DIMENSIONS=true
 # EMBEDDING_MODEL_CONFIG__TRANSPORT=openai
 # EMBEDDING_MODEL_CONFIG__MODEL=text-embedding-3-small
 # EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL=

--- a/docs/v3/contributing/configuration.mdx
+++ b/docs/v3/contributing/configuration.mdx
@@ -208,6 +208,7 @@ Embeddings use their own nested model config, separate from the main text-genera
 EMBEDDING_VECTOR_DIMENSIONS=1536
 EMBEDDING_MAX_INPUT_TOKENS=8192
 EMBEDDING_MAX_TOKENS_PER_REQUEST=300000
+EMBEDDING_SEND_DIMENSIONS=true  # Forward `dimensions` on OpenAI requests
 
 # Embedding transport/model selection
 EMBEDDING_MODEL_CONFIG__TRANSPORT=openai  # openai, gemini
@@ -218,8 +219,9 @@ EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL=http://localhost:8000/v1
 EMBEDDING_MODEL_CONFIG__OVERRIDES__API_KEY_ENV=EMBEDDING_CUSTOM_API_KEY
 ```
 
-Current constraint:
+Current constraints:
 - `EMBEDDING_VECTOR_DIMENSIONS` can be changed for fully migrated external vector stores, but pgvector and dual-write mode still require `1536` until the schema migration lands.
+- `EMBEDDING_SEND_DIMENSIONS` controls whether the OpenAI transport forwards the `dimensions` parameter on `embeddings.create` (default `true`). Enables Matryoshka (MRL) truncation for MRL-capable models served via OpenAI or OpenAI-compatible backends. Set to `false` for providers that reject the field, notably `text-embedding-ada-002`.
 
 ### Feature-Specific Model Configuration
 

--- a/src/config.py
+++ b/src/config.py
@@ -683,6 +683,10 @@ class EmbeddingSettings(HonchoSettings):
     VECTOR_DIMENSIONS: Annotated[int, Field(default=1536, gt=0)] = 1536
     MAX_INPUT_TOKENS: Annotated[int, Field(default=8192, gt=0)] = 8192
     MAX_TOKENS_PER_REQUEST: Annotated[int, Field(default=300_000, gt=0)] = 300_000
+    # Forward `dimensions` on OpenAI embeddings.create requests so MRL-capable
+    # models return VECTOR_DIMENSIONS-sized vectors. Set False for providers
+    # that reject the field (e.g. text-embedding-ada-002).
+    SEND_DIMENSIONS: bool = True
 
     @model_validator(mode="before")
     @classmethod

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import threading
 from collections import defaultdict
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import tiktoken
 from google import genai
@@ -34,10 +34,12 @@ class _EmbeddingClient:
         vector_dimensions: int,
         max_input_tokens: int,
         max_tokens_per_request: int,
+        send_dimensions: bool = True,
     ):
         self.transport: str = config.transport
         self.model: str = config.model
         self.vector_dimensions: int = vector_dimensions
+        self.send_dimensions: bool = send_dimensions
 
         if self.transport == "gemini":
             if not config.api_key:
@@ -98,9 +100,10 @@ class _EmbeddingClient:
                 raise ValueError("No embedding returned from Gemini API")
             return self._validate_embedding_dimensions(response.embeddings[0].values)
         else:  # openai
-            response = await self.client.embeddings.create(
-                model=self.model, input=[query]
-            )
+            openai_kwargs: dict[str, Any] = {"model": self.model, "input": [query]}
+            if self.send_dimensions:
+                openai_kwargs["dimensions"] = self.vector_dimensions
+            response = await self.client.embeddings.create(**openai_kwargs)
             return self._validate_embedding_dimensions(response.data[0].embedding)
 
     async def simple_batch_embed(self, texts: list[str]) -> list[list[float]]:
@@ -135,10 +138,13 @@ class _EmbeddingClient:
                                     self._validate_embedding_dimensions(emb.values)
                                 )
                 else:  # openai
-                    response = await self.client.embeddings.create(
-                        input=batch,
-                        model=self.model,
-                    )
+                    openai_kwargs: dict[str, Any] = {
+                        "model": self.model,
+                        "input": batch,
+                    }
+                    if self.send_dimensions:
+                        openai_kwargs["dimensions"] = self.vector_dimensions
+                    response = await self.client.embeddings.create(**openai_kwargs)
                     embeddings.extend(
                         [
                             self._validate_embedding_dimensions(data.embedding)
@@ -282,9 +288,13 @@ class _EmbeddingClient:
                                     )
                                 )
                 else:  # openai
-                    response = await self.client.embeddings.create(
-                        model=self.model, input=[item.text for item in batch]
-                    )
+                    openai_kwargs: dict[str, Any] = {
+                        "model": self.model,
+                        "input": [item.text for item in batch],
+                    }
+                    if self.send_dimensions:
+                        openai_kwargs["dimensions"] = self.vector_dimensions
+                    response = await self.client.embeddings.create(**openai_kwargs)
                     for item, embedding_data in zip(batch, response.data, strict=True):
                         result[item.text_id][item.chunk_index] = (
                             self._validate_embedding_dimensions(
@@ -406,6 +416,7 @@ class EmbeddingClient:
                         vector_dimensions=settings.EMBEDDING.VECTOR_DIMENSIONS,
                         max_input_tokens=settings.EMBEDDING.MAX_INPUT_TOKENS,
                         max_tokens_per_request=settings.EMBEDDING.MAX_TOKENS_PER_REQUEST,
+                        send_dimensions=settings.EMBEDDING.SEND_DIMENSIONS,
                     )
                     self._instance_signature = signature
                     logger.debug(
@@ -429,6 +440,7 @@ class EmbeddingClient:
             settings.EMBEDDING.VECTOR_DIMENSIONS,
             settings.EMBEDDING.MAX_INPUT_TOKENS,
             settings.EMBEDDING.MAX_TOKENS_PER_REQUEST,
+            settings.EMBEDDING.SEND_DIMENSIONS,
         )
 
     async def embed(self, query: str) -> list[float]:

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -12,21 +12,11 @@ class FakeOpenAIEmbeddingsAPI:
         self.embedding: list[float] = embedding
         self.calls: list[dict[str, Any]] = []
 
-    async def create(
-        self,
-        *,
-        model: str,
-        input: str | list[str],
-        dimensions: int | None = None,
-    ) -> SimpleNamespace:
-        call: dict[str, Any] = {"model": model, "input": input}
-        if dimensions is not None:
-            call["dimensions"] = dimensions
-        self.calls.append(call)
-        if isinstance(input, list):
-            data = [SimpleNamespace(embedding=self.embedding) for _ in input]
-        else:
-            data = [SimpleNamespace(embedding=self.embedding)]
+    async def create(self, **kwargs: Any) -> SimpleNamespace:
+        self.calls.append(dict(kwargs))
+        input_value: str | list[str] = kwargs["input"]
+        count = len(input_value) if isinstance(input_value, list) else 1
+        data = [SimpleNamespace(embedding=self.embedding) for _ in range(count)]
         return SimpleNamespace(data=data)
 
 

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -12,8 +12,17 @@ class FakeOpenAIEmbeddingsAPI:
         self.embedding: list[float] = embedding
         self.calls: list[dict[str, Any]] = []
 
-    async def create(self, *, model: str, input: str | list[str]) -> SimpleNamespace:
-        self.calls.append({"model": model, "input": input})
+    async def create(
+        self,
+        *,
+        model: str,
+        input: str | list[str],
+        dimensions: int | None = None,
+    ) -> SimpleNamespace:
+        call: dict[str, Any] = {"model": model, "input": input}
+        if dimensions is not None:
+            call["dimensions"] = dimensions
+        self.calls.append(call)
         if isinstance(input, list):
             data = [SimpleNamespace(embedding=self.embedding) for _ in input]
         else:
@@ -51,7 +60,42 @@ async def test_openai_embedding_client_uses_configured_model_and_dimensions(
 
     assert embedding == [0.1] * 8
     assert fake_embeddings.calls == [
-        {"model": "text-embedding-3-small", "input": ["hello world"]}
+        {
+            "model": "text-embedding-3-small",
+            "input": ["hello world"],
+            "dimensions": 8,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_client_omits_dimensions_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_embeddings = FakeOpenAIEmbeddingsAPI([0.1] * 1536)
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai",
+            model="text-embedding-ada-002",
+            api_key="test-key",
+        ),
+        vector_dimensions=1536,
+        max_input_tokens=8192,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+    await client.embed("hello world")
+
+    assert fake_embeddings.calls == [
+        {"model": "text-embedding-ada-002", "input": ["hello world"]}
     ]
 
 


### PR DESCRIPTION
Fixes #601.

## Summary

- Forward `dimensions=self.vector_dimensions` on the three OpenAI `embeddings.create` call sites (`embed`, `simple_batch_embed`, `_process_batch`), mirroring the existing Gemini `output_dimensionality` passthrough.
- Add `EMBEDDING_SEND_DIMENSIONS: bool` (default `true`) as an opt-out for providers that reject the field — notably `text-embedding-ada-002`.
- Thread the new setting through the `EmbeddingClient` singleton (init + settings signature) so hot-reloads rebuild cleanly.
- Update `.env.template` and `docs/v3/contributing/configuration.mdx` with the new knob and the ada-002 caveat.

## Why

Today `EMBEDDING_VECTOR_DIMENSIONS` is validated against the response in `_validate_embedding_dimensions` but never requested from the provider on the OpenAI path. That means MRL-capable models (Qwen3-Embedding, Nomic v1.5, mxbai-embed-large-v1, OpenAI's own `text-embedding-3-small`/`-large`) can't negotiate a smaller output size, and any OpenAI-compatible server whose native size ≠ configured value throws on every embed. The Gemini branch already does this correctly via `config={"output_dimensionality": self.vector_dimensions}`; this PR brings the OpenAI branch in line.

Full motivation, backward-compat analysis, and reproduction via Qwen3-Embedding-4B + [oMLX](https://github.com/jundot/omlx) in #601.

## Backward compatibility

`EMBEDDING_SEND_DIMENSIONS=true` is the default. For modern OpenAI-compatible servers this is transparent (they either respect the hint or ignore it). For `text-embedding-ada-002` — which rejects the parameter — set `EMBEDDING_SEND_DIMENSIONS=false`. Documented in both `.env.template` and the v3 configuration doc.

## Test plan

- [x] `uv run pytest tests/llm/test_embedding_client.py` — 4 passed.
  - Updated `test_openai_embedding_client_uses_configured_model_and_dimensions` to assert `dimensions` is now present on the call.
  - New `test_openai_embedding_client_omits_dimensions_when_disabled` covers the opt-out path.
  - Existing Gemini and dimension-mismatch tests unchanged.
- [x] `uv run ruff check` + `uv run ruff format` clean on all edited files.
- [x] `uv run basedpyright` — 0 errors, 0 warnings, 0 notes.
- [ ] End-to-end against a self-hosted MRL-capable backend (oMLX + Qwen3-Embedding-4B → pgvector) — validating on my side; will update this checkbox once confirmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable embedding-dimension control via EMBEDDING_SEND_DIMENSIONS (default: enabled) to include or omit the dimensions field in embedding requests for provider compatibility.

* **Documentation**
  * Updated configuration docs and examples to describe the new setting and its default behavior.

* **Tests**
  * Added/updated tests to verify behavior with dimensions enabled and disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->