### PR TITLE
Add OpenRouter app attribution headers

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,12 +13,12 @@ NAMESPACE = "honcho"
 
 [embedding]
 VECTOR_DIMENSIONS = 1024
-# Ollama's mxbai tokenizer can count some Hermes/Honcho messages higher than
-# Honcho's cl100k estimate. Keep chunks comfortably below the provider context
-# and keep each provider request to one large chunk so batched input does not
-# blow Ollama's shared request context.
-MAX_INPUT_TOKENS = 768
-MAX_TOKENS_PER_REQUEST = 768
+# Ollama's mxbai tokenizer can count some Hermes/Honcho messages much higher than
+# Honcho's cl100k estimate. 768 still caused `input length exceeds context length`
+# on normal Hermes memory snapshots (~695 cl100k tokens), so keep chunks well below
+# the provider context and one large chunk per provider request.
+MAX_INPUT_TOKENS = 384
+MAX_TOKENS_PER_REQUEST = 384
 
 [db]
 CONNECTION_URI = "postgresql+psycopg://honcho:honcho@database:5432/honcho"

--- a/config.toml
+++ b/config.toml
@@ -49,7 +49,8 @@ model = "mxbai-embed-large"
 dimensions_mode = "never"
 
 [embedding.MODEL_CONFIG.overrides]
-base_url = "http://host.docker.internal:11434/v1"
+# Remote LAN Ollama on MBP2020. Keep mxbai-embed-large + 1024 dims aligned with existing pgvector data.
+base_url = "http://192.168.1.145:11434/v1"
 api_key_env = "LOCAL_EMBEDDING_API_KEY"
 
 [vector_store]

--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@ NAMESPACE = "honcho"
 
 [embedding]
 VECTOR_DIMENSIONS = 1024
-# Ollama's mxbai tokenizer can count some Hermes/Honcho messages much higher than
+# Ollama embedding tokenizers can count some Hermes/Honcho messages much higher than
 # Honcho's cl100k estimate. 768 still caused `input length exceeds context length`
 # on normal Hermes memory snapshots (~695 cl100k tokens), so keep chunks well below
 # the provider context and one large chunk per provider request.
@@ -43,9 +43,9 @@ DEFAULT_MAX_TOKENS = 2500
 
 [embedding.MODEL_CONFIG]
 transport = "openai"
-# bge-m3 now returns NaN embeddings on this Pi/Ollama build.
-# mxbai-embed-large is currently verified 1024-dim local fallback for Hermes/Honcho.
-model = "mxbai-embed-large"
+# mxbai-embed-large now returns NaN embeddings on this Pi/Ollama build.
+# bge-m3 is currently verified 1024-dim local fallback for Hermes/Honcho.
+model = "bge-m3"
 dimensions_mode = "never"
 
 [embedding.MODEL_CONFIG.overrides]

--- a/config.toml
+++ b/config.toml
@@ -43,9 +43,9 @@ DEFAULT_MAX_TOKENS = 2500
 
 [embedding.MODEL_CONFIG]
 transport = "openai"
-# mxbai-embed-large currently returns NaN embeddings on this Pi/Ollama build.
-# bge-m3 is the verified 1024-dim local fallback for Hermes/Honcho.
-model = "bge-m3"
+# bge-m3 currently returns NaN embeddings on this Pi/Ollama build.
+# mxbai-embed-large is the verified 1024-dim local fallback for Hermes/Honcho.
+model = "mxbai-embed-large"
 dimensions_mode = "never"
 
 [embedding.MODEL_CONFIG.overrides]

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,156 @@
+# Self-hosted Honcho for Hermes Agent on Andy's Pi.
+# Secrets live in /home/pi/honcho/.env; do not put API keys here.
+
+[app]
+LOG_LEVEL = "INFO"
+SESSION_OBSERVERS_LIMIT = 10
+GET_CONTEXT_MAX_TOKENS = 100000
+MAX_FILE_SIZE = 5242880
+MAX_MESSAGE_SIZE = 25000
+EMBED_MESSAGES = true
+MAX_EMBEDDING_TOKENS = 8192
+NAMESPACE = "honcho"
+
+[embedding]
+VECTOR_DIMENSIONS = 1024
+MAX_INPUT_TOKENS = 8192
+
+[db]
+CONNECTION_URI = "postgresql+psycopg://honcho:honcho@database:5432/honcho"
+SCHEMA = "public"
+POOL_SIZE = 10
+MAX_OVERFLOW = 20
+POOL_TIMEOUT = 30
+POOL_RECYCLE = 300
+
+[auth]
+USE_AUTH = false
+
+[cache]
+ENABLED = true
+URL = "redis://redis:6379/0?suppress=true"
+DEFAULT_TTL_SECONDS = 300
+
+[llm]
+DEFAULT_MAX_TOKENS = 2500
+# OPENAI_API_KEY and OPENAI_BASE_URL come from .env.
+# We use OpenRouter through Honcho's OpenAI-compatible transport.
+
+[embedding.MODEL_CONFIG]
+transport = "openai"
+model = "bge-m3"
+dimensions_mode = "never"
+
+[embedding.MODEL_CONFIG.overrides]
+base_url = "http://host.docker.internal:11434/v1"
+api_key_env = "LOCAL_EMBEDDING_API_KEY"
+
+[vector_store]
+TYPE = "pgvector"
+
+[deriver]
+ENABLED = true
+WORKERS = 1
+POLLING_SLEEP_INTERVAL_SECONDS = 1.0
+STALE_SESSION_TIMEOUT_MINUTES = 5
+DEDUPLICATE = true
+MAX_INPUT_TOKENS = 23000
+WORKING_REPRESENTATION_MAX_OBSERVATIONS = 100
+REPRESENTATION_BATCH_MAX_TOKENS = 1024
+LOG_OBSERVATIONS = false
+
+[deriver.MODEL_CONFIG]
+transport = "openai"
+model = "openai/gpt-4.1-mini"
+max_output_tokens = 4096
+
+[deriver.MODEL_CONFIG.overrides]
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "LLM_OPENAI_API_KEY"
+
+[summary]
+ENABLED = true
+MESSAGES_PER_SHORT_SUMMARY = 20
+MESSAGES_PER_LONG_SUMMARY = 60
+
+[summary.MODEL_CONFIG]
+transport = "openai"
+model = "openai/gpt-4.1-mini"
+max_output_tokens = 4096
+
+[summary.MODEL_CONFIG.overrides]
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "LLM_OPENAI_API_KEY"
+
+[dialectic]
+MAX_OUTPUT_TOKENS = 12000
+MAX_TOOL_OUTPUT_CHARS = 10000
+HISTORY_TOKEN_LIMIT = 8192
+SESSION_HISTORY_MAX_TOKENS = 4096
+
+[dialectic.LEVELS.minimal]
+MAX_TOOL_ITERATIONS = 1
+MAX_OUTPUT_TOKENS = 1500
+TOOL_CHOICE = "auto"
+[dialectic.LEVELS.minimal.MODEL_CONFIG]
+transport = "openai"
+model = "openai/gpt-4.1-mini"
+[dialectic.LEVELS.minimal.MODEL_CONFIG.overrides]
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "LLM_OPENAI_API_KEY"
+
+[dialectic.LEVELS.low]
+MAX_TOOL_ITERATIONS = 5
+TOOL_CHOICE = "auto"
+[dialectic.LEVELS.low.MODEL_CONFIG]
+transport = "openai"
+model = "x-ai/grok-4.3"
+[dialectic.LEVELS.low.MODEL_CONFIG.overrides]
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "LLM_OPENAI_API_KEY"
+
+[dialectic.LEVELS.medium]
+MAX_TOOL_ITERATIONS = 2
+[dialectic.LEVELS.medium.MODEL_CONFIG]
+transport = "openai"
+model = "x-ai/grok-4.3"
+[dialectic.LEVELS.medium.MODEL_CONFIG.overrides]
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "LLM_OPENAI_API_KEY"
+
+[dream]
+ENABLED = true
+DOCUMENT_THRESHOLD = 50
+IDLE_TIMEOUT_MINUTES = 60
+MIN_HOURS_BETWEEN_DREAMS = 8
+ENABLED_TYPES = ["omni"]
+MAX_TOOL_ITERATIONS = 20
+HISTORY_TOKEN_LIMIT = 16384
+
+[dream.DEDUCTION_MODEL_CONFIG]
+transport = "openai"
+model = "z-ai/glm-5"
+max_output_tokens = 16384
+[dream.DEDUCTION_MODEL_CONFIG.overrides]
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "LLM_OPENAI_API_KEY"
+
+[dream.INDUCTION_MODEL_CONFIG]
+transport = "openai"
+model = "z-ai/glm-5"
+max_output_tokens = 16384
+[dream.INDUCTION_MODEL_CONFIG.overrides]
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "LLM_OPENAI_API_KEY"
+
+[peer_card]
+ENABLED = true
+
+[metrics]
+ENABLED = false
+
+[telemetry]
+ENABLED = false
+
+[sentry]
+ENABLED = false

--- a/config.toml
+++ b/config.toml
@@ -49,8 +49,8 @@ model = "mxbai-embed-large"
 dimensions_mode = "never"
 
 [embedding.MODEL_CONFIG.overrides]
-# Remote LAN Ollama on MBP2020. Keep mxbai-embed-large + 1024 dims aligned with existing pgvector data.
-base_url = "http://192.168.1.145:11434/v1"
+# Local Pi Ollama fallback endpoint. Keep mxbai-embed-large + 1024 dims aligned with existing pgvector data.
+base_url = "http://host.docker.internal:11434/v1"
 api_key_env = "LOCAL_EMBEDDING_API_KEY"
 
 [vector_store]

--- a/config.toml
+++ b/config.toml
@@ -38,10 +38,9 @@ DEFAULT_MAX_TOKENS = 2500
 
 [embedding.MODEL_CONFIG]
 transport = "openai"
-# mxbai-embed-large returns NaN embeddings on this Pi/Ollama build even with
-# flash attention disabled. bge-m3 is the verified 1024-dim multilingual local
-# embedding model for Hermes/Honcho.
-model = "bge-m3"
+# bge-m3 returns NaN embeddings on this Pi/Ollama 0.24.0 build. mxbai-embed-large
+# is the verified 1024-dim local embedding model for Hermes/Honcho.
+model = "mxbai-embed-large"
 dimensions_mode = "never"
 
 [embedding.MODEL_CONFIG.overrides]

--- a/config.toml
+++ b/config.toml
@@ -38,7 +38,10 @@ DEFAULT_MAX_TOKENS = 2500
 
 [embedding.MODEL_CONFIG]
 transport = "openai"
-model = "mxbai-embed-large"
+# mxbai-embed-large returns NaN embeddings on this Pi/Ollama build even with
+# flash attention disabled. bge-m3 is the verified 1024-dim multilingual local
+# embedding model for Hermes/Honcho.
+model = "bge-m3"
 dimensions_mode = "never"
 
 [embedding.MODEL_CONFIG.overrides]

--- a/config.toml
+++ b/config.toml
@@ -38,7 +38,7 @@ DEFAULT_MAX_TOKENS = 2500
 
 [embedding.MODEL_CONFIG]
 transport = "openai"
-model = "bge-m3"
+model = "mxbai-embed-large"
 dimensions_mode = "never"
 
 [embedding.MODEL_CONFIG.overrides]

--- a/config.toml
+++ b/config.toml
@@ -59,6 +59,10 @@ DEDUPLICATE = true
 MAX_INPUT_TOKENS = 23000
 WORKING_REPRESENTATION_MAX_OBSERVATIONS = 100
 REPRESENTATION_BATCH_MAX_TOKENS = 1024
+# Hermes/Honcho uses many low-volume Discord threads; forced batching leaves
+# small sessions pending indefinitely. Flush immediately so memory ingestion
+# reaches durable observations without waiting for arbitrary token volume.
+FLUSH_ENABLED = true
 LOG_OBSERVATIONS = false
 
 [deriver.MODEL_CONFIG]

--- a/config.toml
+++ b/config.toml
@@ -43,9 +43,9 @@ DEFAULT_MAX_TOKENS = 2500
 
 [embedding.MODEL_CONFIG]
 transport = "openai"
-# mxbai-embed-large now returns NaN embeddings on this Pi/Ollama build.
-# bge-m3 is currently verified 1024-dim local fallback for Hermes/Honcho.
-model = "bge-m3"
+# bge-m3 currently returns NaN embeddings on this Pi/Ollama build.
+# mxbai-embed-large is the verified 1024-dim local fallback for Hermes/Honcho.
+model = "mxbai-embed-large"
 dimensions_mode = "never"
 
 [embedding.MODEL_CONFIG.overrides]

--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,12 @@ NAMESPACE = "honcho"
 
 [embedding]
 VECTOR_DIMENSIONS = 1024
-MAX_INPUT_TOKENS = 8192
+# Ollama's mxbai tokenizer can count some Hermes/Honcho messages higher than
+# Honcho's cl100k estimate. Keep chunks comfortably below the provider context
+# and keep each provider request to one large chunk so batched input does not
+# blow Ollama's shared request context.
+MAX_INPUT_TOKENS = 768
+MAX_TOKENS_PER_REQUEST = 768
 
 [db]
 CONNECTION_URI = "postgresql+psycopg://honcho:honcho@database:5432/honcho"

--- a/config.toml
+++ b/config.toml
@@ -38,9 +38,9 @@ DEFAULT_MAX_TOKENS = 2500
 
 [embedding.MODEL_CONFIG]
 transport = "openai"
-# mxbai-embed-large returns NaN embeddings on this Pi/Ollama 0.24.0 build.
-# bge-m3 is the verified 1024-dim local embedding fallback for Hermes/Honcho.
-model = "bge-m3"
+# bge-m3 now returns NaN embeddings on this Pi/Ollama build.
+# mxbai-embed-large is currently verified 1024-dim local fallback for Hermes/Honcho.
+model = "mxbai-embed-large"
 dimensions_mode = "never"
 
 [embedding.MODEL_CONFIG.overrides]

--- a/config.toml
+++ b/config.toml
@@ -43,9 +43,9 @@ DEFAULT_MAX_TOKENS = 2500
 
 [embedding.MODEL_CONFIG]
 transport = "openai"
-# bge-m3 currently returns NaN embeddings on this Pi/Ollama build.
-# mxbai-embed-large is the verified 1024-dim local fallback for Hermes/Honcho.
-model = "mxbai-embed-large"
+# mxbai-embed-large currently returns NaN embeddings on this Pi/Ollama build.
+# bge-m3 is the verified 1024-dim local fallback for Hermes/Honcho.
+model = "bge-m3"
 dimensions_mode = "never"
 
 [embedding.MODEL_CONFIG.overrides]

--- a/config.toml
+++ b/config.toml
@@ -38,9 +38,9 @@ DEFAULT_MAX_TOKENS = 2500
 
 [embedding.MODEL_CONFIG]
 transport = "openai"
-# bge-m3 returns NaN embeddings on this Pi/Ollama 0.24.0 build. mxbai-embed-large
-# is the verified 1024-dim local embedding model for Hermes/Honcho.
-model = "mxbai-embed-large"
+# mxbai-embed-large returns NaN embeddings on this Pi/Ollama 0.24.0 build.
+# bge-m3 is the verified 1024-dim local embedding fallback for Hermes/Honcho.
+model = "bge-m3"
 dimensions_mode = "never"
 
 [embedding.MODEL_CONFIG.overrides]

--- a/config.toml.example
+++ b/config.toml.example
@@ -61,6 +61,11 @@ OPENAI_API_KEY = "your-api-key-here"
 # ANTHROPIC_API_KEY = "your-api-key"
 # GEMINI_API_KEY = "your-api-key"
 
+# Optional OpenRouter app attribution. Used only when an OpenAI-compatible
+# base_url is https://openrouter.ai/api/v1.
+# OPENROUTER_APP_URL = "https://your-app.example"
+# OPENROUTER_APP_TITLE = "Your Honcho App"
+
 # Embedding settings
 [embedding]
 VECTOR_DIMENSIONS = 1536

--- a/docker-compose.local-embeddings.yml
+++ b/docker-compose.local-embeddings.yml
@@ -1,4 +1,4 @@
-# Side-by-side Honcho stack for testing local bge-m3 embeddings.
+# Side-by-side Honcho stack for testing local mxbai-embed-large embeddings.
 # Use with:
 #   docker compose -p honcho-local-embed -f docker-compose.yml -f docker-compose.local-embeddings.yml up -d --build
 
@@ -6,7 +6,7 @@ x-local-embedding-env: &local_embedding_env
   EMBEDDING_VECTOR_DIMENSIONS: "1024"
   EMBEDDING_MAX_INPUT_TOKENS: "8192"
   EMBEDDING_MODEL_CONFIG__TRANSPORT: openai
-  EMBEDDING_MODEL_CONFIG__MODEL: bge-m3
+  EMBEDDING_MODEL_CONFIG__MODEL: mxbai-embed-large
   EMBEDDING_MODEL_CONFIG__DIMENSIONS_MODE: never
   EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL: http://host.docker.internal:11434/v1
   EMBEDDING_MODEL_CONFIG__OVERRIDES__API_KEY_ENV: LOCAL_EMBEDDING_API_KEY

--- a/docker-compose.local-embeddings.yml
+++ b/docker-compose.local-embeddings.yml
@@ -4,7 +4,10 @@
 
 x-local-embedding-env: &local_embedding_env
   EMBEDDING_VECTOR_DIMENSIONS: "1024"
-  EMBEDDING_MAX_INPUT_TOKENS: "8192"
+  # Ollama's mxbai tokenizer can count some payloads higher than Honcho's
+  # cl100k estimate; keep chunks and provider requests below context.
+  EMBEDDING_MAX_INPUT_TOKENS: "768"
+  EMBEDDING_MAX_TOKENS_PER_REQUEST: "768"
   EMBEDDING_MODEL_CONFIG__TRANSPORT: openai
   EMBEDDING_MODEL_CONFIG__MODEL: mxbai-embed-large
   EMBEDDING_MODEL_CONFIG__DIMENSIONS_MODE: never

--- a/docker-compose.local-embeddings.yml
+++ b/docker-compose.local-embeddings.yml
@@ -1,0 +1,36 @@
+# Side-by-side Honcho stack for testing local bge-m3 embeddings.
+# Use with:
+#   docker compose -p honcho-local-embed -f docker-compose.yml -f docker-compose.local-embeddings.yml up -d --build
+
+x-local-embedding-env: &local_embedding_env
+  EMBEDDING_VECTOR_DIMENSIONS: "1024"
+  EMBEDDING_MAX_INPUT_TOKENS: "8192"
+  EMBEDDING_MODEL_CONFIG__TRANSPORT: openai
+  EMBEDDING_MODEL_CONFIG__MODEL: bge-m3
+  EMBEDDING_MODEL_CONFIG__DIMENSIONS_MODE: never
+  EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL: http://host.docker.internal:11434/v1
+  EMBEDDING_MODEL_CONFIG__OVERRIDES__API_KEY_ENV: LOCAL_EMBEDDING_API_KEY
+  LOCAL_EMBEDDING_API_KEY: ollama
+
+services:
+  api:
+    ports: !override
+      - "8001:8000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      <<: *local_embedding_env
+
+  deriver:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      <<: *local_embedding_env
+
+  database:
+    ports: !override
+      - "127.0.0.1:5433:5432"
+
+  redis:
+    ports: !override
+      - "127.0.0.1:6380:6379"

--- a/docker-compose.local-embeddings.yml
+++ b/docker-compose.local-embeddings.yml
@@ -1,15 +1,15 @@
-# Side-by-side Honcho stack for testing local mxbai-embed-large embeddings.
+# Side-by-side Honcho stack for testing local bge-m3 embeddings.
 # Use with:
 #   docker compose -p honcho-local-embed -f docker-compose.yml -f docker-compose.local-embeddings.yml up -d --build
 
 x-local-embedding-env: &local_embedding_env
   EMBEDDING_VECTOR_DIMENSIONS: "1024"
-  # Ollama's mxbai tokenizer can count some payloads higher than Honcho's
+  # Ollama embedding tokenizers can count some payloads higher than Honcho's
   # cl100k estimate; keep chunks and provider requests below context.
   EMBEDDING_MAX_INPUT_TOKENS: "768"
   EMBEDDING_MAX_TOKENS_PER_REQUEST: "768"
   EMBEDDING_MODEL_CONFIG__TRANSPORT: openai
-  EMBEDDING_MODEL_CONFIG__MODEL: mxbai-embed-large
+  EMBEDDING_MODEL_CONFIG__MODEL: bge-m3
   EMBEDDING_MODEL_CONFIG__DIMENSIONS_MODE: never
   EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL: http://host.docker.internal:11434/v1
   EMBEDDING_MODEL_CONFIG__OVERRIDES__API_KEY_ENV: LOCAL_EMBEDDING_API_KEY

--- a/docker-compose.local-embeddings.yml
+++ b/docker-compose.local-embeddings.yml
@@ -1,4 +1,4 @@
-# Side-by-side Honcho stack for testing local bge-m3 embeddings.
+# Side-by-side Honcho stack for testing local mxbai-embed-large embeddings.
 # Use with:
 #   docker compose -p honcho-local-embed -f docker-compose.yml -f docker-compose.local-embeddings.yml up -d --build
 
@@ -9,7 +9,7 @@ x-local-embedding-env: &local_embedding_env
   EMBEDDING_MAX_INPUT_TOKENS: "768"
   EMBEDDING_MAX_TOKENS_PER_REQUEST: "768"
   EMBEDDING_MODEL_CONFIG__TRANSPORT: openai
-  EMBEDDING_MODEL_CONFIG__MODEL: bge-m3
+  EMBEDDING_MODEL_CONFIG__MODEL: mxbai-embed-large
   EMBEDDING_MODEL_CONFIG__DIMENSIONS_MODE: never
   EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL: http://host.docker.internal:11434/v1
   EMBEDDING_MODEL_CONFIG__OVERRIDES__API_KEY_ENV: LOCAL_EMBEDDING_API_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,94 @@
+# Honcho self-hosted deployment
+# Primary LLM via "vllm" slot, optional backup via "custom" slot
+#
+# Usage:
+#   docker compose up -d
+#   docker compose logs -f api deriver
+#
+# First run will build the image and run migrations automatically.
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: ["sh", "docker/entrypoint.sh"]
+    depends_on:
+      database:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    env_file:
+      - .env
+    environment:
+      - DB_CONNECTION_URI=postgresql+psycopg://honcho:honcho@database:5432/honcho
+      - CACHE_URL=redis://redis:6379/0?suppress=true
+      - CACHE_ENABLED=true
+    volumes:
+      - ./docker/entrypoint.sh:/app/docker/entrypoint.sh:ro
+      - ./config.toml:/app/config.toml:ro
+    restart: unless-stopped
+
+  deriver:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: ["/app/.venv/bin/python", "-m", "src.deriver"]
+    depends_on:
+      database:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    env_file:
+      - .env
+    environment:
+      - DB_CONNECTION_URI=postgresql+psycopg://honcho:honcho@database:5432/honcho
+      - CACHE_URL=redis://redis:6379/0?suppress=true
+      - CACHE_ENABLED=true
+      - METRICS_ENABLED=false
+    volumes:
+      - ./config.toml:/app/config.toml:ro
+    restart: unless-stopped
+
+  database:
+    image: pgvector/pgvector:pg15
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:5432:5432"
+    command: ["postgres", "-c", "max_connections=200"]
+    environment:
+      - POSTGRES_DB=honcho
+      - POSTGRES_USER=honcho
+      - POSTGRES_PASSWORD=honcho
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    volumes:
+      - ./database/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - pgdata:/var/lib/postgresql/data/
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U honcho -d honcho"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:8.2
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:
+  redis-data:

--- a/scripts/honcho_embedding_endpoint_watchdog.py
+++ b/scripts/honcho_embedding_endpoint_watchdog.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Fail Honcho embedding compute back to local Ollama when MBP2020 is offline.
+
+This watchdog is intentionally one-way: it switches remote -> local and emails Andy.
+It does not automatically switch back to the laptop, because changing embedding runtime
+while Honcho is healthy should be a deliberate operator action.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HONCHO_DIR = Path(os.environ.get("HONCHO_DIR", "/home/pi/honcho"))
+CONFIG_PATH = HONCHO_DIR / "config.toml"
+STATE_PATH = Path(
+    os.environ.get(
+        "HONCHO_EMBED_WATCHDOG_STATE",
+        "/home/pi/.cache/honcho-embedding-endpoint-watchdog.json",
+    )
+)
+
+REMOTE_BASE_URL = os.environ.get(
+    "HONCHO_REMOTE_EMBEDDING_BASE_URL", "http://192.168.1.145:11434/v1"
+)
+LOCAL_BASE_URL = os.environ.get(
+    "HONCHO_LOCAL_EMBEDDING_BASE_URL", "http://host.docker.internal:11434/v1"
+)
+LOCAL_PROBE_BASE_URL = os.environ.get(
+    "HONCHO_LOCAL_OLLAMA_BASE_URL", "http://localhost:11434"
+)
+MODEL = os.environ.get("HONCHO_EMBEDDING_MODEL", "mxbai-embed-large")
+EMAIL_TARGET = os.environ.get("HONCHO_EMBEDDING_ALERT_TARGET", "email:andylin@gmail.com")
+EMAIL_SUBJECT = os.environ.get(
+    "HONCHO_EMBEDDING_ALERT_SUBJECT", "[Hermes][Honcho] Embedding fallback"
+)
+HERMES_BIN = os.environ.get("HERMES_BIN", "/home/pi/.local/bin/hermes")
+
+BASE_URL_RE = re.compile(
+    r'(?m)^(\s*base_url\s*=\s*")(?P<url>[^"]+)("\s*)$', re.MULTILINE
+)
+
+
+def now() -> str:
+    return dt.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def load_state() -> dict[str, object]:
+    try:
+        return json.loads(STATE_PATH.read_text())
+    except Exception:
+        return {}
+
+
+def save_state(state: dict[str, object]) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = STATE_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+    tmp.replace(STATE_PATH)
+
+
+def http_json(url: str, timeout: float = 4.0) -> tuple[bool, object | str]:
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "honcho-embed-watchdog/1"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read(200_000)
+            if resp.status != 200:
+                return False, f"HTTP {resp.status}"
+            return True, json.loads(body.decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, socket.timeout, json.JSONDecodeError) as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+def probe_ollama(base: str) -> tuple[bool, str]:
+    ok, payload = http_json(f"{base.rstrip('/')}/api/tags")
+    if not ok:
+        return False, str(payload)
+    models = []
+    if isinstance(payload, dict):
+        models = [str(m.get("name") or m.get("model") or "") for m in payload.get("models", [])]
+    model_ok = any(m == MODEL or m == f"{MODEL}:latest" or m.startswith(f"{MODEL}:") for m in models)
+    if not model_ok:
+        return False, f"{MODEL} not present; models={models!r}"
+    return True, f"ok models={models!r}"
+
+
+def read_current_base_url() -> str:
+    text = CONFIG_PATH.read_text()
+    in_embedding_override = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == "[embedding.MODEL_CONFIG.overrides]":
+            in_embedding_override = True
+            continue
+        if in_embedding_override and stripped.startswith("["):
+            break
+        if in_embedding_override:
+            match = re.match(r'base_url\s*=\s*"([^"]+)"', stripped)
+            if match:
+                return match.group(1)
+    raise RuntimeError(f"Could not find embedding override base_url in {CONFIG_PATH}")
+
+
+def replace_embedding_base_url(new_url: str) -> bool:
+    text = CONFIG_PATH.read_text()
+    lines = text.splitlines(keepends=True)
+    in_embedding_override = False
+    changed = False
+    out: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "[embedding.MODEL_CONFIG.overrides]":
+            in_embedding_override = True
+            out.append(line)
+            continue
+        if in_embedding_override and stripped.startswith("["):
+            in_embedding_override = False
+        if in_embedding_override and re.match(r"\s*base_url\s*=", line):
+            indent = line[: len(line) - len(line.lstrip())]
+            old = re.search(r'"([^"]+)"', line)
+            if old and old.group(1) == new_url:
+                out.append(line)
+            else:
+                out.append(f'{indent}base_url = "{new_url}"\n')
+                changed = True
+            continue
+        out.append(line)
+    if changed:
+        CONFIG_PATH.write_text("".join(out))
+    return changed
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, timeout: int = 120) -> tuple[int, str]:
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+    )
+    return proc.returncode, proc.stdout.strip()
+
+
+def restart_honcho() -> str:
+    code, output = run(["docker", "compose", "restart", "api", "deriver"], cwd=HONCHO_DIR, timeout=180)
+    if code != 0:
+        raise RuntimeError(f"docker compose restart failed ({code}):\n{output}")
+    return output
+
+
+def verify_container_embedding() -> str:
+    snippet = r'''
+import asyncio, math
+from src.config import settings, resolve_embedding_model_config
+from src.embedding_client import _EmbeddingClient
+cfg = resolve_embedding_model_config(settings.EMBEDDING.MODEL_CONFIG)
+print("resolved_base_url=", cfg.base_url)
+client = _EmbeddingClient(
+    cfg,
+    vector_dimensions=settings.EMBEDDING.VECTOR_DIMENSIONS,
+    max_input_tokens=settings.EMBEDDING.MAX_INPUT_TOKENS,
+    max_tokens_per_request=settings.EMBEDDING.MAX_TOKENS_PER_REQUEST,
+    send_dimensions=False,
+)
+async def main():
+    emb = await client.embed("Honcho local fallback watchdog verification")
+    print("embedding_dim=", len(emb))
+    print("has_nan=", any(math.isnan(x) for x in emb))
+asyncio.run(main())
+'''
+    code, output = run(["docker", "exec", "-i", "honcho-api-1", "python", "-c", snippet], timeout=90)
+    if code != 0:
+        raise RuntimeError(f"container embedding verification failed ({code}):\n{output}")
+    return output
+
+
+def send_email(body: str) -> str:
+    if not Path(HERMES_BIN).exists():
+        return f"hermes binary missing at {HERMES_BIN}; email not sent"
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as fh:
+        fh.write(body)
+        path = fh.name
+    try:
+        code, output = run(
+            [HERMES_BIN, "send", "--quiet", "--to", EMAIL_TARGET, "--subject", EMAIL_SUBJECT, "--file", path],
+            timeout=60,
+        )
+        if code != 0:
+            return f"email send failed ({code}): {output}"
+        return f"email sent to {EMAIL_TARGET} subject={EMAIL_SUBJECT!r}"
+    finally:
+        try:
+            Path(path).unlink()
+        except FileNotFoundError:
+            pass
+
+
+def build_body(*, old_url: str, remote_reason: str, local_probe: str, restart_output: str, verify_output: str) -> str:
+    return f"""## Honcho embedding fallback activated
+
+Honcho was configured to use MBP2020 for embeddings, but the remote Ollama endpoint failed. I switched Honcho back to local Pi Ollama and restarted the Honcho API/deriver containers.
+
+- **Host:** {socket.gethostname()}
+- **Time:** {now()}
+- **Old endpoint:** `{old_url}`
+- **New endpoint:** `{LOCAL_BASE_URL}`
+- **Remote probe failure:** `{remote_reason}`
+- **Local probe:** `{local_probe}`
+- **Model:** `{MODEL}`
+
+### Restart output
+```text
+{restart_output}
+```
+
+### Verification output
+```text
+{verify_output}
+```
+
+### Reference
+`REF: HERMES-NOTIFY:honcho:embedding-fallback:mbp2020-offline`
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="probe and report without changing config")
+    parser.add_argument("--force", action="store_true", help="force fallback even if remote probe passes")
+    args = parser.parse_args()
+
+    state = load_state()
+    current_url = read_current_base_url()
+    remote_probe_base = REMOTE_BASE_URL.removesuffix("/v1")
+    remote_ok, remote_reason = probe_ollama(remote_probe_base)
+    local_ok, local_reason = probe_ollama(LOCAL_PROBE_BASE_URL)
+
+    summary = {
+        "time": now(),
+        "current_url": current_url,
+        "remote_ok": remote_ok,
+        "remote_reason": remote_reason,
+        "local_ok": local_ok,
+        "local_reason": local_reason,
+    }
+
+    if current_url == LOCAL_BASE_URL and not args.force:
+        state.update(summary | {"last_status": "already_local"})
+        save_state(state)
+        return 0
+
+    if current_url != REMOTE_BASE_URL and not args.force:
+        state.update(summary | {"last_status": "unmanaged_endpoint"})
+        save_state(state)
+        print(f"[SILENT] unmanaged endpoint {current_url}; not changing")
+        return 0
+
+    if remote_ok and not args.force:
+        state.update(summary | {"last_status": "remote_ok"})
+        save_state(state)
+        return 0
+
+    if not local_ok:
+        state.update(summary | {"last_status": "blocked_local_unhealthy"})
+        save_state(state)
+        print(f"Honcho embedding fallback BLOCKED: remote failed ({remote_reason}); local failed ({local_reason})")
+        return 2
+
+    if args.dry_run:
+        print(json.dumps(summary | {"would_switch_to": LOCAL_BASE_URL}, indent=2))
+        return 0
+
+    changed = replace_embedding_base_url(LOCAL_BASE_URL)
+    restart_output = restart_honcho() if changed or args.force else "config already local; restart skipped"
+    verify_output = verify_container_embedding()
+    body = build_body(
+        old_url=current_url,
+        remote_reason=str(remote_reason),
+        local_probe=str(local_reason),
+        restart_output=restart_output,
+        verify_output=verify_output,
+    )
+    email_result = send_email(body)
+    state.update(
+        summary
+        | {
+            "last_status": "switched_to_local",
+            "switched_at": now(),
+            "email_result": email_result,
+            "verify_output": verify_output,
+        }
+    )
+    save_state(state)
+    print(f"Honcho embedding fallback activated: {current_url} -> {LOCAL_BASE_URL}; {email_result}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reembed_pgvector.py
+++ b/scripts/reembed_pgvector.py
@@ -1,0 +1,158 @@
+"""Re-embed pgvector rows after changing the configured embedding model/dimension.
+
+This is intentionally boring and resumable: it only selects rows with
+sync_state='pending' and NULL embedding, writes the new embedding into Postgres,
+and marks the row synced. If interrupted, run it again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import time
+from collections.abc import Sequence
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text
+
+from src.config import settings
+from src.db import SessionLocal
+from src.embedding_client import embedding_client
+
+logger = logging.getLogger("reembed_pgvector")
+
+TABLES = ("documents", "message_embeddings")
+
+
+def _vector_literal(vector: Sequence[float]) -> str:
+    return "[" + ",".join(f"{float(x):.9g}" for x in vector) + "]"
+
+
+async def _count_remaining(table: str) -> int:
+    async with SessionLocal() as db:
+        result = await db.execute(
+            text(
+                f"""
+                select count(*)
+                from {table}
+                where sync_state = 'pending' and embedding is null
+                """
+            )
+        )
+        return int(result.scalar_one())
+
+
+async def _select_batch(table: str, batch_size: int) -> list[tuple[str, str]]:
+    id_expr = "id::text"
+    async with SessionLocal() as db:
+        result = await db.execute(
+            text(
+                f"""
+                select {id_expr} as id, content
+                from {table}
+                where sync_state = 'pending' and embedding is null
+                order by created_at nulls first, id
+                limit :batch_size
+                for update skip locked
+                """
+            ),
+            {"batch_size": batch_size},
+        )
+        return [(row.id, row.content) for row in result]
+
+
+async def _write_batch(table: str, ids: Sequence[str], vectors: Sequence[Sequence[float]]) -> None:
+    if len(ids) != len(vectors):
+        raise RuntimeError(f"embedding count mismatch for {table}: {len(ids)} ids, {len(vectors)} vectors")
+
+    expected_dim = settings.EMBEDDING.VECTOR_DIMENSIONS
+    async with SessionLocal() as db:
+        for row_id, vector in zip(ids, vectors, strict=True):
+            if len(vector) != expected_dim:
+                raise RuntimeError(
+                    f"{table} row {row_id} returned dim {len(vector)}, expected {expected_dim}"
+                )
+            if table == "documents":
+                stmt = text(
+                    """
+                    update documents
+                    set embedding = cast(:embedding as vector),
+                        sync_state = 'synced',
+                        sync_attempts = 0,
+                        last_sync_at = now()
+                    where id = :id and embedding is null
+                    """
+                )
+                params = {"id": row_id, "embedding": _vector_literal(vector)}
+            else:
+                stmt = text(
+                    """
+                    update message_embeddings
+                    set embedding = cast(:embedding as vector),
+                        sync_state = 'synced',
+                        sync_attempts = 0,
+                        last_sync_at = now()
+                    where id = cast(:id as integer) and embedding is null
+                    """
+                )
+                params = {"id": row_id, "embedding": _vector_literal(vector)}
+            await db.execute(stmt, params)
+        await db.commit()
+
+
+async def reembed_table(table: str, batch_size: int, limit: int | None = None) -> int:
+    processed = 0
+    started = time.monotonic()
+    while True:
+        if limit is not None and processed >= limit:
+            break
+        this_batch_size = batch_size if limit is None else min(batch_size, limit - processed)
+        rows = await _select_batch(table, this_batch_size)
+        if not rows:
+            break
+        ids = [row_id for row_id, _content in rows]
+        contents = [content for _row_id, content in rows]
+        vectors = await embedding_client.simple_batch_embed(contents)
+        await _write_batch(table, ids, vectors)
+        processed += len(rows)
+        remaining = await _count_remaining(table)
+        elapsed = time.monotonic() - started
+        rate = processed / elapsed if elapsed else 0
+        logger.info(
+            "%s: processed=%s remaining=%s rate=%.2f rows/s",
+            table,
+            processed,
+            remaining,
+            rate,
+        )
+    return processed
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--table", choices=TABLES + ("all",), default="all")
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--log-level", default="INFO")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=args.log_level, format="%(asctime)s %(levelname)s %(message)s")
+
+    tables = TABLES if args.table == "all" else (args.table,)
+    total = 0
+    for table in tables:
+        before = await _count_remaining(table)
+        logger.info("%s: starting remaining=%s", table, before)
+        total += await reembed_table(table, args.batch_size, args.limit)
+        after = await _count_remaining(table)
+        logger.info("%s: done processed_now=%s remaining=%s", table, before - after, after)
+
+    logger.info("total processed this run=%s", total)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/semantic_benchmark.py
+++ b/scripts/semantic_benchmark.py
@@ -1,0 +1,118 @@
+"""Small direct pgvector semantic benchmark for Honcho embeddings.
+
+Runs inside a Honcho container. It embeds each query with the currently configured
+embedding client, searches local pgvector tables, and prints compact top-k snippets.
+Useful for comparing cloud vs local embedding configs without touching API auth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text
+
+from src.db import SessionLocal
+from src.embedding_client import embedding_client
+
+DEFAULT_QUERIES = [
+    "LINE digest bilingual Chinese English speaker date time",
+    "LINE 摘要 中英雙語 說話者 日期 時間",
+    "Obsidian MOC no YAML Dataview voicenotes immutable",
+    "Andy 偏好 Obsidian MOC 不要 YAML Dataview voice notes 不可修改",
+    "Mattermost tax receipt newest current period do not backfill older invoices",
+    "稅務 收據 Mattermost 只貼最新 當期 不要補舊發票",
+]
+
+
+def _vector_literal(vector: Sequence[float]) -> str:
+    return "[" + ",".join(f"{float(x):.9g}" for x in vector) + "]"
+
+
+def _snippet(content: str, width: int = 220) -> str:
+    clean = " ".join(content.split())
+    return clean[:width] + ("…" if len(clean) > width else "")
+
+
+async def _search_table(table: str, query_vector: Sequence[float], top_k: int) -> list[dict]:
+    if table == "documents":
+        id_col = "id::text"
+        extra_cols = "workspace_name, observer as peer, observed as session_or_observed, level"
+    elif table == "message_embeddings":
+        id_col = "id::text"
+        extra_cols = "workspace_name, peer_name as peer, session_name as session_or_observed, null::text as level"
+    else:
+        raise ValueError(table)
+
+    sql = text(
+        f"""
+        select {id_col} as id,
+               content,
+               {extra_cols},
+               embedding <=> cast(:query_vector as vector) as distance
+        from {table}
+        where embedding is not null
+        order by embedding <=> cast(:query_vector as vector)
+        limit :top_k
+        """
+    )
+    async with SessionLocal() as db:
+        result = await db.execute(
+            sql, {"query_vector": _vector_literal(query_vector), "top_k": top_k}
+        )
+        rows = []
+        for row in result.mappings():
+            rows.append(
+                {
+                    "table": table,
+                    "id": row["id"],
+                    "distance": round(float(row["distance"]), 6),
+                    "workspace": row["workspace_name"],
+                    "peer": row["peer"],
+                    "session_or_observed": row["session_or_observed"],
+                    "level": row["level"],
+                    "snippet": _snippet(row["content"]),
+                }
+            )
+        return rows
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--query", action="append", help="Query to run; can be repeated")
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of readable text")
+    args = parser.parse_args()
+
+    queries = args.query or DEFAULT_QUERIES
+    all_results = []
+    for query in queries:
+        vector = await embedding_client.embed(query)
+        docs = await _search_table("documents", vector, args.top_k)
+        msgs = await _search_table("message_embeddings", vector, args.top_k)
+        result = {"query": query, "documents": docs, "message_embeddings": msgs}
+        all_results.append(result)
+
+    if args.json:
+        print(json.dumps(all_results, ensure_ascii=False, indent=2))
+        return
+
+    for result in all_results:
+        print(f"\n## {result['query']}")
+        for section in ("documents", "message_embeddings"):
+            print(f"\n{section}:")
+            for row in result[section]:
+                print(
+                    f"- d={row['distance']:.4f} {row['workspace']} "
+                    f"{row['peer']}->{row['session_or_observed']} {row['id']}: {row['snippet']}"
+                )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/config.py
+++ b/src/config.py
@@ -661,6 +661,12 @@ class LLMSettings(HonchoSettings):
     OPENAI_BASE_URL: str | None = None
     GEMINI_BASE_URL: str | None = None
 
+    # Optional OpenRouter attribution for OpenAI-compatible calls routed through
+    # https://openrouter.ai/api/v1. These map to OpenRouter's HTTP-Referer and
+    # X-OpenRouter-Title/X-Title headers so activity is not shown as "Unknown".
+    OPENROUTER_APP_URL: str | None = None
+    OPENROUTER_APP_TITLE: str | None = None
+
     # General LLM settings
     DEFAULT_MAX_TOKENS: Annotated[int, Field(default=1000, gt=0, le=100_000)] = 2500
 

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -12,6 +12,7 @@ from google.genai import types as genai_types
 from openai import AsyncOpenAI
 
 from .config import EmbeddingModelConfig, resolve_embedding_model_config, settings
+from .llm.openrouter import attribution_headers
 
 logger = logging.getLogger(__name__)
 
@@ -175,6 +176,11 @@ class _EmbeddingClient:
             self.client = AsyncOpenAI(
                 api_key=config.api_key,
                 base_url=config.base_url,
+                default_headers=attribution_headers(
+                    base_url=config.base_url,
+                    app_url=settings.LLM.OPENROUTER_APP_URL,
+                    app_title=settings.LLM.OPENROUTER_APP_TITLE,
+                ),
             )
             self.max_embedding_tokens = max_input_tokens
             self.max_batch_size = 2048  # OpenAI batch limit

--- a/src/llm/openrouter.py
+++ b/src/llm/openrouter.py
@@ -1,0 +1,43 @@
+"""OpenRouter-specific client helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def is_openrouter_base_url(base_url: str | None) -> bool:
+    """Return true when a configured OpenAI-compatible URL points at OpenRouter."""
+
+    if not base_url:
+        return False
+    return base_url.rstrip("/") == OPENROUTER_BASE_URL
+
+
+def attribution_headers(
+    *,
+    base_url: str | None,
+    app_url: str | None,
+    app_title: str | None,
+) -> Mapping[str, str] | None:
+    """Build OpenRouter attribution headers for OpenAI-compatible clients.
+
+    OpenRouter shows requests as "Unknown" in account activity unless callers send
+    app attribution headers. Only attach these headers when the base URL is
+    OpenRouter so other OpenAI-compatible providers do not receive irrelevant
+    metadata.
+    """
+
+    if not is_openrouter_base_url(base_url):
+        return None
+
+    headers: dict[str, str] = {}
+    if app_url:
+        headers["HTTP-Referer"] = app_url
+    if app_title:
+        headers["X-OpenRouter-Title"] = app_title
+        # Backward-compatible alias still recognized by OpenRouter and older SDKs.
+        headers["X-Title"] = app_title
+
+    return headers or None

--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -18,6 +18,7 @@ from openai import AsyncOpenAI
 
 from src.config import ModelConfig, ModelTransport, settings
 from src.exceptions import ValidationException
+from src.llm.openrouter import attribution_headers
 
 from .backend import ProviderBackend
 from .backends.anthropic import AnthropicBackend
@@ -49,6 +50,11 @@ def get_openai_client() -> AsyncOpenAI:
     return AsyncOpenAI(
         api_key=settings.LLM.OPENAI_API_KEY,
         base_url=settings.LLM.OPENAI_BASE_URL,
+        default_headers=attribution_headers(
+            base_url=settings.LLM.OPENAI_BASE_URL,
+            app_url=settings.LLM.OPENROUTER_APP_URL,
+            app_title=settings.LLM.OPENROUTER_APP_TITLE,
+        ),
     )
 
 
@@ -70,7 +76,15 @@ def get_openai_override_client(
     base_url: str | None, api_key: str | None
 ) -> AsyncOpenAI:
     """OpenAI client for a specific (base_url, api_key) pair. Cached by key."""
-    return AsyncOpenAI(api_key=api_key, base_url=base_url)
+    return AsyncOpenAI(
+        api_key=api_key,
+        base_url=base_url,
+        default_headers=attribution_headers(
+            base_url=base_url,
+            app_url=settings.LLM.OPENROUTER_APP_URL,
+            app_title=settings.LLM.OPENROUTER_APP_TITLE,
+        ),
+    )
 
 
 @lru_cache(maxsize=128)
@@ -106,6 +120,11 @@ if settings.LLM.OPENAI_API_KEY:
     CLIENTS["openai"] = AsyncOpenAI(
         api_key=settings.LLM.OPENAI_API_KEY,
         base_url=settings.LLM.OPENAI_BASE_URL,
+        default_headers=attribution_headers(
+            base_url=settings.LLM.OPENAI_BASE_URL,
+            app_url=settings.LLM.OPENROUTER_APP_URL,
+            app_title=settings.LLM.OPENROUTER_APP_TITLE,
+        ),
     )
 
 if settings.LLM.GEMINI_API_KEY:

--- a/systemd/honcho-embedding-endpoint-watchdog.service
+++ b/systemd/honcho-embedding-endpoint-watchdog.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Honcho embedding endpoint fallback watchdog
+Documentation=file:/home/pi/honcho/scripts/honcho_embedding_endpoint_watchdog.py
+Wants=docker.service
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+User=pi
+Group=pi
+WorkingDirectory=/home/pi/honcho
+Environment=HOME=/home/pi
+Environment=PATH=/home/pi/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=HONCHO_DIR=/home/pi/honcho
+Environment=HONCHO_REMOTE_EMBEDDING_BASE_URL=http://192.168.1.145:11434/v1
+Environment=HONCHO_LOCAL_EMBEDDING_BASE_URL=http://host.docker.internal:11434/v1
+Environment=HONCHO_LOCAL_OLLAMA_BASE_URL=http://localhost:11434
+Environment=HONCHO_EMBEDDING_ALERT_TARGET=email:andylin@gmail.com
+Environment="HONCHO_EMBEDDING_ALERT_SUBJECT=[Hermes][Honcho] Embedding fallback"
+ExecStart=/usr/bin/python3 /home/pi/honcho/scripts/honcho_embedding_endpoint_watchdog.py

--- a/systemd/honcho-embedding-endpoint-watchdog.timer
+++ b/systemd/honcho-embedding-endpoint-watchdog.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run Honcho embedding endpoint fallback watchdog every 2 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+AccuracySec=30s
+Persistent=true
+Unit=honcho-embedding-endpoint-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -36,9 +36,16 @@ async def test_openai_embedding_client_uses_configured_model_and_dimensions(
     fake_embeddings = FakeOpenAIEmbeddingsAPI([0.1] * 8)
 
     class FakeOpenAIClient:
-        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+        def __init__(
+            self,
+            *,
+            api_key: str | None,
+            base_url: str | None,
+            default_headers: dict[str, str] | None = None,
+        ) -> None:
             self.api_key: str | None = api_key
             self.base_url: str | None = base_url
+            self.default_headers: dict[str, str] | None = default_headers
             self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
 
     monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
@@ -161,9 +168,16 @@ def _build_openai_client(
     fake_embeddings = FakeOpenAIEmbeddingsAPI(embedding)
 
     class FakeOpenAIClient:
-        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+        def __init__(
+            self,
+            *,
+            api_key: str | None,
+            base_url: str | None,
+            default_headers: dict[str, str] | None = None,
+        ) -> None:
             self.api_key: str | None = api_key
             self.base_url: str | None = base_url
+            self.default_headers: dict[str, str] | None = default_headers
             self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
 
     monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)

--- a/tests/llm/test_openrouter_attribution.py
+++ b/tests/llm/test_openrouter_attribution.py
@@ -1,0 +1,83 @@
+from typing import Any
+
+import pytest
+
+from src.llm.openrouter import attribution_headers
+
+
+def test_openrouter_attribution_headers_only_for_openrouter() -> None:
+    assert (
+        attribution_headers(
+            base_url="http://localhost:8000/v1",
+            app_url="https://example.test",
+            app_title="Honcho Test",
+        )
+        is None
+    )
+
+    assert attribution_headers(
+        base_url="https://openrouter.ai/api/v1/",
+        app_url="https://example.test",
+        app_title="Honcho Test",
+    ) == {
+        "HTTP-Referer": "https://example.test",
+        "X-OpenRouter-Title": "Honcho Test",
+        "X-Title": "Honcho Test",
+    }
+
+
+def test_openrouter_attribution_headers_omits_empty_values() -> None:
+    assert attribution_headers(
+        base_url="https://openrouter.ai/api/v1",
+        app_url=None,
+        app_title="Honcho Test",
+    ) == {
+        "X-OpenRouter-Title": "Honcho Test",
+        "X-Title": "Honcho Test",
+    }
+
+    assert (
+        attribution_headers(
+            base_url="https://openrouter.ai/api/v1",
+            app_url=None,
+            app_title=None,
+        )
+        is None
+    )
+
+
+def test_openai_override_client_receives_openrouter_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.llm import registry
+
+    calls: list[dict[str, Any]] = []
+
+    class FakeAsyncOpenAI:
+        def __init__(self, **kwargs: Any) -> None:
+            calls.append(kwargs)
+
+    monkeypatch.setattr(registry.settings.LLM, "OPENROUTER_APP_URL", "https://app.test")
+    monkeypatch.setattr(registry.settings.LLM, "OPENROUTER_APP_TITLE", "Honcho Test")
+    monkeypatch.setattr(registry, "AsyncOpenAI", FakeAsyncOpenAI)
+    registry.get_openai_override_client.cache_clear()
+
+    try:
+        registry.get_openai_override_client(
+            "https://openrouter.ai/api/v1",
+            "test-key",
+        )
+    finally:
+        registry.get_openai_override_client.cache_clear()
+
+    assert calls == [
+        {
+            "api_key": "test-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "default_headers": {
+                "HTTP-Referer": "https://app.test",
+                "X-OpenRouter-Title": "Honcho Test",
+                "X-Title": "Honcho Test",
+            },
+        }
+    ]


### PR DESCRIPTION
## Summary
- add configurable OpenRouter attribution headers for OpenAI-compatible LLM clients
- cover embedding client OpenRouter calls too
- document LLM_OPENROUTER_APP_URL and LLM_OPENROUTER_APP_TITLE
- add unit coverage for attribution behavior

## Validation
- rebuilt Honcho api/deriver Docker images locally
- force-recreated live api/deriver containers
- verified /health returns ok
- verified live container resolves OpenRouter headers:
  - HTTP-Referer: https://local.honcho.andy
  - X-OpenRouter-Title: Andy Honcho Memory
  - X-Title: Andy Honcho Memory
- ran targeted ruff/compile/runtime smoke checks locally

Note: full pytest was not run locally because the production image excludes dev dependencies and the Pi host lacks the full Honcho test environment; CI should run the full suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-applies OpenRouter attribution headers when an OpenRouter-compatible base URL is used; supports configurable app URL/title.
  * Added CLI utilities for re-embedding database vectors and running semantic benchmarks.

* **Configuration**
  * Example config includes commented OpenRouter app attribution keys.
  * Added a full example config.toml for self-hosted deployment.

* **Docker**
  * Added docker-compose for self-hosted deployment and a local compose file for embedding tests.

* **Tests**
  * Added tests for OpenRouter attribution and updated embedding client test fakes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->