### PR TITLE
fix(deriver): use json_object + prompt schema injection for openai-compatible backends

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -241,14 +241,23 @@ class OpenAIBackend:
         params["stream_options"] = {"include_usage": True}
         if isinstance(response_format, type):
             # parse() supports BaseModel types but streaming create() does not —
-            # convert to a json_schema dict so the streaming path works.
-            params["response_format"] = {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": response_format.__name__,
-                    "schema": response_format.model_json_schema(),
-                },
-            }
+            # convert to a json_object dict so the streaming path works.
+            # json_schema is ignored by many OpenAI-compatible proxies; json_object
+            # is near-universally supported. Schema validation is handled manually
+            # by the repair logic downstream.
+            params["response_format"] = {"type": "json_object"}
+            # Inject schema into the last user message so the model knows the
+            # expected output format — mirrors what the Anthropic path does.
+            schema_json = json.dumps(response_format.model_json_schema(), indent=2)
+            msgs = params.get("messages", [])
+            if msgs:
+                last_msg = msgs[-1]
+                if isinstance(last_msg.get("content"), str):
+                    last_msg = dict(last_msg)
+                    last_msg["content"] += (
+                        f"\n\nRespond with valid JSON matching this schema:\n{schema_json}"
+                    )
+                    params["messages"] = list(msgs[:-1]) + [last_msg]
         elif response_format is not None:
             params["response_format"] = response_format
         elif extra_params and extra_params.get("json_mode"):
@@ -378,13 +387,24 @@ class OpenAIBackend:
         response_format: type[BaseModel],
     ) -> Any:
         structured_params = dict(params)
-        structured_params["response_format"] = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": response_format.__name__,
-                "schema": response_format.model_json_schema(),
-            },
-        }
+        # Use json_object instead of json_schema: most OpenAI-compatible
+        # endpoints (proxies, aggregators, vLLM without guided decoding)
+        # silently ignore json_schema and return empty or free-form text.
+        # json_object is near-universally supported; schema validation is
+        # handled manually by the repair + fallback logic in structured_output.py.
+        structured_params["response_format"] = {"type": "json_object"}
+        # Inject schema into the last user message so the model knows the
+        # expected output format — mirrors what the Anthropic path does.
+        schema_json = json.dumps(response_format.model_json_schema(), indent=2)
+        msgs = structured_params.get("messages", [])
+        if msgs:
+            last_msg = msgs[-1]
+            if isinstance(last_msg.get("content"), str):
+                last_msg = dict(last_msg)
+                last_msg["content"] += (
+                    f"\n\nRespond with valid JSON matching this schema:\n{schema_json}"
+                )
+                structured_params["messages"] = list(msgs[:-1]) + [last_msg]
         return await self._client.chat.completions.create(**structured_params)
 
     @staticmethod


### PR DESCRIPTION
## Problem

The OpenAI backend sends `response_format: {"type": "json_schema", ...}` when making structured output calls. In practice, most OpenAI-compatible endpoints — proxies, aggregators (OpenRouter, ZAI, opencode, etc.), and local vLLM servers without guided decoding enabled — silently ignore this field and return either empty content or free-form text.

This causes a cascade of failures:
1. `validate_and_repair_json` raises `ValueError` on empty/non-JSON content
2. `ValueError` is not always in the except clause, so it propagates up
3. Tenacity retries 3 times, then raises `RetryError`
4. The deriver hard-crashes on every task, queue never drains

## Fix

Two changes to `src/llm/backends/openai.py`:

**1. Switch from `json_schema` to `json_object`**
`json_object` is supported by virtually every OpenAI-compatible endpoint. Schema correctness is already handled by the manual parse + fallback logic that follows (`repair_response_model_json` → `PromptRepresentation` fallback).

**2. Inject schema into the prompt**
Append the JSON schema to the last user message so the model knows what structure to produce. This is identical to what the Anthropic path already does. Without this, models receiving `json_object` with no schema guidance return arbitrary JSON keys.

**3. Add `ValueError` to the except clause**
`validate_and_repair_json` raises `ValueError` (not `json.JSONDecodeError`) when repair fails. Adding it to the except ensures the existing fallback path (`PromptRepresentation(explicit=[])`) is reached instead of crashing.

## Testing

Verified against ZAI (GLM models) and opencode.go proxy — both now correctly extract and store observations. The existing fallback logic (`validate_and_repair_json` → schema-aware repair → `PromptRepresentation` fallback) is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal handling of structured response formatting for OpenAI-compatible API calls. Schema guidance is now provided through prompt instructions rather than API parameters, enhancing compatibility with the API's JSON response format requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->