### PR TITLE
fix: add FORCE_IPV4 option to prevent httpx async IPv6 crashes in Docker

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -290,3 +290,10 @@ VECTOR_STORE_MIGRATED=false
 
 # Reconciliation interval for background sync (default: 5 minutes)
 # VECTOR_STORE_RECONCILIATION_INTERVAL_SECONDS=300
+
+# ── Network ──────────────────────────────────────────────────────────────────
+# Force httpx async connections to use IPv4 only. Enable this when running in
+# Docker bridge networks (IPv4-only) where the anyio Happy Eyeballs algorithm
+# causes POST requests to hang or crash the uvicorn worker.
+# See: https://github.com/plastic-labs/honcho/issues/605
+# FORCE_IPV4=true

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -10,6 +10,7 @@ from google.genai import types as genai_types
 from openai import AsyncOpenAI
 
 from .config import EmbeddingModelConfig, resolve_embedding_model_config, settings
+from .httpx_utils import get_httpx_client
 
 logger = logging.getLogger(__name__)
 
@@ -58,10 +59,14 @@ class _EmbeddingClient:
         else:  # openai
             if not config.api_key:
                 raise ValueError("OpenAI API key is required")
-            self.client = AsyncOpenAI(
+            http_client = get_httpx_client()
+            client_kwargs: dict = dict(
                 api_key=config.api_key,
                 base_url=config.base_url,
             )
+            if http_client is not None:
+                client_kwargs["http_client"] = http_client
+            self.client = AsyncOpenAI(**client_kwargs)
             self.max_embedding_tokens = max_input_tokens
             self.max_batch_size = 2048  # OpenAI batch limit
 

--- a/src/httpx_utils.py
+++ b/src/httpx_utils.py
@@ -1,0 +1,42 @@
+"""Utility for creating httpx transports that work in IPv4-only Docker networks.
+
+When running in Docker bridge networks (IPv4-only), httpx's async transport
+uses anyio's Happy Eyeballs (RFC 8305) algorithm which can attempt IPv6
+resolution before IPv4, causing POST requests to hang or crash the uvicorn
+worker. Setting ``FORCE_IPV4=true`` forces all httpx async connections to
+bind to ``0.0.0.0``, skipping the IPv6 path entirely.
+
+See: https://github.com/plastic-labs/honcho/issues/605
+"""
+
+import os
+
+import httpx
+
+
+def _force_ipv4_enabled() -> bool:
+    """Return True when the FORCE_IPV4 env var is set to a truthy value."""
+    return os.environ.get("FORCE_IPV4", "").lower() in ("1", "true", "yes")
+
+
+def get_async_transport(**kwargs) -> httpx.AsyncHTTPTransport | None:
+    """Return an IPv4-bound async transport when FORCE_IPV4 is enabled.
+
+    Pass the result as ``transport=`` to :class:`httpx.AsyncClient`.
+    Returns ``None`` when no override is needed (the default).
+    """
+    if _force_ipv4_enabled():
+        return httpx.AsyncHTTPTransport(local_address="0.0.0.0", **kwargs)
+    return None
+
+
+def get_httpx_client(**kwargs) -> httpx.AsyncClient | None:
+    """Return a pre-configured :class:`httpx.AsyncClient` for libraries that
+    accept an ``http_client`` parameter (e.g. ``openai.AsyncOpenAI``).
+
+    Returns ``None`` when no override is needed.
+    """
+    transport = get_async_transport()
+    if transport is not None:
+        return httpx.AsyncClient(transport=transport, **kwargs)
+    return None

--- a/src/httpx_utils.py
+++ b/src/httpx_utils.py
@@ -26,7 +26,13 @@ def get_async_transport(**kwargs) -> httpx.AsyncHTTPTransport | None:
     Returns ``None`` when no override is needed (the default).
     """
     if _force_ipv4_enabled():
-        return httpx.AsyncHTTPTransport(local_address="0.0.0.0", **kwargs)
+        # local_address="0.0.0.0" is an outbound source-address hint (bind to
+        # any IPv4 local interface), not a server listen bind, so Ruff's S104
+        # "binding to all interfaces" warning is a false positive here.
+        return httpx.AsyncHTTPTransport(
+            local_address="0.0.0.0",  # noqa: S104
+            **kwargs,
+        )
     return None
 
 

--- a/src/telemetry/emitter.py
+++ b/src/telemetry/emitter.py
@@ -19,6 +19,8 @@ import httpx
 from cloudevents.conversion import to_json  # pyright: ignore[reportUnknownVariableType]
 from cloudevents.http import CloudEvent
 
+from ..httpx_utils import get_async_transport
+
 if TYPE_CHECKING:
     from src.telemetry.events.base import BaseEvent
 
@@ -109,6 +111,7 @@ class TelemetryEmitter:
 
         self._client = httpx.AsyncClient(
             timeout=30.0,
+            transport=get_async_transport(),
             headers={
                 "Content-Type": "application/cloudevents+json",
                 **self.headers,

--- a/src/webhooks/webhook_delivery.py
+++ b/src/webhooks/webhook_delivery.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.config import settings
 from src.crud.webhook import list_webhook_endpoints
 from src.dependencies import tracked_db
+from src.httpx_utils import get_async_transport
 from src.utils.formatting import utc_now_iso
 from src.utils.queue_payload import WebhookPayload
 
@@ -43,7 +44,7 @@ async def deliver_webhook(payload: WebhookPayload, workspace_name: str) -> None:
             logger.exception("Failed to generate webhook signature")
             return
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=30.0, transport=get_async_transport()) as client:
             tasks = [
                 client.post(
                     url=url,

--- a/src/webhooks/webhook_delivery.py
+++ b/src/webhooks/webhook_delivery.py
@@ -44,7 +44,9 @@ async def deliver_webhook(payload: WebhookPayload, workspace_name: str) -> None:
             logger.exception("Failed to generate webhook signature")
             return
 
-        async with httpx.AsyncClient(timeout=30.0, transport=get_async_transport()) as client:
+        async with httpx.AsyncClient(
+            timeout=30.0, transport=get_async_transport()
+        ) as client:
             tasks = [
                 client.post(
                     url=url,


### PR DESCRIPTION
## Summary

In Docker bridge networks (IPv4-only), httpx's async transport uses anyio's Happy Eyeballs (RFC 8305) algorithm which attempts IPv6 resolution before IPv4. For POST requests specifically, this causes connections to hang or reset, silently crashing the uvicorn worker with exit code 0 and no error log.

This adds a `FORCE_IPV4` env var that, when set to `true`, binds all httpx async connections to `0.0.0.0` (IPv4 only).

## Changes

**New file:** `src/httpx_utils.py`
- `get_async_transport()` — returns an IPv4-bound `httpx.AsyncHTTPTransport` when `FORCE_IPV4=true`
- `get_httpx_client()` — returns a pre-configured `httpx.AsyncClient` for libraries like `openai.AsyncOpenAI` that accept `http_client`

**Modified files:**
- `src/embedding_client.py` — pass IPv4-bound httpx client to `AsyncOpenAI` when enabled
- `src/telemetry/emitter.py` — use IPv4 transport for telemetry POST requests
- `src/webhooks/webhook_delivery.py` — use IPv4 transport for webhook POST delivery
- `.env.template` — document the `FORCE_IPV4` option

## Usage

```bash
# Docker Compose
environment:
  FORCE_IPV4: "true"

# Or in .env
FORCE_IPV4=true
```

When `FORCE_IPV4` is not set or falsy, behavior is completely unchanged (all helpers return `None` and callers use defaults).

## Root Cause

`httpcore` uses `anyio.connect_tcp()` which implements RFC 8305 Happy Eyeballs. In Docker bridge mode (IPv4-only), this attempts `::ffff:x.x.x.x` before falling back to IPv4. GET requests work fine but POST requests hang/crash. Setting `local_address="0.0.0.0"` skips the IPv6 path entirely.

Fixes #605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `FORCE_IPV4` configuration in the environment template to improve behavior in IPv4-only Docker bridge network setups.

* **Bug Fixes**
  * Improved outbound HTTP reliability by using a custom HTTP transport when `FORCE_IPV4` is enabled, affecting embedding API calls and webhook/telemetry request delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->