### PR TITLE
fix: add JSON-only output instructions to deriver prompt

### DIFF
--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -45,6 +45,13 @@ EXAMPLES:
 - EXPLICIT: "I took my dog for a walk in NYC" → "{peer_id} has a dog", "{peer_id} lives in NYC"
 - EXPLICIT: "{peer_id} attended college" + general knowledge → "{peer_id} completed high school or equivalent"
 
+OUTPUT FORMAT:
+Return ONLY valid JSON. No markdown. No explanation. No prose before or after the JSON.
+The JSON must exactly match this shape:
+{{"explicit":[{{"content":"self-contained fact about {peer_id}"}}]}}
+If there are no explicit facts about {peer_id}, return exactly:
+{{"explicit":[]}}
+
 Messages to analyze:
 <messages>
 {messages}

--- a/tests/llm/test_deriver_prompts.py
+++ b/tests/llm/test_deriver_prompts.py
@@ -1,0 +1,13 @@
+from src.deriver.prompts import minimal_deriver_prompt
+
+
+def test_minimal_deriver_prompt_requires_json_only_output() -> None:
+    prompt = minimal_deriver_prompt(
+        peer_id="alice",
+        messages="[2026-05-03] alice: I enjoy hiking on weekends.",
+    )
+
+    assert "Return ONLY valid JSON" in prompt
+    assert "No markdown" in prompt
+    assert '"explicit"' in prompt
+    assert '{"explicit":[]}' in prompt


### PR DESCRIPTION
## Summary

- Adds explicit JSON-only output format instructions to the minimal deriver prompt

## Rationale

Some OpenAI-compatible providers accept `response_format=json_schema` but do not reliably enforce it, returning natural language instead of JSON. Adding explicit natural-language instructions in the prompt gives these providers a fallback signal to return valid JSON even when they ignore the schema constraint.

## Test plan

- `uv run pytest tests/llm/test_deriver_prompts.py -q`
- `uv run ruff check src/deriver/prompts.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the deriver prompt to enforce strict JSON-only output format, eliminating potential markdown interference with response parsing.

* **Tests**
  * Added test coverage validating JSON-only output requirements and response format specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->