### PR TITLE
feat(deriver): add optional external telemetry hook

### DIFF
--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import time
 
@@ -5,6 +6,7 @@ from src import crud
 from src.config import ConfiguredModelSettings, settings
 from src.crud.representation import RepresentationManager
 from src.dependencies import tracked_db
+from src.external_telemetry import log_llm_call as _external_telemetry_log
 from src.llm import honcho_llm_call
 from src.models import Message
 from src.schemas import ResolvedConfiguration
@@ -148,6 +150,18 @@ async def process_representation_tasks_batch(
         "llm_call_duration",
         llm_duration,
         "ms",
+    )
+
+    # Optional external telemetry. Errors are swallowed inside log_llm_call.
+    asyncio.create_task(
+        _external_telemetry_log(
+            component="honcho-deriver",
+            model=settings.DERIVER.MODEL,
+            prompt_tokens=getattr(response, "input_tokens", None),
+            completion_tokens=getattr(response, "output_tokens", None),
+            latency_s=llm_duration / 1000.0,
+            session_id=latest_message.session_name,
+        )
     )
 
     # Prometheus metrics

--- a/src/external_telemetry.py
+++ b/src/external_telemetry.py
@@ -1,0 +1,80 @@
+"""
+external_telemetry.py -- optional async telemetry hook for Honcho components.
+
+Posts LLM usage metadata to an operator-configured HTTP endpoint. Never raises;
+all errors are logged and swallowed so a telemetry collector outage cannot block
+the deriver or any other caller.
+
+Usage (inside an async function):
+    from src.external_telemetry import log_llm_call
+
+    await log_llm_call(
+        component="honcho-deriver",
+        model="example-model",
+        prompt_tokens=1234,
+        completion_tokens=56,
+        latency_s=1.83,
+        session_id=session_name,
+    )
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Optional endpoint for operators who want to collect LLM usage outside Honcho.
+_TELEMETRY_URL = os.environ.get("HONCHO_EXTERNAL_TELEMETRY_URL")
+_TIMEOUT_S = 2.0  # short timeout so we never block the event loop for long
+
+
+async def log_llm_call(
+    *,
+    component: str,
+    model: Optional[str] = None,
+    prompt_tokens: Optional[int] = None,
+    completion_tokens: Optional[int] = None,
+    reasoning_tokens: Optional[int] = None,
+    cost: Optional[float] = None,
+    latency_s: Optional[float] = None,
+    session_id: Optional[str] = None,
+) -> None:
+    """POST LLM usage metadata to an external telemetry endpoint. Never raises."""
+    if not _TELEMETRY_URL:
+        return
+
+    payload: dict = {"component": component}
+    if model is not None:
+        payload["model"] = model
+    if prompt_tokens is not None:
+        payload["prompt_tokens"] = prompt_tokens
+    if completion_tokens is not None:
+        payload["completion_tokens"] = completion_tokens
+    if reasoning_tokens is not None:
+        payload["reasoning_tokens"] = reasoning_tokens
+    if cost is not None:
+        payload["cost"] = cost
+    if latency_s is not None:
+        payload["latency_s"] = latency_s
+    if session_id is not None:
+        payload["session_id"] = session_id
+
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
+            resp = await client.post(_TELEMETRY_URL, json=payload)
+            if resp.status_code not in (200, 201):
+                logger.debug(
+                    "external telemetry: unexpected status %s from collector: %s",
+                    resp.status_code,
+                    resp.text[:200],
+                )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        # Swallow all errors at DEBUG level so collector outages are invisible.
+        logger.debug("external telemetry: post failed (ignored): %s", exc)


### PR DESCRIPTION
# Add optional external telemetry hook for deriver LLM calls

## Problem

Operators may want to export deriver LLM usage metadata, such as model name, token counts, latency, and session id, to their own telemetry collector. Honcho currently does not expose a lightweight hook for this.

## Fix

Add `src/external_telemetry.py` with an async `log_llm_call` helper and call it from the deriver after the LLM request completes.

The hook is opt-in via `HONCHO_EXTERNAL_TELEMETRY_URL`. If the variable is unset, it is a no-op. If the collector is slow or unavailable, errors are logged at debug level and swallowed.

The deriver schedules the hook with `asyncio.create_task(...)` so telemetry export does not block batch processing.

## Files touched

- `src/external_telemetry.py`
- `src/deriver/deriver.py`

## Verification

- Syntax checked with `python3 -m py_compile src/deriver/deriver.py src/external_telemetry.py`.
- Suggested follow-up: add tests for unset URL, collector failure, and successful POST payload shape.
