### PR TITLE
fix: dedupe duplicate observations in retrieval output

### DIFF
--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import weakref
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, cast
@@ -38,6 +38,21 @@ def _normalized_observation_input(
 ) -> schemas.ObservationInput:
     """Return an observation input with content normalized for persistence/embedding."""
     return obs.model_copy(update={"content": obs.content.strip()})
+
+
+def _dedupe_observation_docs_for_tool_output(
+    documents: Sequence[Document],
+) -> list[Document]:
+    """Remove exact duplicate observations from tool output without mutating storage."""
+    seen: set[tuple[str, str]] = set()
+    deduped: list[Document] = []
+    for doc in documents:
+        key = (doc.level or "explicit", " ".join(doc.content.casefold().split()))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(doc)
+    return deduped
 
 
 def _base_observation_properties() -> dict[str, Any]:
@@ -1957,6 +1972,7 @@ async def _handle_get_reasoning_chain(
                     db, ctx.workspace_name, doc.source_ids
                 )
                 if premises:
+                    premises = _dedupe_observation_docs_for_tool_output(premises)
                     premise_lines: list[Any] = []
                     for p in premises:
                         p_level = p.level or "explicit"
@@ -1976,6 +1992,7 @@ async def _handle_get_reasoning_chain(
                     db, ctx.workspace_name, doc.source_ids
                 )
                 if sources:
+                    sources = _dedupe_observation_docs_for_tool_output(sources)
                     source_lines: list[Any] = []
                     for s in sources:
                         s_level = s.level or "explicit"
@@ -2004,6 +2021,7 @@ async def _handle_get_reasoning_chain(
                 observed=ctx.observed,
             )
             if children:
+                children = _dedupe_observation_docs_for_tool_output(children)
                 child_lines: list[Any] = []
                 for c in children:
                     c_level = c.level or "explicit"

--- a/src/utils/representation.py
+++ b/src/utils/representation.py
@@ -15,6 +15,32 @@ def _strip_microseconds_and_timezone(timestamp: datetime) -> datetime:
     return timestamp.replace(microsecond=0, tzinfo=None)
 
 
+def _normalize_observation_content(content: str) -> str:
+    """Normalize observation content for retrieval-time exact deduplication."""
+    return " ".join(content.casefold().split())
+
+
+def _dedupe_documents_for_representation(
+    documents: Sequence[models.Document],
+) -> list[models.Document]:
+    """
+    Remove exact duplicate observations before formatting LLM-facing context.
+
+    This is intentionally retrieval-time only: it does not mutate the database,
+    vector store, or source/premise links. Keep the first document in the input
+    order so semantic/recent/derived ranking remains stable.
+    """
+    seen: set[tuple[str, str]] = set()
+    deduped: list[models.Document] = []
+    for doc in documents:
+        key = (doc.level or "explicit", _normalize_observation_content(doc.content))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(doc)
+    return deduped
+
+
 def flatten_message_ids(
     message_ids: list[int] | list[list[int]] | list[tuple[int, int]],
 ) -> list[int]:
@@ -581,6 +607,7 @@ class Representation(BaseModel):
 
     @classmethod
     def from_documents(cls, documents: Sequence[models.Document]) -> "Representation":
+        documents = _dedupe_documents_for_representation(documents)
         return cls(
             explicit=[
                 ExplicitObservation(

--- a/tests/utils/test_representation_retrieval_dedupe.py
+++ b/tests/utils/test_representation_retrieval_dedupe.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+
+from src.utils.representation import Representation
+
+
+def _doc(doc_id: str, level: str, content: str):
+    return SimpleNamespace(
+        id=doc_id,
+        level=level,
+        content=content,
+        created_at=dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC),
+        internal_metadata={"message_ids": [1]},
+        session_name="s1",
+        source_ids=None,
+    )
+
+
+def test_representation_from_documents_dedupes_exact_normalized_content():
+    representation = Representation.from_documents(
+        [
+            _doc("doc-a", "explicit", "User prefers concise responses."),
+            _doc("doc-b", "explicit", " user   prefers CONCISE responses. "),
+            _doc("doc-c", "deductive", "User prefers concise responses."),
+        ]
+    )
+
+    assert [obs.id for obs in representation.explicit] == ["doc-a"]
+    # Same normalized content in a different observation level is retained.
+    assert [obs.id for obs in representation.deductive] == ["doc-c"]


### PR DESCRIPTION
## Summary
- dedupe exact normalized duplicate observations at representation formatting time
- dedupe reasoning-chain source/premise/child tool output without mutating stored observations
- add regression coverage proving duplicates are removed per observation level while same content across different levels is retained

## Safety
This is retrieval-time only. It does not delete, rewrite, or merge raw `documents` rows, vector-store data, source IDs, premise links, or session metadata. Ranking remains stable by keeping the first document in input order.

## Test plan
- `python -m pytest tests/utils/test_representation_retrieval_dedupe.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated duplicate observation documents from reasoning chains to prevent repeated content in output.
  * Enhanced document deduplication for LLM representations by intelligently normalizing content comparisons across whitespace and casing variations.

* **Tests**
  * Added test coverage for document deduplication behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/673)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->