### PR TITLE
feat(deriver): add stale batch timeout to prevent indefinite queue stall

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -780,6 +780,9 @@ class DeriverSettings(HonchoSettings):
     # When enabled, bypasses the batch token threshold and processes work immediately
     FLUSH_ENABLED: bool = False
 
+    # Force-process representation work units whose oldest queue item is older than this many hours
+    STALE_BATCH_HOURS: Annotated[int, Field(default=0, ge=0, le=168)] = 0
+
     @model_validator(mode="before")
     @classmethod
     def _merge_model_config_defaults(cls, data: Any) -> Any:

--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -310,16 +310,51 @@ class QueueManager:
             )
 
             # Apply batch threshold filter (skip if FLUSH_ENABLED is True)
+            # Also force-process work units whose oldest item exceeds STALE_BATCH_HOURS
             if not settings.DERIVER.FLUSH_ENABLED and batch_max_tokens > 0:
-                query = query.where(
-                    or_(
-                        ~work_units_subq.c.work_unit_key.startswith(
-                            representation_prefix
-                        ),
-                        func.coalesce(token_stats_subq.c.total_tokens, 0)
-                        >= batch_max_tokens,
+                stale_hours = settings.DERIVER.STALE_BATCH_HOURS
+                if stale_hours > 0:
+                    stale_cutoff = datetime.now(timezone.utc) - timedelta(
+                        hours=stale_hours
                     )
-                )
+                    oldest_item_subq = (
+                        select(
+                            models.QueueItem.work_unit_key,
+                            func.min(models.QueueItem.created_at).label(
+                                "oldest_created"
+                            ),
+                        )
+                        .where(~models.QueueItem.processed)
+                        .group_by(models.QueueItem.work_unit_key)
+                        .subquery()
+                    )
+                    query = query.outerjoin(
+                        oldest_item_subq,
+                        work_units_subq.c.work_unit_key
+                        == oldest_item_subq.c.work_unit_key,
+                    ).where(
+                        or_(
+                            ~work_units_subq.c.work_unit_key.startswith(
+                                representation_prefix
+                            ),
+                            func.coalesce(token_stats_subq.c.total_tokens, 0)
+                            >= batch_max_tokens,
+                            func.coalesce(
+                                oldest_item_subq.c.oldest_created, stale_cutoff
+                            )
+                            <= stale_cutoff,
+                        )
+                    )
+                else:
+                    query = query.where(
+                        or_(
+                            ~work_units_subq.c.work_unit_key.startswith(
+                                representation_prefix
+                            ),
+                            func.coalesce(token_stats_subq.c.total_tokens, 0)
+                            >= batch_max_tokens,
+                        )
+                    )
 
             result = await db.execute(query)
             available_units = result.scalars().all()


### PR DESCRIPTION
## Problem

When `REPRESENTATION_BATCH_MAX_TOKENS` is configured and `FLUSH_ENABLED` is `false`, work units that never accumulate enough tokens remain stuck in the queue indefinitely. This is especially problematic for short conversational sessions where individual session message tokens never reach the batch threshold.

In our deployment (Hermes agent with FLUSH at ~2K tokens but batch threshold at 4K), short sessions would produce ~2K tokens per flush — never reaching the 4K threshold. This resulted in **245 queue items accumulated over 10 days** with zero processing.

### Why not just use FLUSH_ENABLED=true?

FLUSH mode processes every message immediately, which produces fragmented observations lacking context. The extracted information is broken into tiny pieces with high redundancy and poor quality. The token-batch threshold exists to group related messages together for richer, more coherent observations.

The trade-off: batch mode gives better quality, but work units that never reach the threshold are **never processed at all**.

## Solution

Add a `STALE_BATCH_HOURS` configuration option (default `0` = disabled) to DeriverSettings. When set to a positive value, work units whose oldest queue item exceeds this age are force-processed regardless of token count.

This provides a safety net that:
- Preserves batch quality for active sessions (messages are still grouped up to the token threshold)
- Ensures no work unit is abandoned forever (stale work units get processed after the timeout)
- Is fully opt-in with a default of 0 (no behavior change for existing deployments)

### Changes

- **`src/config.py`**: Add `STALE_BATCH_HOURS` field to `DeriverSettings` with validation (0-168 hours)
- **`src/deriver/queue_manager.py`**: Extend `get_and_claim_work_units()` to include stale work units via a subquery on `MIN(QueueItem.created_at)` when `STALE_BATCH_HOURS > 0`

### Configuration Example

```toml
[deriver]
REPRESENTATION_BATCH_MAX_TOKENS = 2048
FLUSH_ENABLED = false
STALE_BATCH_HOURS = 5  # Force-process work units older than 5 hours
```

### Related

Possibly related to #494 (messages ingested but derived memory does not appear automatically).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added `STALE_BATCH_HOURS` setting (0-168 hours) to control work unit processing thresholds.

* **Improvements**
  * Enhanced queue management to process items based on age when batching conditions are applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->