### PR TITLE
fix: pass provider params to OpenAI-compatible embeddings

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -330,6 +330,7 @@ class EmbeddingModelConfig(BaseModel):
     transport: EmbeddingTransport = "openai"
     api_key: str | None = None
     base_url: str | None = None
+    provider_params: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="before")
     @classmethod
@@ -452,6 +453,7 @@ def resolve_embedding_model_config(
         transport=configured.transport,
         api_key=api_key,
         base_url=configured.overrides.base_url,
+        provider_params=configured.overrides.provider_params,
     )
 
 

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import threading
 from collections import defaultdict
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import tiktoken
 from google import genai
@@ -38,6 +38,7 @@ class _EmbeddingClient:
         self.transport: str = config.transport
         self.model: str = config.model
         self.vector_dimensions: int = vector_dimensions
+        self.provider_params: dict[str, Any] = config.provider_params
 
         if self.transport == "gemini":
             if not config.api_key:
@@ -72,6 +73,14 @@ class _EmbeddingClient:
     def provider(self) -> str:
         return self.transport
 
+    def _openai_embedding_kwargs(self, input: str | list[str]) -> dict[str, Any]:
+        """Build kwargs for OpenAI embedding API calls with provider params."""
+        return {
+            "model": self.model,
+            "input": input,
+            **self.provider_params,
+        }
+
     def _validate_embedding_dimensions(self, embedding: list[float]) -> list[float]:
         if len(embedding) != self.vector_dimensions:
             raise ValueError(
@@ -99,7 +108,7 @@ class _EmbeddingClient:
             return self._validate_embedding_dimensions(response.embeddings[0].values)
         else:  # openai
             response = await self.client.embeddings.create(
-                model=self.model, input=[query]
+                **self._openai_embedding_kwargs([query])
             )
             return self._validate_embedding_dimensions(response.data[0].embedding)
 
@@ -136,8 +145,7 @@ class _EmbeddingClient:
                                 )
                 else:  # openai
                     response = await self.client.embeddings.create(
-                        input=batch,
-                        model=self.model,
+                        **self._openai_embedding_kwargs(batch)
                     )
                     embeddings.extend(
                         [
@@ -283,7 +291,7 @@ class _EmbeddingClient:
                                 )
                 else:  # openai
                     response = await self.client.embeddings.create(
-                        model=self.model, input=[item.text for item in batch]
+                        **self._openai_embedding_kwargs([item.text for item in batch])
                     )
                     for item, embedding_data in zip(batch, response.data, strict=True):
                         result[item.text_id][item.chunk_index] = (

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -434,6 +434,9 @@ class EmbeddingClient:
             runtime_config.model,
             runtime_config.api_key,
             runtime_config.base_url,
+            tuple(
+                sorted(runtime_config.provider_params.items())
+            ),  # Include provider_params in cache key
             settings.EMBEDDING.VECTOR_DIMENSIONS,
             settings.EMBEDDING.MAX_INPUT_TOKENS,
             settings.EMBEDDING.MAX_TOKENS_PER_REQUEST,

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -260,21 +260,26 @@ async def test_openai_embedding_client_passes_provider_params_to_chunked_batch_e
             provider_params={"dimensions": 8},
         ),
         vector_dimensions=8,
-        max_input_tokens=8192,
+        max_input_tokens=1,  # Force chunking by setting very low token limit
         max_tokens_per_request=300_000,
     )
 
-    text = "hello world"
+    text = "hello world " * 100  # Long text to trigger chunking
     result = await client.batch_embed({"doc-1": (text, client.encoding.encode(text))})
 
-    assert result == {"doc-1": [[0.1] * 8]}
-    assert fake_embeddings.calls == [
-        {
-            "model": "text-embedding-v4",
-            "input": ["hello world"],
-            "dimensions": 8,
-        }
-    ]
+    # With max_input_tokens=1, the text will be chunked into multiple pieces
+    # Each chunk gets embedded, so we expect multiple embedding vectors
+    assert "doc-1" in result
+    assert len(result["doc-1"]) > 1  # Should have multiple chunks
+    assert all(
+        emb == [0.1] * 8 for emb in result["doc-1"]
+    )  # Each chunk has same embedding
+
+    # Verify provider_params were passed in all chunk calls
+    assert len(fake_embeddings.calls) > 0
+    for call in fake_embeddings.calls:
+        assert call["model"] == "text-embedding-v4"
+        assert call["dimensions"] == 8
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -3,7 +3,11 @@ from typing import Any
 
 import pytest
 
-from src.config import EmbeddingModelConfig
+from src.config import (
+    ConfiguredEmbeddingModelSettings,
+    EmbeddingModelConfig,
+    resolve_embedding_model_config,
+)
 from src.embedding_client import _EmbeddingClient  # pyright: ignore[reportPrivateUsage]
 
 
@@ -12,8 +16,10 @@ class FakeOpenAIEmbeddingsAPI:
         self.embedding: list[float] = embedding
         self.calls: list[dict[str, Any]] = []
 
-    async def create(self, *, model: str, input: str | list[str]) -> SimpleNamespace:
-        self.calls.append({"model": model, "input": input})
+    async def create(
+        self, *, model: str, input: str | list[str], **kwargs: Any
+    ) -> SimpleNamespace:
+        self.calls.append({"model": model, "input": input, **kwargs})
         if isinstance(input, list):
             data = [SimpleNamespace(embedding=self.embedding) for _ in input]
         else:
@@ -136,4 +142,168 @@ async def test_gemini_embedding_client_uses_output_dimensionality(
             "contents": "hello world",
             "config": {"output_dimensionality": 12},
         }
+    ]
+
+
+def test_resolve_embedding_model_config_preserves_provider_params() -> None:
+    configured = ConfiguredEmbeddingModelSettings(
+        model="text-embedding-v4",
+        transport="openai",
+        overrides={
+            "base_url": "https://example.test/v1",
+            "api_key": "test-key",
+            "provider_params": {"dimensions": 1536},
+        },
+    )
+
+    resolved = resolve_embedding_model_config(configured)
+
+    assert resolved.model == "text-embedding-v4"
+    assert resolved.transport == "openai"
+    assert resolved.base_url == "https://example.test/v1"
+    assert resolved.api_key == "test-key"
+    assert resolved.provider_params == {"dimensions": 1536}
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_client_passes_provider_params_to_single_embed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_embeddings = FakeOpenAIEmbeddingsAPI(embedding=[0.1] * 8)
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai",
+            model="text-embedding-v4",
+            api_key="test-key",
+            base_url="https://example.test/v1",
+            provider_params={"dimensions": 8},
+        ),
+        vector_dimensions=8,
+        max_input_tokens=8192,
+        max_tokens_per_request=300_000,
+    )
+
+    result = await client.embed("hello world")
+
+    assert result == [0.1] * 8
+    assert fake_embeddings.calls == [
+        {
+            "model": "text-embedding-v4",
+            "input": ["hello world"],
+            "dimensions": 8,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_client_passes_provider_params_to_simple_batch_embed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_embeddings = FakeOpenAIEmbeddingsAPI(embedding=[0.1] * 8)
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai",
+            model="text-embedding-v4",
+            api_key="test-key",
+            base_url="https://example.test/v1",
+            provider_params={"dimensions": 8},
+        ),
+        vector_dimensions=8,
+        max_input_tokens=8192,
+        max_tokens_per_request=300_000,
+    )
+
+    result = await client.simple_batch_embed(["hello", "world"])
+
+    assert result == [[0.1] * 8, [0.1] * 8]
+    assert fake_embeddings.calls == [
+        {
+            "model": "text-embedding-v4",
+            "input": ["hello", "world"],
+            "dimensions": 8,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_client_passes_provider_params_to_chunked_batch_embed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_embeddings = FakeOpenAIEmbeddingsAPI(embedding=[0.1] * 8)
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai",
+            model="text-embedding-v4",
+            api_key="test-key",
+            base_url="https://example.test/v1",
+            provider_params={"dimensions": 8},
+        ),
+        vector_dimensions=8,
+        max_input_tokens=8192,
+        max_tokens_per_request=300_000,
+    )
+
+    text = "hello world"
+    result = await client.batch_embed({"doc-1": (text, client.encoding.encode(text))})
+
+    assert result == {"doc-1": [[0.1] * 8]}
+    assert fake_embeddings.calls == [
+        {
+            "model": "text-embedding-v4",
+            "input": ["hello world"],
+            "dimensions": 8,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_client_omits_provider_params_when_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_embeddings = FakeOpenAIEmbeddingsAPI(embedding=[0.1] * 8)
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai",
+            model="text-embedding-3-small",
+            api_key="test-key",
+            base_url="https://example.test/v1",
+        ),
+        vector_dimensions=8,
+        max_input_tokens=8192,
+        max_tokens_per_request=300_000,
+    )
+
+    result = await client.embed("hello world")
+
+    assert result == [0.1] * 8
+    assert fake_embeddings.calls == [
+        {"model": "text-embedding-3-small", "input": ["hello world"]}
     ]


### PR DESCRIPTION
Allow embedding provider-specific parameters to be passed through to OpenAI-compatible embedding APIs. This enables providers that support configurable output dimensions (e.g., via a dimensions parameter) to return embeddings matching Honcho's configured VECTOR_DIMENSIONS.

Changes:
- Add provider_params field to EmbeddingModelConfig
- Preserve embedding overrides.provider_params during config resolution
- Pass provider params to all three OpenAI embedding call sites
- Add tests for single and batch embedding calls with provider params
- Add backward compatibility test proving empty provider_params works

The implementation reuses the existing provider_params pattern from ModelOverrideSettings, keeping the change backward-compatible. Existing configs without provider_params behave identically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding models now accept and forward provider-specific parameters (e.g., dimensions) to the embedding provider for single and batch requests.

* **Bug Fixes**
  * Client re-initialization now respects changes to provider-specific parameters so updates take effect.

* **Tests**
  * Added tests verifying provider-parameter preservation, forwarding, and omission when not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->