### PR TITLE
Fix delete_observations crash with stringified observation_ids

### DIFF
--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+import re
 import logging
 import weakref
 from collections.abc import Callable
@@ -2064,11 +2066,59 @@ async def _handle_get_peer_card(ctx: ToolContext, tool_input: dict[str, Any]) ->
     )
 
 
+
+def _normalize_observation_ids(raw: Any) -> list[str]:
+    """Normalize observation_ids to a clean list of strings.
+
+    Handles cases where LLM tool-call output provides observation_ids as
+    a string or stringified list instead of a proper JSON array.
+    See: https://github.com/plastic-labs/honcho/issues/719
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, list | tuple | set):
+        ids = list(raw)
+    elif isinstance(raw, str):
+        s = raw.strip()
+        if not s:
+            return []
+        # Try JSON parse first (handles '["a","b"]')
+        try:
+            parsed = json.loads(s)
+            if isinstance(parsed, list):
+                ids = parsed
+            else:
+                ids = [str(parsed)]
+        except (json.JSONDecodeError, ValueError):
+            # Strip surrounding brackets, split by comma/whitespace
+            s = s.strip("[]")
+            ids = re.split(r"[,\s]+", s) if s else []
+    else:
+        ids = [str(raw)]
+
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for item in ids:
+        if not isinstance(item, str):
+            item = str(item)
+        # Strip quotes and brackets
+        item = item.strip().strip('"\'[]')
+        # Strip leading "id:" prefix
+        item = re.sub(r"^id:", "", item)
+        # Validate against conservative charset
+        if item and re.fullmatch(r"[A-Za-z0-9_-]+", item) and item not in seen:
+            cleaned.append(item)
+            seen.add(item)
+    return cleaned
+
+
 async def _handle_delete_observations(
     ctx: ToolContext, tool_input: dict[str, Any]
 ) -> "str | ToolResult":
     """Handle delete_observations tool."""
-    observation_ids = tool_input.get("observation_ids", [])
+    observation_ids = _normalize_observation_ids(
+        tool_input.get("observation_ids")
+    )
     if not observation_ids:
         return "ERROR: observation_ids list is empty"
 

--- a/tests/utils/test_agent_tools.py
+++ b/tests/utils/test_agent_tools.py
@@ -1762,3 +1762,49 @@ class TestObserverPeerNameWiring:
         await _handle_get_messages_by_date_range(ctx, {"after_date": "2024-01-01"})
 
         assert captured_kwargs["observer"] == ctx.observer
+
+
+class TestNormalizeObservationIds:
+    """Tests for _normalize_observation_ids helper."""
+
+    def _call(self, raw: Any) -> list[str]:
+        from src.utils.agent_tools import _normalize_observation_ids
+        return _normalize_observation_ids(raw)
+
+    def test_none_returns_empty(self):
+        assert self._call(None) == []
+
+    def test_empty_string_returns_empty(self):
+        assert self._call("") == []
+
+    def test_list_passthrough(self):
+        assert self._call(["abc123", "def456"]) == ["abc123", "def456"]
+
+    def test_json_string_list(self):
+        assert self._call('["abc123", "def456"]') == ["abc123", "def456"]
+
+    def test_bracketed_single_id(self):
+        assert self._call("[abc123]") == ["abc123"]
+
+    def test_id_prefix_stripped(self):
+        assert self._call("[id:abc123]") == ["abc123"]
+
+    def test_comma_separated_string(self):
+        assert self._call("abc123, def456") == ["abc123", "def456"]
+
+    def test_deduplicates(self):
+        assert self._call(["abc123", "abc123"]) == ["abc123"]
+
+    def test_invalid_chars_filtered(self):
+        result = self._call(["valid-id_123", "has spaces", ""])
+        assert result == ["valid-id_123"]
+
+    def test_tuple_and_set(self):
+        assert self._call(("abc", "def")) == ["abc", "def"]
+        assert self._call({"abc"}) == ["abc"]
+
+    def test_single_string_id(self):
+        assert self._call("abc123") == ["abc123"]
+
+    def test_quoted_bracketed_ids(self):
+        assert self._call('"[abc123]"') == ["abc123"]


### PR DESCRIPTION
## Problem

`delete_observations` crashes when LLM tool-call output sends `observation_ids` as a string or stringified list instead of a proper JSON array. This triggers `sqlalchemy.exc.ArgumentError` when the raw string hits `.in_()`.

Reproducer: any agentic dream/dialectic loop where the model copies IDs from earlier tool output in bracketed or `id:` prefixed format.

Closes #719

## Fix

Added `_normalize_observation_ids()` helper that normalizes input before the CRUD call:

- **None** → empty list (returns controlled error)
- **list/tuple/set** → pass through
- **JSON string** (e.g. `"[\"abc\"]"`) → parse and extract
- **Bracketed string** (e.g. `"[abc123]"`) → strip brackets, split
- **id: prefix** (e.g. `"[id:abc123]"`) → stripped
- **Comma/whitespace separated** → split
- **Validation** → conservative `[A-Za-z0-9_-]+` charset filter
- **Dedup** → preserves order, removes duplicates

## Tests

12 unit tests covering: None, empty string, list passthrough, JSON string, bracketed single ID, id: prefix, comma-separated, deduplication, invalid character filtering, tuple/set, single string, quoted+bracketed IDs.

## Files changed

- `src/utils/agent_tools.py` — added `_normalize_observation_ids()`, updated `_handle_delete_observations` to use it
- `tests/utils/test_agent_tools.py` — added `TestNormalizeObservationIds` class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of the observation deletion tool to handle multiple input formats for observation IDs, including JSON-encoded strings, bracketed formats, and comma-separated values.
  * Added validation and deduplication of observation IDs.

* **Tests**
  * Added comprehensive test coverage for observation ID normalization across various input formats and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->