### PR TITLE
feat: support Langfuse trace grouping via LiteLLM proxy metadata

### DIFF
--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -1,6 +1,8 @@
 import logging
 import time
 
+from nanoid import generate as generate_nanoid
+
 from src import crud
 from src.config import ConfiguredModelSettings, settings
 from src.crud.representation import RepresentationManager
@@ -62,6 +64,8 @@ async def process_representation_tasks_batch(
         return
 
     overall_start = time.perf_counter()
+
+    batch_id = generate_nanoid()
 
     messages.sort(key=lambda x: x.id)
     latest_message = messages[-1]
@@ -159,7 +163,7 @@ async def process_representation_tasks_batch(
             call_purpose=CallPurpose.DERIVER_REPRESENTATION.value,
             parent_category="representation",
             observed=observed,
-            langfuse_session_id=f"deriver-{latest_message.workspace_name}-{observed}",
+            langfuse_session_id=f"deriver-{batch_id}",
         ),
     )
     llm_duration = (time.perf_counter() - llm_start) * 1000

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -159,6 +159,7 @@ async def process_representation_tasks_batch(
             call_purpose=CallPurpose.DERIVER_REPRESENTATION.value,
             parent_category="representation",
             observed=observed,
+            langfuse_session_id=f"deriver-{latest_message.workspace_name}-{observed}",
         ),
     )
     llm_duration = (time.perf_counter() - llm_start) * 1000

--- a/src/dialectic/core.py
+++ b/src/dialectic/core.py
@@ -316,6 +316,7 @@ class DialecticAgent:
             agent_type="dialectic",
             run_id=self._run_id,
             peer_name=self.observed,
+            langfuse_session_id=f"dialectic-{self._run_id}" if self._run_id else None,
         )
 
     def _log_response_metrics(

--- a/src/dreamer/specialists.py
+++ b/src/dreamer/specialists.py
@@ -277,6 +277,7 @@ If you update it, send the full deduplicated list and remove stale entries.
                     run_id=run_id,
                     observer=observer,
                     observed=observed,
+                    langfuse_session_id=f"dream-{run_id}" if run_id else None,
                 ),
             )
 

--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -324,9 +324,10 @@ class OpenAIBackend:
         # LiteLLM's Langfuse callback reads metadata.session_id to group
         # traces from the same agent operation (dream cycle, dialectic
         # request, etc.) under one Langfuse session.
-        if extra_params and "langfuse_session_id" in extra_params:
+        session_id = extra_params.get("langfuse_session_id") if extra_params else None
+        if isinstance(session_id, str) and session_id:
             params["extra_body"] = {
-                "metadata": {"session_id": extra_params["langfuse_session_id"]}
+                "metadata": {"session_id": session_id}
             }
 
         return params

--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -319,6 +319,16 @@ class OpenAIBackend:
             ):
                 if key in extra_params:
                     params[key] = extra_params[key]
+
+        # Propagate Langfuse session_id for trace grouping via LiteLLM proxy.
+        # LiteLLM's Langfuse callback reads metadata.session_id to group
+        # traces from the same agent operation (dream cycle, dialectic
+        # request, etc.) under one Langfuse session.
+        if extra_params and "langfuse_session_id" in extra_params:
+            params["extra_body"] = {
+                "metadata": {"session_id": extra_params["langfuse_session_id"]}
+            }
+
         return params
 
     def _normalize_response(

--- a/src/llm/executor.py
+++ b/src/llm/executor.py
@@ -322,7 +322,11 @@ async def honcho_llm_call_inner(
     # Propagate Langfuse session_id for trace grouping via LiteLLM proxy.
     # When set, backends include it in the request metadata so LiteLLM's
     # Langfuse callback groups all calls from the same agent operation.
-    if telemetry and telemetry.langfuse_session_id:
+    if (
+        telemetry
+        and telemetry.langfuse_session_id
+        and isinstance(telemetry.langfuse_session_id, str)
+    ):
         call_extras["langfuse_session_id"] = telemetry.langfuse_session_id
 
     if stream:

--- a/src/llm/executor.py
+++ b/src/llm/executor.py
@@ -319,6 +319,12 @@ async def honcho_llm_call_inner(
     # build_config_extra_params(effective_config) on top for top_p/seed/etc.
     call_extras: dict[str, Any] = {"json_mode": json_mode, "verbosity": verbosity}
 
+    # Propagate Langfuse session_id for trace grouping via LiteLLM proxy.
+    # When set, backends include it in the request metadata so LiteLLM's
+    # Langfuse callback groups all calls from the same agent operation.
+    if telemetry and telemetry.langfuse_session_id:
+        call_extras["langfuse_session_id"] = telemetry.langfuse_session_id
+
     if stream:
         # Stream path: setup must run inside the awaited coroutine so it
         # sits inside the outer retry wrapper (tool_loop.stream_final_response

--- a/src/llm/tool_loop.py
+++ b/src/llm/tool_loop.py
@@ -89,6 +89,7 @@ def _telemetry_for_iteration(
         observed=base.observed,
         peer_name=base.peer_name,
         agent_type=base.agent_type,
+        langfuse_session_id=base.langfuse_session_id,
     )
 
 

--- a/src/llm/types.py
+++ b/src/llm/types.py
@@ -75,6 +75,10 @@ class LLMTelemetryContext:
     # agent — dialectic/deduction/induction. Used by agent iteration
     # event and tool call event.
     agent_type: str | None = None
+    # Langfuse trace grouping: when set, passed as `metadata.session_id` to
+    # LiteLLM proxy so all LLM calls within the same agent operation (dream
+    # cycle, dialectic request, deriver batch) appear under one Langfuse session.
+    langfuse_session_id: str | None = None
 
 
 IterationCallback = Callable[[IterationData], None]

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -351,3 +351,43 @@ async def test_openai_backend_omits_extra_body_without_langfuse_session_id() -> 
     assert await_args is not None
     call = await_args.kwargs
     assert "extra_body" not in call
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_omits_extra_body_when_langfuse_session_id_is_none() -> (
+    None
+):
+    """When langfuse_session_id is explicitly None, extra_body should not be set."""
+    client = Mock()
+    client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        content="Hello",
+                        tool_calls=[],
+                        reasoning_details=[],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=5,
+                completion_tokens=1,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            ),
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    await backend.complete(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        extra_params={"langfuse_session_id": None},
+    )
+
+    await_args = client.chat.completions.create.await_args
+    assert await_args is not None
+    call = await_args.kwargs
+    assert "extra_body" not in call

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -274,3 +274,80 @@ def test_openai_classic_models_use_max_tokens(model: str) -> None:
     )
 
     assert _uses_max_completion_tokens(model) is False
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_includes_langfuse_session_id_in_extra_body() -> None:
+    """When langfuse_session_id is provided in extra_params, the backend
+    should pass it as metadata.session_id via extra_body so LiteLLM proxy's
+    Langfuse callback can group traces from the same agent operation."""
+    client = Mock()
+    client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        content="Hello",
+                        tool_calls=[],
+                        reasoning_details=[],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=5,
+                completion_tokens=1,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            ),
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    await backend.complete(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        extra_params={"langfuse_session_id": "dream-abc123"},
+    )
+
+    await_args = client.chat.completions.create.await_args
+    assert await_args is not None
+    call = await_args.kwargs
+    assert call["extra_body"] == {"metadata": {"session_id": "dream-abc123"}}
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_omits_extra_body_without_langfuse_session_id() -> None:
+    """When no langfuse_session_id is present, extra_body should not be set."""
+    client = Mock()
+    client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        content="Hello",
+                        tool_calls=[],
+                        reasoning_details=[],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=5,
+                completion_tokens=1,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            ),
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    await backend.complete(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+    )
+
+    await_args = client.chat.completions.create.await_args
+    assert await_args is not None
+    call = await_args.kwargs
+    assert "extra_body" not in call


### PR DESCRIPTION
## Summary

Support Langfuse trace grouping for Honcho's agent loops by passing `session_id` through to LiteLLM proxy via request metadata. When LLM calls are routed through a LiteLLM proxy with `callbacks: ["langfuse"]`, all calls from the same agent operation (dream cycle, dialectic request, deriver batch) are now grouped under one Langfuse session.

## Problem

When Honcho's LLM calls are routed through a LiteLLM proxy with `callbacks: ["langfuse"]`, each completion request creates a separate Langfuse trace with no correlation between them. A single dream cycle (deduction specialist → induction specialist, potentially 10–20 LLM calls) produces 10–20 orphaned traces. The same applies to dialectic tool loops and deriver batches.

This makes it difficult to:
- Understand the full lifecycle of an agent operation
- Attribute cost and latency to a specific dream/dialectic/deriver run
- Debug multi-step agent behaviour in context

## Solution

Add `langfuse_session_id` to `LLMTelemetryContext`. Agent entry points set it, and the OpenAI backend passes it as `extra_body={metadata: {session_id: ...}}` to LiteLLM. LiteLLM's Langfuse callback reads `metadata.session_id` to group traces under one session.

### Data flow

```
Agent entry point (e.g. run_dream)
  → LLMTelemetryContext(langfuse_session_id="dream-abc123")
    → honcho_llm_call(telemetry=ctx)
      → honcho_llm_call_inner
        → extra_params["langfuse_session_id"] = "dream-abc123"
          → execute_completion / execute_stream
            → OpenAIBackend._build_params
              → params["extra_body"] = {"metadata": {"session_id": "dream-abc123"}}
                → LiteLLM proxy
                  → Langfuse callback: trace.session_id = "dream-abc123"
```

### Session ID format

| Agent | Format | Example | Scope |
|-------|--------|---------|-------|
| Dreamer specialist | `dream-{run_id}` | `dream-V1StGXR8` | One dream cycle |
| Dialectic | `dialectic-{run_id}` | `dialectic-3KjR9mN2` | One chat request |
| Deriver | `deriver-{batch_id}` | `deriver-K7pWxQ4z` | One message batch |

Each agent already generates a unique ID for internal telemetry (the dreamer and dialectic use `run_id` from nanoid). The deriver now generates a `batch_id` nanoid per batch in `process_representation_tasks_batch`, matching the same pattern.

### Changes

- **`src/llm/types.py`**: Add `langfuse_session_id: str | None = None` to `LLMTelemetryContext`
- **`src/llm/executor.py`**: Propagate `langfuse_session_id` from telemetry to `extra_params` dict
- **`src/llm/backends/openai.py`**: When `extra_params` contains `langfuse_session_id`, emit `extra_body` with `metadata.session_id`
- **`src/dreamer/specialists.py`**: Set `langfuse_session_id` from `run_id`
- **`src/dialectic/core.py`**: Set `langfuse_session_id` from `run_id`
- **`src/deriver/deriver.py`**: Generate `batch_id` nanoid per batch; set `langfuse_session_id` from it
- **`src/llm/tool_loop.py`**: Preserve `langfuse_session_id` in per-iteration telemetry context copies
- **Tests**: Verify `extra_body` is present when `langfuse_session_id` is set, absent when not

### Why session_id, not trace_id?

LiteLLM supports both `session_id` (groups traces into a session) and `trace_id`/`existing_trace_id` (merges calls into a single trace). I chose `session_id` because:

1. **Robustness**: If the first LLM call fails, subsequent calls still appear under the session. With `existing_trace_id`, orphaned spans result if the parent trace was never created.
2. **Simplicity**: No need to distinguish "first call" vs "subsequent calls" — every call just carries the same `session_id`.
3. **Semantics**: A dream cycle or dialectic request IS a session — multiple related traces that should be viewed together.

If tighter single-trace grouping is desired in the future, the same plumbing can carry `trace_id`/`existing_trace_id` with minimal changes.

## Complements #693

This PR is complementary to #693 (Langfuse generation tracing). That PR makes individual LLM calls visible as proper generation observations via `@conditional_observe`. This PR ensures that when those calls are routed through a LiteLLM proxy, they're also grouped together by agent operation.

## Related

- #693 — Langfuse generation tracing (active PR)
- #565 — Langfuse metadata (namespace, model, provider)
- #253 — Langfuse rework introducing conditional_observe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-operation session IDs across components so related interactions are consistently tagged and grouped in observability traces and propagated to upstream requests for improved trace correlation.

* **Tests**
  * Added tests ensuring session IDs are included in backend requests when provided and omitted when not present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->