### PR TITLE
fix(llm/openai): pass through `extra_body` from extra_params

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -322,6 +322,8 @@ class OpenAIBackend:
             ):
                 if key in extra_params:
                     params[key] = extra_params[key]
+            if "extra_body" in extra_params:
+                params.setdefault("extra_body", {}).update(extra_params["extra_body"])
         return params
 
     def _normalize_response(

--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -322,8 +322,24 @@ class OpenAIBackend:
             ):
                 if key in extra_params:
                     params[key] = extra_params[key]
-            if "extra_body" in extra_params:
-                params.setdefault("extra_body", {}).update(extra_params["extra_body"])
+            extra_body_in = extra_params.get("extra_body")
+            if isinstance(extra_body_in, dict):
+                base_extra_body = params.setdefault("extra_body", {})
+                for key, value in extra_body_in.items():
+                    # Deep-merge `reasoning` so a caller-supplied `reasoning` dict
+                    # does not clobber `reasoning.max_tokens` that the
+                    # thinking_budget_tokens block above may have populated.
+                    if (
+                        key == "reasoning"
+                        and isinstance(value, dict)
+                        and isinstance(base_extra_body.get("reasoning"), dict)
+                    ):
+                        base_extra_body["reasoning"] = {
+                            **base_extra_body["reasoning"],
+                            **value,
+                        }
+                    else:
+                        base_extra_body[key] = value
         return params
 
     def _normalize_response(

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -228,6 +228,148 @@ async def test_openai_backend_skips_extra_body_when_thinking_budget_zero() -> No
 
 
 @pytest.mark.asyncio
+async def test_openai_backend_merges_caller_extra_body_alongside_reasoning() -> None:
+    """Caller-supplied `extra_body` keys (e.g. `provider`) flow through alongside
+    the `reasoning.max_tokens` block populated from `thinking_budget_tokens`."""
+    client = Mock()
+    client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        content="ok",
+                        tool_calls=[],
+                        reasoning_details=[],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                prompt_tokens_details=None,
+            ),
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    await backend.complete(
+        model="x-ai/grok-4.1-fast",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        thinking_budget_tokens=256,
+        extra_params={
+            "extra_body": {
+                "provider": {
+                    "ignore": ["alibaba", "novita"],
+                    "order": ["fireworks", "together"],
+                },
+            },
+        },
+    )
+
+    await_args = client.chat.completions.create.await_args
+    if await_args is None:
+        raise AssertionError("Expected OpenAI create call")
+    call = await_args.kwargs
+    assert call["extra_body"] == {
+        "reasoning": {"max_tokens": 256},
+        "provider": {
+            "ignore": ["alibaba", "novita"],
+            "order": ["fireworks", "together"],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_deep_merges_caller_reasoning_without_clobbering_max_tokens() -> None:
+    """Caller-supplied `extra_body.reasoning` deep-merges with the
+    `reasoning.max_tokens` set from `thinking_budget_tokens` — does not clobber it."""
+    client = Mock()
+    client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        content="ok",
+                        tool_calls=[],
+                        reasoning_details=[],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                prompt_tokens_details=None,
+            ),
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    await backend.complete(
+        model="x-ai/grok-4.1-fast",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        thinking_budget_tokens=256,
+        extra_params={
+            "extra_body": {
+                "reasoning": {"exclude": True},
+            },
+        },
+    )
+
+    await_args = client.chat.completions.create.await_args
+    if await_args is None:
+        raise AssertionError("Expected OpenAI create call")
+    call = await_args.kwargs
+    assert call["extra_body"] == {
+        "reasoning": {"max_tokens": 256, "exclude": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_ignores_non_dict_extra_body() -> None:
+    """A malformed (non-dict) caller-supplied `extra_body` is ignored, not crashed on."""
+    client = Mock()
+    client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        content="ok",
+                        tool_calls=[],
+                        reasoning_details=[],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                prompt_tokens_details=None,
+            ),
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    await backend.complete(
+        model="x-ai/grok-4.1-fast",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        thinking_budget_tokens=256,
+        extra_params={"extra_body": "not-a-dict"},
+    )
+
+    await_args = client.chat.completions.create.await_args
+    if await_args is None:
+        raise AssertionError("Expected OpenAI create call")
+    call = await_args.kwargs
+    # thinking_budget reasoning block stays intact; bogus extra_body is dropped.
+    assert call["extra_body"] == {"reasoning": {"max_tokens": 256}}
+
+
+@pytest.mark.asyncio
 async def test_openai_backend_converts_anthropic_style_tools() -> None:
     client = Mock()
     client.chat.completions.create = AsyncMock(


### PR DESCRIPTION
## Summary

`OpenAIBackend._build_params` in `src/llm/backends/openai.py` already builds an `extra_body` dict internally for token-budget thinking on OpenRouter (lines 305-307), but it silently drops any `extra_body` the caller passed in via `ModelConfig.provider_params` (routed through `extra_params`).

This leaves OpenAI-compatible-backend callers unable to specify provider preferences such as:

```python
extra_body = {
    "provider": {
        "ignore": ["alibaba", "novita", "chutes"],
        "order": ["fireworks", "together"]
    }
}
```

…which is the documented way to pin to specific upstream providers, exclude hosts that quantize a model below the original-quality FP8, or set quantization / latency / throughput priorities per [OpenRouter's provider-routing docs](https://openrouter.ai/docs/features/provider-routing).

## Patch

Two functional lines inside the existing `if extra_params:` block:

```python
if "extra_body" in extra_params:
    params.setdefault("extra_body", {}).update(extra_params["extra_body"])
```

`setdefault(...).update(...)` rather than `params["extra_body"] = extra_params["extra_body"]` is deliberate — plain assignment would clobber the `reasoning.max_tokens` block `_build_params` may have already populated for token-budget thinking. The merge form preserves both.

## Motivation

A production Honcho deployment routing the deriver through OpenRouter to `qwen/qwen3-235b-a22b-2507` needs `extra_body.provider.ignore` to avoid third-party hosts that quantize the model below FP8 (observed Hebrew-language quality regression on those hosts vs the original-quality ones). Without this patch we maintained a bind-mount overlay; with the patch the config flows naturally through `extra_params`.

## Testing

Verified locally — the deriver picks up `extra_body.provider` preferences end-to-end via `ModelConfig.provider_params → extra_params → params["extra_body"]`, and the existing `reasoning.max_tokens` thinking-budget block is preserved when both are set.

No new behavior on the existing callers (the whitelist guard ensures `extra_body` only flows through when the caller explicitly populates it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request parameter handling so provider-supplied extra request fields are preserved and merged (including deep-merge of reasoning sub-keys) alongside budget-driven reasoning limits; malformed extra inputs are ignored without crashing.

* **Tests**
  * Added tests validating merge behavior, preservation of extra reasoning keys, and resilience to malformed extra parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->