### PR TITLE
fix(deriver): filter empty-string observations before embedding

### DIFF
--- a/src/crud/representation.py
+++ b/src/crud/representation.py
@@ -72,10 +72,17 @@ class RepresentationManager:
         # Batch embed all observations
         batch_embed_start = time.perf_counter()
 
-        observation_texts = [
-            obs.conclusion if isinstance(obs, DeductiveObservation) else obs.content
+        # Filter empty strings — OpenAI embeddings API rejects them with 400
+        obs_text_pairs = [
+            (obs, obs.conclusion if isinstance(obs, DeductiveObservation) else obs.content)
             for obs in all_observations
         ]
+        obs_text_pairs = [(obs, text) for obs, text in obs_text_pairs if text and text.strip()]
+        if not obs_text_pairs:
+            logger.debug("All observations have empty content; skipping embedding")
+            return new_documents
+        all_observations, observation_texts = map(list, zip(*obs_text_pairs))
+
         try:
             embeddings = await embedding_client.simple_batch_embed(observation_texts)
         except ValueError as e:

--- a/tests/crud/test_representation_manager.py
+++ b/tests/crud/test_representation_manager.py
@@ -1,3 +1,7 @@
+import datetime
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from nanoid import generate as generate_nanoid
 from sqlalchemy import func, update
@@ -5,6 +9,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import models
 from src.crud.representation import RepresentationManager
+from src.schemas import (
+    ResolvedConfiguration,
+    ResolvedDreamConfiguration,
+    ResolvedPeerCardConfiguration,
+    ResolvedReasoningConfiguration,
+    ResolvedSummaryConfiguration,
+)
+from src.utils.representation import ExplicitObservation, Representation
 
 
 class TestRepresentationManagerSoftDelete:
@@ -134,3 +146,183 @@ class TestRepresentationManagerSoftDelete:
         result_ids = [doc.id for doc in results]
         assert doc_live.id in result_ids
         assert doc_deleted.id not in result_ids
+
+
+class TestRepresentationManagerSaveFiltering:
+    """Tests that save_representation filters invalid observations before embedding."""
+
+    @pytest.mark.asyncio
+    async def test_empty_content_observations_are_filtered_before_embedding(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ) -> None:
+        """Observations with empty or whitespace-only content must be dropped before
+        the embedding API call. OpenAI returns 400 Bad Request for empty strings.
+        """
+        test_workspace, test_peer = sample_data
+
+        test_peer2 = models.Peer(
+            name=generate_nanoid(), workspace_name=test_workspace.name
+        )
+        db_session.add(test_peer2)
+        await db_session.flush()
+
+        test_session = models.Session(
+            name=generate_nanoid(), workspace_name=test_workspace.name
+        )
+        db_session.add(test_session)
+        await db_session.flush()
+
+        manager = RepresentationManager(
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer2.name,
+        )
+
+        captured_texts: list[list[str]] = []
+
+        async def fake_batch_embed(texts: list[str]) -> list[list[float]]:
+            captured_texts.append(list(texts))
+            return [[0.1] * 8 for _ in texts]
+
+        @asynccontextmanager
+        async def fake_tracked_db(*args: object, **kwargs: object):  # type: ignore[misc]
+            yield db_session
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        config = ResolvedConfiguration(
+            reasoning=ResolvedReasoningConfiguration(enabled=False),
+            peer_card=ResolvedPeerCardConfiguration(use=False, create=False),
+            summary=ResolvedSummaryConfiguration(
+                enabled=False,
+                messages_per_short_summary=20,
+                messages_per_long_summary=60,
+            ),
+            dream=ResolvedDreamConfiguration(enabled=False),
+        )
+        rep = Representation(
+            explicit=[
+                ExplicitObservation(
+                    content="valid observation",
+                    created_at=now,
+                    message_ids=[1],
+                    session_name=test_session.name,
+                ),
+                ExplicitObservation(
+                    content="",
+                    created_at=now,
+                    message_ids=[1],
+                    session_name=test_session.name,
+                ),
+                ExplicitObservation(
+                    content="   ",
+                    created_at=now,
+                    message_ids=[1],
+                    session_name=test_session.name,
+                ),
+                ExplicitObservation(
+                    content="another valid",
+                    created_at=now,
+                    message_ids=[1],
+                    session_name=test_session.name,
+                ),
+            ]
+        )
+
+        with (
+            patch(
+                "src.crud.representation.embedding_client.simple_batch_embed",
+                fake_batch_embed,
+            ),
+            patch("src.crud.representation.tracked_db", fake_tracked_db),
+            patch(
+                "src.crud.representation.check_and_schedule_dream", AsyncMock()
+            ),
+            patch("src.crud.representation.accumulate_metric"),
+        ):
+            count = await manager.save_representation(
+                rep,
+                message_ids=[1],
+                session_name=test_session.name,
+                message_created_at=now,
+                message_level_configuration=config,
+            )
+
+        assert len(captured_texts) == 1, "embedding client called exactly once"
+        assert captured_texts[0] == [
+            "valid observation",
+            "another valid",
+        ], "only non-empty texts passed to embedder"
+        assert count == 2, "two documents saved for the two non-empty observations"
+
+    @pytest.mark.asyncio
+    async def test_all_empty_content_observations_skips_embedding(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ) -> None:
+        """If every observation has empty content, embedding is never called and 0 is returned."""
+        test_workspace, test_peer = sample_data
+
+        test_peer2 = models.Peer(
+            name=generate_nanoid(), workspace_name=test_workspace.name
+        )
+        db_session.add(test_peer2)
+        await db_session.flush()
+
+        manager = RepresentationManager(
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer2.name,
+        )
+
+        embed_called = False
+
+        async def fake_batch_embed(texts: list[str]) -> list[list[float]]:  # pragma: no cover
+            nonlocal embed_called
+            embed_called = True
+            return []
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        config = ResolvedConfiguration(
+            reasoning=ResolvedReasoningConfiguration(enabled=False),
+            peer_card=ResolvedPeerCardConfiguration(use=False, create=False),
+            summary=ResolvedSummaryConfiguration(
+                enabled=False,
+                messages_per_short_summary=20,
+                messages_per_long_summary=60,
+            ),
+            dream=ResolvedDreamConfiguration(enabled=False),
+        )
+        rep = Representation(
+            explicit=[
+                ExplicitObservation(
+                    content="",
+                    created_at=now,
+                    message_ids=[1],
+                    session_name="s",
+                ),
+                ExplicitObservation(
+                    content="  ",
+                    created_at=now,
+                    message_ids=[1],
+                    session_name="s",
+                ),
+            ]
+        )
+
+        with patch(
+            "src.crud.representation.embedding_client.simple_batch_embed",
+            fake_batch_embed,
+        ):
+            count = await manager.save_representation(
+                rep,
+                message_ids=[1],
+                session_name="s",
+                message_created_at=now,
+                message_level_configuration=config,
+            )
+
+        assert not embed_called, "embedding client must not be called for all-empty input"
+        assert count == 0


### PR DESCRIPTION
**Problem**

The deriver's `save_representation` builds `observation_texts` from `Representation.explicit` and `.deductive` without guarding against empty or whitespace-only content. The OpenAI embeddings API rejects any batch containing an empty string with HTTP 400:

```
Error code: 400 - Invalid 'input[2]': input cannot be an empty string.
```

This causes `save_representation` to raise, which is caught in the deriver loop and logged as an error — silently dropping all observations for that message batch.

**Fix**

Filter observation/text pairs before the `simple_batch_embed` call, dropping any entry whose content is empty or whitespace-only. If all observations are filtered out, return early with 0 saved — consistent with the existing early return for a fully empty `Representation`.

```diff
-        observation_texts = [
-            obs.conclusion if isinstance(obs, DeductiveObservation) else obs.content
-            for obs in all_observations
-        ]
+        # Filter empty strings — OpenAI embeddings API rejects them with 400
+        obs_text_pairs = [
+            (obs, obs.conclusion if isinstance(obs, DeductiveObservation) else obs.content)
+            for obs in all_observations
+        ]
+        obs_text_pairs = [(obs, text) for obs, text in obs_text_pairs if text and text.strip()]
+        if not obs_text_pairs:
+            logger.debug("All observations have empty content; skipping embedding")
+            return new_documents
+        all_observations, observation_texts = map(list, zip(*obs_text_pairs))
```

**Testing**

Two new tests in `tests/crud/test_representation_manager.py`:

1. `test_empty_content_observations_are_filtered_before_embedding` — mix of valid and empty/whitespace observations; asserts embedding client receives only non-empty texts and the correct document count is returned.
2. `test_all_empty_content_observations_skips_embedding` — all observations empty; asserts embedding client is never called and 0 is returned.

Observed in production logs with observers `moltar`, `basit`, `claude-basits-macbook-air-1`, and `webhook-github` on both `input[2]` and `input[7]`, confirming the index varies with message batch size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed API errors that occurred when processing observations with empty or whitespace-only content. The system now gracefully filters out invalid entries before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->