### PR TITLE
docs(integrations): rewrite Vercel AI SDK guide as cookbook style (DEV-1485)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -104,6 +104,7 @@
                 "pages": [
                   "v3/guides/integrations/claude-code",
                   "v3/guides/integrations/opencode",
+                  "v3/guides/integrations/vercel-ai-sdk",
                   "v3/guides/integrations/crewai",
                   "v3/guides/integrations/langgraph",
                   "v3/guides/integrations/mcp",

--- a/docs/v3/guides/integrations/vercel-ai-sdk.mdx
+++ b/docs/v3/guides/integrations/vercel-ai-sdk.mdx
@@ -273,13 +273,27 @@ Based on what we've talked about, what do you know about me?
 
 If the model recalls preferences from previous sessions without them being in the current conversation, cross-session memory is working. Honcho processed the prior turns between sessions and updated the user's representation.
 
+<Note>
+The deriver waits until 1024 tokens are accumulated before batch processing - short conversations won't trigger cross-session recall!
+</Note>
+
 ### 5. Test tool calling directly
 
 ```text
-Use your honcho_chat tool to tell me what patterns you've noticed about me.
+Call your honcho_search tool with the query 'TypeScript' and quote the exact verbatim message that contained TypeScript. Do not paraphrase.
 ```
 
-If the model calls the tool and returns a synthesized answer, the full tool pipeline is functional. To confirm which tool fired, inspect `result.toolCalls` — tool names like `honcho_chat` appear there, not in `result.text`.
+If the model returns the exact prior message word-for-word, the tool pipeline is functional. To confirm which tool fired, inspect `result.steps[i].toolCalls`:
+
+```typescript
+const toolFires = result.steps?.flatMap((step, i) =>
+  (step.toolCalls ?? []).map((tc) => ({ step: i, tool: tc.toolName, input: tc.input }))
+) ?? [];
+console.log(toolFires);
+// [{ step: 0, tool: "honcho_search", input: { query: "TypeScript", limit: 10 } }]
+```
+
+When the model takes more than one turn (call a tool, see the result, then answer), the top-level `result.toolCalls` is empty — check inside each `step`.
 
 ## Full Script
 

--- a/docs/v3/guides/integrations/vercel-ai-sdk.mdx
+++ b/docs/v3/guides/integrations/vercel-ai-sdk.mdx
@@ -1,0 +1,345 @@
+---
+title: "Vercel AI SDK"
+icon: "triangle"
+iconType: "solid"
+description: "Add persistent user memory and reasoning to any Vercel AI SDK app with Honcho"
+sidebarTitle: "Vercel AI SDK"
+---
+
+Integrate Honcho with the Vercel AI SDK to build AI apps that remember users across sessions. The [Vercel AI SDK](https://sdk.vercel.ai) is an open-source TypeScript toolkit for building AI-powered apps with a unified API across providers. This guide shows you how to wrap any `generateText` or `streamText` call with Honcho's memory middleware and reasoning tools.
+
+<Note>
+The full package source and examples are available on [GitHub](https://github.com/plastic-labs/vercel-ai-sdk-package).
+</Note>
+
+## What We're Building
+
+We'll wire Honcho into a Vercel AI SDK app so the model automatically receives context from past conversations and can query what it knows about the user mid-generation. Here's how the pieces fit together:
+
+- **Vercel AI SDK** handles model calls and streaming
+- **Honcho** stores messages and retrieves user context before each generation
+- **Your model provider** can be Anthropic, OpenAI, Google, etc.
+
+The key benefit: you don't manually manage conversation history across sessions. Honcho handles persistence and context injection — the model always has a rich picture of who it's talking to.
+
+<Note>
+Before proceeding, it helps to understand Honcho's core concepts (`Peers` and `Sessions`). Review the [Honcho Architecture](/v3/documentation/core-concepts/architecture) to familiarize yourself with these primitives.
+</Note>
+
+## Setup
+
+Install the package:
+
+<CodeGroup>
+```bash npm
+npm install @honcho-ai/vercel-ai-sdk
+```
+
+```bash pnpm
+pnpm add @honcho-ai/vercel-ai-sdk
+```
+
+```bash yarn
+yarn add @honcho-ai/vercel-ai-sdk
+```
+
+```bash bun
+bun add @honcho-ai/vercel-ai-sdk
+```
+</CodeGroup>
+
+Set your API key and workspace ID:
+
+```bash
+HONCHO_API_KEY=your-api-key
+HONCHO_WORKSPACE_ID=your-workspace-id
+```
+
+<Note>
+Get your API key and workspace ID at [app.honcho.dev](https://app.honcho.dev). For local development, pass `environment: "local"` to `createHoncho()`.
+</Note>
+
+## Create a Provider Instance
+
+`createHoncho()` is the entry point. It reads your API key and workspace from environment variables and returns a provider object with `middleware()`, `tools()`, and `send()`.
+
+```typescript
+import { createHoncho } from '@honcho-ai/vercel-ai-sdk';
+
+const honcho = createHoncho();
+```
+
+You can set a stable `defaultAssistantId` on the provider to identify the AI peer across all calls:
+
+```typescript
+const honcho = createHoncho({
+  defaultAssistantId: 'my-assistant',
+});
+```
+
+## Add Middleware
+
+`honcho.middleware()` is compatible with `wrapLanguageModel`. Two things happen automatically on each call:
+
+1. **Before generation** — Honcho fetches the user's representation, peer card, session summary, and recent messages and injects them into the system prompt
+2. **After generation** — the user message and assistant response are stored back in Honcho with correct peer attribution
+
+```typescript
+import { createHoncho } from '@honcho-ai/vercel-ai-sdk';
+import { wrapLanguageModel, generateText } from 'ai';
+import { anthropic } from '@ai-sdk/anthropic';
+
+const honcho = createHoncho();
+
+const model = wrapLanguageModel({
+  model: anthropic('claude-sonnet-4-6'),
+  middleware: honcho.middleware({
+    userId: 'user-abc',
+    sessionId: 'session-123',
+  }),
+});
+
+const { text } = await generateText({
+  model,
+  prompt: 'What should I focus on today?',
+});
+```
+
+Pass `userId` and `sessionId` per request — no session handles to construct. Both default to lazily generated IDs if omitted, which is fine for local scripts but not for multi-user server traffic.
+
+<Note>
+The first turn returns empty context — there's nothing stored yet. Every turn after that, the model receives the user's representation, derived conclusions, and session history automatically.
+</Note>
+
+## Add Tools
+
+`honcho.tools()` gives the model six tools it can call mid-generation to query or update what it knows about the user:
+
+| Tool | What it does |
+| --- | --- |
+| `honcho_chat` | Dialectic reasoning — ask natural-language questions about the user; answers synthesized from full interaction history |
+| `honcho_context` | Short summary of recent context within the session |
+| `honcho_search` | Semantic search over stored conversation messages |
+| `honcho_search_conclusions` | Query derived conclusions: personality traits, preferences, behavioral patterns |
+| `honcho_get_representation` | Full synthesized profile of the user |
+| `honcho_save_conclusion` | Persist an observation about the user for future sessions |
+
+Pass the same `userId` and `sessionId` to `honcho.tools()` so tool calls bind to the same peers as the middleware:
+
+```typescript
+const { text } = await generateText({
+  model,
+  tools: honcho.tools({
+    userId: 'user-abc',
+    sessionId: 'session-123',
+  }),
+  maxSteps: 3,
+  prompt: 'Based on our conversations, what do I care about most?',
+});
+```
+
+## Complete Example
+
+Here's a full working example combining middleware and tools:
+
+```typescript
+import { createHoncho } from '@honcho-ai/vercel-ai-sdk';
+import { wrapLanguageModel, generateText } from 'ai';
+import { anthropic } from '@ai-sdk/anthropic';
+
+const honcho = createHoncho({
+  defaultAssistantId: 'assistant',
+});
+
+const userId = 'user-abc';
+const sessionId = 'session-123';
+
+const model = wrapLanguageModel({
+  model: anthropic('claude-sonnet-4-6'),
+  middleware: honcho.middleware({ userId, sessionId }),
+});
+
+const { text } = await generateText({
+  model,
+  tools: honcho.tools({ userId, sessionId }),
+  maxSteps: 3,
+  prompt: 'What should we work on today?',
+});
+
+console.log(text);
+```
+
+## Streaming
+
+`streamText` works the same way — middleware handles persistence after the stream completes:
+
+```typescript
+import { createHoncho } from '@honcho-ai/vercel-ai-sdk';
+import { wrapLanguageModel, streamText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const honcho = createHoncho();
+
+const userId = 'user-abc';
+const sessionId = 'session-456';
+
+const model = wrapLanguageModel({
+  model: openai('gpt-4o'),
+  middleware: honcho.middleware({ userId, sessionId }),
+});
+
+const result = streamText({
+  model,
+  tools: honcho.tools({ userId, sessionId }),
+  prompt: 'What should we work on today?',
+});
+
+for await (const chunk of result.textStream) {
+  process.stdout.write(chunk);
+}
+```
+
+## Using with `messages`
+
+If your app already manages conversation history and passes a `messages` array directly, set `injectHistory: false` to prevent Honcho from prepending duplicate history:
+
+```typescript
+honcho.middleware({
+  userId,
+  sessionId,
+  injectHistory: false, // don't prepend history — we're passing messages directly
+})
+```
+
+Honcho still injects the user's representation and peer card into the system prompt, and still persists messages after generation.
+
+## Verifying the Integration
+
+### 1. First turn
+
+Send any message. The model responds normally — nothing is stored yet. Context injection returns empty on the first turn.
+
+### 2. Build memory across turns
+
+Have a multi-turn conversation and share something about yourself:
+
+```text
+I prefer concise answers and I mostly work in TypeScript.
+```
+
+After a few turns, ask:
+
+```text
+What do you know about my preferences?
+```
+
+If the model references TypeScript and concise answers without being told again in this session, memory is working.
+
+### 3. Cross-session recall
+
+Start a new session (new `sessionId`). Ask:
+
+```text
+Based on what we've talked about, what do you know about me?
+```
+
+If the model recalls preferences from previous sessions without them being in the current conversation, cross-session memory is working. Honcho processed the prior turns between sessions and updated the user's representation.
+
+### 4. Test tool calling directly
+
+```text
+Use your honcho_chat tool to tell me what patterns you've noticed about me.
+```
+
+If the model calls the tool and returns a synthesized answer, the full tool pipeline is functional.
+
+## Full Script
+
+<Accordion title="honcho_vercel_chat.ts">
+```typescript
+/**
+ * Multi-turn chat with Honcho memory + Vercel AI SDK.
+ *
+ * Prerequisites:
+ * 1. Install dependencies:
+ *    npm install @honcho-ai/vercel-ai-sdk ai @ai-sdk/anthropic dotenv
+ * 2. Set environment variables in `.env`:
+ *    HONCHO_API_KEY=your-honcho-api-key
+ *    HONCHO_WORKSPACE_ID=your-workspace-id
+ *    ANTHROPIC_API_KEY=your-anthropic-api-key
+ * 3. Run with: npx tsx honcho_vercel_chat.ts
+ *
+ * Pass a stable userId from your auth system and a sessionId for the conversation
+ * thread; Honcho handles persistence and context injection on every turn.
+ */
+
+import 'dotenv/config';
+import { createHoncho } from '@honcho-ai/vercel-ai-sdk';
+import { wrapLanguageModel, generateText } from 'ai';
+import { anthropic } from '@ai-sdk/anthropic';
+import * as readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+const honcho = createHoncho({
+  defaultAssistantId: 'assistant',
+});
+
+const userId = process.env.USER_ID ?? 'demo-user';
+const sessionId = process.env.SESSION_ID ?? `session-${Date.now()}`;
+
+const model = wrapLanguageModel({
+  model: anthropic('claude-sonnet-4-6'),
+  middleware: honcho.middleware({ userId, sessionId }),
+});
+
+async function chat(prompt: string): Promise<string> {
+  const { text } = await generateText({
+    model,
+    tools: honcho.tools({ userId, sessionId }),
+    maxSteps: 3,
+    prompt,
+  });
+  return text;
+}
+
+async function main() {
+  const rl = readline.createInterface({ input, output });
+  console.log(`Honcho session: ${sessionId} (user: ${userId})`);
+  console.log('Type a message, or "exit" to quit.\n');
+
+  while (true) {
+    const userMessage = (await rl.question('you > ')).trim();
+    if (!userMessage || userMessage === 'exit') break;
+    const reply = await chat(userMessage);
+    console.log(`bot > ${reply}\n`);
+  }
+
+  rl.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+</Accordion>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Package Source" icon="github" href="https://github.com/plastic-labs/vercel-ai-sdk-package">
+    Source, tests, and full API reference for @honcho-ai/vercel-ai-sdk.
+  </Card>
+
+  <Card title="Honcho Architecture" icon="sitemap" href="/v3/documentation/core-concepts/architecture">
+    Learn about peers, sessions, and dialectic reasoning.
+  </Card>
+
+  <Card title="Self-Hosting Guide" icon="server" href="/v3/contributing/self-hosting">
+    Run Honcho locally with your Vercel AI SDK app.
+  </Card>
+
+  <Card title="Vercel AI SDK Docs" icon="book" href="https://sdk.vercel.ai">
+    wrapLanguageModel, middleware, and tool use reference.
+  </Card>
+</CardGroup>

--- a/docs/v3/guides/integrations/vercel-ai-sdk.mdx
+++ b/docs/v3/guides/integrations/vercel-ai-sdk.mdx
@@ -20,11 +20,7 @@ We'll wire Honcho into a Vercel AI SDK app so the model automatically receives c
 - **Honcho** stores messages and retrieves user context before each generation
 - **Your model provider** can be Anthropic, OpenAI, Google, etc.
 
-The key benefit: you don't manually manage conversation history across sessions. Honcho handles persistence and context injection — the model always has a rich picture of who it's talking to.
-
-<Note>
-Before proceeding, it helps to understand Honcho's core concepts (`Peers` and `Sessions`). Review the [Honcho Architecture](/v3/documentation/core-concepts/architecture) to familiarize yourself with these primitives.
-</Note>
+The key benefit: you don't manually manage conversation history across sessions. Honcho handles persistence and context injection — the model always has a rich picture of who it's talking to. (New to Honcho's primitives? See [peers and sessions](/v3/documentation/core-concepts/architecture).)
 
 ## Setup
 
@@ -48,16 +44,12 @@ bun add @honcho-ai/vercel-ai-sdk
 ```
 </CodeGroup>
 
-Set your API key and workspace ID:
+Get your API key at [app.honcho.dev](https://app.honcho.dev).
 
 ```bash
 HONCHO_API_KEY=your-api-key
 HONCHO_WORKSPACE_ID=your-workspace-id
 ```
-
-<Note>
-Get your API key and workspace ID at [app.honcho.dev](https://app.honcho.dev). For local development, pass `environment: "local"` to `createHoncho()`.
-</Note>
 
 ## Create a Provider Instance
 
@@ -107,10 +99,6 @@ const { text } = await generateText({
 
 Pass `userId` and `sessionId` per request — no session handles to construct. Both default to lazily generated IDs if omitted, which is fine for local scripts but not for multi-user server traffic.
 
-<Note>
-The first turn returns empty context — there's nothing stored yet. Every turn after that, the model receives the user's representation, derived conclusions, and session history automatically.
-</Note>
-
 ## Add Tools
 
 `honcho.tools()` gives the model six tools it can call mid-generation to query or update what it knows about the user:
@@ -127,13 +115,15 @@ The first turn returns empty context — there's nothing stored yet. Every turn 
 Pass the same `userId` and `sessionId` to `honcho.tools()` so tool calls bind to the same peers as the middleware:
 
 ```typescript
+import { generateText, stepCountIs } from 'ai';
+
 const { text } = await generateText({
   model,
   tools: honcho.tools({
     userId: 'user-abc',
     sessionId: 'session-123',
   }),
-  maxSteps: 3,
+  stopWhen: stepCountIs(3),
   prompt: 'Based on our conversations, what do I care about most?',
 });
 ```
@@ -144,7 +134,7 @@ Here's a full working example combining middleware and tools:
 
 ```typescript
 import { createHoncho } from '@honcho-ai/vercel-ai-sdk';
-import { wrapLanguageModel, generateText } from 'ai';
+import { wrapLanguageModel, generateText, stepCountIs } from 'ai';
 import { anthropic } from '@ai-sdk/anthropic';
 
 const honcho = createHoncho({
@@ -162,7 +152,7 @@ const model = wrapLanguageModel({
 const { text } = await generateText({
   model,
   tools: honcho.tools({ userId, sessionId }),
-  maxSteps: 3,
+  stopWhen: stepCountIs(3),
   prompt: 'What should we work on today?',
 });
 
@@ -211,7 +201,7 @@ honcho.middleware({
 })
 ```
 
-Honcho still injects the user's representation and peer card into the system prompt, and still persists messages after generation.
+Honcho still injects the user's representation and peer card into the system prompt, and still persists messages after generation. With `injectHistory: false` you must pass a `messages` array — without either `messages` or `prompt`, the Vercel AI SDK throws `Invalid prompt: prompt or messages must be defined`.
 
 ## Verifying the Integration
 
@@ -275,7 +265,7 @@ If the model calls the tool and returns a synthesized answer, the full tool pipe
 
 import 'dotenv/config';
 import { createHoncho } from '@honcho-ai/vercel-ai-sdk';
-import { wrapLanguageModel, generateText } from 'ai';
+import { wrapLanguageModel, generateText, stepCountIs } from 'ai';
 import { anthropic } from '@ai-sdk/anthropic';
 import * as readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
@@ -296,7 +286,7 @@ async function chat(prompt: string): Promise<string> {
   const { text } = await generateText({
     model,
     tools: honcho.tools({ userId, sessionId }),
-    maxSteps: 3,
+    stopWhen: stepCountIs(3),
     prompt,
   });
   return text;
@@ -327,7 +317,7 @@ main().catch((err) => {
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Package Source" icon="github" href="https://github.com/plastic-labs/vercel-ai-sdk-package">
+  <Card title="Github Repository" icon="github" href="https://github.com/plastic-labs/vercel-ai-sdk-package">
     Source, tests, and full API reference for @honcho-ai/vercel-ai-sdk.
   </Card>
 

--- a/docs/v3/guides/integrations/vercel-ai-sdk.mdx
+++ b/docs/v3/guides/integrations/vercel-ai-sdk.mdx
@@ -14,7 +14,7 @@ The full package source and examples are available on [GitHub](https://github.co
 
 ## What We're Building
 
-We'll wire Honcho into a Vercel AI SDK app so the model automatically receives context from past conversations and can query what it knows about the user mid-generation. Here's how the pieces fit together:
+We'll wire Honcho into a Vercel AI SDK app so the model receives context from past conversations and can query what it knows about the user mid-generation. Here's how the pieces fit together:
 
 - **Vercel AI SDK** handles model calls and streaming
 - **Honcho** stores messages and retrieves user context before each generation
@@ -71,7 +71,7 @@ const honcho = createHoncho({
 
 ## Add Middleware
 
-`honcho.middleware()` is compatible with `wrapLanguageModel`. Two things happen automatically on each call:
+`honcho.middleware()` is compatible with `wrapLanguageModel`. Two things happen on each call:
 
 1. **Before generation** — Honcho fetches the user's representation, peer card, session summary, and recent messages and injects them into the system prompt
 2. **After generation** — the user message and assistant response are stored back in Honcho with correct peer attribution
@@ -130,7 +130,9 @@ const { text } = await generateText({
 
 ## Complete Example
 
-Here's a full working example combining middleware and tools:
+Here's a full working example combining middleware and tools.
+
+Want a runnable end-to-end version? See the [Full Script](#full-script).
 
 ```typescript
 import { createHoncho } from '@honcho-ai/vercel-ai-sdk';
@@ -205,11 +207,47 @@ Honcho still injects the user's representation and peer card into the system pro
 
 ## Verifying the Integration
 
-### 1. First turn
+### 1. Isolate Honcho's Contribution
+
+Let's confirm the memory is actually coming from Honcho and not your app's existing conversation history.
+
+Two ways to check: 1) through a developer method 2) through the UI.
+
+**Token delta (developer check).** On a session with a few prior turns, run the same prompt twice — once with `injectHistory: false` and once without.
+
+Compare `result.usage.inputTokens`:
+
+```typescript
+const baseline = await generateText({
+  model: wrapLanguageModel({
+    model: anthropic('claude-sonnet-4-6'),
+    middleware: honcho.middleware({ userId, sessionId, injectHistory: false }),
+  }),
+  prompt: 'What do you know about my preferences?',
+});
+
+const injected = await generateText({
+  model: wrapLanguageModel({
+    model: anthropic('claude-sonnet-4-6'),
+    middleware: honcho.middleware({ userId, sessionId }),
+  }),
+  prompt: 'What do you know about my preferences?',
+});
+
+console.log(injected.usage.inputTokens - baseline.usage.inputTokens);
+```
+
+A positive delta is Honcho's representation, peer card, and session summary being injected into the system prompt. Expect ~0 on a fresh peer — the deriver runs asynchronously after messages persist, so injected context only populates after a few prior turns.
+
+**Dashboard (UI check).** Open [app.honcho.dev/explore](https://app.honcho.dev/explore), select your workspace, and confirm your peer and session appear under the Peers and Sessions tables.
+
+With Honcho's contribution isolated, the rest of this section shows what the integration feels like in practice.
+
+### 2. First turn
 
 Send any message. The model responds normally — nothing is stored yet. Context injection returns empty on the first turn.
 
-### 2. Build memory across turns
+### 3. Build memory across turns
 
 Have a multi-turn conversation and share something about yourself:
 
@@ -225,7 +263,7 @@ What do you know about my preferences?
 
 If the model references TypeScript and concise answers without being told again in this session, memory is working.
 
-### 3. Cross-session recall
+### 4. Cross-session recall
 
 Start a new session (new `sessionId`). Ask:
 
@@ -235,13 +273,13 @@ Based on what we've talked about, what do you know about me?
 
 If the model recalls preferences from previous sessions without them being in the current conversation, cross-session memory is working. Honcho processed the prior turns between sessions and updated the user's representation.
 
-### 4. Test tool calling directly
+### 5. Test tool calling directly
 
 ```text
 Use your honcho_chat tool to tell me what patterns you've noticed about me.
 ```
 
-If the model calls the tool and returns a synthesized answer, the full tool pipeline is functional.
+If the model calls the tool and returns a synthesized answer, the full tool pipeline is functional. To confirm which tool fired, inspect `result.toolCalls` — tool names like `honcho_chat` appear there, not in `result.text`.
 
 ## Full Script
 

--- a/docs/v3/guides/integrations/vercel-ai-sdk.mdx
+++ b/docs/v3/guides/integrations/vercel-ai-sdk.mdx
@@ -265,25 +265,15 @@ If the model references TypeScript and concise answers without being told again 
 
 ### 4. Cross-session recall
 
-Start a new session (new `sessionId`). Ask:
-
-```text
-Based on what we've talked about, what do you know about me?
-```
-
-If the model recalls preferences from previous sessions without them being in the current conversation, cross-session memory is working. Honcho processed the prior turns between sessions and updated the user's representation.
-
-<Note>
-The deriver waits until 1024 tokens are accumulated before batch processing - short conversations won't trigger cross-session recall!
-</Note>
-
-### 5. Test tool calling directly
+Start a new session (new `sessionId`) with the same `userId`. Ask:
 
 ```text
 Call your honcho_search tool with the query 'TypeScript' and quote the exact verbatim message that contained TypeScript. Do not paraphrase.
 ```
 
-If the model returns the exact prior message word-for-word, the tool pipeline is functional. To confirm which tool fired, inspect `result.steps[i].toolCalls`:
+If the search returns a message from the prior session word-for-word, peer-scoped retrieval is crossing session boundaries. `honcho_search` queries the user's messages across all their sessions and doesn't depend on the deriver, so it works regardless of how short the prior session was.
+
+To confirm the tool actually fired, inspect `result.steps[i].toolCalls`:
 
 ```typescript
 const toolFires = result.steps?.flatMap((step, i) =>

--- a/tests/crud/test_representation_manager.py
+++ b/tests/crud/test_representation_manager.py
@@ -24,6 +24,7 @@ async def _fake_tracked_db(_name: str):
 
 def _saved_observations(mock_save: AsyncMock):
     call = mock_save.await_args
+    assert call is not None, "mock was not awaited"
     if "all_observations" in call.kwargs:
         return call.kwargs["all_observations"]
     if len(call.args) > 1:
@@ -162,7 +163,9 @@ class TestRepresentationManagerSoftDelete:
 
 class TestRepresentationManagerSave:
     @pytest.mark.asyncio
-    async def test_save_representation_filters_blank_observations_before_embedding(self):
+    async def test_save_representation_filters_blank_observations_before_embedding(
+        self,
+    ):
         manager = RepresentationManager(
             "workspace",
             observer="observer",
@@ -202,7 +205,7 @@ class TestRepresentationManagerSave:
                 message_ids=[1],
                 session_name="session",
                 message_created_at=datetime.now(timezone.utc),
-                message_level_configuration=SimpleNamespace(
+                message_level_configuration=SimpleNamespace(  # pyright: ignore[reportArgumentType]
                     dream=SimpleNamespace(enabled=False)
                 ),
             )
@@ -258,7 +261,7 @@ class TestRepresentationManagerSave:
                 message_ids=[1],
                 session_name="session",
                 message_created_at=datetime.now(timezone.utc),
-                message_level_configuration=SimpleNamespace(
+                message_level_configuration=SimpleNamespace(  # pyright: ignore[reportArgumentType]
                     dream=SimpleNamespace(enabled=False)
                 ),
             )
@@ -311,7 +314,7 @@ class TestRepresentationManagerSave:
                 message_ids=[1],
                 session_name="session",
                 message_created_at=datetime.now(timezone.utc),
-                message_level_configuration=SimpleNamespace(
+                message_level_configuration=SimpleNamespace(  # pyright: ignore[reportArgumentType]
                     dream=SimpleNamespace(enabled=False)
                 ),
             )

--- a/tests/routes/test_messages.py
+++ b/tests/routes/test_messages.py
@@ -1001,8 +1001,10 @@ async def test_create_message_without_timestamp_uses_default(
     db_session.add(test_session)
     await db_session.commit()
 
-    # Record time before request
-    before_request = datetime.datetime.now(datetime.timezone.utc)
+    # Pad the window to absorb client/Postgres clock skew under Docker.
+    before_request = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=1
+    )
 
     response = client.post(
         f"/v3/workspaces/{test_workspace.name}/sessions/{test_session.name}/messages",
@@ -1017,8 +1019,9 @@ async def test_create_message_without_timestamp_uses_default(
         },
     )
 
-    # Record time after request
-    after_request = datetime.datetime.now(datetime.timezone.utc)
+    after_request = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=1
+    )
 
     assert response.status_code == 201
     data = response.json()
@@ -1053,8 +1056,9 @@ async def test_create_batch_messages_with_mixed_timestamps(
     timestamp1 = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     timestamp2 = datetime.datetime(2023, 1, 2, 12, 0, 0, tzinfo=datetime.timezone.utc)
 
-    # Record time before request for default timestamp
-    before_request = datetime.datetime.now(datetime.timezone.utc)
+    before_request = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=1
+    )
 
     response = client.post(
         f"/v3/workspaces/{test_workspace.name}/sessions/{test_session.name}/messages",
@@ -1081,7 +1085,9 @@ async def test_create_batch_messages_with_mixed_timestamps(
         },
     )
 
-    after_request = datetime.datetime.now(datetime.timezone.utc)
+    after_request = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=1
+    )
 
     assert response.status_code == 201
     data = response.json()
@@ -1124,8 +1130,9 @@ async def test_create_message_with_null_timestamp(
     db_session.add(test_session)
     await db_session.commit()
 
-    # Record time before request
-    before_request = datetime.datetime.now(datetime.timezone.utc)
+    before_request = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=1
+    )
 
     response = client.post(
         f"/v3/workspaces/{test_workspace.name}/sessions/{test_session.name}/messages",
@@ -1141,7 +1148,9 @@ async def test_create_message_with_null_timestamp(
         },
     )
 
-    after_request = datetime.datetime.now(datetime.timezone.utc)
+    after_request = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=1
+    )
 
     assert response.status_code == 201
     data = response.json()


### PR DESCRIPTION
## Summary

Writes `vercel-ai-sdk.mdx` in SDK/build tool cookbook style similar to `CrewAI` and `LangGraph` docs.  

## Decisions

| ID | Type | Notes |
|---|---|---|
| 1 | Visual identity | Icon `wand-magic-sparkles` → `triangle` with `iconType: "solid"` to match Vercel's brand mark; disambiguated from Agent Zero's outline triangle. |
| 2 | Title casing | Section headings normalized to Title Case ("How It Works", "Quick Start", "Reasoning Tools"). |
| 3 | Package rename | Package renamed from `@honcho-ai/ai-sdk` to `@honcho-ai/vercel-ai-sdk`, scoping it to its actual integration target and avoiding name collision with future Honcho SDK adapters for other AI frameworks. |
| 4 | Reshape | Opener rewritten to cookbook formula: `Integrate Honcho with X to <benefit>. The [X](url) is <one-line description>. This guide shows you how to <scope>.` Sections reordered to one-concept-per-section spine: What We're Building → Setup → Create Provider → Add Middleware → Add Tools → Complete Example → Streaming → Using with messages → Verifying → Full Script → Next Steps. |
| 5 | Full Script added | New `## Full Script` section added before Next Steps, mirroring `gmail.mdx`. `<Accordion title="honcho_vercel_chat.ts">` wraps a ~60-line runnable multi-turn chat loop. |
| 6 | Code fix | `maxSteps: 3` → `stopWhen: stepCountIs(3)` in 3 code blocks; `stepCountIs` added to `'ai'` imports. `maxSteps` was dropped in ai-sdk v5 — without the fix, Full Script returns empty text on first turn. |
| 7 | Pruning | Setup: one prose line ("Get your API key at app.honcho.dev.") + bash block, Notes stripped, self-hosting moved to Next Steps. Notes: 6 → 1 (GitHub source link); cut architecture-prereq, `injectHistory: false` warning (inline prose), tools-null-on-fresh-users, async-deriver-lag. Concept Mapping table dropped; replaced with inline link to Architecture page. |

## Verification

Tested against a sandbox install of `@honcho-ai/vercel-ai-sdk` with real Honcho + Anthropic + OpenAI keys (`file:` install from local package, since not yet on npm). 

### Step 3 — Full Script (cookbook integration test for the whole page)

- [x] Pasted-as-is `honcho_vercel_chat.ts` from the doc's Accordion runs after the `maxSteps` → `stopWhen` fix
- [x] First turn: model responds normally
- [x] Build memory across 2-3 turns: model recalls TypeScript preference without re-prompt
- [x] Cross-session recall: new `sessionId`, same `userId` → recalled (immediate, no async wait needed)
- [x] Force tool call: model fires `honcho_chat`, returns synthesized answer

### Step 4 — divergent code blocks

- [x] `streamText` block (Streaming section): runs verbatim with `openai('gpt-4o')`, chunks visibly stream, exits clean
- [x] `injectHistory: false` block: token delta confirmed (16 tokens with flag set vs 117 default = ~101 tokens of suppressed Honcho context). Persistence still happens (4 messages saved on the test session)
- [x] Tools-only block: tools fire consistently, `maxSteps: 3` → `stopWhen: stepCountIs(3)` confirmed multi-step capable

### Step 5 — failure-mode probes

- [x] Bad API key → exits in 0.37s, no hang. Honcho 401 caught by middleware `onError` → `console.warn`; Anthropic 401 thrown as the actual exception.
- [x] Bad workspace ID → silently auto-creates the workspace; no error state. (Doc no longer makes the false implication that the workspace must exist beforehand.)
- [x] `userId: undefined` → SDK generates a random ID and logs `console.warn`. Matches doc's "lazily generated IDs" claim.
- [x] Repeated run with same `userId` + `sessionId` → context grows linearly, no duplication
- [x] `injectHistory: false` with no `messages` and no `prompt` → ai-sdk throws `Invalid prompt: prompt or messages must be defined` (clean, immediate)
- [ ] Network drop mid-stream — deferred (manual test later)

### Step 6 — cross-verify persistence

- [x] Workspace reachable, peers list returns expected 16 peers from the test runs
- [x] User messages carry user `peer_id`; assistant messages carry `peer_id: "assistant"` — no silent-drop, attribution clean
- [x] `injectHistory: false` session has 4 messages persisted (confirms persistence is independent of injection setting)
- [x] Representations form asynchronously (lag verified, expected per architecture)

### Step 7 — fresh-eyes test

- [ ] Local Mintlify preview + colleague walk-through (another human to review)

## Follow-up work

- **`@honcho-ai/vercel-ai-sdk` npm publish** — package is currently `file:` install only
- **Step 7 fresh-eyes test** — second human reviewer


## Linear

- Implementation ticket: [DEV-1485](https://linear.app/plastic-labs/issue/DEV-1485)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Vercel AI SDK integration guide in v3 Guides → Integrations covering install/env setup, middleware usage, tool-enabled memory and tool calls, injectHistory option, per-request user/session handling, verification steps, a runnable example, and links to related resources.
* **Tests**
  * Made timestamp tests tolerant of small clock skew and ensured certain async save calls are properly awaited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->