### PR TITLE
fix(deriver): disable json_mode when response_model specified to fix empty content on non-OpenAI providers

### DIFF
--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -135,7 +135,8 @@ async def process_representation_tasks_batch(
         max_tokens=max_tokens,
         track_name="Minimal Deriver",
         response_model=PromptRepresentation,
-        json_mode=True,
+        json_mode=False,  # Changed from True: rely on prompt instructions instead of
+        # response_format to avoid empty content from non-OpenAI providers
         max_input_tokens=settings.DERIVER.MAX_INPUT_TOKENS,
         enable_retry=True,
         retry_attempts=3,

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -45,6 +45,13 @@ EXAMPLES:
 - EXPLICIT: "I took my dog for a walk in NYC" → "{peer_id} has a dog", "{peer_id} lives in NYC"
 - EXPLICIT: "{peer_id} attended college" + general knowledge → "{peer_id} completed high school or equivalent"
 
+OUTPUT FORMAT:
+Return ONLY valid JSON. Do not wrap the response in markdown code fences or add any prose before or after the JSON.
+The JSON must match exactly this shape, with no extra fields:
+{{"explicit":[{{"content":"your self-contained observation here"}}]}}
+If there are no explicit facts about {peer_id}, return exactly:
+{{"explicit":[]}}
+
 Messages to analyze:
 <messages>
 {messages}


### PR DESCRIPTION
## Summary

This PR addresses the **root cause** of "Repair failed: Expecting value: line 1 column 1" errors in the deriver when using non-OpenAI providers (Ollama, etc.) with models that return structured data in `reasoning`/`refusal` fields instead of `content`.

It complements PR #644 by targeting the **LLM API layer** rather than relying solely on prompt engineering.

## Root Cause

When `response_model` is passed alongside `json_mode=True`, Honcho sets `response_format={type: "json_object"}`. Some providers accept this but:

1. **Ignore** the JSON schema constraint
2. **Return empty `content`** — JSON lands in `reasoning` or `refusal` fields
3. `response.content` = `None` or `""`
4. JSON repair fails with `Expecting value: line 1 column 1`

**Confirmed with:** `deepseek/deepseek-v3-0324` via Ollama Cloud

## Changes

### 1. `src/deriver/deriver.py` — Disable `json_mode` when `response_model` is specified
- `json_mode=True` → `json_mode=False`
- Rely on `response_model` pydantic parsing + prompt instructions instead of `response_format` enforcement

### 2. `src/deriver/prompts.py` — Added explicit JSON output instructions
```
OUTPUT FORMAT:
Return ONLY valid JSON. Do not wrap the response in markdown code fences.
The JSON must match exactly this shape:
{"explicit":[{"content":"your observation here"}]}
If there are no facts, return exactly: {"explicit":[]}
```

This combines PR #644's approach with the actual root cause fix.

## Test Plan
- [x] `response.content` is non-empty with `json_mode=False` on Ollama
- [x] `PromptRepresentation` parsing succeeds
- [x] No API changes, fully backward compatible

## Related
- PR #644 (prompt-only JSON instruction fix)
- Closes silent deriver stall on non-OpenAI providers

## Deployment Notes
No config changes required for self-hosted Ollama/OpenRouter deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with non-OpenAI language model providers
  * Enhanced output format consistency for data derivation processes to prevent empty responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->