### PR TITLE
feat(embedding): pass dimensions to OpenAI embedding calls

### DIFF
--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -98,9 +98,10 @@ class _EmbeddingClient:
                 raise ValueError("No embedding returned from Gemini API")
             return self._validate_embedding_dimensions(response.embeddings[0].values)
         else:  # openai
-            response = await self.client.embeddings.create(
-                model=self.model, input=[query]
-            )
+            kwargs: dict = {"model": self.model, "input": [query]}
+            if self.vector_dimensions:
+                kwargs["dimensions"] = self.vector_dimensions
+            response = await self.client.embeddings.create(**kwargs)
             return self._validate_embedding_dimensions(response.data[0].embedding)
 
     async def simple_batch_embed(self, texts: list[str]) -> list[list[float]]:
@@ -135,10 +136,10 @@ class _EmbeddingClient:
                                     self._validate_embedding_dimensions(emb.values)
                                 )
                 else:  # openai
-                    response = await self.client.embeddings.create(
-                        input=batch,
-                        model=self.model,
-                    )
+                    kwargs: dict = {"input": batch, "model": self.model}
+                    if self.vector_dimensions:
+                        kwargs["dimensions"] = self.vector_dimensions
+                    response = await self.client.embeddings.create(**kwargs)
                     embeddings.extend(
                         [
                             self._validate_embedding_dimensions(data.embedding)
@@ -282,9 +283,10 @@ class _EmbeddingClient:
                                     )
                                 )
                 else:  # openai
-                    response = await self.client.embeddings.create(
-                        model=self.model, input=[item.text for item in batch]
-                    )
+                    kwargs: dict = {"model": self.model, "input": [item.text for item in batch]}
+                    if self.vector_dimensions:
+                        kwargs["dimensions"] = self.vector_dimensions
+                    response = await self.client.embeddings.create(**kwargs)
                     for item, embedding_data in zip(batch, response.data, strict=True):
                         result[item.text_id][item.chunk_index] = (
                             self._validate_embedding_dimensions(


### PR DESCRIPTION
OpenAI transport was missing the dimensions parameter that Gemini
    transport already passes as output_dimensionality. This causes
    dimension mismatch with third-party embedding models (e.g.
    Qwen3-Embedding via SiliconFlow) that default to non-1536 output
    while pgvector enforces 1536-dimensional vectors.
    
    Changes
    
    - Add dimensions=self.vector_dimensions to all 3 OpenAI embedding
      call sites in src/embedding_client.py
    - Guard with if self.vector_dimensions so the parameter is only
      passed when configured — fully backward compatible with models
      that don't support it (e.g. text-embedding-ada-002)
    
    Motivation
    
    When using self-hosted Honcho with third-party OpenAI-compatible
    embedding providers, the configured EMBEDDING_VECTOR_DIMENSIONS
    had no effect on actual API calls, causing dimension mismatch
    between model output and pgvector schema.
    
    Verification
    
    - Tested with Qwen3-Embedding-4B via SiliconFlow API
    - honcho_conclude, honcho_search all pass without dimension errors
    - Existing models without dimensions support remain unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored OpenAI embedding request construction for improved parameter handling, including conditional support for vector dimension configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->