### PR TITLE
fix: flush session before upserting session_peers to prevent FK violation

### DIFF
--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -226,11 +226,12 @@ async def get_or_create_session(
         try:
             async with db.begin_nested():
                 db.add(honcho_session)
-            # Flush so the session row exists in PostgreSQL before
-            # _get_or_add_peers_to_session tries to upsert session_peers
-            # (which has a FK to sessions). Without this flush, the Core-level
-            # pg_insert executes before the ORM flush (autoflush=False in db.py).
-            await db.flush()
+                # Flush inside the savepoint so any IntegrityError (race condition)
+                # is confined to the nested transaction and the retry logic stays valid.
+                # Without this flush, the Core-level pg_insert in
+                # _get_or_add_peers_to_session executes before the ORM flush
+                # (autoflush=False in db.py), causing a FK violation on session_peers.
+                await db.flush()
             needs_cache_update = True
             created = True
 

--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -226,6 +226,11 @@ async def get_or_create_session(
         try:
             async with db.begin_nested():
                 db.add(honcho_session)
+            # Flush so the session row exists in PostgreSQL before
+            # _get_or_add_peers_to_session tries to upsert session_peers
+            # (which has a FK to sessions). Without this flush, the Core-level
+            # pg_insert executes before the ORM flush (autoflush=False in db.py).
+            await db.flush()
             needs_cache_update = True
             created = True
 


### PR DESCRIPTION
## Description

With `autoflush=False` in `src/db.py`, Core-level SQL statements like `pg_insert` do not automatically flush pending ORM objects before executing. In `get_or_create_session`, `db.add(honcho_session)` marks the session as pending, but when `_get_or_add_peers_to_session` executes the `pg_insert` upsert on `session_peers` (which has a foreign key to `sessions`), the session row doesn't exist in PostgreSQL yet, causing a `ForeignKeyViolation`.

## Fix

Added `await db.flush()` after the session creation and before the peer upsert, ensuring the session row exists in the database before the FK-dependent upsert executes.

## Testing

Verified working with the OWUI sync script that was previously hitting this error (500 from server after a few imports).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition during session creation that could cause related participant/peer records to fail to attach reliably, improving session setup consistency and reducing intermittent errors when joining or initializing sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->