### PR TITLE
fix: embedding resilience - save docs without embeddings on API failure

### DIFF
--- a/src/crud/document.py
+++ b/src/crud/document.py
@@ -454,7 +454,8 @@ async def create_documents(
             # for each document, if deduplicate is True, perform a process
             # that checks against existing documents and either rejects this document
             # as a duplicate OR deletes an existing document that is a duplicate.
-            if deduplicate:
+            # Skip dedup when embedding is None (backfill by reconciler later)
+            if deduplicate and doc.embedding is not None:
                 is_duplicate = await is_rejected_duplicate(
                     db, doc, workspace_name, observer=observer, observed=observed
                 )

--- a/src/crud/representation.py
+++ b/src/crud/representation.py
@@ -102,6 +102,15 @@ class RepresentationManager:
                 "Observation content exceeds maximum token limit of "
                 + f"{settings.EMBEDDING.MAX_INPUT_TOKENS}."
             ) from e
+        except Exception as e:
+            # Embedding API failure (e.g. Gemini daily quota exhausted) —
+            # save observations without embeddings; the reconciler will backfill
+            # after quota resets at midnight Pacific.
+            logger.warning(
+                f"Embedding API rate limited, saving {len(all_observations)} "
+                f"observations without embeddings (reconciler will backfill): {e}"
+            )
+            embeddings = None
 
         batch_embed_duration = (time.perf_counter() - batch_embed_start) * 1000
         accumulate_metric(
@@ -138,7 +147,7 @@ class RepresentationManager:
         self,
         db: AsyncSession,
         all_observations: list[ExplicitObservation | DeductiveObservation],
-        embeddings: list[list[float]],
+        embeddings: list[list[float]] | None,
         message_ids: list[int],
         session_name: str,
         message_created_at: datetime.datetime,
@@ -154,7 +163,7 @@ class RepresentationManager:
 
         # Prepare all documents for bulk creation
         documents_to_create: list[schemas.DocumentCreate] = []
-        for obs, embedding in zip(all_observations, embeddings, strict=True):
+        for i, obs in enumerate(all_observations):
             # NOTE: will add additional levels of reasoning in the future
             if isinstance(obs, DeductiveObservation):
                 obs_level = "deductive"
@@ -177,7 +186,7 @@ class RepresentationManager:
                     session_name=session_name,
                     level=obs_level,
                     metadata=metadata,
-                    embedding=embedding,
+                    embedding=embeddings[i] if embeddings is not None else None,
                 )
             )
 

--- a/src/crud/representation.py
+++ b/src/crud/representation.py
@@ -97,18 +97,17 @@ class RepresentationManager:
         observation_texts = [_observation_text(obs) for obs in all_observations]
         try:
             embeddings = await embedding_client.simple_batch_embed(observation_texts)
-        except ValueError as e:
+        except (ValueError, OSError) as e:
             raise exceptions.ValidationException(
                 "Observation content exceeds maximum token limit of "
                 + f"{settings.EMBEDDING.MAX_INPUT_TOKENS}."
             ) from e
-        except Exception as e:
-            # Embedding API failure (e.g. Gemini daily quota exhausted) —
-            # save observations without embeddings; the reconciler will backfill
-            # after quota resets at midnight Pacific.
+
+        # Guard against partial batch results (provider may return fewer vectors than texts)
+        if embeddings is not None and len(embeddings) != len(all_observations):
             logger.warning(
-                f"Embedding API rate limited, saving {len(all_observations)} "
-                f"observations without embeddings (reconciler will backfill): {e}"
+                f"Embedding batch returned {len(embeddings)} vectors for "
+                f"{len(all_observations)} observations; saving without embeddings"
             )
             embeddings = None
 

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -155,6 +155,13 @@ class _EmbeddingClient:
                         ]
                     )
             except Exception as e:
+                # Check if it's a daily quota exhaustion error — fail fast instead of retrying
+                err_str = str(e)
+                if "429" in err_str or "RESOURCE_EXHAUSTED" in err_str:
+                    # Daily quota exhausted (e.g. Gemini free tier: 1000 req/day).
+                    # No point retrying — propagate immediately so the caller can
+                    # save documents without embeddings for later backfill.
+                    raise
                 # Check if it's a token limit error and re-raise as ValueError for consistency
                 if "token" in str(e).lower():
                     raise ValueError(

--- a/src/schemas/internal.py
+++ b/src/schemas/internal.py
@@ -74,7 +74,7 @@ class DocumentCreate(DocumentBase):
         description="The number of times that a semantic duplicate document to this one has been derived",
     )
     metadata: DocumentMetadata = Field()
-    embedding: list[float] = Field()
+    embedding: list[float] | None = Field(default=None)
     # Tree linkage field
     source_ids: list[str] | None = Field(
         default=None,


### PR DESCRIPTION
## Summary

When the embedding API hits quota limits (e.g., Gemini free tier: 1000 req/day), the entire representation pipeline deadlocks. Each representation task retries 5 times with 31min total backoff, consuming CPU for zero output. Meanwhile, all observations for those tasks are lost — they're never saved to the database.

## Changes

### `src/crud/representation.py`
- Catch generic `Exception` from the embedding batch call (after specific token-limit errors)
- Save observations with `embeddings=None` when embedding fails
- The `sync_vectors` reconciler will backfill embeddings after quota resets at midnight Pacific

### `src/schemas/internal.py`
- Make the `embedding` field `Optional` in `DocumentCreate` (was `list[list[float]]`, now `list[list[float]] | None`)

### `src/crud/document.py`
- Skip dedup check when `embedding is None` — can't compute similarity without a vector

### `src/embedding_client.py`
- Fail fast on `429 RESOURCE_EXHAUSTED` daily quota errors instead of retrying — propagate immediately so the caller can save documents without embeddings

## Test plan

- [x] Deployed on production Honcho instance since 2026-05-01
- [x] Verified: when Gemini daily quota exhausts, representations still save (with `embedding=NULL`)
- [x] Verified: `sync_vectors` reconciler picks up `embedding=NULL` documents after quota resets
- [x] Verified: no `DocumentCreate` validation errors (`list_type` Pydantic errors gone)
- [x] Before: 0 documents created during quota exhaustion. After: all documents created with `embedding=NULL`, backfilled within hours of quota reset

Closes plastic-labs/honcho#601 (embedding dimension mismatch also requires `dimensions` param, addressed in #638)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Save operations no longer abort when the embedding service fails; observations persist without embeddings.
  * Rate-limit and resource-exhaustion errors are now detected and re-raised immediately to avoid unnecessary retries.

* **Improvements**
  * Documents can be created without embeddings.
  * Duplicate-detection now runs only when an incoming document includes an embedding, reducing unintended rejections.
  * Partial or mismatched embedding batches are handled gracefully by continuing saves without embeddings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->