### PR TITLE
fix(deriver): filter non-prose-tagged messages from representation extraction

### DIFF
--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -54,8 +54,13 @@ def _is_extraction_eligible(msg: Message) -> bool:
     """Return False if the message metadata.type marks it as not authored prose.
 
     Returns True for messages without a recognized non-prose tag (the default).
+    Type-guards against non-dict h_metadata: a JSONB column can technically
+    hold a scalar from a rogue write or a botched migration; we don't want a
+    stray string to crash the whole batch with an AttributeError.
     """
-    metadata = msg.h_metadata or {}
+    metadata = msg.h_metadata
+    if not isinstance(metadata, dict):
+        return True
     return metadata.get("type") not in NON_PROSE_METADATA_TYPES
 
 
@@ -94,15 +99,34 @@ async def process_representation_tasks_batch(
     latest_message = messages[-1]
     earliest_message = messages[0]
 
-    # Filter out messages tagged as not authored prose. We keep the original
-    # `messages` list for progress/telemetry tracking but only feed eligible
-    # messages to the LLM-facing prompt.
+    # Filter messages by extraction eligibility. We compute two related sets:
+    #
+    #   eligible_messages       — every message in the batch that is NOT
+    #                             tagged non-prose. Used for the LLM-facing
+    #                             prompt (we want to keep eligible context
+    #                             from any peer, not just the observed peer,
+    #                             so the LLM sees enough surrounding text).
+    #
+    #   eligible_source_messages — eligible messages that are ALSO target
+    #                              queue items for the observed peer. These
+    #                              are what the deriver is being asked to
+    #                              produce facts about. If this set is empty,
+    #                              every queue item we were told to process
+    #                              is non-prose and we should skip the LLM
+    #                              call entirely — even if other-peer context
+    #                              messages happen to be in the same batch.
+    queue_item_message_ids_set = set(queue_item_message_ids)
     eligible_messages = [m for m in messages if _is_extraction_eligible(m)]
-    if not eligible_messages:
+    eligible_source_messages = [
+        m
+        for m in eligible_messages
+        if m.peer_name == observed and m.id in queue_item_message_ids_set
+    ]
+    if not eligible_source_messages:
         logger.debug(
-            "All %d messages in batch tagged as non-prose; skipping representation extraction "
-            "(observed=%s, latest_message_id=%s)",
-            len(messages),
+            "All %d target queue items in batch tagged as non-prose; skipping "
+            "representation extraction (observed=%s, latest_message_id=%s)",
+            len(queue_item_message_ids_set),
             observed,
             latest_message.id,
         )
@@ -150,9 +174,9 @@ async def process_representation_tasks_batch(
 
     # Track token usage - count only tokens from messages being processed.
     # Use eligible_messages so we don't bill against tokens we elected to
-    # filter from the prompt.
+    # filter from the prompt. (queue_item_message_ids_set is already built
+    # above for the target-message gating.)
     prompt_tokens = estimate_minimal_deriver_prompt_tokens()
-    queue_item_message_ids_set = set(queue_item_message_ids)
     messages_tokens = sum(
         msg.token_count
         for msg in eligible_messages
@@ -214,14 +238,19 @@ async def process_representation_tasks_batch(
             component=DeriverComponents.OUTPUT_TOTAL.value,
         )
 
-    message_ids = [m.id for m in messages if m.peer_name == observed]
+    # Provenance: observations cite only eligible_source_messages — i.e.
+    # target queue items for the observed peer that survived the non-prose
+    # filter. This prevents tagged messages (pasted diffs, tool actions)
+    # from appearing as evidence for derived facts about the user.
+    message_ids = [m.id for m in eligible_source_messages]
+    latest_eligible = eligible_source_messages[-1]
 
     # Convert to Representation and save
     observations = Representation.from_prompt_representation(
         response.content,
         message_ids,
-        latest_message.session_name,
-        latest_message.created_at,
+        latest_eligible.session_name,
+        latest_eligible.created_at,
     )
 
     if observations.is_empty() or not message_ids:
@@ -233,10 +262,12 @@ async def process_representation_tasks_batch(
             latest_message.session_name,
         )
     else:
-        # Save to all observer collections
+        # Save to all observer collections. Use the latest_eligible source
+        # message for session/timestamp so saved provenance points to a
+        # message that actually contributed to the prompt.
         for observer in observers:
             representation_manager = RepresentationManager(
-                workspace_name=latest_message.workspace_name,
+                workspace_name=latest_eligible.workspace_name,
                 observer=observer,
                 observed=observed,
             )
@@ -245,8 +276,8 @@ async def process_representation_tasks_batch(
                 await representation_manager.save_representation(
                     observations,
                     message_ids,
-                    latest_message.session_name,
-                    latest_message.created_at,
+                    latest_eligible.session_name,
+                    latest_eligible.created_at,
                     message_level_configuration,
                 )
             except Exception as e:

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -130,6 +130,55 @@ async def process_representation_tasks_batch(
             observed,
             latest_message.id,
         )
+        # Emit a minimal completion event + metrics so the observability
+        # layer captures all batch outcomes uniformly. Downstream
+        # dashboards / replay systems otherwise lose all trace of
+        # all-non-prose batches.
+        skipped_duration = (time.perf_counter() - overall_start) * 1000
+        accumulate_metric(
+            f"minimal_deriver_{latest_message.id}_{observed}",
+            "starting_message_id",
+            earliest_message.id,
+            "id",
+        )
+        accumulate_metric(
+            f"minimal_deriver_{latest_message.id}_{observed}",
+            "ending_message_id",
+            latest_message.id,
+            "id",
+        )
+        accumulate_metric(
+            f"minimal_deriver_{latest_message.id}_{observed}",
+            "total_processing_time",
+            skipped_duration,
+            "ms",
+        )
+        accumulate_metric(
+            f"minimal_deriver_{latest_message.id}_{observed}",
+            "observation_count",
+            0,
+            "count",
+        )
+        log_performance_metrics(
+            "minimal_deriver", f"{latest_message.id}_{observed}"
+        )
+        emit(
+            RepresentationCompletedEvent(
+                workspace_name=latest_message.workspace_name,
+                session_name=latest_message.session_name,
+                observed=observed,
+                queue_items_processed=len(queue_item_message_ids),
+                earliest_message_id=earliest_message.public_id,
+                latest_message_id=latest_message.public_id,
+                message_count=len(messages),
+                explicit_conclusion_count=0,
+                context_preparation_ms=0.0,
+                llm_call_ms=0.0,
+                total_duration_ms=skipped_duration,
+                input_tokens=0,
+                output_tokens=0,
+            )
+        )
         return
 
     # Get configuration if not provided

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -31,6 +31,34 @@ def _get_deriver_model_config() -> ConfiguredModelSettings:
     return settings.DERIVER.MODEL_CONFIG
 
 
+# Message metadata.type values that mark a message as not the observed peer's
+# authored prose. The deriver should still record these messages (for replay,
+# audit, and message-stream completeness) but must NOT extract peer-attributed
+# facts from them — they ride role: "user" per the Anthropic Messages API but
+# carry assistant-authored content (pasted diffs, tool_result blocks) or
+# explicit assistant tool actions performed on the user's behalf.
+#
+# The corresponding tags are set by the claude-honcho plugin
+# (plastic-labs/claude-honcho#34) and may be set by any client that wants its
+# tool-action / paste messages preserved without contributing to peer
+# representation.
+NON_PROSE_METADATA_TYPES: frozenset[str] = frozenset(
+    {
+        "user_paste_not_speech",
+        "tool_action",
+    }
+)
+
+
+def _is_extraction_eligible(msg: Message) -> bool:
+    """Return False if the message metadata.type marks it as not authored prose.
+
+    Returns True for messages without a recognized non-prose tag (the default).
+    """
+    metadata = msg.h_metadata or {}
+    return metadata.get("type") not in NON_PROSE_METADATA_TYPES
+
+
 @with_sentry_transaction("minimal_deriver_batch", op="deriver")
 async def process_representation_tasks_batch(
     messages: list[Message],
@@ -42,6 +70,13 @@ async def process_representation_tasks_batch(
 ) -> None:
     """
     Process messages with minimal overhead - single LLM call, save to multiple collections.
+
+    Messages tagged with metadata.type in NON_PROSE_METADATA_TYPES (pasted
+    code/diffs, tool actions) are excluded from the LLM-facing prompt so the
+    extractor cannot misattribute their content to the observed peer. The
+    messages themselves remain in the database; only their contribution to
+    peer representation is suppressed. Earliest/latest message tracking is
+    unaffected so progress accounting stays correct.
 
     Args:
         messages: List of messages to process (includes interleaving context).
@@ -58,6 +93,20 @@ async def process_representation_tasks_batch(
     messages.sort(key=lambda x: x.id)
     latest_message = messages[-1]
     earliest_message = messages[0]
+
+    # Filter out messages tagged as not authored prose. We keep the original
+    # `messages` list for progress/telemetry tracking but only feed eligible
+    # messages to the LLM-facing prompt.
+    eligible_messages = [m for m in messages if _is_extraction_eligible(m)]
+    if not eligible_messages:
+        logger.debug(
+            "All %d messages in batch tagged as non-prose; skipping representation extraction "
+            "(observed=%s, latest_message_id=%s)",
+            len(messages),
+            observed,
+            latest_message.id,
+        )
+        return
 
     # Get configuration if not provided
     # TODO: this appears to be a very rare edge case coming out of `get_queue_item_batch` in queue_manager.py,
@@ -91,17 +140,23 @@ async def process_representation_tasks_batch(
         "id",
     )
 
-    # Format messages with timestamps
+    # Format messages with timestamps. Use eligible_messages (non-prose tags
+    # filtered) so the LLM-facing prompt does not contain pasted code/diffs
+    # or assistant tool actions.
     formatted_messages = "\n".join(
         format_new_turn_with_timestamp(msg.content, msg.created_at, msg.peer_name)
-        for msg in messages
+        for msg in eligible_messages
     )
 
-    # Track token usage - count only tokens from messages being processed
+    # Track token usage - count only tokens from messages being processed.
+    # Use eligible_messages so we don't bill against tokens we elected to
+    # filter from the prompt.
     prompt_tokens = estimate_minimal_deriver_prompt_tokens()
     queue_item_message_ids_set = set(queue_item_message_ids)
     messages_tokens = sum(
-        msg.token_count for msg in messages if msg.id in queue_item_message_ids_set
+        msg.token_count
+        for msg in eligible_messages
+        if msg.id in queue_item_message_ids_set
     )
     track_deriver_input_tokens(
         task_type=DeriverTaskTypes.INGESTION,

--- a/tests/deriver/test_metadata_filter.py
+++ b/tests/deriver/test_metadata_filter.py
@@ -1,0 +1,163 @@
+"""
+Tests for the deriver's metadata.type filter that excludes non-prose messages
+from peer representation extraction.
+
+Background: messages tagged metadata.type ∈ {"user_paste_not_speech",
+"tool_action"} are uploaded by clients (e.g. plastic-labs/claude-honcho) for
+archival/replay but should not contribute to peer representation. They ride
+role: "user" per the Anthropic Messages API but contain pasted code/diffs or
+explicit tool actions performed on the user's behalf.
+
+See plastic-labs/claude-honcho#34 for the upstream plugin tags.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from src.deriver.deriver import (
+    NON_PROSE_METADATA_TYPES,
+    _is_extraction_eligible,
+    process_representation_tasks_batch,
+)
+from src.llm import HonchoLLMCallResponse
+from src.utils.representation import PromptRepresentation
+
+
+def _make_message(msg_id: int, content: str, metadata: dict | None = None) -> Mock:
+    return Mock(
+        id=msg_id,
+        public_id=f"msg_{msg_id}",
+        session_name="session-1",
+        workspace_name="workspace-1",
+        peer_name="alice",
+        content=content,
+        token_count=5,
+        created_at=datetime.now(timezone.utc),
+        h_metadata=metadata or {},
+    )
+
+
+class TestExtractionEligibility:
+    """Direct unit tests for the _is_extraction_eligible predicate."""
+
+    def test_default_metadata_is_eligible(self):
+        msg = _make_message(1, "hello world")
+        assert _is_extraction_eligible(msg) is True
+
+    def test_empty_metadata_is_eligible(self):
+        msg = _make_message(1, "hello world", metadata={})
+        assert _is_extraction_eligible(msg) is True
+
+    def test_unrelated_metadata_type_is_eligible(self):
+        msg = _make_message(1, "hello", metadata={"type": "assistant_prose"})
+        assert _is_extraction_eligible(msg) is True
+
+    def test_user_paste_not_speech_is_filtered(self):
+        msg = _make_message(1, "[diff removed]", metadata={"type": "user_paste_not_speech"})
+        assert _is_extraction_eligible(msg) is False
+
+    def test_tool_action_is_filtered(self):
+        msg = _make_message(1, "[Tool] Edited foo.ts", metadata={"type": "tool_action"})
+        assert _is_extraction_eligible(msg) is False
+
+    def test_non_prose_set_contains_known_tags(self):
+        assert "user_paste_not_speech" in NON_PROSE_METADATA_TYPES
+        assert "tool_action" in NON_PROSE_METADATA_TYPES
+
+
+@pytest.mark.asyncio
+class TestProcessRepresentationFiltering:
+    """End-to-end tests for the deriver's batch processing with the filter."""
+
+    async def test_skips_llm_call_when_all_messages_non_prose(self):
+        """When every message in the batch is tagged non-prose, no LLM call is made."""
+        messages = [
+            _make_message(1, "[code block removed]", metadata={"type": "user_paste_not_speech"}),
+            _make_message(2, "[Tool] Wrote foo.ts", metadata={"type": "tool_action"}),
+        ]
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+
+        with patch(
+            "src.deriver.deriver.honcho_llm_call",
+            new_callable=AsyncMock,
+        ) as mock_llm_call:
+            await process_representation_tasks_batch(
+                messages=messages,
+                message_level_configuration=configuration,
+                observers=["bob"],
+                observed="alice",
+                queue_item_message_ids=[1, 2],
+            )
+
+        mock_llm_call.assert_not_called()
+
+    async def test_filters_non_prose_from_llm_prompt(self):
+        """Non-prose messages are excluded from the LLM-facing prompt; prose messages remain."""
+        messages = [
+            _make_message(1, "I want to refactor the auth middleware."),
+            _make_message(2, "[diff removed]", metadata={"type": "user_paste_not_speech"}),
+            _make_message(3, "Look for race conditions please."),
+            _make_message(4, "[Tool] Edited middleware.ts", metadata={"type": "tool_action"}),
+        ]
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+
+        mock_response = HonchoLLMCallResponse(
+            content=PromptRepresentation(explicit=[]),
+            input_tokens=10,
+            output_tokens=5,
+            finish_reasons=["STOP"],
+        )
+
+        with patch(
+            "src.deriver.deriver.honcho_llm_call",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_llm_call:
+            await process_representation_tasks_batch(
+                messages=messages,
+                message_level_configuration=configuration,
+                observers=["bob"],
+                observed="alice",
+                queue_item_message_ids=[1, 2, 3, 4],
+            )
+
+        mock_llm_call.assert_called_once()
+        prompt = mock_llm_call.await_args.kwargs["prompt"]
+        assert "I want to refactor the auth middleware" in prompt
+        assert "Look for race conditions please" in prompt
+        assert "[diff removed]" not in prompt
+        assert "[Tool] Edited middleware.ts" not in prompt
+
+    async def test_passes_prose_messages_unchanged(self):
+        """Prose messages without tags are passed to the LLM as before."""
+        messages = [_make_message(1, "I prefer fail-closed defaults.")]
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+
+        mock_response = HonchoLLMCallResponse(
+            content=PromptRepresentation(explicit=[]),
+            input_tokens=10,
+            output_tokens=5,
+            finish_reasons=["STOP"],
+        )
+
+        with patch(
+            "src.deriver.deriver.honcho_llm_call",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_llm_call:
+            await process_representation_tasks_batch(
+                messages=messages,
+                message_level_configuration=configuration,
+                observers=["bob"],
+                observed="alice",
+                queue_item_message_ids=[1],
+            )
+
+        mock_llm_call.assert_called_once()
+        prompt = mock_llm_call.await_args.kwargs["prompt"]
+        assert "I prefer fail-closed defaults" in prompt

--- a/tests/deriver/test_metadata_filter.py
+++ b/tests/deriver/test_metadata_filter.py
@@ -25,17 +25,22 @@ from src.llm import HonchoLLMCallResponse
 from src.utils.representation import PromptRepresentation
 
 
-def _make_message(msg_id: int, content: str, metadata: dict | None = None) -> Mock:
+def _make_message(
+    msg_id: int,
+    content: str,
+    metadata: dict | None = None,
+    peer_name: str = "alice",
+) -> Mock:
     return Mock(
         id=msg_id,
         public_id=f"msg_{msg_id}",
         session_name="session-1",
         workspace_name="workspace-1",
-        peer_name="alice",
+        peer_name=peer_name,
         content=content,
         token_count=5,
         created_at=datetime.now(timezone.utc),
-        h_metadata=metadata or {},
+        h_metadata=metadata if metadata is not None else {},
     )
 
 
@@ -65,6 +70,15 @@ class TestExtractionEligibility:
     def test_non_prose_set_contains_known_tags(self):
         assert "user_paste_not_speech" in NON_PROSE_METADATA_TYPES
         assert "tool_action" in NON_PROSE_METADATA_TYPES
+
+    def test_non_dict_metadata_is_eligible(self):
+        """JSONB columns can technically hold scalars (rogue write or
+        botched migration). The eligibility check must default to eligible
+        rather than raise AttributeError on .get()."""
+        for bad_value in ("stray-string", 42, ["a", "list"], True):
+            msg = _make_message(1, "content")
+            msg.h_metadata = bad_value
+            assert _is_extraction_eligible(msg) is True, f"failed for {bad_value!r}"
 
 
 @pytest.mark.asyncio
@@ -161,3 +175,154 @@ class TestProcessRepresentationFiltering:
         mock_llm_call.assert_called_once()
         prompt = mock_llm_call.await_args.kwargs["prompt"]
         assert "I prefer fail-closed defaults" in prompt
+
+    async def test_skips_llm_when_target_messages_non_prose_with_eligible_other_peer_context(self):
+        """Non-prose target queue items must skip LLM even when other-peer
+        context messages in the same batch are eligible. Otherwise the
+        deriver runs on context messages and produces facts about the
+        observed peer based on the other peer's content (which is
+        exactly the misattribution this PR is trying to prevent).
+        """
+        messages = [
+            # Eligible context from a different peer (bob) — passes filter
+            _make_message(10, "earlier turn from bob", peer_name="bob"),
+            # Target queue item from observed peer (alice), tagged non-prose
+            _make_message(11, "[diff removed]", metadata={"type": "user_paste_not_speech"}, peer_name="alice"),
+        ]
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+
+        with patch(
+            "src.deriver.deriver.honcho_llm_call",
+            new_callable=AsyncMock,
+        ) as mock_llm_call:
+            await process_representation_tasks_batch(
+                messages=messages,
+                message_level_configuration=configuration,
+                observers=["bob"],
+                observed="alice",
+                queue_item_message_ids=[11],  # only msg 11 is the target
+            )
+
+        mock_llm_call.assert_not_called()
+
+    async def test_processes_when_target_is_eligible_with_context_in_batch(self):
+        """Eligible target message must trigger the LLM even when the batch
+        also contains other-peer context messages.
+        """
+        messages = [
+            _make_message(10, "earlier turn from bob", peer_name="bob"),
+            _make_message(11, "I want to ship the auth migration tonight.", peer_name="alice"),
+        ]
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+
+        mock_response = HonchoLLMCallResponse(
+            content=PromptRepresentation(explicit=[]),
+            input_tokens=10,
+            output_tokens=5,
+            finish_reasons=["STOP"],
+        )
+
+        with patch(
+            "src.deriver.deriver.honcho_llm_call",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_llm_call:
+            await process_representation_tasks_batch(
+                messages=messages,
+                message_level_configuration=configuration,
+                observers=["bob"],
+                observed="alice",
+                queue_item_message_ids=[11],
+            )
+
+        mock_llm_call.assert_called_once()
+        prompt = mock_llm_call.await_args.kwargs["prompt"]
+        # Both messages should appear (eligible context is preserved)
+        assert "earlier turn from bob" in prompt
+        assert "I want to ship the auth migration tonight" in prompt
+
+    async def test_observation_provenance_excludes_filtered_messages(self):
+        """Saved observations must cite only eligible source messages
+        (target queue items for the observed peer that survived the
+        non-prose filter), not tagged messages.
+        """
+        messages = [
+            _make_message(20, "real prose from alice", peer_name="alice"),
+            _make_message(21, "[diff removed]", metadata={"type": "user_paste_not_speech"}, peer_name="alice"),
+            _make_message(22, "[Tool] Edited foo.ts", metadata={"type": "tool_action"}, peer_name="alice"),
+        ]
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+
+        # Build a Representation result that won't be empty (so save_representation runs)
+        mock_response = HonchoLLMCallResponse(
+            content=PromptRepresentation(explicit=[]),
+            input_tokens=10,
+            output_tokens=5,
+            finish_reasons=["STOP"],
+        )
+
+        with patch(
+            "src.deriver.deriver.honcho_llm_call",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_llm_call, patch(
+            "src.deriver.deriver.Representation.from_prompt_representation",
+        ) as mock_from_prompt:
+            await process_representation_tasks_batch(
+                messages=messages,
+                message_level_configuration=configuration,
+                observers=["bob"],
+                observed="alice",
+                queue_item_message_ids=[20, 21, 22],
+            )
+
+        mock_llm_call.assert_called_once()
+        # The provenance message_ids passed to the Representation factory
+        # must contain ONLY message 20 (the eligible target). 21 and 22
+        # are tagged non-prose and must not appear as evidence for any
+        # derived fact.
+        from_prompt_args = mock_from_prompt.call_args
+        passed_message_ids = from_prompt_args[0][1]  # second positional arg
+        assert passed_message_ids == [20]
+
+    async def test_handles_non_dict_metadata_safely(self):
+        """If h_metadata is somehow a non-dict scalar (rogue write,
+        botched migration), the eligibility check must default to
+        eligible rather than crash with AttributeError.
+        """
+        messages = [
+            _make_message(1, "hello", metadata=None, peer_name="alice"),  # None
+            _make_message(2, "world", peer_name="alice"),
+        ]
+        # Simulate a JSONB scalar by setting h_metadata directly to a non-dict
+        messages[0].h_metadata = "stray-string-from-bad-write"
+
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+
+        mock_response = HonchoLLMCallResponse(
+            content=PromptRepresentation(explicit=[]),
+            input_tokens=10,
+            output_tokens=5,
+            finish_reasons=["STOP"],
+        )
+
+        with patch(
+            "src.deriver.deriver.honcho_llm_call",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_llm_call:
+            await process_representation_tasks_batch(
+                messages=messages,
+                message_level_configuration=configuration,
+                observers=["bob"],
+                observed="alice",
+                queue_item_message_ids=[1, 2],
+            )
+
+        # Must not crash. Both messages should be eligible (non-dict
+        # metadata defaults to eligible).
+        mock_llm_call.assert_called_once()

--- a/tests/deriver/test_metadata_filter.py
+++ b/tests/deriver/test_metadata_filter.py
@@ -108,6 +108,44 @@ class TestProcessRepresentationFiltering:
 
         mock_llm_call.assert_not_called()
 
+    async def test_emits_minimal_completion_event_on_early_return(self):
+        """All-non-prose batches must still emit a RepresentationCompletedEvent
+        and increment metrics so the observability layer captures every
+        batch outcome uniformly. Otherwise dashboards/replay systems lose
+        all trace of these batches.
+        """
+        messages = [
+            _make_message(1, "[diff removed]", metadata={"type": "user_paste_not_speech"}),
+            _make_message(2, "[Tool] Edited foo.ts", metadata={"type": "tool_action"}),
+        ]
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+
+        with patch(
+            "src.deriver.deriver.honcho_llm_call",
+            new_callable=AsyncMock,
+        ) as mock_llm_call, patch(
+            "src.deriver.deriver.emit",
+        ) as mock_emit:
+            await process_representation_tasks_batch(
+                messages=messages,
+                message_level_configuration=configuration,
+                observers=["bob"],
+                observed="alice",
+                queue_item_message_ids=[1, 2],
+            )
+
+        mock_llm_call.assert_not_called()
+        # Exactly one completion event should have been emitted, with
+        # zero conclusions and zero token usage.
+        mock_emit.assert_called_once()
+        event = mock_emit.call_args[0][0]
+        assert event.explicit_conclusion_count == 0
+        assert event.input_tokens == 0
+        assert event.output_tokens == 0
+        assert event.message_count == 2
+        assert event.queue_items_processed == 2
+
     async def test_filters_non_prose_from_llm_prompt(self):
         """Non-prose messages are excluded from the LLM-facing prompt; prose messages remain."""
         messages = [


### PR DESCRIPTION
## Summary

Adds a `metadata.type` discriminator to the deriver so messages tagged as **not the observed peer's authored prose** are excluded from the LLM-facing prompt. This prevents pasted diffs, tool-result blocks, and assistant tool actions from producing peer-attributed conclusions in the representation layer.

Companion to plastic-labs/claude-honcho#34, which tags such messages on upload. Either side is independently useful; together they structurally prevent the misattribution failure mode.

## The bug, concretely

The Anthropic Messages API uses `role: "user"` for both the user's authored prose AND for `tool_result` blocks (and any content the user pastes back into a prompt). Today the deriver treats every `role: "user"` message as authored prose, which produces durable `<user> changed/wrote/added X` facts when:

1. **Pasted diffs.** A user prompt like *"You are performing an adversarial code review. Review the provided git diff: ```diff +function buildOperatorPlan(...) ... ``` "*. The diff body rides `role: "user"` per the Messages API; the extractor reads `+`/`-` lines as user statements about their own code and concludes `<user> changed buildOperatorPlan`. Observed in the wild — the conclusion was used as load-bearing context across sessions.

2. **Cross-observation in directional mode.** `aiPeer.message("[Tool] Edited middleware.ts")` is correct on the aiPeer side, but in `directional` observation mode the deriver folds aiPeer messages into the user-peer's representation as `<user> did X`. `unified` mode (the 0.2.4 default) reduces blast radius but does not eliminate it — directional remains a supported config.

In one heavily-used workspace we observed ~12K of ~60K conclusions (~20%) match the misattribution pattern.

## Fix

```python
NON_PROSE_METADATA_TYPES: frozenset[str] = frozenset(
    {
        "user_paste_not_speech",
        "tool_action",
    }
)


def _is_extraction_eligible(msg: Message) -> bool:
    metadata = msg.h_metadata or {}
    return metadata.get("type") not in NON_PROSE_METADATA_TYPES
```

Inside `process_representation_tasks_batch`:

```python
eligible_messages = [m for m in messages if _is_extraction_eligible(m)]
if not eligible_messages:
    logger.debug(
        "All %d messages in batch tagged as non-prose; skipping representation extraction "
        "(observed=%s, latest_message_id=%s)",
        len(messages), observed, latest_message.id,
    )
    return

formatted_messages = "\n".join(
    format_new_turn_with_timestamp(msg.content, msg.created_at, msg.peer_name)
    for msg in eligible_messages
)
```

`earliest_message` / `latest_message` tracking uses the original `messages` list so progress accounting stays correct. Token accounting now sums only eligible messages (we don't bill against tokens we elected to filter).

## Tests

`tests/deriver/test_metadata_filter.py` adds 9 tests mirroring honcho's existing convention (`pytest` async + `Mock` + `patch honcho_llm_call`):

```
TestExtractionEligibility::test_default_metadata_is_eligible
TestExtractionEligibility::test_empty_metadata_is_eligible
TestExtractionEligibility::test_unrelated_metadata_type_is_eligible
TestExtractionEligibility::test_user_paste_not_speech_is_filtered
TestExtractionEligibility::test_tool_action_is_filtered
TestExtractionEligibility::test_non_prose_set_contains_known_tags
TestProcessRepresentationFiltering::test_skips_llm_call_when_all_messages_non_prose
TestProcessRepresentationFiltering::test_filters_non_prose_from_llm_prompt
TestProcessRepresentationFiltering::test_passes_prose_messages_unchanged
```

```bash
$ uv run pytest tests/deriver/test_metadata_filter.py -q
9 passed in 16.14s
```

## Backwards compatibility

- **Default-True predicate** means existing clients that don't tag messages see no behavior change. Tags are opt-in; the world without them is exactly what it is today.
- **Messages stay in the database.** Only the deriver's representation extraction is suppressed for tagged messages. Replay, audit, message-stream completeness, and search are unaffected.
- **Tag set is private to the deriver.** Adding new tags is a one-line addition to `NON_PROSE_METADATA_TYPES`; no API schema change.

## Notes for reviewers

- The set lives in `deriver.py` for proximity to its only consumer. Happy to move it to `src/utils/` or `src/schemas/` if you'd prefer the tag vocabulary to be more discoverable for future filter sites (e.g. dialectic, dream).
- The early-return when every message in a batch is non-prose is the only "shape" change to the extractor; the per-message filter in the formatted-prompt comprehension is otherwise the minimal possible change.
- I did not touch the dream / dialectic layers. Those are downstream consumers of the same message stream and likely benefit from the same filter, but they're separate code paths and merit their own PR with their own tests.
- If you'd prefer the `type` key be namespaced (e.g. `honcho.role` / `honcho.subject`), I'm happy to rename. The plugin PR uses bare `type` because that's the existing convention in `session-end.ts` (`type: "assistant_prose"`, `type: "assistant_brief"`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metadata-driven filtering: messages marked non-prose are excluded from LLM prompts and token accounting; if no prose remains the LLM call is skipped. Persisted provenance and attributions now reference only prose-eligible source messages.

* **Tests**
  * Added unit and integration tests for metadata eligibility, mixed batches, edge cases, LLM-skip behavior, prompt construction, and provenance/attribution filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->