### PR TITLE
chore: MCP Dockerfile improvements and native Bun runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,7 @@ docker-compose.yml.example
 .vscode/**
 data/**
 .venv
+.wrangler
+**/.wrangler
+mcp/.wrangler
+mcp/node_modules

--- a/mcp/.dockerignore
+++ b/mcp/.dockerignore
@@ -1,0 +1,2 @@
+.wrangler
+node_modules

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -2,15 +2,15 @@
 FROM oven/bun:1 AS builder
 WORKDIR /app
 
-# Copy configuration and use Bun's superior async network stack to bypass WSL MTU hangs
-COPY package.json ./
-RUN bun install
+# Copy lockfile + config for deterministic, cached installs
+COPY bun.lock package.json ./
+RUN bun install --frozen-lockfile
 
 # Copy source code
 COPY . .
 
-# --- Stage 2: Node Native Runtime ---
-FROM node:20
+# --- Stage 2: Bun Runtime ---
+FROM oven/bun:1
 WORKDIR /app
 
 # Ingest all the raw files (including node_modules) built gracefully by Bun
@@ -18,6 +18,9 @@ COPY --from=builder /app /app
 
 # Setup environment 
 ENV CI=true
+
+# Run as non-root user (bun user is built into the oven/bun image)
+USER bun
 
 # Run the native Bun mock server (no wrangler dev)
 CMD ["bun", "run", "run-mocked.ts"]

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,23 @@
+# --- Stage 1: Lightning Fast Dependencies ---
+FROM oven/bun:1 AS builder
+WORKDIR /app
+
+# Copy configuration and use Bun's superior async network stack to bypass WSL MTU hangs
+COPY package.json ./
+RUN bun install
+
+# Copy source code
+COPY . .
+
+# --- Stage 2: Node Native Runtime ---
+FROM node:20
+WORKDIR /app
+
+# Ingest all the raw files (including node_modules) built gracefully by Bun
+COPY --from=builder /app /app
+
+# Setup environment 
+ENV CI=true
+
+# Run the native Bun mock server (no wrangler dev)
+CMD ["bun", "run", "run-mocked.ts"]

--- a/mcp/bun.lock
+++ b/mcp/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "honcho-mcp-proxy",
       "dependencies": {
-        "@honcho-ai/sdk": "^2.0.0",
+        "@honcho-ai/sdk": "^2.1.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "agents": "^0.4.0",
         "nanoid": "^5.1.7",
@@ -107,7 +107,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.4", "", { "os": "win32", "cpu": "x64" }, "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ=="],
 
-    "@honcho-ai/sdk": ["@honcho-ai/sdk@2.0.1", "", { "dependencies": { "@types/node": "^24.0.1", "zod": "4.0.0" } }, "sha512-y/Wk49C0N1miI9BZTNWFIbzdUkMZfP4Do/EJ1q4lEIK+FAOKxQgces/zET3kPKV3zF9sOUl2pXrFb/XKYayeYw=="],
+    "@honcho-ai/sdk": ["@honcho-ai/sdk@2.1.1", "", { "dependencies": { "zod": "4.0.0" } }, "sha512-1EgDchnK2bTllhUCNhH1PZbw65fExmTtY2sraqXc1O41o1gY4Rpqrl1XCo+7RfdcZo85N7vl461hqYCouhbR1A=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
@@ -176,8 +176,6 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/lodash": ["@types/lodash@4.17.23", "", {}, "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA=="],
-
-    "@types/node": ["@types/node@24.1.0", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
@@ -470,8 +468,6 @@
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
     "undici": ["undici@7.12.0", "", {}, "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug=="],
-
-    "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 
     "unenv": ["unenv@2.0.0-rc.17", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.4", "ohash": "^2.0.11", "pathe": "^2.0.3", "ufo": "^1.6.1" } }, "sha512-B06u0wXkEd+o5gOCMl/ZHl5cfpYbDZKAT+HWTL+Hws6jWu7dCiqBBXXXzMFcFVJb8D4ytAnYmxJA83uwOQRSsg=="],
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -21,6 +21,10 @@
     "nanoid": "^5.1.7",
     "zod": "^4.3.6"
   },
+  "browser": {
+    "cloudflare:email": false,
+    "core-js-pure/features/instance/trim": false
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241002.0",
     "typescript": "^5.3.3",

--- a/mcp/run-mocked.ts
+++ b/mcp/run-mocked.ts
@@ -1,0 +1,31 @@
+// The "Bùa Ngải" Mock execution strategy requested by the User
+import { plugin } from "bun";
+
+plugin({
+  name: "cloudflare-mock",
+  setup(build) {
+    // Intercept standard resolution for cloudflare:email
+    build.onResolve({ filter: /^cloudflare:email$/ }, () => ({
+      path: "mock-cloudflare-email",
+      namespace: "mock",
+    }));
+
+    // Supply a dummy payload that successfully resolves but does nothing
+    build.onLoad({ filter: /.*/, namespace: "mock" }, () => ({
+      contents: "export default {}; export const EmailMessage = class {};",
+      loader: "js",
+    }));
+  },
+});
+
+// We dynamically import the main index ONLY AFTER the plugin is registered
+import("./src/index.ts").then((module) => {
+  const port = process.env.HONCHO_MCP_PORT ? Number(process.env.HONCHO_MCP_PORT) : 8787;
+  Bun.serve({
+    fetch: module.default.fetch as any,
+    port: port,
+  });
+  console.log(`[Honcho MCP] Native mock server booted up on port ${port}!`);
+}).catch(err => {
+  console.error("Failed to dynamically load MCP:", err);
+});

--- a/mcp/run-mocked.ts
+++ b/mcp/run-mocked.ts
@@ -20,12 +20,22 @@ plugin({
 
 // We dynamically import the main index ONLY AFTER the plugin is registered
 import("./src/index.ts").then((module) => {
-  const port = process.env.HONCHO_MCP_PORT ? Number(process.env.HONCHO_MCP_PORT) : 8787;
-  Bun.serve({
-    fetch: module.default.fetch as any,
-    port: port,
-  });
-  console.log(`[Honcho MCP] Native mock server booted up on port ${port}!`);
+  const envPort = process.env.HONCHO_MCP_PORT;
+  const port = envPort ? Number(envPort) : 8787;
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    console.error(`Invalid HONCHO_MCP_PORT: ${envPort}, falling back to 8787`);
+    Bun.serve({
+      fetch: module.default.fetch as any,
+      port: 8787,
+    });
+    console.log("[Honcho MCP] Native mock server booted up on port 8787!");
+  } else {
+    Bun.serve({
+      fetch: module.default.fetch as any,
+      port: port,
+    });
+    console.log(`[Honcho MCP] Native mock server booted up on port ${port}!`);
+  }
 }).catch(err => {
   console.error("Failed to dynamically load MCP:", err);
 });


### PR DESCRIPTION
## Summary

Improves the MCP server Docker setup with better build performance and native Bun runtime.

### Key Changes
- **Multi-stage Docker build**: Bun builder stage → Node 20 runtime for optimal install speed
- **Native Bun CMD**: Replaces `npx wrangler dev` with `bun run run-mocked.ts` — bypasses Wrangler's anti-Bun blocker
- **Mock server**: `run-mocked.ts` provides a Cloudflare-free execution path using Bun's plugin system to stub `cloudflare:email`
- **Tightened .dockerignore**: Excludes `.wrangler/` directories and `node_modules` from build context

### Files Changed
- `mcp/Dockerfile` — multi-stage build, native Bun CMD
- `mcp/run-mocked.ts` — Bun mock server with Cloudflare stub
- `mcp/.dockerignore` — MCP-specific ignores
- `mcp/package.json` / `mcp/bun.lock` — dependency updates
- `.dockerignore` — root-level wrangler exclusions

---
Split from #692 per maintainer request to separate MCP infrastructure from LLM fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Excluded Wrangler-related dirs and node_modules from Docker build contexts
  * Implemented multi-stage Bun-based container build for smaller, deterministic images
  * Added a local mock server runner for development/testing that starts on a configurable port
  * Set package metadata to disable certain browser/Cloudflare polyfills in the package.json

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->