### PR TITLE
feat(models): make vector embedding dimensions configurable

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -5,6 +5,14 @@ from typing import Any, final
 from dotenv import load_dotenv
 from nanoid import generate as generate_nanoid
 from pgvector.sqlalchemy import Vector
+
+# Resolve embedding dimensions from config; fallback to 1536 for backward compat.
+# Must be set before any model class that references Vector(...) is defined.
+try:
+    from .config import settings as _settings
+    _EMBEDDING_DIMS: int = _settings.VECTOR_STORE.DIMENSIONS  # type: ignore[union-attr]
+except Exception:
+    _EMBEDDING_DIMS = 1536
 from sqlalchemy import (
     BigInteger,
     Boolean,
@@ -278,7 +286,7 @@ class MessageEmbedding(Base):
         BigInteger, Identity(), primary_key=True, autoincrement=True
     )
     content: Mapped[str] = mapped_column(TEXT)
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(_EMBEDDING_DIMS), nullable=True)
     message_id: Mapped[str] = mapped_column(
         ForeignKey("messages.public_id", ondelete="CASCADE"), nullable=False, index=True
     )
@@ -386,7 +394,7 @@ class Document(Base):
     times_derived: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("1")
     )
-    embedding: MappedColumn[Any] = mapped_column(Vector(1536), nullable=True)
+    embedding: MappedColumn[Any] = mapped_column(Vector(_EMBEDDING_DIMS), nullable=True)
     source_ids: Mapped[list[str] | None] = mapped_column(
         JSONB, nullable=True, server_default=text("NULL")
     )


### PR DESCRIPTION
## Summary

Hardcoded \`Vector(1536)\` in both \`Document\` and \`MessageEmbedding\` SQLAlchemy models locks users into OpenAI embedding dimensionality. Any alternative embedding model (bge-m3=1024, nomic-embed=768, Cohere v3=1024, etc.) produces a \`ValueError: expected 1536 dimensions, not N\` on every insert.

## Changes

- **\`src/models.py\`**: Read vector dimensions from existing \`VECTOR_STORE.DIMENSIONS\` config setting (default 1536) instead of hardcoding
- Graceful fallback to 1536 if config is unavailable at import time
- Zero behavior change for default OpenAI/Gemini users (still 1536 dims)

## Motivation

The config system already supports \`VECTOR_STORE.DIMENSIONS\` for LanceDB/Turbopuffer vector stores, but the pgvector ORM models ignored this setting. This disconnect meant:
- Users **could** configure a custom embedding provider via \`EMBEDDING_MODEL_CONFIG\`
- But **could not** actually use it because pgvector rejected non-1536 vectors

This unblocks local/Ollama embeddings (bge-m3), open-source models (nomic, e5), and any model with different output dimensions.

## Test Plan

1. Set \`VECTOR_STORE_DIMENSIONS=1024\` in \`.env\`
2. Configure embedding via \`EMBEDDING_MODEL_CONFIG\` for Ollama bge-m3
3. Run deriver — observations save without dimension errors  
4. Default config (no changes) — existing 1536-dim behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Embedding configuration now supports dynamic dimension settings with automatic fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->