### PR TITLE
fix(llm): inject system prompt with JSON schema for structured output

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -357,9 +357,11 @@ class OpenAIBackend:
 
         cache_creation, cache_read = extract_openai_cache_tokens(usage)
         return CompletionResult(
-            content=content_override
-            if content_override is not None
-            else (message.content or ""),
+            content=(
+                content_override
+                if content_override is not None
+                else (message.content or "")
+            ),
             input_tokens=usage.prompt_tokens if usage else 0,
             output_tokens=usage.completion_tokens if usage else 0,
             cache_creation_input_tokens=cache_creation,
@@ -385,6 +387,23 @@ class OpenAIBackend:
                 "schema": response_format.model_json_schema(),
             },
         }
+
+        # Inject system prompt with schema for models that ignore response_format
+        schema_str = json.dumps(response_format.model_json_schema(), ensure_ascii=False)
+        system_injection = {
+            "role": "system",
+            "content": (
+                "You MUST respond with valid JSON only. "
+                "No markdown, no code fences, no bullet points, no explanations. "
+                f"Your response must strictly follow this JSON schema:\n{schema_str}\n"
+                "Respond with a raw JSON object only, starting with { and ending with }."
+            ),
+        }
+        messages = structured_params.get("messages", [])
+        has_system = any(m.get("role") == "system" for m in messages)
+        if not has_system:
+            structured_params["messages"] = [system_injection] + messages
+
         return await self._client.chat.completions.create(**structured_params)
 
     @staticmethod


### PR DESCRIPTION
## Summary
Some OpenAI-compatible models ignore the `response_format` parameter and return 
markdown-formatted JSON or include explanations, causing downstream parsing failures.

## Changes
- In `OpenAIBackend.generate_structured`, inject a system prompt containing the 
  target JSON schema when no existing system message is present.
- The injected prompt instructs the model to respond with raw JSON only, without 
  markdown or explanations.

## Motivation
Increases the robustness of structured output generation across models that do not 
strictly adhere to the `response_format` contract.

## Testing
- Existing structured output tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced structured output handling in the AI backend with automatic system message injection when needed, improving JSON schema compliance and response reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/668)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->