### PR TITLE
fix: graceful embedding fallback in dialectic search tools

### DIFF
--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -1468,6 +1468,13 @@ async def _handle_search_memory(ctx: ToolContext, tool_input: dict[str, Any]) ->
             "ERROR: Query exceeds maximum token limit of "
             + f"{settings.EMBEDDING.MAX_INPUT_TOKENS}. Please use a shorter query."
         )
+    except Exception as e:
+        logger.warning("Embedding unavailable for search_memory: %s", e)
+        return (
+            "Semantic search is unavailable (embedding model not configured). "
+            "Use grep_messages for exact text search or get_messages_by_date_range "
+            "for date-based retrieval instead."
+        )
 
     documents = await crud.query_documents(
         db=None,
@@ -1549,7 +1556,15 @@ async def _handle_search_messages(ctx: ToolContext, tool_input: dict[str, Any]) 
     limit = min(_safe_int(tool_input.get("limit"), 10), 20)  # Cap at 20
     # Pre-compute embedding outside DB session to avoid holding a connection
     # during the external API call (same pattern as _handle_search_memory).
-    query_embedding = await embedding_client.embed(query)
+    try:
+        query_embedding = await embedding_client.embed(query)
+    except Exception as e:
+        logger.warning("Embedding unavailable for search_messages: %s", e)
+        return (
+            "Semantic message search is unavailable (embedding model not configured). "
+            "Use grep_messages for exact text search or get_messages_by_date_range "
+            "for date-based retrieval instead."
+        )
     snippets = await crud.search_messages(
         workspace_name=ctx.workspace_name,
         session_name=ctx.session_name,
@@ -1703,7 +1718,15 @@ async def _handle_search_messages_temporal(
 
     # Pre-compute embedding outside DB session to avoid holding a connection
     # during the external API call.
-    query_embedding = await embedding_client.embed(query)
+    try:
+        query_embedding = await embedding_client.embed(query)
+    except Exception as e:
+        logger.warning("Embedding unavailable for search_messages_temporal: %s", e)
+        return (
+            "Temporal semantic search is unavailable (embedding model not configured). "
+            "Use grep_messages for exact text search or get_messages_by_date_range "
+            "for date-based retrieval instead."
+        )
     snippets = await crud.search_messages_temporal(
         workspace_name=ctx.workspace_name,
         session_name=ctx.session_name,


### PR DESCRIPTION
## Problem

When the embedding model is unavailable (e.g. API key is a placeholder like `not-needed`, or the gateway doesn't serve an embedding model), the dialectic agent's `search_memory`, `search_messages`, and `search_messages_temporal` tools throw `openai.AuthenticationError` which:

1. Produces noisy ERROR-level stack traces in container logs
2. Returns an unhelpful raw error message to the LLM agent
3. Wastes LLM tokens as the agent retries the same failing tool

## Fix

**Code changes** (`src/utils/agent_tools.py`):
- `_handle_search_memory`: Added `except Exception` handler (in addition to existing `ValueError` catch) that returns a clear fallback message directing the LLM to use `grep_messages` or `get_messages_by_date_range`
- `_handle_search_messages`: Wrapped `embedding_client.embed()` call in try/except with the same fallback pattern
- `_handle_search_messages_temporal`: Same treatment

**Config changes** (`.env`, not committed — gitignored):
- Configured `EMBEDDING_MODEL_CONFIG` to route through the Aperture/LMStudio gateway (`http://ai-gateway.bengal-wahoo.ts.net/v1`) so embeddings will work once a model is loaded
- Added comments explaining the embedding model requirement

## Behavior after fix

When embeddings are unavailable, instead of:
```
Tool search_memory failed unexpectedly: AuthenticationError: Error code: 401 - ...
```

The LLM receives:
```
Semantic search is unavailable (embedding model not configured).
Use grep_messages for exact text search or get_messages_by_date_range for date-based retrieval instead.
```

This allows the agent to immediately use working alternative tools without wasting iterations on retries.

_Conversation: https://app.warp.dev/conversation/f1a0932c-d22a-4a3d-a5e9-5665e11a448c_
_Run: https://oz.warp.dev/runs/019e0e79-64ad-7091-89b1-0ac63f685265_

_This PR was generated with [Oz](https://warp.dev/oz)._
