### PR TITLE
docs: update opencode install command

### DIFF
--- a/docs/v3/guides/integrations/opencode.mdx
+++ b/docs/v3/guides/integrations/opencode.mdx
@@ -15,35 +15,29 @@ Give OpenCode long-term memory that survives context wipes, session restarts, an
 2. Sign up or log in
 3. Copy your API key (starts with `hch-`)
 
-### Step 2: Install or Update the Plugin
+### Step 2: Install the Plugin
 
 <Note>
-This plugin requires [Bun](https://bun.sh) and the [OpenCode CLI](https://opencode.ai). If `opencode` isn't on your `PATH`, install it first, then restart your shell.
+This plugin requires the [OpenCode CLI](https://opencode.ai). If `opencode` isn't on your `PATH`, install it first, then restart your shell.
 </Note>
 
-Run the installer:
+Install the plugin:
 
 ```bash
-bunx @honcho-ai/opencode-honcho@latest install --force
+opencode plugin "@honcho-ai/opencode-honcho" --global
 ```
 
-<Accordion title="Windows install">
+To update an existing plugin install:
 
-Windows Command Prompt:
-
-```cmd
-git clone --branch main https://github.com/plastic-labs/opencode-honcho.git
-cd opencode-honcho
-bun install && bun run build && bun .\dist\cli.js install --plugin-spec "%CD%" --force
+```bash
+opencode plugin "@honcho-ai/opencode-honcho" --force
 ```
 
-</Accordion>
-
-The installer:
+OpenCode:
 
 - registers `@honcho-ai/opencode-honcho` with OpenCode
-- enables both the native server and TUI plugin targets
-- writes the Honcho command templates into your global OpenCode config
+- resolves the package's native server and TUI plugin targets
+- updates plugin entries in your global OpenCode config
 - activates the plugin globally for every OpenCode project
 
 ### Step 3: Run Setup in OpenCode

--- a/docs/v3/guides/integrations/opencode.mdx
+++ b/docs/v3/guides/integrations/opencode.mdx
@@ -15,7 +15,7 @@ Give OpenCode long-term memory that survives context wipes, session restarts, an
 2. Sign up or log in
 3. Copy your API key (starts with `hch-`)
 
-### Step 2: Install the Plugin
+### Step 2: Install or Update the Plugin
 
 <Note>
 This plugin requires [Bun](https://bun.sh) and the [OpenCode CLI](https://opencode.ai). If `opencode` isn't on your `PATH`, install it first, then restart your shell.
@@ -24,7 +24,7 @@ This plugin requires [Bun](https://bun.sh) and the [OpenCode CLI](https://openco
 Run the installer:
 
 ```bash
-bunx @honcho-ai/opencode-honcho install
+bunx @honcho-ai/opencode-honcho@latest install --force
 ```
 
 <Accordion title="Windows install">


### PR DESCRIPTION
- quick 2 line fix for updating installation/update command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated integration guide to use the `opencode plugin ... --global` command instead of Bun/Bunx instructions.
  * Removed Windows-specific clone/build steps; consolidated to a single cross-platform update/install command using `--force`.
  * Revised step descriptions to reflect resolving target entries and updating global plugin configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->