### PR TITLE
feat(deriver): attach provenance and validate observation candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Gemini JSON-schema sanitizer for `function_declarations` — strips keywords Gemini's validator rejects (`additionalProperties`, `allOf`, etc.) while preserving semantics for all other backends
 - Dreamer specialists derive `effective_max_tokens` from `model_config.max_output_tokens` with a per-specialist default fallback
 - Regression tests covering fallback-config thinking-param reach, provider_params → extra_params boundary, OpenAI reasoning-model parameter routing, Gemini blocked finish_reason handling, and fail-fast `max_tool_iterations` validation
+- Deterministic observation-candidate validation and provenance metadata for deriver and agent-tool observation writes
 
 ### Changed
 

--- a/src/crud/representation.py
+++ b/src/crud/representation.py
@@ -17,6 +17,10 @@ from src.embedding_client import embedding_client
 from src.schemas import ResolvedConfiguration
 from src.telemetry.logging import accumulate_metric
 from src.utils.formatting import format_datetime_utc
+from src.utils.observation_validation import (
+    ObservationValidationResult,
+    validate_observation_candidate,
+)
 from src.utils.representation import (
     DeductiveObservation,
     ExplicitObservation,
@@ -68,13 +72,66 @@ class RepresentationManager:
             return new_documents
 
         all_observations = representation.deductive + representation.explicit
+        source_ids_to_validate = sorted(
+            {
+                source_id
+                for obs in all_observations
+                if isinstance(obs, DeductiveObservation)
+                for source_id in obs.source_ids
+            }
+        )
+        available_source_ids: set[str] | None = None
+        if source_ids_to_validate:
+            async with tracked_db("representation_manager.validate_sources") as db:
+                source_documents = await crud.fetch_documents_by_ids(
+                    db,
+                    self.workspace_name,
+                    self.observer,
+                    self.observed,
+                    source_ids_to_validate,
+                )
+            available_source_ids = {doc.id for doc in source_documents}
+
+        validated_observations: list[
+            tuple[ExplicitObservation | DeductiveObservation, ObservationValidationResult]
+        ] = []
+        for obs in all_observations:
+            if isinstance(obs, DeductiveObservation):
+                obs_content = obs.conclusion
+                obs_level = "deductive"
+                obs_source_ids = obs.source_ids
+            else:
+                obs_content = obs.content
+                obs_level = "explicit"
+                obs_source_ids = None
+
+            validation = validate_observation_candidate(
+                content=obs_content,
+                level=obs_level,
+                origin="minimal_deriver",
+                source_message_ids=message_ids,
+                source_ids=obs_source_ids,
+                available_source_ids=available_source_ids,
+            )
+            if validation.accepted:
+                validated_observations.append((obs, validation))
+            else:
+                logger.warning(
+                    "Dropping invalid %s observation before embedding: %s",
+                    obs_level,
+                    "; ".join(validation.errors),
+                )
+
+        if not validated_observations:
+            logger.debug("No valid observations to save")
+            return new_documents
 
         # Batch embed all observations
         batch_embed_start = time.perf_counter()
 
         observation_texts = [
             obs.conclusion if isinstance(obs, DeductiveObservation) else obs.content
-            for obs in all_observations
+            for obs, _validation in validated_observations
         ]
         try:
             embeddings = await embedding_client.simple_batch_embed(observation_texts)
@@ -97,7 +154,7 @@ class RepresentationManager:
         async with tracked_db("representation_manager.save_representation") as db:
             new_documents = await self._save_representation_internal(
                 db,
-                all_observations,
+                validated_observations,
                 embeddings,
                 message_ids,
                 session_name,
@@ -118,7 +175,9 @@ class RepresentationManager:
     async def _save_representation_internal(
         self,
         db: AsyncSession,
-        all_observations: list[ExplicitObservation | DeductiveObservation],
+        all_observations: list[
+            tuple[ExplicitObservation | DeductiveObservation, ObservationValidationResult]
+        ],
         embeddings: list[list[float]],
         message_ids: list[int],
         session_name: str,
@@ -135,21 +194,25 @@ class RepresentationManager:
 
         # Prepare all documents for bulk creation
         documents_to_create: list[schemas.DocumentCreate] = []
-        for obs, embedding in zip(all_observations, embeddings, strict=True):
+        for (obs, validation), embedding in zip(all_observations, embeddings, strict=True):
             # NOTE: will add additional levels of reasoning in the future
             if isinstance(obs, DeductiveObservation):
                 obs_level = "deductive"
                 obs_content = obs.conclusion
                 obs_premises = obs.premises
+                obs_source_ids = obs.source_ids
             else:
                 obs_level = "explicit"
                 obs_content = obs.content
                 obs_premises = None
+                obs_source_ids = None
 
             metadata: schemas.DocumentMetadata = schemas.DocumentMetadata(
                 message_ids=message_ids,
                 premises=obs_premises,
                 message_created_at=format_datetime_utc(message_created_at),
+                source_ids=obs_source_ids,
+                provenance=validation.provenance,
             )
 
             documents_to_create.append(

--- a/src/schemas/internal.py
+++ b/src/schemas/internal.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from src.schemas.api import MessageCreate
 from src.schemas.configuration import SessionPeerConfig
+from src.utils.observation_validation import ObservationProvenance
 from src.utils.types import DocumentLevel
 
 
@@ -56,6 +57,10 @@ class DocumentMetadata(BaseModel):
         default=None,
         description="Confidence level (high, medium, low) -- only applicable for inductive documents",
     )
+    provenance: ObservationProvenance | None = Field(
+        default=None,
+        description="Machine-readable origin and validation provenance for this observation",
+    )
 
 
 class DocumentCreate(DocumentBase):
@@ -98,8 +103,10 @@ class ObservationInput(BaseModel):
 
     @field_validator("content", mode="after")
     @classmethod
-    def sanitize_content(cls, v: str) -> str:
-        return v.replace("\x00", "")
+    def validate_content(cls, v: str) -> str:
+        if "\x00" in v:
+            raise ValueError("NUL bytes are not allowed in observation content")
+        return v
 
     @model_validator(mode="after")
     def validate_level_fields(self) -> Self:

--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -24,6 +24,10 @@ from src.telemetry.events import (
 )
 from src.utils import summarizer
 from src.utils.formatting import format_new_turn_with_timestamp, utc_now_iso
+from src.utils.observation_validation import (
+    ObservationValidationResult,
+    validate_observation_candidate,
+)
 from src.utils.representation import Representation
 from src.utils.types import get_current_iteration
 
@@ -800,22 +804,62 @@ async def create_observations(
         logger.warning("create_observations called with empty list")
         return ObservationsCreatedResult(created_count=0, created_levels=[], failed=[])
 
-    # Phase 1: Ensure collection exists (short DB scope)
-    async with tracked_db("create_observations.collection") as db:
-        await crud.get_or_create_collection(
-            db,
-            workspace_name,
-            observer=observer,
-            observed=observed,
+    # Phase 1: Validate source document links (short DB scope only when needed)
+    source_ids_to_validate = sorted(
+        {
+            source_id
+            for obs in observations
+            for source_id in (obs.source_ids or [])
+        }
+    )
+    available_source_ids: set[str] | None = None
+    if source_ids_to_validate:
+        async with tracked_db("create_observations.sources") as db:
+            source_documents = await crud.fetch_documents_by_ids(
+                db=db,
+                workspace_name=workspace_name,
+                observer=observer,
+                observed=observed,
+                document_ids=source_ids_to_validate,
+                filters=None,
+            )
+            available_source_ids = {doc.id for doc in source_documents}
+
+    validated_observations: list[tuple[schemas.ObservationInput, ObservationValidationResult]] = []
+    failed: list[ObservationFailure] = []
+    for obs in observations:
+        validation = validate_observation_candidate(
+            content=obs.content,
+            level=obs.level,
+            origin="agent_tool",
+            source_message_ids=message_ids,
+            source_ids=obs.source_ids,
+            available_source_ids=available_source_ids,
+        )
+        if validation.accepted:
+            validated_observations.append((obs, validation))
+        else:
+            failed.append(
+                ObservationFailure(
+                    content_preview=obs.content[:50],
+                    error="Validation failed: " + "; ".join(validation.errors),
+                )
+            )
+
+    if not validated_observations:
+        return ObservationsCreatedResult(
+            created_count=0,
+            created_levels=[],
+            failed=failed,
         )
 
     # Phase 2: Compute embeddings (no DB needed)
-    contents = [obs.content for obs in observations]
+    contents = [obs.content for obs, _validation in validated_observations]
     embeddings_by_index: dict[int, list[float]] | None = None
     try:
         embeddings = await embedding_client.simple_batch_embed(contents)
         embeddings_by_index = dict(
-            zip(range(len(observations)), embeddings, strict=True)
+            zip(range(len(validated_observations)), embeddings, strict=True)
         )
     except Exception as e:
         logger.warning(
@@ -825,8 +869,7 @@ async def create_observations(
 
     # Build document objects with pre-computed embeddings
     documents: list[schemas.DocumentCreate] = []
-    failed: list[ObservationFailure] = []
-    for i, obs in enumerate(observations):
+    for i, (obs, validation) in enumerate(validated_observations):
         embedding: list[float]
         if embeddings_by_index is not None:
             embedding = embeddings_by_index[i]
@@ -862,6 +905,7 @@ async def create_observations(
             confidence=(obs.confidence or "medium")
             if obs.level == "inductive"
             else None,
+            provenance=validation.provenance,
         )
 
         doc = schemas.DocumentCreate(
@@ -880,6 +924,12 @@ async def create_observations(
     accepted: list[schemas.DocumentCreate] = []
     if documents:
         async with tracked_db("create_observations.save") as db:
+            await crud.get_or_create_collection(
+                db,
+                workspace_name,
+                observer=observer,
+                observed=observed,
+            )
             accepted = await crud.create_documents(
                 db,
                 documents=documents,

--- a/src/utils/observation_validation.py
+++ b/src/utils/observation_validation.py
@@ -1,0 +1,77 @@
+"""Deterministic validation and provenance for observation candidates."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from src.utils.types import DocumentLevel
+
+ObservationOrigin = Literal["minimal_deriver", "agent_tool", "api", "dreamer", "dialectic"]
+ValidationStatus = Literal["accepted", "rejected"]
+
+
+class ObservationProvenance(BaseModel):
+    """Machine-readable provenance attached to persisted observations."""
+
+    origin: ObservationOrigin
+    validation_status: ValidationStatus
+    validation_errors: list[str] = Field(default_factory=list)
+    source_message_ids: list[int] = Field(default_factory=list)
+    source_document_ids: list[str] = Field(default_factory=list)
+
+
+class ObservationValidationResult(BaseModel):
+    """Result of deterministic validation for one observation candidate."""
+
+    accepted: bool
+    errors: list[str] = Field(default_factory=list)
+    provenance: ObservationProvenance
+
+
+def validate_observation_candidate(
+    *,
+    content: str,
+    level: DocumentLevel,
+    origin: ObservationOrigin,
+    source_message_ids: list[int] | None = None,
+    source_ids: list[str] | None = None,
+    available_source_ids: set[str] | None = None,
+) -> ObservationValidationResult:
+    """Validate an observation candidate without calling an LLM or embedding model."""
+
+    errors: list[str] = []
+    normalized_source_ids = list(source_ids or [])
+    distinct_source_ids = set(normalized_source_ids)
+
+    if not content.strip():
+        errors.append("content must not be empty or whitespace-only")
+    if "\x00" in content:
+        errors.append("content must not contain NUL bytes")
+
+    if level in ("deductive", "inductive") and not normalized_source_ids:
+        errors.append(f"{level} observations require source_ids")
+    if level == "contradiction" and len(distinct_source_ids) < 2:
+        errors.append("contradiction observations require at least 2 distinct source_ids")
+
+    if available_source_ids is not None:
+        missing_source_ids = sorted(set(normalized_source_ids) - available_source_ids)
+        if missing_source_ids:
+            errors.append(
+                f"source_ids not found in available context: {', '.join(missing_source_ids)}"
+            )
+
+    accepted = not errors
+    provenance = ObservationProvenance(
+        origin=origin,
+        validation_status="accepted" if accepted else "rejected",
+        validation_errors=errors,
+        source_message_ids=list(source_message_ids or []),
+        source_document_ids=normalized_source_ids,
+    )
+    return ObservationValidationResult(
+        accepted=accepted,
+        errors=errors,
+        provenance=provenance,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,7 @@ _RUNTIME_MOCK_TEST_BLOCKLIST_PREFIXES = (
     # LLM transport tests mock providers directly and don't need database/runtime setup.
     "tests/utils/test_length_finish_reason.py",
     "tests/utils/test_clients.py",
+    "tests/utils/test_observation_validation.py",
 )
 
 _LIVE_LLM_MARKER = "live_llm"

--- a/tests/utils/test_observation_validation.py
+++ b/tests/utils/test_observation_validation.py
@@ -1,0 +1,519 @@
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import schemas
+from src.crud import representation as representation_crud
+from src.crud.representation import RepresentationManager
+from src.utils import agent_tools
+from src.utils.observation_validation import (
+    ObservationValidationResult,
+    validate_observation_candidate,
+)
+from src.utils.representation import (
+    DeductiveObservation,
+    ExplicitObservation,
+    Representation,
+)
+
+
+def _disabled_dream_configuration() -> schemas.ResolvedConfiguration:
+    return schemas.ResolvedConfiguration(
+        reasoning=schemas.ResolvedReasoningConfiguration(enabled=False),
+        peer_card=schemas.ResolvedPeerCardConfiguration(use=False, create=False),
+        summary=schemas.ResolvedSummaryConfiguration(
+            enabled=False,
+            messages_per_short_summary=20,
+            messages_per_long_summary=100,
+        ),
+        dream=schemas.ResolvedDreamConfiguration(enabled=False),
+    )
+
+
+def test_accepts_explicit_observation_with_provenance():
+    result = validate_observation_candidate(
+        content="Chris prefers durable infrastructure fixes.",
+        level="explicit",
+        origin="minimal_deriver",
+        source_message_ids=[101, 102],
+    )
+
+    assert result.accepted is True
+    assert result.provenance.origin == "minimal_deriver"
+    assert result.provenance.validation_status == "accepted"
+    assert result.provenance.source_message_ids == [101, 102]
+    assert result.provenance.validation_errors == []
+
+
+@pytest.mark.parametrize("content", ["", "   \n\t  ", "contains\x00nul"])
+def test_rejects_empty_whitespace_and_nul_content(content: str):
+    result = validate_observation_candidate(
+        content=content,
+        level="explicit",
+        origin="minimal_deriver",
+        source_message_ids=[1],
+    )
+
+    assert result.accepted is False
+    assert result.provenance.validation_status == "rejected"
+    assert result.errors
+
+
+def test_observation_input_rejects_nul_content():
+    with pytest.raises(ValidationError, match="NUL"):
+        schemas.ObservationInput(content="foo\x00bar", level="explicit")
+
+
+def test_rejects_reasoned_observation_with_missing_source_ids():
+    result = validate_observation_candidate(
+        content="Chris prefers ZFS because it supports snapshots.",
+        level="deductive",
+        origin="agent_tool",
+        source_ids=[],
+        available_source_ids={"doc-1"},
+    )
+
+    assert result.accepted is False
+    assert "source_ids" in " ".join(result.errors)
+
+
+def test_rejects_source_ids_outside_available_context():
+    result = validate_observation_candidate(
+        content="Chris tends to prefer conservative infrastructure changes.",
+        level="inductive",
+        origin="agent_tool",
+        source_ids=["doc-1", "missing-doc"],
+        available_source_ids={"doc-1"},
+    )
+
+    assert result.accepted is False
+    assert "missing-doc" in " ".join(result.errors)
+
+
+def test_accepts_reasoned_observation_when_sources_exist():
+    result = validate_observation_candidate(
+        content="Chris tends to prefer conservative infrastructure changes.",
+        level="inductive",
+        origin="agent_tool",
+        source_ids=["doc-1", "doc-2"],
+        available_source_ids={"doc-1", "doc-2"},
+    )
+
+    assert result.accepted is True
+    assert result.provenance.validation_status == "accepted"
+    assert result.provenance.source_document_ids == ["doc-1", "doc-2"]
+
+
+def test_accepts_contradiction_observation_with_two_sources():
+    result = validate_observation_candidate(
+        content="Chris both prefers and avoids automatic deploys depending on risk.",
+        level="contradiction",
+        origin="agent_tool",
+        source_ids=["doc-1", "doc-2"],
+        available_source_ids={"doc-1", "doc-2"},
+    )
+
+    assert result.accepted is True
+    assert result.provenance.validation_status == "accepted"
+    assert result.provenance.source_document_ids == ["doc-1", "doc-2"]
+
+
+def test_rejects_contradiction_observation_without_two_distinct_sources():
+    result = validate_observation_candidate(
+        content="Chris both prefers and avoids automatic deploys depending on risk.",
+        level="contradiction",
+        origin="agent_tool",
+        source_ids=["doc-1", "doc-1"],
+        available_source_ids={"doc-1", "doc-2"},
+    )
+
+    assert result.accepted is False
+    assert "at least 2 distinct source_ids" in " ".join(result.errors)
+
+
+@pytest.mark.parametrize("source_ids", [None, [], ["doc-1"]])
+def test_rejects_contradiction_observation_without_two_sources(
+    source_ids: list[str] | None,
+):
+    result = validate_observation_candidate(
+        content="Chris both prefers and avoids automatic deploys depending on risk.",
+        level="contradiction",
+        origin="agent_tool",
+        source_ids=source_ids,
+        available_source_ids={"doc-1", "doc-2"},
+    )
+
+    assert result.accepted is False
+    assert "at least 2 distinct source_ids" in " ".join(result.errors)
+
+
+@pytest.mark.asyncio
+async def test_save_representation_validates_before_embedding(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    embedded_texts: list[str] = []
+    captured_observations: list[
+        tuple[ExplicitObservation | DeductiveObservation, ObservationValidationResult]
+    ] = []
+
+    async def fake_batch_embed(texts: list[str]) -> list[list[float]]:
+        embedded_texts.extend(texts)
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    @asynccontextmanager
+    async def fake_tracked_db(_: str):
+        yield object()
+
+    async def fake_save_internal(
+        _self: RepresentationManager,
+        _db: object,
+        all_observations: list[
+            tuple[ExplicitObservation | DeductiveObservation, ObservationValidationResult]
+        ],
+        *_args: object,
+    ) -> int:
+        captured_observations.extend(all_observations)
+        return len(all_observations)
+
+    monkeypatch.setattr(
+        representation_crud.embedding_client,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "simple_batch_embed",
+        fake_batch_embed,
+    )
+    monkeypatch.setattr(representation_crud, "tracked_db", fake_tracked_db)
+    monkeypatch.setattr(
+        RepresentationManager,
+        "_save_representation_internal",
+        fake_save_internal,
+    )
+
+    manager = RepresentationManager("workspace", observer="observer", observed="observed")
+    representation = Representation(
+        explicit=[
+            ExplicitObservation(
+                content="Valid observation",
+                created_at=datetime(2026, 4, 26, tzinfo=UTC),
+                message_ids=[1],
+                session_name="session",
+            ),
+            ExplicitObservation(
+                content="   \n",
+                created_at=datetime(2026, 4, 26, tzinfo=UTC),
+                message_ids=[1],
+                session_name="session",
+            ),
+        ]
+    )
+
+    saved = await manager.save_representation(
+        representation,
+        message_ids=[1],
+        session_name="session",
+        message_created_at=datetime(2026, 4, 26, tzinfo=UTC),
+        message_level_configuration=_disabled_dream_configuration(),
+    )
+
+    assert saved == 1
+    assert embedded_texts == ["Valid observation"]
+    assert [
+        obs.conclusion if isinstance(obs, DeductiveObservation) else obs.content
+        for obs, _validation in captured_observations
+    ] == ["Valid observation"]
+
+
+@pytest.mark.asyncio
+async def test_save_representation_rejects_missing_deductive_source_ids(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    embedded_texts: list[str] = []
+
+    async def fake_fetch_documents_by_ids(
+        *_args: object,
+        **_kwargs: object,
+    ) -> list[object]:
+        return []
+
+    async def fake_batch_embed(texts: list[str]) -> list[list[float]]:
+        embedded_texts.extend(texts)
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    @asynccontextmanager
+    async def fake_tracked_db(_: str):
+        yield object()
+
+    monkeypatch.setattr(representation_crud, "tracked_db", fake_tracked_db)
+    monkeypatch.setattr(
+        representation_crud.crud,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "fetch_documents_by_ids",
+        fake_fetch_documents_by_ids,
+    )
+    monkeypatch.setattr(
+        representation_crud.embedding_client,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "simple_batch_embed",
+        fake_batch_embed,
+    )
+
+    manager = RepresentationManager("workspace", observer="observer", observed="observed")
+    representation = Representation(
+        deductive=[
+            DeductiveObservation(
+                conclusion="Derived conclusion",
+                source_ids=["missing-doc"],
+                premises=["Missing premise"],
+                created_at=datetime(2026, 4, 26, tzinfo=UTC),
+                message_ids=[1],
+                session_name="session",
+            )
+        ]
+    )
+
+    saved = await manager.save_representation(
+        representation,
+        message_ids=[1],
+        session_name="session",
+        message_created_at=datetime(2026, 4, 26, tzinfo=UTC),
+        message_level_configuration=_disabled_dream_configuration(),
+    )
+
+    assert saved == 0
+    assert embedded_texts == []
+
+
+@pytest.mark.asyncio
+async def test_save_representation_attaches_minimal_deriver_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created_documents: list[schemas.DocumentCreate] = []
+
+    async def fake_get_or_create_collection(
+        *_args: object,
+        **_kwargs: object,
+    ) -> object:
+        return SimpleNamespace(id="collection-id")
+
+    async def fake_create_documents(
+        _db: object,
+        documents: list[schemas.DocumentCreate],
+        *_args: object,
+        **_kwargs: object,
+    ) -> list[schemas.DocumentCreate]:
+        created_documents.extend(documents)
+        return documents
+
+    monkeypatch.setattr(
+        representation_crud.crud,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "get_or_create_collection",
+        fake_get_or_create_collection,
+    )
+    monkeypatch.setattr(
+        representation_crud.crud,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "create_documents",
+        fake_create_documents,
+    )
+
+    manager = RepresentationManager("workspace", observer="observer", observed="observed")
+    observation = ExplicitObservation(
+        content="Valid observation",
+        created_at=datetime(2026, 4, 26, tzinfo=UTC),
+        message_ids=[1],
+        session_name="session",
+    )
+
+    validation = validate_observation_candidate(
+        content=observation.content,
+        level="explicit",
+        origin="minimal_deriver",
+        source_message_ids=[1],
+    )
+
+    saved = await manager._save_representation_internal(  # pyright: ignore[reportPrivateUsage]
+        db=cast(AsyncSession, object()),
+        all_observations=[(observation, validation)],
+        embeddings=[[0.1, 0.2, 0.3]],
+        message_ids=[1],
+        session_name="session",
+        message_created_at=datetime(2026, 4, 26, tzinfo=UTC),
+        message_level_configuration=_disabled_dream_configuration(),
+    )
+
+    assert saved == 1
+    assert created_documents[0].metadata.provenance is not None
+    assert created_documents[0].metadata.provenance.origin == "minimal_deriver"
+    assert created_documents[0].metadata.provenance.validation_status == "accepted"
+    assert created_documents[0].metadata.provenance.source_message_ids == [1]
+
+
+@pytest.mark.asyncio
+async def test_create_observations_rejects_missing_source_ids_before_embedding(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    embedded_texts: list[str] = []
+    created_documents: list[schemas.DocumentCreate] = []
+
+    @asynccontextmanager
+    async def fake_tracked_db(_: str):
+        yield object()
+
+    async def fake_get_or_create_collection(
+        *_args: object,
+        **_kwargs: object,
+    ) -> object:
+        return SimpleNamespace(id="collection-id")
+
+    async def fake_fetch_documents_by_ids(
+        *_args: object,
+        **_kwargs: object,
+    ) -> list[object]:
+        return []
+
+    async def fake_batch_embed(texts: list[str]) -> list[list[float]]:
+        embedded_texts.extend(texts)
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    async def fake_create_documents(
+        _db: object,
+        documents: list[schemas.DocumentCreate],
+        *_args: object,
+        **_kwargs: object,
+    ) -> list[schemas.DocumentCreate]:
+        created_documents.extend(documents)
+        return documents
+
+    monkeypatch.setattr(agent_tools, "tracked_db", fake_tracked_db)
+    monkeypatch.setattr(
+        agent_tools.crud,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "get_or_create_collection",
+        fake_get_or_create_collection,
+    )
+    monkeypatch.setattr(
+        agent_tools.crud,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "fetch_documents_by_ids",
+        fake_fetch_documents_by_ids,
+    )
+    monkeypatch.setattr(
+        agent_tools.embedding_client,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "simple_batch_embed",
+        fake_batch_embed,
+    )
+    monkeypatch.setattr(
+        agent_tools.crud,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "create_documents",
+        fake_create_documents,
+    )
+
+    result = await agent_tools.create_observations(
+        observations=[
+            schemas.ObservationInput(content="Explicit observation", level="explicit"),
+            schemas.ObservationInput(
+                content="Deductive observation",
+                level="deductive",
+                source_ids=["missing-doc"],
+                premises=["missing premise"],
+            ),
+        ],
+        observer="observer",
+        observed="observed",
+        session_name="session",
+        workspace_name="workspace",
+        message_ids=[1],
+        message_created_at="2026-04-26T00:00:00Z",
+    )
+
+    assert result.created_count == 1
+    assert embedded_texts == ["Explicit observation"]
+    assert [doc.content for doc in created_documents] == ["Explicit observation"]
+    assert len(result.failed) == 1
+    assert "missing-doc" in result.failed[0].error
+
+
+@pytest.mark.asyncio
+async def test_create_observations_does_not_create_collection_when_all_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    get_or_create_calls = 0
+    create_documents_calls = 0
+    embed_calls = 0
+
+    @asynccontextmanager
+    async def fake_tracked_db(_: str):
+        yield object()
+
+    async def fake_get_or_create_collection(
+        *_args: object,
+        **_kwargs: object,
+    ) -> object:
+        nonlocal get_or_create_calls
+        get_or_create_calls += 1
+        return SimpleNamespace(id="collection-id")
+
+    async def fake_fetch_documents_by_ids(
+        *_args: object,
+        **_kwargs: object,
+    ) -> list[object]:
+        return []
+
+    async def fake_batch_embed(texts: list[str]) -> list[list[float]]:
+        nonlocal embed_calls
+        embed_calls += 1
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    async def fake_create_documents(
+        _db: object,
+        documents: list[schemas.DocumentCreate],
+        *_args: object,
+        **_kwargs: object,
+    ) -> list[schemas.DocumentCreate]:
+        nonlocal create_documents_calls
+        create_documents_calls += 1
+        return documents
+
+    monkeypatch.setattr(agent_tools, "tracked_db", fake_tracked_db)
+    monkeypatch.setattr(
+        agent_tools.crud,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "get_or_create_collection",
+        fake_get_or_create_collection,
+    )
+    monkeypatch.setattr(
+        agent_tools.crud,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "fetch_documents_by_ids",
+        fake_fetch_documents_by_ids,
+    )
+    monkeypatch.setattr(
+        agent_tools.embedding_client,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "simple_batch_embed",
+        fake_batch_embed,
+    )
+    monkeypatch.setattr(
+        agent_tools.crud,  # pyright: ignore[reportPrivateLocalImportUsage]
+        "create_documents",
+        fake_create_documents,
+    )
+
+    result = await agent_tools.create_observations(
+        observations=[
+            schemas.ObservationInput(
+                content="Deductive observation",
+                level="deductive",
+                source_ids=["missing-doc"],
+                premises=["missing premise"],
+            )
+        ],
+        observer="observer",
+        observed="observed",
+        session_name="session",
+        workspace_name="workspace",
+        message_ids=[1],
+        message_created_at="2026-04-26T00:00:00Z",
+    )
+
+    assert result.created_count == 0
+    assert len(result.failed) == 1
+    assert "missing-doc" in result.failed[0].error
+    assert get_or_create_calls == 0
+    assert embed_calls == 0
+    assert create_documents_calls == 0


### PR DESCRIPTION
## Summary
- add deterministic observation-candidate validation before embedding/persistence
- attach machine-readable provenance to accepted observations in document metadata
- validate agent-created source document links against the current workspace/observer/observed context
- add focused coverage for validation, deriver save-path filtering, provenance metadata, and agent-tool rejection behavior

## Motivation / context
This is intended as a narrow safety layer for Honcho's memory write paths. Recent/open upstream work is already tightening adjacent deriver behavior:

- #615 / #618 filter blank observations before embedding
- #619 filters non-prose-tagged messages from representation extraction
- #445 narrows deriver prompt behavior toward durable observations
- #457 and #485 touch source/document metadata and scoped retrieval, but are broader and/or schema-level

This PR keeps the scope smaller: no LLM validator, no schema migration, no prompt semantics change, and no production data rewrite. It rejects deterministic structural failures early and records where accepted observations came from.

## Design notes
- Validation is deterministic only: empty/whitespace content, NUL bytes, required `source_ids` for reasoned observations, contradiction source cardinality, and available-context source checks where the caller can cheaply provide them.
- Rejected candidates are dropped before embedding, so invalid content does not reach embedding providers or persistence.
- Accepted observations store provenance in existing JSON metadata via `DocumentMetadata.provenance`; this avoids a migration and preserves backward compatibility because provenance is optional.
- The minimal deriver path records `origin=minimal_deriver` and message IDs. Agent-tool writes record `origin=agent_tool` and validate `source_ids` against documents in the same workspace/observer/observed scope.

## Local / staged validation
- `uv run pytest tests/utils/test_observation_validation.py -q` → `18 passed`
- `uv run ruff check src/utils/observation_validation.py src/crud/representation.py src/utils/agent_tools.py src/schemas/internal.py tests/conftest.py tests/utils/test_observation_validation.py` → passed
- `uv run basedpyright` → `0 errors, 0 warnings, 0 notes`
- Full local `uv run pytest tests/ -q` still fails in this checkout because the local Postgres fixture cannot authenticate as `postgres` (`FATAL: password authentication failed for user "postgres"`); before that environment failure it reports `154 passed, 8 skipped` and then DB-backed tests error during setup.

I also validated this branch behavior against an isolated staging copy of a live Honcho database on a loopback-only API port. Production services and the production DB were not modified. The staging run confirmed accepted observations were persisted with provenance and invalid candidates were rejected before embedding/persistence.

## Notes for reviewers
- This deliberately does not solve semantic truthfulness or attribution by itself; it is a structural/provenance guardrail that complements #619-style input filtering and prompt/schema hardening.
- No credentials or live-production data are included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic observation validation runs before embedding/storage.
  * Provenance metadata recorded for accepted observations (origin, validation status, errors, source IDs).
  * Observations with empty/whitespace content, NUL bytes, or missing/insufficient source IDs (including deductive/contradiction rules) are rejected and excluded from persistence.

* **Tests**
  * New tests verify validation rules, provenance recording, and that rejected observations are not embedded or stored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### CodeRabbit remediation
- Deferred agent-tool collection creation until accepted observations exist, preventing empty collections when all candidates are rejected.
- Changed `ObservationInput` NUL handling from silent stripping to validation failure, so raw tool payloads containing NUL bytes cannot normalize into persisted content.
- Added regression tests for both cases.


### Additional CodeRabbit remediation
- Minimal-deriver deductive `source_ids` now validate against fetched in-scope documents before embedding/persistence.
- Added regression coverage proving missing deductive source IDs are rejected before embedding.


### Additional CodeRabbit remediation
- Contradiction observations now require at least two distinct source IDs; duplicate source IDs no longer satisfy the contradiction cardinality check.
- Renamed the NUL schema test to match reject-not-sanitize behavior.
