### PR TITLE
fix(tests/unified): use argparse mutex group for --test-dir/--test-file

### DIFF
--- a/tests/unified/run.py
+++ b/tests/unified/run.py
@@ -12,13 +12,13 @@ from tests.unified.runner import UnifiedTestRunner
 
 async def main():
     parser = argparse.ArgumentParser(description="Run Unified Honcho Tests")
-    parser.add_argument(
+    target_group = parser.add_mutually_exclusive_group()
+    target_group.add_argument(
         "--test-dir",
         type=str,
-        default="tests/unified/test_cases",
         help="Directory containing JSON test files",
     )
-    parser.add_argument(
+    target_group.add_argument(
         "--test-file",
         type=str,
         help="Path to a single JSON test file to run",
@@ -32,10 +32,8 @@ async def main():
 
     args = parser.parse_args()
 
-    # Validate mutually exclusive args
-    if args.test_file and args.test_dir != "tests/unified/test_cases":
-        print("Error: Cannot specify both --test-file and --test-dir")
-        sys.exit(1)
+    if args.test_file is None and args.test_dir is None:
+        args.test_dir = "tests/unified/test_cases"
 
     if args.test_file:
         test_path = Path(args.test_file)


### PR DESCRIPTION
The previous mutual-exclusion check compared --test-dir against its default string literal, so passing --test-file together with an explicit --test-dir tests/unified/test_cases silently bypassed the check. Replace with argparse.add_mutually_exclusive_group() and apply the default path post-parse so the bare invocation still works.

  - Replace with `argparse.add_mutually_exclusive_group()`; apply the default path post-parse so the bare `python -m tests.unified.run` invocation still works.
  - Net diff: +5 / -7 in one file.                                                                                                                                                                                   
                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                       
  - [x] `python -m tests.unified.run --help` renders the mutex group                                                                                                                                                 
  - [x] `python -m tests.unified.run --test-file x --test-dir y` exits with argparse's standard "not allowed with argument" error                                                                                    
  - [x] `python -m tests.unified.run` (no flags) still defaults to `tests/unified/test_cases`                                                                                                                        
  - [ ] CI `unified-tests.yml` workflow runs green (only call site, uses no flags) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test runner command-line argument handling with mutually-exclusive option groups and fallback defaults, reducing configuration errors when running tests without explicit arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->