### PR TITLE
feat(api): add deduplication support to conclusions endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added optional storage-level deduplication to the Conclusions API endpoint.
 - New `src/llm/` package as the single owner of provider runtime: clients, backends, history adapters, tool loop, request builder, credentials, and caching policy
 - `AttemptPlan` dataclass captures per-retry provider selection (client, model, reasoning_effort, thinking_budget_tokens, selected_config) and pins it across stream-final retries so streaming doesn't bounce back to primary after the tool loop has settled on fallback
 - Gemini JSON-schema sanitizer for `function_declarations` — strips keywords Gemini's validator rejects (`additionalProperties`, `allOf`, etc.) while preserving semantics for all other backends

--- a/src/crud/document.py
+++ b/src/crud/document.py
@@ -703,6 +703,7 @@ async def create_observations(
     db: AsyncSession,
     observations: Sequence[schemas.ConclusionCreate],
     workspace_name: str,
+    deduplicate: bool = False,
 ) -> list[models.Document]:
     """
     Create multiple observations (documents) from user input.
@@ -772,6 +773,30 @@ async def create_observations(
     )
 
     for obs, embedding in zip(observations, embeddings, strict=True):
+        if deduplicate:
+            # For each document, if deduplicate is True, perform a process
+            # that checks against existing documents and either rejects this document
+            # as a duplicate OR deletes an existing document that is a superior duplicate.
+            temp_doc = schemas.DocumentCreate(
+                content=obs.content,
+                session_name=obs.session_id,
+                level="explicit",
+                times_derived=1,
+                metadata=schemas.DocumentMetadata(
+                    message_ids=[], message_created_at=""
+                ),
+                embedding=embedding,
+            )
+            is_duplicate = await is_rejected_duplicate(
+                db,
+                temp_doc,
+                workspace_name,
+                observer=obs.observer_id,
+                observed=obs.observed_id,
+            )
+            if is_duplicate:
+                continue
+
         if store_embeddings_in_postgres:
             doc = models.Document(
                 workspace_name=workspace_name,

--- a/src/routers/conclusions.py
+++ b/src/routers/conclusions.py
@@ -41,6 +41,7 @@ async def create_conclusions(
         db,
         observations=body.conclusions,
         workspace_name=workspace_id,
+        deduplicate=body.deduplicate,
     )
 
     logger.debug(

--- a/src/schemas/api.py
+++ b/src/schemas/api.py
@@ -519,6 +519,7 @@ class ConclusionBatchCreate(BaseModel):
         max_length=100,
         validation_alias=AliasChoices("conclusions", "observations"),
     )
+    deduplicate: bool = False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/routes/test_conclusions_dedup.py
+++ b/tests/routes/test_conclusions_dedup.py
@@ -17,7 +17,14 @@ class TestConclusionDedupRoutes:
         db_session: AsyncSession,
         sample_data: tuple[Workspace, Peer],
     ):
-        """Test that creating duplicate conclusions with deduplicate=True works"""
+        """Test that creating duplicate conclusions with deduplicate=True works.
+
+        When deduplicate=True:
+        - Identical content: the new document replaces the old one (soft-delete old,
+          insert new). This is the "replace" path in is_rejected_duplicate().
+        - New content is more informative: same replace behavior.
+        - Existing content is more informative: the new content is rejected/skipped.
+        """
         test_workspace, test_peer = sample_data
 
         # Create another peer
@@ -64,12 +71,13 @@ class TestConclusionDedupRoutes:
         )
         assert response2.status_code == 201
         data2 = response2.json()
-        
-        # In Honcho, if content is identical, the new one replaces the old one
-        # so data2 should have 1 item (the new one).
+
+        # Identical content triggers the "replace" path: new document replaces old.
+        # is_rejected_duplicate sees equal scores -> soft-deletes old, returns False
+        # (don't reject new). So we get a new id, and only the active count is 1.
         assert len(data2) == 1
         id2 = data2[0]["id"]
-        assert id1 != id2
+        assert id1 != id2  # New id != old id (replacement)
 
         # Verify only one exists in DB (active)
         list_response = client.post(

--- a/tests/routes/test_conclusions_dedup.py
+++ b/tests/routes/test_conclusions_dedup.py
@@ -1,0 +1,135 @@
+import pytest
+from fastapi.testclient import TestClient
+from nanoid import generate as generate_nanoid
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import models
+from src.models import Peer, Workspace
+
+
+class TestConclusionDedupRoutes:
+    """Test suite for conclusion deduplication API"""
+
+    @pytest.mark.asyncio
+    async def test_create_conclusion_deduplication(
+        self,
+        client: TestClient,
+        db_session: AsyncSession,
+        sample_data: tuple[Workspace, Peer],
+    ):
+        """Test that creating duplicate conclusions with deduplicate=True works"""
+        test_workspace, test_peer = sample_data
+
+        # Create another peer
+        test_peer2 = models.Peer(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        db_session.add(test_peer2)
+        await db_session.commit()
+
+        content = "User loves semantic memory"
+
+        # Create conclusion first time
+        response1 = client.post(
+            f"/v3/workspaces/{test_workspace.name}/conclusions",
+            json={
+                "conclusions": [
+                    {
+                        "content": content,
+                        "observer_id": test_peer.name,
+                        "observed_id": test_peer2.name,
+                    }
+                ],
+                "deduplicate": True
+            },
+        )
+        assert response1.status_code == 201
+        data1 = response1.json()
+        assert len(data1) == 1
+        id1 = data1[0]["id"]
+
+        # Create identical conclusion with deduplicate=True
+        response2 = client.post(
+            f"/v3/workspaces/{test_workspace.name}/conclusions",
+            json={
+                "conclusions": [
+                    {
+                        "content": content,
+                        "observer_id": test_peer.name,
+                        "observed_id": test_peer2.name,
+                    }
+                ],
+                "deduplicate": True
+            },
+        )
+        assert response2.status_code == 201
+        data2 = response2.json()
+        
+        # In Honcho, if content is identical, the new one replaces the old one
+        # so data2 should have 1 item (the new one).
+        assert len(data2) == 1
+        id2 = data2[0]["id"]
+        assert id1 != id2
+
+        # Verify only one exists in DB (active)
+        list_response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/conclusions/list",
+            json={
+                "filters": {
+                    "observer_id": test_peer.name,
+                    "observed_id": test_peer2.name,
+                }
+            },
+        )
+        assert list_response.status_code == 200
+        # The list endpoint only returns active (non-deleted) documents
+        assert len(list_response.json()["items"]) == 1
+        assert list_response.json()["items"][0]["id"] == id2
+
+    @pytest.mark.asyncio
+    async def test_create_conclusion_no_deduplication_by_default(
+        self,
+        client: TestClient,
+        db_session: AsyncSession,
+        sample_data: tuple[Workspace, Peer],
+    ):
+        """Test that conclusions are NOT deduplicated by default (backward compatibility)"""
+        test_workspace, test_peer = sample_data
+
+        # Create another peer
+        test_peer2 = models.Peer(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        db_session.add(test_peer2)
+        await db_session.commit()
+
+        content = "User loves maximalist storage"
+
+        # Create conclusion twice without explicit dedup flag
+        for _ in range(2):
+            response = client.post(
+                f"/v3/workspaces/{test_workspace.name}/conclusions",
+                json={
+                    "conclusions": [
+                        {
+                            "content": content,
+                            "observer_id": test_peer.name,
+                            "observed_id": test_peer2.name,
+                        }
+                    ]
+                },
+            )
+            assert response.status_code == 201
+
+        # Verify BOTH exist in DB
+        list_response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/conclusions/list",
+            json={
+                "filters": {
+                    "observer_id": test_peer.name,
+                    "observed_id": test_peer2.name,
+                }
+            },
+        )
+        assert list_response.status_code == 200
+        assert len(list_response.json()["items"]) == 2


### PR DESCRIPTION
## Summary
Adds optional storage-level deduplication to the Conclusions API.

## Changelog
### Added
- Optional `deduplicate` flag in `ConclusionBatchCreate` schema.
- Semantic similarity checks in `create_observations` CRUD path.

## Additional context
Aligns public API hygiene with internal Deriver/Dreamer standards.
Closes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-request deduplication for batch observation/conclusion creation (off by default).

* **API**
  * Batch creation endpoint accepts a new boolean flag to enable deduplication.

* **Tests**
  * End-to-end tests added to verify deduplication behavior and the default no-deduplication flow.

* **Changelog**
  * Documented optional storage-level deduplication for the Conclusions endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/690)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->