### PR TITLE
feat: add sort_by and sort_order params to session list endpoint

### DIFF
--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -131,6 +131,17 @@ async def get_sessions(
     if sort_by == "created_at":
         col = models.Session.created_at
         stmt = stmt.order_by(col.desc() if sort_order == "desc" else col.asc())
+    elif sort_by == "last_message_at":
+        last_msg_subq = (
+            select(func.max(models.Message.created_at))
+            .where(models.Message.session_name == models.Session.name)
+            .where(models.Message.workspace_name == models.Session.workspace_name)
+            .correlate(models.Session)
+            .scalar_subquery()
+        )
+        stmt = stmt.order_by(
+            last_msg_subq.desc() if sort_order == "desc" else last_msg_subq.asc()
+        )
     else:
         stmt = stmt.order_by(models.Session.created_at)
 

--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -117,8 +117,19 @@ async def get_sessions(
     sort_by: str | None = None,
     sort_order: str | None = None,
 ) -> Select[tuple[models.Session]]:
-    """
-    Get all active sessions in a workspace.
+    """Get all active sessions in a workspace.
+
+    Args:
+        workspace_name: Name of the workspace to query.
+        filters: Optional dictionary of filter conditions to apply.
+        sort_by: Field to sort by. Accepts ``"created_at"`` or
+            ``"last_message_at"``. Defaults to ``None`` (sorts by
+            ``created_at`` ascending).
+        sort_order: Sort direction. Accepts ``"asc"`` or ``"desc"``.
+            Defaults to ``None`` (ascending order).
+
+    Returns:
+        SQLAlchemy Select statement for querying Session objects.
     """
     stmt = (
         select(models.Session)

--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -114,6 +114,8 @@ def count_observers_in_config(
 async def get_sessions(
     workspace_name: str,
     filters: dict[str, Any] | None = None,
+    sort_by: str | None = None,
+    sort_order: str | None = None,
 ) -> Select[tuple[models.Session]]:
     """
     Get all active sessions in a workspace.
@@ -126,7 +128,13 @@ async def get_sessions(
 
     stmt = apply_filter(stmt, models.Session, filters)
 
-    return stmt.order_by(models.Session.created_at)
+    if sort_by == "created_at":
+        col = models.Session.created_at
+        stmt = stmt.order_by(col.desc() if sort_order == "desc" else col.asc())
+    else:
+        stmt = stmt.order_by(models.Session.created_at)
+
+    return stmt
 
 
 async def get_or_create_session(

--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -139,9 +139,10 @@ async def get_sessions(
             .correlate(models.Session)
             .scalar_subquery()
         )
-        stmt = stmt.order_by(
-            last_msg_subq.desc() if sort_order == "desc" else last_msg_subq.asc()
-        )
+        if sort_order == "desc":
+            stmt = stmt.order_by(last_msg_subq.desc().nulls_last())
+        else:
+            stmt = stmt.order_by(last_msg_subq.asc().nulls_last())
     else:
         stmt = stmt.order_by(models.Session.created_at)
 

--- a/src/routers/sessions.py
+++ b/src/routers/sessions.py
@@ -247,14 +247,25 @@ async def get_sessions(
 ):
     """Get all Sessions for a Workspace, paginated with optional filters."""
     filter_param = None
+    sort_by = None
+    sort_order = None
 
-    if options and hasattr(options, "filters") and options.filters:
-        filter_param = options.filters
-        if filter_param == {}:  # Explicitly check for empty dict
-            filter_param = None
+    if options:
+        if hasattr(options, "filters") and options.filters:
+            filter_param = options.filters
+            if filter_param == {}:  # Explicitly check for empty dict
+                filter_param = None
+        sort_by = options.sort_by
+        sort_order = options.sort_order
 
     return await apaginate(
-        db, await crud.get_sessions(workspace_name=workspace_id, filters=filter_param)
+        db,
+        await crud.get_sessions(
+            workspace_name=workspace_id,
+            filters=filter_param,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        ),
     )
 
 

--- a/src/routers/sessions.py
+++ b/src/routers/sessions.py
@@ -251,10 +251,7 @@ async def get_sessions(
     sort_order = None
 
     if options:
-        if hasattr(options, "filters") and options.filters:
-            filter_param = options.filters
-            if filter_param == {}:  # Explicitly check for empty dict
-                filter_param = None
+        filter_param = options.filters or None
         sort_by = options.sort_by
         sort_order = options.sort_order
 

--- a/src/schemas/api.py
+++ b/src/schemas/api.py
@@ -333,7 +333,7 @@ class SessionCreate(SessionBase):
 
 class SessionGet(SessionBase):
     filters: dict[str, Any] | None = None
-    sort_by: Literal["created_at"] | None = None
+    sort_by: Literal["created_at", "last_message_at"] | None = None
     sort_order: Literal["asc", "desc"] | None = None
 
 

--- a/src/schemas/api.py
+++ b/src/schemas/api.py
@@ -6,7 +6,7 @@ API contract.
 
 import datetime
 import ipaddress
-from typing import Annotated, Any, Self, cast
+from typing import Annotated, Any, Literal, Self, cast
 from urllib.parse import urlparse
 
 import tiktoken
@@ -333,6 +333,8 @@ class SessionCreate(SessionBase):
 
 class SessionGet(SessionBase):
     filters: dict[str, Any] | None = None
+    sort_by: Literal["created_at"] | None = None
+    sort_order: Literal["asc", "desc"] | None = None
 
 
 class SessionUpdate(SessionBase):

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -112,6 +112,148 @@ class TestSessionCRUD:
         assert returned_ids[:3] == session_ids
 
     @pytest.mark.asyncio
+    async def test_get_sessions_sort_by_last_message_at_desc(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Test get_sessions sorts by most recent message timestamp descending"""
+        test_workspace, test_peer = sample_data
+
+        # Create three sessions all at the same time
+        base_time = datetime.datetime.now(datetime.timezone.utc)
+        session_ids = []
+        for _i in range(3):
+            sid = str(generate_nanoid())
+            session_ids.append(sid)
+            session = models.Session(
+                name=sid,
+                workspace_name=test_workspace.name,
+                created_at=base_time,
+            )
+            db_session.add(session)
+        await db_session.flush()
+
+        # Add messages with different timestamps to each session.
+        # Session 0 gets the oldest message, session 2 gets the newest.
+        for i, sid in enumerate(session_ids):
+            msg = models.Message(
+                content=f"msg-{i}",
+                session_name=sid,
+                peer_name=test_peer.name,
+                workspace_name=test_workspace.name,
+                seq_in_session=1,
+                created_at=base_time + datetime.timedelta(seconds=i + 10),
+            )
+            db_session.add(msg)
+        await db_session.flush()
+
+        # Query with descending sort by last_message_at
+        stmt = await crud.get_sessions(
+            workspace_name=test_workspace.name,
+            sort_by="last_message_at",
+            sort_order="desc",
+        )
+        result = await db_session.execute(stmt)
+        sessions = result.scalars().all()
+        returned_ids = [s.name for s in sessions]
+
+        # Session 2 (newest message) should come first
+        assert returned_ids[:3] == session_ids[::-1]
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_sort_by_last_message_at_asc(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Test get_sessions sorts by most recent message timestamp ascending"""
+        test_workspace, test_peer = sample_data
+
+        base_time = datetime.datetime.now(datetime.timezone.utc)
+        session_ids = []
+        for _i in range(3):
+            sid = str(generate_nanoid())
+            session_ids.append(sid)
+            session = models.Session(
+                name=sid,
+                workspace_name=test_workspace.name,
+                created_at=base_time,
+            )
+            db_session.add(session)
+        await db_session.flush()
+
+        for i, sid in enumerate(session_ids):
+            msg = models.Message(
+                content=f"msg-{i}",
+                session_name=sid,
+                peer_name=test_peer.name,
+                workspace_name=test_workspace.name,
+                seq_in_session=1,
+                created_at=base_time + datetime.timedelta(seconds=i + 10),
+            )
+            db_session.add(msg)
+        await db_session.flush()
+
+        stmt = await crud.get_sessions(
+            workspace_name=test_workspace.name,
+            sort_by="last_message_at",
+            sort_order="asc",
+        )
+        result = await db_session.execute(stmt)
+        sessions = result.scalars().all()
+        returned_ids = [s.name for s in sessions]
+
+        # Session 0 (oldest message) should come first
+        assert returned_ids[:3] == session_ids
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_sort_by_last_message_at_no_messages(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Test last_message_at sort puts sessions with no messages last (desc)"""
+        test_workspace, test_peer = sample_data
+
+        base_time = datetime.datetime.now(datetime.timezone.utc)
+
+        # Session A has a message, session B does not
+        sid_a = str(generate_nanoid())
+        sid_b = str(generate_nanoid())
+        for sid in [sid_a, sid_b]:
+            session = models.Session(
+                name=sid,
+                workspace_name=test_workspace.name,
+                created_at=base_time,
+            )
+            db_session.add(session)
+        await db_session.flush()
+
+        msg = models.Message(
+            content="hello",
+            session_name=sid_a,
+            peer_name=test_peer.name,
+            workspace_name=test_workspace.name,
+            seq_in_session=1,
+            created_at=base_time + datetime.timedelta(seconds=5),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        stmt = await crud.get_sessions(
+            workspace_name=test_workspace.name,
+            sort_by="last_message_at",
+            sort_order="desc",
+        )
+        result = await db_session.execute(stmt)
+        sessions = result.scalars().all()
+        returned_ids = [s.name for s in sessions]
+
+        # Session with a message should come before the one without
+        assert returned_ids.index(sid_a) < returned_ids.index(sid_b)
+
+    @pytest.mark.asyncio
     async def test_get_session_peer_configuration(
         self,
         db_session: AsyncSession,

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from nanoid import generate as generate_nanoid
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,15 +18,18 @@ class TestSessionCRUD:
         sample_data: tuple[models.Workspace, models.Peer],
     ):
         """Test get_sessions returns sessions in descending created_at order"""
-        test_workspace, test_peer = sample_data
+        test_workspace, _ = sample_data
 
-        # Create three sessions in order
+        # Create three sessions with explicit monotonic timestamps
+        base_time = datetime.datetime.now(datetime.timezone.utc)
         session_ids = []
-        for _ in range(3):
+        for i in range(3):
             sid = str(generate_nanoid())
             session_ids.append(sid)
             session = models.Session(
-                name=sid, workspace_name=test_workspace.name
+                name=sid,
+                workspace_name=test_workspace.name,
+                created_at=base_time + datetime.timedelta(seconds=i),
             )
             db_session.add(session)
         await db_session.flush()
@@ -49,14 +54,17 @@ class TestSessionCRUD:
         sample_data: tuple[models.Workspace, models.Peer],
     ):
         """Test get_sessions returns sessions in ascending created_at order"""
-        test_workspace, test_peer = sample_data
+        test_workspace, _ = sample_data
 
+        base_time = datetime.datetime.now(datetime.timezone.utc)
         session_ids = []
-        for _ in range(3):
+        for i in range(3):
             sid = str(generate_nanoid())
             session_ids.append(sid)
             session = models.Session(
-                name=sid, workspace_name=test_workspace.name
+                name=sid,
+                workspace_name=test_workspace.name,
+                created_at=base_time + datetime.timedelta(seconds=i),
             )
             db_session.add(session)
         await db_session.flush()
@@ -80,14 +88,17 @@ class TestSessionCRUD:
         sample_data: tuple[models.Workspace, models.Peer],
     ):
         """Test that get_sessions defaults to ascending created_at order"""
-        test_workspace, test_peer = sample_data
+        test_workspace, _ = sample_data
 
+        base_time = datetime.datetime.now(datetime.timezone.utc)
         session_ids = []
-        for _ in range(3):
+        for i in range(3):
             sid = str(generate_nanoid())
             session_ids.append(sid)
             session = models.Session(
-                name=sid, workspace_name=test_workspace.name
+                name=sid,
+                workspace_name=test_workspace.name,
+                created_at=base_time + datetime.timedelta(seconds=i),
             )
             db_session.add(session)
         await db_session.flush()

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -254,6 +254,153 @@ class TestSessionCRUD:
         assert returned_ids.index(sid_a) < returned_ids.index(sid_b)
 
     @pytest.mark.asyncio
+    async def test_get_sessions_sort_by_last_message_at_nulls_last_asc(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Test last_message_at sort puts sessions with no messages last (asc)"""
+        test_workspace, test_peer = sample_data
+
+        base_time = datetime.datetime.now(datetime.timezone.utc)
+
+        # Session A has a message, session B does not
+        sid_a = str(generate_nanoid())
+        sid_b = str(generate_nanoid())
+        for sid in [sid_a, sid_b]:
+            session = models.Session(
+                name=sid,
+                workspace_name=test_workspace.name,
+                created_at=base_time,
+            )
+            db_session.add(session)
+        await db_session.flush()
+
+        msg = models.Message(
+            content="hello",
+            session_name=sid_a,
+            peer_name=test_peer.name,
+            workspace_name=test_workspace.name,
+            seq_in_session=1,
+            created_at=base_time + datetime.timedelta(seconds=5),
+        )
+        db_session.add(msg)
+        await db_session.flush()
+
+        stmt = await crud.get_sessions(
+            workspace_name=test_workspace.name,
+            sort_by="last_message_at",
+            sort_order="asc",
+        )
+        result = await db_session.execute(stmt)
+        sessions = result.scalars().all()
+        returned_ids = [s.name for s in sessions]
+
+        # Session with a message should come before the one without (NULLS LAST)
+        assert returned_ids.index(sid_a) < returned_ids.index(sid_b)
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_sort_by_last_message_at_mixed_nulls_desc(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Test that messageless sessions sort last among sessions with messages (desc)"""
+        test_workspace, test_peer = sample_data
+
+        base_time = datetime.datetime.now(datetime.timezone.utc)
+
+        # Create 3 sessions: 2 with messages, 1 without
+        sid_with_msg_1 = str(generate_nanoid())
+        sid_with_msg_2 = str(generate_nanoid())
+        sid_no_msg = str(generate_nanoid())
+        for sid in [sid_with_msg_1, sid_with_msg_2, sid_no_msg]:
+            session = models.Session(
+                name=sid,
+                workspace_name=test_workspace.name,
+                created_at=base_time,
+            )
+            db_session.add(session)
+        await db_session.flush()
+
+        # Give the two sessions messages with different timestamps
+        for i, sid in enumerate([sid_with_msg_1, sid_with_msg_2]):
+            msg = models.Message(
+                content=f"msg-{i}",
+                session_name=sid,
+                peer_name=test_peer.name,
+                workspace_name=test_workspace.name,
+                seq_in_session=1,
+                created_at=base_time + datetime.timedelta(seconds=i + 10),
+            )
+            db_session.add(msg)
+        await db_session.flush()
+
+        stmt = await crud.get_sessions(
+            workspace_name=test_workspace.name,
+            sort_by="last_message_at",
+            sort_order="desc",
+        )
+        result = await db_session.execute(stmt)
+        sessions = result.scalars().all()
+        returned_ids = [s.name for s in sessions]
+
+        # Descending: newest message first, no-message session last
+        assert returned_ids[0] == sid_with_msg_2
+        assert returned_ids[1] == sid_with_msg_1
+        assert returned_ids[2] == sid_no_msg
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_sort_by_last_message_at_mixed_nulls_asc(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Test that messageless sessions sort last among sessions with messages (asc)"""
+        test_workspace, test_peer = sample_data
+
+        base_time = datetime.datetime.now(datetime.timezone.utc)
+
+        # Create 3 sessions: 2 with messages, 1 without
+        sid_with_msg_1 = str(generate_nanoid())
+        sid_with_msg_2 = str(generate_nanoid())
+        sid_no_msg = str(generate_nanoid())
+        for sid in [sid_with_msg_1, sid_with_msg_2, sid_no_msg]:
+            session = models.Session(
+                name=sid,
+                workspace_name=test_workspace.name,
+                created_at=base_time,
+            )
+            db_session.add(session)
+        await db_session.flush()
+
+        for i, sid in enumerate([sid_with_msg_1, sid_with_msg_2]):
+            msg = models.Message(
+                content=f"msg-{i}",
+                session_name=sid,
+                peer_name=test_peer.name,
+                workspace_name=test_workspace.name,
+                seq_in_session=1,
+                created_at=base_time + datetime.timedelta(seconds=i + 10),
+            )
+            db_session.add(msg)
+        await db_session.flush()
+
+        stmt = await crud.get_sessions(
+            workspace_name=test_workspace.name,
+            sort_by="last_message_at",
+            sort_order="asc",
+        )
+        result = await db_session.execute(stmt)
+        sessions = result.scalars().all()
+        returned_ids = [s.name for s in sessions]
+
+        # Ascending: oldest message first, no-message session last (NULLS LAST)
+        assert returned_ids[0] == sid_with_msg_1
+        assert returned_ids[1] == sid_with_msg_2
+        assert returned_ids[2] == sid_no_msg
+
+    @pytest.mark.asyncio
     async def test_get_session_peer_configuration(
         self,
         db_session: AsyncSession,

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -10,6 +10,97 @@ class TestSessionCRUD:
     """Test suite for session CRUD operations"""
 
     @pytest.mark.asyncio
+    async def test_get_sessions_sort_by_created_at_desc(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Test get_sessions returns sessions in descending created_at order"""
+        test_workspace, test_peer = sample_data
+
+        # Create three sessions in order
+        session_ids = []
+        for _ in range(3):
+            sid = str(generate_nanoid())
+            session_ids.append(sid)
+            session = models.Session(
+                name=sid, workspace_name=test_workspace.name
+            )
+            db_session.add(session)
+        await db_session.flush()
+
+        # Query with descending sort
+        stmt = await crud.get_sessions(
+            workspace_name=test_workspace.name,
+            sort_by="created_at",
+            sort_order="desc",
+        )
+        result = await db_session.execute(stmt)
+        sessions = result.scalars().all()
+        returned_ids = [s.name for s in sessions]
+
+        # Our three sessions should appear in reverse creation order
+        assert returned_ids[:3] == session_ids[::-1]
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_sort_by_created_at_asc(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Test get_sessions returns sessions in ascending created_at order"""
+        test_workspace, test_peer = sample_data
+
+        session_ids = []
+        for _ in range(3):
+            sid = str(generate_nanoid())
+            session_ids.append(sid)
+            session = models.Session(
+                name=sid, workspace_name=test_workspace.name
+            )
+            db_session.add(session)
+        await db_session.flush()
+
+        # Query with ascending sort
+        stmt = await crud.get_sessions(
+            workspace_name=test_workspace.name,
+            sort_by="created_at",
+            sort_order="asc",
+        )
+        result = await db_session.execute(stmt)
+        sessions = result.scalars().all()
+        returned_ids = [s.name for s in sessions]
+
+        assert returned_ids[:3] == session_ids
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_default_sort_is_asc(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Test that get_sessions defaults to ascending created_at order"""
+        test_workspace, test_peer = sample_data
+
+        session_ids = []
+        for _ in range(3):
+            sid = str(generate_nanoid())
+            session_ids.append(sid)
+            session = models.Session(
+                name=sid, workspace_name=test_workspace.name
+            )
+            db_session.add(session)
+        await db_session.flush()
+
+        # Query with no sort params
+        stmt = await crud.get_sessions(workspace_name=test_workspace.name)
+        result = await db_session.execute(stmt)
+        sessions = result.scalars().all()
+        returned_ids = [s.name for s in sessions]
+
+        assert returned_ids[:3] == session_ids
+
+    @pytest.mark.asyncio
     async def test_get_session_peer_configuration(
         self,
         db_session: AsyncSession,

--- a/tests/routes/test_sessions.py
+++ b/tests/routes/test_sessions.py
@@ -315,6 +315,94 @@ def test_get_sessions_default_sort_is_asc(
     assert returned_ids[:3] == session_ids
 
 
+def test_get_sessions_sort_by_last_message_at_desc(
+    client: TestClient, sample_data: tuple[Workspace, Peer]
+):
+    """Test session listing sorted by most recent message, descending"""
+    test_workspace, test_peer = sample_data
+
+    # Create three sessions
+    session_ids = []
+    for _ in range(3):
+        sid = str(generate_nanoid())
+        session_ids.append(sid)
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions",
+            json={"id": sid, "peer_names": {test_peer.name: {}}},
+        )
+        assert response.status_code in [200, 201]
+
+    # Add a message to each session with explicit timestamps (oldest → newest)
+    for i, sid in enumerate(session_ids):
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions/{sid}/messages",
+            json={
+                "messages": [
+                    {
+                        "content": f"msg-{i}",
+                        "peer_id": test_peer.name,
+                        "created_at": f"2026-01-01T00:00:{i:02d}Z",
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 201
+
+    # List with descending sort by last_message_at
+    response = client.post(
+        f"/v3/workspaces/{test_workspace.name}/sessions/list",
+        json={"sort_by": "last_message_at", "sort_order": "desc"},
+    )
+    assert response.status_code == 200
+    items = response.json()["items"]
+    returned_ids = [item["id"] for item in items]
+
+    # Session 2 (newest message) should come first
+    assert returned_ids[:3] == session_ids[::-1]
+
+
+def test_get_sessions_sort_by_last_message_at_asc(
+    client: TestClient, sample_data: tuple[Workspace, Peer]
+):
+    """Test session listing sorted by most recent message, ascending"""
+    test_workspace, test_peer = sample_data
+
+    session_ids = []
+    for _ in range(3):
+        sid = str(generate_nanoid())
+        session_ids.append(sid)
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions",
+            json={"id": sid, "peer_names": {test_peer.name: {}}},
+        )
+        assert response.status_code in [200, 201]
+
+    for i, sid in enumerate(session_ids):
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions/{sid}/messages",
+            json={
+                "messages": [
+                    {
+                        "content": f"msg-{i}",
+                        "peer_id": test_peer.name,
+                        "created_at": f"2026-01-01T00:00:{i:02d}Z",
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 201
+
+    response = client.post(
+        f"/v3/workspaces/{test_workspace.name}/sessions/list",
+        json={"sort_by": "last_message_at", "sort_order": "asc"},
+    )
+    assert response.status_code == 200
+    items = response.json()["items"]
+    returned_ids = [item["id"] for item in items]
+
+    assert returned_ids[:3] == session_ids
+
+
 def test_update_delete_metadata(
     client: TestClient, sample_data: tuple[Workspace, Peer]
 ):

--- a/tests/routes/test_sessions.py
+++ b/tests/routes/test_sessions.py
@@ -223,6 +223,92 @@ def test_get_sessions_with_empty_filter(
     assert isinstance(data["items"], list)
 
 
+def test_get_sessions_sort_by_created_at_desc(
+    client: TestClient, sample_data: tuple[Workspace, Peer]
+):
+    """Test session listing with sort_by=created_at and sort_order=desc"""
+    test_workspace, test_peer = sample_data
+
+    # Create three sessions with distinct names so we can identify ordering
+    session_ids = []
+    for _ in range(3):
+        sid = str(generate_nanoid())
+        session_ids.append(sid)
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions",
+            json={"id": sid, "peer_names": {test_peer.name: {}}},
+        )
+        assert response.status_code in [200, 201]
+
+    # List with descending sort — newest (last created) should come first
+    response = client.post(
+        f"/v3/workspaces/{test_workspace.name}/sessions/list",
+        json={"sort_by": "created_at", "sort_order": "desc"},
+    )
+    assert response.status_code == 200
+    items = response.json()["items"]
+    returned_ids = [item["id"] for item in items]
+
+    # Our three sessions should appear in reverse creation order
+    assert returned_ids[:3] == session_ids[::-1]
+
+
+def test_get_sessions_sort_by_created_at_asc(
+    client: TestClient, sample_data: tuple[Workspace, Peer]
+):
+    """Test session listing with sort_by=created_at and sort_order=asc"""
+    test_workspace, test_peer = sample_data
+
+    session_ids = []
+    for _ in range(3):
+        sid = str(generate_nanoid())
+        session_ids.append(sid)
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions",
+            json={"id": sid, "peer_names": {test_peer.name: {}}},
+        )
+        assert response.status_code in [200, 201]
+
+    # List with ascending sort — oldest (first created) should come first
+    response = client.post(
+        f"/v3/workspaces/{test_workspace.name}/sessions/list",
+        json={"sort_by": "created_at", "sort_order": "asc"},
+    )
+    assert response.status_code == 200
+    items = response.json()["items"]
+    returned_ids = [item["id"] for item in items]
+
+    assert returned_ids[:3] == session_ids
+
+
+def test_get_sessions_default_sort_is_asc(
+    client: TestClient, sample_data: tuple[Workspace, Peer]
+):
+    """Test that the default sort order (no sort params) is created_at ascending"""
+    test_workspace, test_peer = sample_data
+
+    session_ids = []
+    for _ in range(3):
+        sid = str(generate_nanoid())
+        session_ids.append(sid)
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions",
+            json={"id": sid, "peer_names": {test_peer.name: {}}},
+        )
+        assert response.status_code in [200, 201]
+
+    # List with no sort params — should default to ascending
+    response = client.post(
+        f"/v3/workspaces/{test_workspace.name}/sessions/list",
+        json={},
+    )
+    assert response.status_code == 200
+    items = response.json()["items"]
+    returned_ids = [item["id"] for item in items]
+
+    assert returned_ids[:3] == session_ids
+
+
 def test_update_delete_metadata(
     client: TestClient, sample_data: tuple[Workspace, Peer]
 ):

--- a/tests/routes/test_sessions.py
+++ b/tests/routes/test_sessions.py
@@ -228,8 +228,9 @@ def test_get_sessions_sort_by_created_at_desc(
 ):
     """Test session listing with sort_by=created_at and sort_order=desc"""
     test_workspace, test_peer = sample_data
+    import time
 
-    # Create three sessions with distinct names so we can identify ordering
+    # Create three sessions with delays to ensure distinct timestamps
     session_ids = []
     for _ in range(3):
         sid = str(generate_nanoid())
@@ -239,6 +240,7 @@ def test_get_sessions_sort_by_created_at_desc(
             json={"id": sid, "peer_names": {test_peer.name: {}}},
         )
         assert response.status_code in [200, 201]
+        time.sleep(0.05)
 
     # List with descending sort — newest (last created) should come first
     response = client.post(
@@ -258,6 +260,7 @@ def test_get_sessions_sort_by_created_at_asc(
 ):
     """Test session listing with sort_by=created_at and sort_order=asc"""
     test_workspace, test_peer = sample_data
+    import time
 
     session_ids = []
     for _ in range(3):
@@ -268,6 +271,7 @@ def test_get_sessions_sort_by_created_at_asc(
             json={"id": sid, "peer_names": {test_peer.name: {}}},
         )
         assert response.status_code in [200, 201]
+        time.sleep(0.05)
 
     # List with ascending sort — oldest (first created) should come first
     response = client.post(
@@ -286,6 +290,7 @@ def test_get_sessions_default_sort_is_asc(
 ):
     """Test that the default sort order (no sort params) is created_at ascending"""
     test_workspace, test_peer = sample_data
+    import time
 
     session_ids = []
     for _ in range(3):
@@ -296,6 +301,7 @@ def test_get_sessions_default_sort_is_asc(
             json={"id": sid, "peer_names": {test_peer.name: {}}},
         )
         assert response.status_code in [200, 201]
+        time.sleep(0.05)
 
     # List with no sort params — should default to ascending
     response = client.post(

--- a/tests/routes/test_sessions.py
+++ b/tests/routes/test_sessions.py
@@ -403,6 +403,99 @@ def test_get_sessions_sort_by_last_message_at_asc(
     assert returned_ids[:3] == session_ids
 
 
+def test_get_sessions_sort_by_last_message_at_nulls_last_desc(
+    client: TestClient, sample_data: tuple[Workspace, Peer]
+):
+    """Test that messageless sessions sort last when sorting by last_message_at (desc)"""
+    test_workspace, test_peer = sample_data
+
+    # Create 3 sessions: 2 with messages, 1 without
+    sid_with_msg_1 = str(generate_nanoid())
+    sid_with_msg_2 = str(generate_nanoid())
+    sid_no_msg = str(generate_nanoid())
+    for sid in [sid_with_msg_1, sid_with_msg_2, sid_no_msg]:
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions",
+            json={"id": sid, "peer_names": {test_peer.name: {}}},
+        )
+        assert response.status_code in [200, 201]
+
+    # Add messages with different timestamps to two sessions
+    for i, sid in enumerate([sid_with_msg_1, sid_with_msg_2]):
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions/{sid}/messages",
+            json={
+                "messages": [
+                    {
+                        "content": f"msg-{i}",
+                        "peer_id": test_peer.name,
+                        "created_at": f"2026-01-01T00:00:{i + 10:02d}Z",
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 201
+
+    response = client.post(
+        f"/v3/workspaces/{test_workspace.name}/sessions/list",
+        json={"sort_by": "last_message_at", "sort_order": "desc"},
+    )
+    assert response.status_code == 200
+    items = response.json()["items"]
+    returned_ids = [item["id"] for item in items]
+
+    # Descending: newest message first, no-message session last
+    assert returned_ids[0] == sid_with_msg_2
+    assert returned_ids[1] == sid_with_msg_1
+    assert returned_ids[2] == sid_no_msg
+
+
+def test_get_sessions_sort_by_last_message_at_nulls_last_asc(
+    client: TestClient, sample_data: tuple[Workspace, Peer]
+):
+    """Test that messageless sessions sort last when sorting by last_message_at (asc)"""
+    test_workspace, test_peer = sample_data
+
+    # Create 3 sessions: 2 with messages, 1 without
+    sid_with_msg_1 = str(generate_nanoid())
+    sid_with_msg_2 = str(generate_nanoid())
+    sid_no_msg = str(generate_nanoid())
+    for sid in [sid_with_msg_1, sid_with_msg_2, sid_no_msg]:
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions",
+            json={"id": sid, "peer_names": {test_peer.name: {}}},
+        )
+        assert response.status_code in [200, 201]
+
+    for i, sid in enumerate([sid_with_msg_1, sid_with_msg_2]):
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions/{sid}/messages",
+            json={
+                "messages": [
+                    {
+                        "content": f"msg-{i}",
+                        "peer_id": test_peer.name,
+                        "created_at": f"2026-01-01T00:00:{i + 10:02d}Z",
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 201
+
+    response = client.post(
+        f"/v3/workspaces/{test_workspace.name}/sessions/list",
+        json={"sort_by": "last_message_at", "sort_order": "asc"},
+    )
+    assert response.status_code == 200
+    items = response.json()["items"]
+    returned_ids = [item["id"] for item in items]
+
+    # Ascending: oldest message first, no-message session last (NULLS LAST)
+    assert returned_ids[0] == sid_with_msg_1
+    assert returned_ids[1] == sid_with_msg_2
+    assert returned_ids[2] == sid_no_msg
+
+
 def test_update_delete_metadata(
     client: TestClient, sample_data: tuple[Workspace, Peer]
 ):


### PR DESCRIPTION
## Problem

The  endpoint returns sessions ordered by  ascending (oldest first) with no way to change the sort order. This breaks paginated UIs that need newest-first ordering — client-side re-sorting only shuffles items within the current page, leaving newer sessions invisible on later pages.

## Solution

Add optional  and  fields to the  schema:

```json
{
  "sort_by": "created_at",
  "sort_order": "desc"
}
```

- `sort_by` accepts `"created_at"` (extensible to other fields later)
- `sort_order` accepts `"asc"` or `"desc"`
- Both are optional; omitting them preserves the existing default (created_at asc)
- Fully backwards-compatible — existing clients that send `{}` or omit the body get the same behavior as before

## Changes

- `src/schemas/api.py` — add `sort_by` and `sort_order` to `SessionGet`
- `src/crud/session.py` — accept and apply sort params in `get_sessions()`
- `src/routers/sessions.py` — pass sort params from the request to the CRUD layer

## Testing

Lint and typecheck pass. No existing tests for session list ordering to update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions list can be sorted by creation date or last message timestamp (asc/desc) via optional sort parameters.
  * API accepts optional sort field and sort order in session-list requests.

* **Bug Fixes**
  * Empty filter payloads are treated as no filters, avoiding unintended filtering when listing sessions.

* **Tests**
  * Added unit and route tests validating session-list ordering for asc/desc/default.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/669)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->