### PR TITLE
fix(deriver): document minimal prompt JSON schema

### DIFF
--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -49,6 +49,16 @@ Messages to analyze:
 <messages>
 {messages}
 </messages>
+
+Return a JSON object with this exact schema:
+{{
+  "explicit": [
+    {{"content": "one atomic fact about {peer_id}"}},
+    {{"content": "another atomic fact about {peer_id}"}}
+  ]
+}}
+Each item inside the "explicit" array MUST be an object with a "content" string field (not a bare string).
+If there are no observations to extract, return {{"explicit": []}}.
 """
     )
 


### PR DESCRIPTION
# Document the minimal deriver prompt JSON schema

## Problem

The minimal deriver prompt asks for JSON output but does not show the exact schema expected by `PromptRepresentation`. Some JSON-mode providers can return an array of bare strings instead of an array of objects with a `content` field.

## Fix

Add explicit schema instructions to `minimal_deriver_prompt`:

```json
{"explicit": [{"content": "one atomic fact"}]}
```

The prompt also documents the empty result shape:

```json
{"explicit": []}
```

## Files touched

- `src/deriver/prompts.py`

## Verification

- Syntax checked with `python3 -m py_compile src/deriver/prompts.py`.
- Suggested follow-up: add a test that asserts the generated prompt contains the object-with-content example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened the output format for extracted observations to enforce a strict JSON schema.
  * Clarified representation of explicit findings as an array of objects for consistent downstream parsing.
  * Added explicit handling for empty extraction results to return a predictable empty-structure response, reducing ambiguity and parsing errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->