### PR TITLE
feat(docker): make API port configurable via PORT environment variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,6 +7,10 @@
 # =============================================================================
 # Application Settings
 # =============================================================================
+# Port for the API server (default: 8000)
+# Change this if port 8000 conflicts with other services (e.g., Ollama, LM Studio)
+PORT=8000
+
 LOG_LEVEL=INFO
 # SESSION_OBSERVERS_LIMIT=10
 # GET_CONTEXT_MAX_TOKENS=100000

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ COPY --chown=app:app config.toml* /app/
 # Switch to non-root user
 USER app
 
+# Default port (can be overridden with PORT environment variable)
 EXPOSE 8000
 
-CMD ["fastapi", "run", "--host", "0.0.0.0", "src/main.py"]
+CMD ["sh", "-c", "fastapi run --host 0.0.0.0 --port ${PORT:-8000} src/main.py"]

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Then point the SDKs at it:
 ```python
 honcho = Honcho(workspace_id="my-app-testing", base_url="http://localhost:8000")
 # or: export HONCHO_URL=http://localhost:8000
+# If you changed PORT in .env, use that port instead (e.g., http://localhost:3001)
 ```
 
 <!-- markdownlint-disable MD033 -->

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ cp .env.template .env       # fill in LLM_GEMINI_API_KEY / LLM_ANTHROPIC_API_KEY
 docker compose up
 ```
 
-> **Note:** To use a different port (e.g., if 8000 conflicts with another service like Ollama), set `PORT=8080` in your `.env` file before running `docker compose up`.
+> **Note:** To use a different port (e.g., if 8000 conflicts with another service like Ollama), set `PORT={your desired port}` in your `.env` file before running `docker compose up`, then point SDKs to `http://localhost:{your desired port}`.
 
 Then point the SDKs at it:
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ cp .env.template .env       # fill in LLM_GEMINI_API_KEY / LLM_ANTHROPIC_API_KEY
 docker compose up
 ```
 
+> **Note:** To use a different port (e.g., if 8000 conflicts with another service like Ollama), set `PORT=8080` in your `.env` file before running `docker compose up`.
+
 Then point the SDKs at it:
 
 ```python

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -20,14 +20,15 @@ services:
       redis:
         condition: service_healthy
     ports:
-      - "127.0.0.1:8000:8000"
+      # Set PORT in .env to change the API server port (e.g., PORT=8080)
+      - "127.0.0.1:${PORT:-8000}:${PORT:-8000}"
     healthcheck:
       test:
         [
           "CMD",
-          "/app/.venv/bin/python",
+          "sh",
           "-c",
-          "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2).read()",
+          "/app/.venv/bin/python -c \"import urllib.request, os; urllib.request.urlopen(f'http://localhost:{os.getenv(\\\"PORT\\\", \\\"8000\\\")}/health', timeout=2).read()\"",
         ]
       interval: 5s
       timeout: 5s
@@ -38,6 +39,8 @@ services:
     #   - .:/app
     #   - venv:/app/.venv
     environment:
+      # PORT is set in .env (defaults to 8000 if not specified)
+      - PORT=${PORT:-8000}
       - DB_CONNECTION_URI=postgresql+psycopg://postgres:postgres@database:5432/postgres
       - CACHE_URL=redis://redis:6379/0?suppress=true
       - CACHE_ENABLED=true

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,5 +4,5 @@ set -e
 echo "Running database migrations..."
 /app/.venv/bin/python scripts/provision_db.py
 
-echo "Starting API server..."
-exec /app/.venv/bin/fastapi run --host 0.0.0.0 src/main.py
+echo "Starting API server on port ${PORT:-8000}..."
+exec /app/.venv/bin/fastapi run --host 0.0.0.0 --port "${PORT:-8000}" src/main.py


### PR DESCRIPTION
This PR makes the Honcho API server port configurable via a PORT environment variable in the .env file, allowing users to easily avoid port conflicts with services that commonly use port 8000.

## MOTIVATION

Port 8000 is commonly used by local LLM engines (Ollama, LM Studio, vLLM, etc.), making it difficult to run Honcho alongside these tools. Previously, users had to manually edit multiple files (docker-compose.yml, docker/entrypoint.sh, Dockerfile, and healthcheck configuration) to change the port. This PR simplifies the process to a single environment variable change.

## CHANGES

Added PORT setting to .env.template with clear documentation (defaults to 8000)
Updated docker-compose.yml.example to use ${PORT:-8000} for port mapping
Updated docker/entrypoint.sh to accept PORT environment variable
Updated Dockerfile CMD to use PORT environment variable
Updated healthcheck to dynamically read the configured port
Updated README with instructions for customizing the port

## TESTING
Verified both scenarios work correctly with Docker Compose:
Default behavior (PORT=8000):
API responds on http://localhost:8000/health

Custom port (PORT=3001):
API responds on http://localhost:3001/health


## USAGE EXAMPLE

Users can now simply set the port in their .env file:
cp docker-compose.yml.example docker-compose.yml
cp .env.template .env
Edit .env and set PORT=3001 (or any desired port)
docker compose up

All services automatically use the configured port with no additional file edits required.

Closes #706 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server port is configurable via a PORT environment variable (defaults to 8000); runtime and container startup honor this setting.

* **Documentation**
  * Updated self-hosting quick start and examples to show setting PORT in .env and adjusting SDK base URL if you change the port.
  * Docker Compose example and healthcheck updated to demonstrate using the PORT variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->