### PR TITLE
fix: keep generated memory output in English

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,9 @@ ENV/
 env.bak/
 venv.bak/
 .env.backup*
+.env.*
+backups/
+logs/
 
 # Spyder project settings
 .spyderproject

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -60,6 +60,10 @@ Analyze messages from {peer_id} to extract **explicit atomic facts** about them.
    - Use absolute dates/times when possible (e.g. "June 26, 2025" not "yesterday")
 
 RULES:
+- Output language: write every extracted conclusion in English. If source messages
+  contain another language, translate the meaning into plain English. Do not emit
+  Chinese or other non-English text unless it is an exact user-provided name,
+  code token, command, path, URL, or quoted string that must remain literal.
 - Properly attribute observations to the correct subject: if it is about {peer_id}, say so. If {peer_id} is referencing someone or something else, make that clear.
 - Observations should make sense on their own. Each observation will be used in the future to better understand {peer_id}.
 - Extract ALL observations from {peer_id} messages, using others as context.

--- a/src/dialectic/prompts.py
+++ b/src/dialectic/prompts.py
@@ -84,6 +84,8 @@ You are a helpful and concise context synthesis agent that answers questions abo
 
 Always give users the answer *they expect* based on the message history -- the goal is to help recall and *reason through* insights that the memory system has already gathered. You have many tools for gathering context. Search wisely.
 
+Output language: answer in English. If retrieved memory or message history contains Chinese or another non-English language, translate the relevant meaning into plain English instead of repeating the non-English text, unless the exact literal text is necessary as a name, command, path, URL, code token, or short quoted evidence.
+
 {perspective_section}
 {peer_card_explanation}
 ## AVAILABLE TOOLS

--- a/src/utils/summarizer.py
+++ b/src/utils/summarizer.py
@@ -104,6 +104,11 @@ def short_summary_prompt(
     return c(f"""
 You are a system that summarizes parts of a conversation to create a concise and accurate summary. Focus on capturing:
 
+Output language: write the summary in English. If source messages contain Chinese
+or another non-English language, translate the relevant meaning into English
+instead of preserving the non-English text, unless exact literal text is necessary
+as a name, command, path, URL, code token, or short quote.
+
 1. Key facts and information shared (**Capture as many explicit facts as possible**)
 2. User preferences, opinions, and questions
 3. Important context and requests
@@ -135,6 +140,11 @@ def long_summary_prompt(
     """Generate the long summary prompt."""
     return c(f"""
 You are a system that creates thorough, comprehensive summaries of conversations. Focus on capturing:
+
+Output language: write the summary in English. If source messages contain Chinese
+or another non-English language, translate the relevant meaning into English
+instead of preserving the non-English text, unless exact literal text is necessary
+as a name, command, path, URL, code token, or short quote.
 
 1. Key facts and information shared (**Capture as many explicit facts as possible**)
 2. User preferences, opinions, and questions


### PR DESCRIPTION
## Summary
- Add explicit English-output rules to deriver, dialectic, and summarizer prompts
- Translate non-English source content into English unless literal text is required for names, commands, paths, URLs, code tokens, or short quotes
- Ignore local backups and logs so secret-bearing runtime artifacts are not accidentally committed

## Why
Hermes/Honcho persistent memory can re-seed language contamination when generated summaries or conclusions preserve non-English handoff/context text. This keeps generated memory artifacts in English while still allowing literal source text when it is semantically required.

## Test plan
- uv run python -m py_compile src/deriver/prompts.py src/dialectic/prompts.py src/utils/summarizer.py
- uv run ruff check src/deriver/prompts.py src/dialectic/prompts.py src/utils/summarizer.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved language consistency: system now outputs in English and translates non-English source content into plain English while preserving literal elements like code tokens, commands, and URLs.

* **Chores**
  * Updated configuration to ignore additional environment and backup files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->