### PR TITLE
fix(llm): pass base_url to default provider clients from LLMSettings

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -648,6 +648,12 @@ class LLMSettings(HonchoSettings):
     OPENAI_API_KEY: str | None = None
     GEMINI_API_KEY: str | None = None
 
+    # Base URLs for LLM providers (for OpenAI-compatible proxies like
+    # OpenRouter, vLLM, Together, Anyscale, self-hosted, etc.)
+    ANTHROPIC_BASE_URL: str | None = None
+    OPENAI_BASE_URL: str | None = None
+    GEMINI_BASE_URL: str | None = None
+
     # General LLM settings
     DEFAULT_MAX_TOKENS: Annotated[int, Field(default=1000, gt=0, le=100_000)] = 2500
 

--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -38,6 +38,7 @@ def get_anthropic_client() -> AsyncAnthropic:
     """Default Anthropic client built from settings.LLM.ANTHROPIC_API_KEY."""
     return AsyncAnthropic(
         api_key=settings.LLM.ANTHROPIC_API_KEY,
+        base_url=settings.LLM.ANTHROPIC_BASE_URL,
         timeout=600.0,
     )
 
@@ -47,13 +48,19 @@ def get_openai_client() -> AsyncOpenAI:
     """Default OpenAI client built from settings.LLM.OPENAI_API_KEY."""
     return AsyncOpenAI(
         api_key=settings.LLM.OPENAI_API_KEY,
+        base_url=settings.LLM.OPENAI_BASE_URL,
     )
 
 
 @lru_cache(maxsize=1)
 def get_gemini_client() -> genai.Client:
     """Default Gemini client built from settings.LLM.GEMINI_API_KEY."""
-    return genai.Client(api_key=settings.LLM.GEMINI_API_KEY)
+    http_options = (
+        genai_types.HttpOptions(base_url=settings.LLM.GEMINI_BASE_URL)
+        if settings.LLM.GEMINI_BASE_URL
+        else None
+    )
+    return genai.Client(api_key=settings.LLM.GEMINI_API_KEY, http_options=http_options)
 
 
 # Bounded cache — in practice the (base_url, api_key) key space is small
@@ -91,17 +98,25 @@ CLIENTS: dict[ModelTransport, ProviderClient] = {}
 if settings.LLM.ANTHROPIC_API_KEY:
     CLIENTS["anthropic"] = AsyncAnthropic(
         api_key=settings.LLM.ANTHROPIC_API_KEY,
+        base_url=settings.LLM.ANTHROPIC_BASE_URL,
         timeout=600.0,
     )
 
 if settings.LLM.OPENAI_API_KEY:
     CLIENTS["openai"] = AsyncOpenAI(
         api_key=settings.LLM.OPENAI_API_KEY,
+        base_url=settings.LLM.OPENAI_BASE_URL,
     )
 
 if settings.LLM.GEMINI_API_KEY:
+    http_options = (
+        genai_types.HttpOptions(base_url=settings.LLM.GEMINI_BASE_URL)
+        if settings.LLM.GEMINI_BASE_URL
+        else None
+    )
     CLIENTS["gemini"] = genai.client.Client(
         api_key=settings.LLM.GEMINI_API_KEY,
+        http_options=http_options,
     )
 
 

--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -114,7 +114,7 @@ if settings.LLM.GEMINI_API_KEY:
         if settings.LLM.GEMINI_BASE_URL
         else None
     )
-    CLIENTS["gemini"] = genai.client.Client(
+    CLIENTS["gemini"] = genai.Client(
         api_key=settings.LLM.GEMINI_API_KEY,
         http_options=http_options,
     )


### PR DESCRIPTION
## Summary

Fixes #641 — when self-hosting Honcho with an OpenAI-compatible provider (OpenRouter, vLLM, Together, Anyscale, etc.), every LLM call fails with 401 because the default `AsyncOpenAI` client always hits `https://api.openai.com/v1` instead of the configured proxy.

## Root Cause

`LLMSettings` has `OPENAI_API_KEY` but **no** `OPENAI_BASE_URL` field (same for Anthropic and Gemini). The default client construction in `registry.py` never passes `base_url`:

```python
# Before — always hits api.openai.com
CLIENTS["openai"] = AsyncOpenAI(
    api_key=settings.LLM.OPENAI_API_KEY,
)
```

The per-service override path (`MODEL_CONFIG__OVERRIDES__BASE_URL`) works correctly, but operators who set `LLM_OPENAI_BASE_URL` in `.env` expect the default client to use it too.

## Changes

1. **`src/config.py`**: Add `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, `GEMINI_BASE_URL` to `LLMSettings` (env vars: `LLM_OPENAI_BASE_URL`, `LLM_ANTHROPIC_BASE_URL`, `LLM_GEMINI_BASE_URL`).

2. **`src/llm/registry.py`**: Pass `base_url` from settings to all three default client constructors (`CLIENTS` dict entries and `get_*_client()` helpers).

## Backward Compatibility

All three `*_BASE_URL` fields default to `None`, so existing deployments that don't set them are unaffected. The `AsyncOpenAI(api_key=..., base_url=None)` behavior is identical to `AsyncOpenAI(api_key=...)` — the SDK uses its default endpoint.

## Test Plan

- Set `LLM_OPENAI_BASE_URL=https://openrouter.ai/api/v1` and `LLM_OPENAI_API_KEY=sk-or-v1-...` in `.env`
- Start Honcho and call any dialectic/deriver/summary endpoint
- Verify requests go to `openrouter.ai` instead of `api.openai.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure custom base URLs for multiple LLM providers (Anthropic, OpenAI-compatible services, Gemini) via configuration files or environment variables.
  * Runtime connections to LLM providers will honor these configured endpoints, enabling use of self-hosted or alternative provider deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/643)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->