### PR TITLE
fix(docker): gate deriver startup on api healthcheck

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -21,6 +21,18 @@ services:
         condition: service_healthy
     ports:
       - "127.0.0.1:8000:8000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "/app/.venv/bin/python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2).read()",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     # -- Development: mount source for live reload --
     # volumes:
     #   - .:/app
@@ -40,6 +52,8 @@ services:
       dockerfile: Dockerfile
     entrypoint: ["/app/.venv/bin/python", "-m", "src.deriver"]
     depends_on:
+      api:
+        condition: service_healthy
       database:
         condition: service_healthy
       redis:


### PR DESCRIPTION
## Problem

The deriver service can start before the API container has finished provisioning the database and begun serving requests. The previous approach made the deriver run `scripts/provision_db.py` too, but that could create concurrent Alembic migration attempts with the API entrypoint.

## Fix

- Add an API container healthcheck against `GET /health`.
- Use Python stdlib `urllib.request` for the healthcheck because the Docker image is based on `python:3.13-slim-bookworm` and does not install `curl`.
- Make the deriver depend on `api: service_healthy` while keeping the existing database and Redis health dependencies.
- Keep deriver startup as the direct worker command: `/app/.venv/bin/python -m src.deriver`.

## Behavior

The API remains the single migration runner through `docker/entrypoint.sh`. The deriver starts only after the database and Redis are healthy, the API has run its existing provisioning step, and `/health` is serving successfully.

## Validation

- `docker compose -f docker-compose.yml.example config`
- Python assertion check for the expected compose healthcheck, deriver entrypoint, and `api: service_healthy` dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced service health monitoring with automated health checks
  * Improved service startup sequencing to ensure proper initialization order

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->