### PR TITLE
fix(dreamer): reduce peer-card overgeneralization

### DIFF
--- a/src/dreamer/specialists.py
+++ b/src/dreamer/specialists.py
@@ -464,7 +464,11 @@ class InductionSpecialist(BaseSpecialist):
     """
 
     name: str = "induction"
-    peer_card_update_instruction: str = "Only add highly stable profile traits/preferences; do not copy transient conclusions."
+    peer_card_update_instruction: str = (
+        "Only add highly stable profile traits/preferences. Preserve applicability conditions: "
+        "if a pattern is domain-specific, encode that scope explicitly. Do not merge "
+        "unrelated examples into one trait, and do not include evidence lists or `e.g.` clauses."
+    )
 
     def get_tools(self, *, peer_card_enabled: bool = True) -> list[dict[str, Any]]:
         if peer_card_enabled:
@@ -496,14 +500,25 @@ class InductionSpecialist(BaseSpecialist):
 
 ## PEER CARD (REQUIRED)
 
-After identifying patterns, only update the peer card for durable profile-level traits/preferences:
-- `TRAIT: Analytical thinker`
-- `TRAIT: Tends to reschedule when stressed`
-- `PREFERENCE: Prefers detailed explanations`
+After identifying patterns, only update the peer card for durable profile-level traits/preferences.
 
-Do NOT add temporary patterns, episode-specific conclusions, or reasoning summaries.
-Call `update_peer_card` with the complete deduplicated list only when a durable profile update is warranted.
-Keep it concise (max 40 entries)."""
+### Preserve scope and applicability conditions
+- If a pattern is only supported within one domain, NAME THAT DOMAIN explicitly in the peer card entry.
+- Prefer scoped preferences over global traits when the evidence is domain-specific.
+- Good: `PREFERENCE: For reading nonfiction, prefers annotated print books over ebooks`
+- Bad: `TRAIT: Prefers physical media`
+
+### Avoid cross-domain over-generalization
+- Do NOT merge unrelated examples into a single personality trait just because they sound similar.
+- If evidence comes from different domains and the shared mechanism is interpretive rather than explicit, do NOT create a `TRAIT:` entry.
+- Bad: `TRAIT: Meticulous planner (e.g., vacation itinerary optimization, desk cable management by length)`
+- Better: keep separate scoped observations, or leave them as inductive observations only.
+
+### Peer card hygiene
+- Do NOT add temporary patterns, episode-specific conclusions, or reasoning summaries.
+- Do NOT include evidence lists, parenthetical example bundles, or `e.g.` clauses in peer card entries.
+- Call `update_peer_card` with the complete deduplicated list only when a durable profile update is warranted.
+- Keep it concise (max 40 entries)."""
 
         return f"""You are an inductive reasoning agent identifying patterns about {observed}.
 
@@ -565,7 +580,10 @@ Use `create_observations_inductive`.
 3. Confidence based on evidence count: 2=low, 3-4=medium, 5+=high
 4. Look for HOW things change over time, not just static facts
 5. Include source_ids - always link back to evidence
-6. Empty or missing source_ids will be rejected"""
+6. Empty or missing source_ids will be rejected
+7. Preserve applicability conditions - if a pattern only holds in one domain or context, state that scope explicitly
+8. Do not generalize from superficially similar but unrelated examples into a personality trait
+9. When in doubt, prefer a scoped `PREFERENCE:` or keep the insight as an inductive observation rather than promoting it to a global `TRAIT:`"""
 
     def build_user_prompt(
         self,

--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -431,7 +431,8 @@ TOOLS: dict[str, dict[str, Any]] = {
         "description": (
             "Update the peer card with durable profile facts about the observed peer. "
             + "Only include stable biographical facts, standing instructions, and long-lived preferences/traits. "
-            + "Do not include one-off conclusions, temporary events, or duplicate entries."
+            + "Preserve applicability conditions: if something is domain-specific, name that scope explicitly. "
+            + "Do not merge unrelated examples into one trait, and do not include evidence bundles, `e.g.` clauses, one-off conclusions, temporary events, or duplicate entries."
         ),
         "input_schema": {
             "type": "object",
@@ -440,7 +441,7 @@ TOOLS: dict[str, dict[str, Any]] = {
                     "type": "array",
                     "description": (
                         "Complete deduplicated peer card list (max 40 entries). "
-                        + "Each entry should be a concise standalone profile fact."
+                        + "Each entry should be a concise standalone profile fact with any necessary scope, not an evidence list or example bundle."
                     ),
                     "items": {"type": "string"},
                 },

--- a/tests/dreamer/test_model_config_usage.py
+++ b/tests/dreamer/test_model_config_usage.py
@@ -3,8 +3,37 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from src.config import settings
-from src.dreamer.specialists import DeductionSpecialist
+from src.dreamer.specialists import DeductionSpecialist, InductionSpecialist
 from src.llm import HonchoLLMCallResponse
+from src.utils.agent_tools import TOOLS
+
+
+def test_induction_specialist_prompt_discourages_cross_domain_trait_merges() -> None:
+    specialist = InductionSpecialist()
+    prompt = specialist.build_system_prompt("alice")
+
+    assert "Preserve scope and applicability conditions" in prompt
+    assert "Do NOT merge unrelated examples into a single personality trait" in prompt
+    assert (
+        "PREFERENCE: For reading nonfiction, prefers annotated print books over ebooks"
+        in prompt
+    )
+    assert (
+        "TRAIT: Meticulous planner (e.g., vacation itinerary optimization, desk cable management by length)"
+        in prompt
+    )
+
+
+def test_update_peer_card_tool_description_mentions_scope_and_example_bundles() -> None:
+    tool = TOOLS["update_peer_card"]
+    description = tool["description"]
+    content_description = tool["input_schema"]["properties"]["content"]["description"]
+
+    assert "Preserve applicability conditions" in description
+    assert "Do not merge unrelated examples into one trait" in description
+    assert "temporary events" in description
+    assert "duplicate entries" in description
+    assert "not an evidence list or example bundle" in content_description
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- tighten Dreamer induction prompt guidance for peer-card updates
- preserve domain scope instead of promoting domain-specific evidence into global traits
- forbid example-bundle / `e.g.`-style peer-card entries that compress evidence into a polished trait
- restore explicit tool guidance against temporary events and duplicate entries
- add regression tests for the prompt/tool contract

## Problem
Honcho's Dreamer induction path could promote loosely related observations into broad peer-card traits.

The failure mode is not just "too much abstraction" in the abstract; it is specifically that peer-card updates were underconstrained about:
- scope/applicability conditions
- cross-domain trait fusion
- evidence bundles presented as profile facts

That makes it too easy for the model to transform a couple of scoped observations into a global-sounding trait entry.

## What changed
### Prompt guidance
The induction specialist now explicitly instructs the model to:
- preserve applicability conditions
- prefer scoped `PREFERENCE:` entries over global `TRAIT:` entries when the evidence is domain-specific
- avoid merging unrelated examples into a single personality trait
- avoid parenthetical example bundles / `e.g.` clauses in peer-card entries

### Tool contract guidance
The `update_peer_card` tool description now also says to:
- name domain scope explicitly when needed
- avoid merging unrelated examples into one trait
- avoid evidence bundles / `e.g.` clauses
- avoid one-off conclusions, temporary events, and duplicate entries

### Regression coverage
Added deterministic tests that assert the prompt/tool text includes these anti-overgeneralization constraints.

## Why this approach
This is a minimal fix at the model-policy layer where the behavior is induced:
- the induction specialist prompt
- the peer-card update tool schema/description

It avoids trying to bolt on brittle semantic validation after the fact, while still making the intended behavior explicit and testable.

## Example of the bad pattern this discourages
Bad:
- `TRAIT: Meticulous planner (e.g., vacation itinerary optimization, desk cable management by length)`

Better:
- keep those as separate scoped observations, or leave them as inductive observations unless there is real evidence for a broader trait

## Validation
- `uv run ruff check src/dreamer/specialists.py src/utils/agent_tools.py tests/dreamer/test_model_config_usage.py`
- direct file-level assertions for the new prompt/schema strings

Note: a targeted local `pytest` run was blocked by repo test DB auth in this environment (`postgres` auth failure during fixture setup), so the new regression tests were validated as contract checks rather than via a clean local pytest pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened profile data quality safeguards to prevent incorrect generalizations across different contexts and ensure profile entries remain accurate and clean.

* **Tests**
  * Added test coverage for profile update validation rules to ensure data integrity guidelines are properly enforced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/675)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->