### PR TITLE
feat(k8s): add Helm chart

### DIFF
--- a/charts/honcho/.helmignore
+++ b/charts/honcho/.helmignore
@@ -1,0 +1,10 @@
+.DS_Store
+.git/
+.gitignore
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.idea/
+.vscode/

--- a/charts/honcho/Chart.yaml
+++ b/charts/honcho/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: honcho
+description: Honcho memory infrastructure for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "3.0.7"
+icon: https://raw.githubusercontent.com/plastic-labs/honcho/main/assets/honcho.svg

--- a/charts/honcho/README.md
+++ b/charts/honcho/README.md
@@ -1,0 +1,107 @@
+# Honcho Helm chart
+
+This chart deploys the Honcho API server, deriver worker, an optional Redis
+instance, and an optional database migration Job.
+
+The chart expects PostgreSQL with the `pgvector` extension to be available. Use a
+managed PostgreSQL service, an existing in-cluster database, or enable the
+optional CloudNativePG template if your cluster already runs the CloudNativePG
+operator.
+
+## Install
+
+Create a runtime Secret with the required application settings:
+
+```bash
+kubectl create namespace honcho
+kubectl create secret generic honcho-runtime \
+  --namespace honcho \
+  --from-literal=DB_CONNECTION_URI='postgresql+psycopg://postgres:postgres@postgres.example.com:5432/postgres' \
+  --from-literal=LLM_OPENAI_API_KEY='sk-...' \
+  --from-literal=AUTH_JWT_SECRET='replace-with-a-random-secret'
+```
+
+Install the chart:
+
+```bash
+helm install honcho ./charts/honcho \
+  --namespace honcho \
+  --set runtimeSecret.enabled=true \
+  --set runtimeSecret.name=honcho-runtime \
+  --set database.host=postgres.example.com
+```
+
+When the included unauthenticated Redis deployment is enabled, the chart sets
+`CACHE_URL` automatically. If you disable the included Redis deployment or enable
+Redis authentication, provide `CACHE_URL` through the runtime Secret or
+`config.env`.
+
+## Configuration
+
+Common values:
+
+| Value | Description | Default |
+| --- | --- | --- |
+| `image.repository` | Honcho container image repository | `ghcr.io/plastic-labs/honcho` |
+| `image.tag` | Honcho image tag | chart `appVersion` |
+| `runtimeSecret.enabled` | Add an `envFrom` reference to a runtime Secret | `false` |
+| `runtimeSecret.name` | Runtime Secret name | `<release>-honcho-runtime` |
+| `database.host` | PostgreSQL host used by dependency wait init containers | `""` |
+| `redis.enabled` | Deploy a Redis instance for Honcho cache/queue use | `true` |
+| `migration.enabled` | Run `scripts/provision_db.py` as a Helm hook | `true` |
+| `ingress.enabled` | Create an Ingress for the API service | `false` |
+| `monitoring.podMonitor.enabled` | Create a Prometheus Operator PodMonitor | `false` |
+| `networkPolicy.enabled` | Create NetworkPolicy resources | `false` |
+
+The runtime Secret commonly includes:
+
+```text
+DB_CONNECTION_URI
+CACHE_URL
+AUTH_JWT_SECRET
+LLM_OPENAI_API_KEY
+LLM_ANTHROPIC_API_KEY
+LLM_GEMINI_API_KEY
+```
+
+Honcho can also read any other supported environment variable through
+`config.env`, `extraEnv`, or `extraEnvFrom`.
+
+## Optional CloudNativePG database
+
+If CloudNativePG is installed in the cluster, the chart can create a PostgreSQL
+cluster:
+
+```bash
+kubectl create secret generic honcho-db-credentials \
+  --namespace honcho \
+  --from-literal=username=honcho \
+  --from-literal=password='replace-with-a-password'
+
+helm upgrade --install honcho ./charts/honcho \
+  --namespace honcho \
+  --set cnpg.enabled=true \
+  --set cnpg.credentialsSecret.name=honcho-db-credentials \
+  --set runtimeSecret.enabled=true \
+  --set runtimeSecret.name=honcho-runtime
+```
+
+Set `DB_CONNECTION_URI` in `honcho-runtime` to the CloudNativePG read-write
+service, for example:
+
+```text
+postgresql+psycopg://honcho:<password>@honcho-db-rw.honcho.svc.cluster.local:5432/honcho
+```
+
+The CNPG template is disabled by default so the chart can be used with managed
+databases and clusters that do not install the CloudNativePG CRDs.
+
+## Validate
+
+```bash
+helm lint charts/honcho
+helm template honcho charts/honcho \
+  --set runtimeSecret.enabled=true \
+  --set runtimeSecret.name=honcho-runtime \
+  --set database.host=postgres.example.com
+```

--- a/charts/honcho/templates/NOTES.txt
+++ b/charts/honcho/templates/NOTES.txt
@@ -1,0 +1,23 @@
+Honcho has been installed.
+
+Required next checks:
+
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl get svc -n {{ .Release.Namespace }} {{ include "honcho.fullname" . }}-api
+
+{{- if not .Values.runtimeSecret.enabled }}
+
+runtimeSecret.enabled is false. The API and deriver need DB_CONNECTION_URI and
+LLM provider credentials from config.env, extraEnv, extraEnvFrom, or a Secret.
+{{- end }}
+
+{{- if and .Values.runtimeSecret.enabled (not .Values.runtimeSecret.name) }}
+
+The chart will read runtime settings from Secret:
+
+  {{ include "honcho.runtimeSecretName" . }}
+{{- end }}
+
+Run the health test after the API pod is ready:
+
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/charts/honcho/templates/_helpers.tpl
+++ b/charts/honcho/templates/_helpers.tpl
@@ -1,0 +1,119 @@
+{{- define "honcho.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "honcho.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "honcho.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "honcho.labels" -}}
+helm.sh/chart: {{ include "honcho.chart" . }}
+{{ include "honcho.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: honcho
+{{- end }}
+
+{{- define "honcho.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "honcho.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "honcho.componentLabels" -}}
+{{ include "honcho.selectorLabels" . }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{- define "honcho.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "honcho.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "honcho.runtimeSecretName" -}}
+{{- default (printf "%s-runtime" (include "honcho.fullname" .)) .Values.runtimeSecret.name }}
+{{- end }}
+
+{{- define "honcho.dbSecretName" -}}
+{{- default (printf "%s-db-credentials" (include "honcho.fullname" .)) .Values.cnpg.credentialsSecret.name }}
+{{- end }}
+
+{{- define "honcho.redisName" -}}
+{{- default (printf "%s-redis" (include "honcho.fullname" .)) .Values.redis.fullnameOverride }}
+{{- end }}
+
+{{- define "honcho.dbName" -}}
+{{- default (printf "%s-db" (include "honcho.fullname" .)) .Values.cnpg.fullnameOverride }}
+{{- end }}
+
+{{- define "honcho.dbHost" -}}
+{{- if .Values.database.host }}
+{{- .Values.database.host }}
+{{- else if .Values.cnpg.enabled }}
+{{- printf "%s-rw.%s.svc.cluster.local" (include "honcho.dbName" .) .Release.Namespace }}
+{{- else }}
+{{- required "database.host is required when cnpg.enabled=false" .Values.database.host }}
+{{- end }}
+{{- end }}
+
+{{- define "honcho.waitContainers" -}}
+{{- if .Values.waitForDependencies.enabled }}
+initContainers:
+  {{- if or .Values.cnpg.enabled .Values.database.host }}
+  - name: wait-db
+    image: {{ .Values.waitForDependencies.image | quote }}
+    imagePullPolicy: IfNotPresent
+    command:
+      - sh
+      - -ec
+      - |
+        until nc -z {{ include "honcho.dbHost" . }} {{ .Values.database.port }}; do
+          echo "waiting for postgres"
+          sleep 5
+        done
+  {{- end }}
+  {{- if .Values.redis.enabled }}
+  - name: wait-redis
+    image: {{ .Values.waitForDependencies.image | quote }}
+    imagePullPolicy: IfNotPresent
+    command:
+      - sh
+      - -ec
+      - |
+        until nc -z {{ include "honcho.redisName" . }} {{ .Values.redis.service.port }}; do
+          echo "waiting for redis"
+          sleep 5
+        done
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "honcho.envFrom" -}}
+envFrom:
+  - configMapRef:
+      name: {{ include "honcho.fullname" . }}-config
+  {{- if .Values.runtimeSecret.enabled }}
+  - secretRef:
+      name: {{ include "honcho.runtimeSecretName" . }}
+  {{- end }}
+  {{- range .Values.extraEnvFrom }}
+  - {{ toYaml . | nindent 4 | trim }}
+  {{- end }}
+{{- end }}

--- a/charts/honcho/templates/cnpg.yaml
+++ b/charts/honcho/templates/cnpg.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.cnpg.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "honcho.dbName" . }}
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+spec:
+  description: {{ .Values.cnpg.description | quote }}
+  imageName: {{ .Values.cnpg.imageName | quote }}
+  {{- with .Values.cnpg.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  instances: {{ .Values.cnpg.instances }}
+  bootstrap:
+    initdb:
+      database: {{ .Values.cnpg.database | quote }}
+      owner: {{ .Values.cnpg.owner | quote }}
+      secret:
+        name: {{ include "honcho.dbSecretName" . }}
+      {{- with .Values.cnpg.postInitApplicationSQL }}
+      postInitApplicationSQL:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  storage:
+    size: {{ .Values.cnpg.storage.size | quote }}
+    {{- with .Values.cnpg.storage.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
+  walStorage:
+    size: {{ .Values.cnpg.walStorage.size | quote }}
+    {{- with .Values.cnpg.walStorage.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
+  monitoring:
+    enablePodMonitor: {{ .Values.cnpg.monitoring.enablePodMonitor }}
+  {{- with .Values.cnpg.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cnpg.backup }}
+  backup:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cnpg.postgresql }}
+  postgresql:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/honcho/templates/configmap.yaml
+++ b/charts/honcho/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "honcho.fullname" . }}-config
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- if and .Values.redis.enabled (not .Values.redis.auth.enabled) (not (hasKey .Values.config.env "CACHE_URL")) }}
+  CACHE_URL: {{ printf "redis://%s:%v/0?suppress=true" (include "honcho.redisName" .) .Values.redis.service.port | quote }}
+  {{- end }}

--- a/charts/honcho/templates/deployment-api.yaml
+++ b/charts/honcho/templates/deployment-api.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "honcho.fullname" . }}-api
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "api") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "api") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ toJson .Values.config.env | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "honcho.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- include "honcho.waitContainers" . | nindent 6 }}
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            {{- toYaml .Values.api.command | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          {{- include "honcho.envFrom" . | nindent 10 }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          startupProbe:
+            {{- toYaml .Values.api.startupProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.api.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.api.livenessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/honcho/templates/deployment-deriver.yaml
+++ b/charts/honcho/templates/deployment-deriver.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "honcho.fullname" . }}-deriver
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+    app.kubernetes.io/component: deriver
+spec:
+  replicas: {{ .Values.deriver.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "deriver") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "deriver") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ toJson .Values.config.env | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "honcho.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- include "honcho.waitContainers" . | nindent 6 }}
+      containers:
+        - name: deriver
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            {{- toYaml .Values.deriver.command | nindent 12 }}
+          {{- include "honcho.envFrom" . | nindent 10 }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.deriver.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/honcho/templates/ingress.yaml
+++ b/charts/honcho/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "honcho.fullname" . }}-api
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "honcho.fullname" $ }}-api
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/honcho/templates/migration-job.yaml
+++ b/charts/honcho/templates/migration-job.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "honcho.fullname" . }}-migrate
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migration
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migration.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.migration.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "migration") | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "honcho.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- include "honcho.waitContainers" . | nindent 6 }}
+      containers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            {{- toYaml .Values.migration.command | nindent 12 }}
+          {{- include "honcho.envFrom" . | nindent 10 }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+{{- end }}

--- a/charts/honcho/templates/networkpolicy.yaml
+++ b/charts/honcho/templates/networkpolicy.yaml
@@ -1,0 +1,204 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- if .Values.networkPolicy.defaultDeny }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "honcho.fullname" . }}-default-deny
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "honcho.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "honcho.fullname" . }}-api
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "api") | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        {{- toYaml .Values.networkPolicy.apiIngressFrom | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.targetPort }}
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+        {{- range .Values.networkPolicy.dnsIpBlocks }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- if .Values.redis.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "redis") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.redis.service.port }}
+    {{- end }}
+    {{- if .Values.cnpg.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: {{ include "honcho.dbName" . }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.database.port }}
+    {{- end }}
+    {{- if .Values.networkPolicy.allowExternalHttps }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+{{- if .Values.redis.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "honcho.fullname" . }}-redis
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "redis") | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "api") | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "deriver") | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "migration") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.redis.service.port }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "honcho.fullname" . }}-migration
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "migration") | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+        {{- range .Values.networkPolicy.dnsIpBlocks }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- if .Values.redis.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "redis") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.redis.service.port }}
+    {{- end }}
+    {{- if .Values.cnpg.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: {{ include "honcho.dbName" . }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.database.port }}
+    {{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "honcho.fullname" . }}-deriver
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "deriver") | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+        {{- range .Values.networkPolicy.dnsIpBlocks }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- if .Values.redis.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "redis") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.redis.service.port }}
+    {{- end }}
+    {{- if .Values.cnpg.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: {{ include "honcho.dbName" . }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.database.port }}
+    {{- end }}
+    {{- if .Values.networkPolicy.allowExternalHttps }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+{{- end }}

--- a/charts/honcho/templates/pdb.yaml
+++ b/charts/honcho/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.api.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "honcho.fullname" . }}-api
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  minAvailable: {{ .Values.api.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "api") | nindent 6 }}
+{{- end }}

--- a/charts/honcho/templates/podmonitor.yaml
+++ b/charts/honcho/templates/podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.monitoring.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "honcho.fullname" . }}
+  namespace: {{ .Values.monitoring.podMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+    {{- with .Values.monitoring.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "api") | nindent 6 }}
+  podMetricsEndpoints:
+    - port: http
+      path: {{ .Values.monitoring.podMonitor.path }}
+      interval: {{ .Values.monitoring.podMonitor.interval }}
+      scrapeTimeout: {{ .Values.monitoring.podMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/honcho/templates/redis.yaml
+++ b/charts/honcho/templates/redis.yaml
@@ -1,0 +1,116 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "honcho.redisName" . }}
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "redis") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "redis") | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.redis.podSecurityContext | nindent 8 }}
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.redis.securityContext | nindent 12 }}
+          {{- if .Values.redis.auth.enabled }}
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redis.auth.secretName | quote }}
+                  key: {{ .Values.redis.auth.secretKey | quote }}
+          {{- end }}
+          command:
+            - sh
+            - -ec
+          args:
+            - |
+              {{- if .Values.redis.auth.enabled }}
+              exec redis-server --requirepass "$REDIS_PASSWORD" --appendonly {{ ternary "yes" "no" .Values.redis.persistence.enabled }}
+              {{- else }}
+              exec redis-server --appendonly {{ ternary "yes" "no" .Values.redis.persistence.enabled }}
+              {{- end }}
+          ports:
+            - name: redis
+              containerPort: {{ .Values.redis.service.port }}
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ ternary "redis-cli -a \"$REDIS_PASSWORD\" ping" "redis-cli ping" .Values.redis.auth.enabled | quote }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ ternary "redis-cli -a \"$REDIS_PASSWORD\" ping" "redis-cli ping" .Values.redis.auth.enabled | quote }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          {{- if .Values.redis.persistence.enabled }}
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+          {{- end }}
+      {{- if .Values.redis.persistence.enabled }}
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: {{ include "honcho.redisName" . }}-data
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "honcho.redisName" . }}
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: {{ .Values.redis.service.port }}
+      targetPort: redis
+      protocol: TCP
+  selector:
+    {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "redis") | nindent 4 }}
+{{- if .Values.redis.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "honcho.redisName" . }}-data
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.redis.persistence.storageClass | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.redis.persistence.size | quote }}
+{{- end }}
+{{- end }}

--- a/charts/honcho/templates/service.yaml
+++ b/charts/honcho/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "honcho.fullname" . }}-api
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "honcho.componentLabels" (dict "Chart" .Chart "Values" .Values "Release" .Release "component" "api") | nindent 4 }}

--- a/charts/honcho/templates/serviceaccount.yaml
+++ b/charts/honcho/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "honcho.serviceAccountName" . }}
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/honcho/templates/tests/test-health.yaml
+++ b/charts/honcho/templates/tests/test-health.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "honcho.fullname" . }}-test-health"
+  labels:
+    {{- include "honcho.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: busybox:1.36
+      command:
+        - wget
+      args:
+        - -qO-
+        - http://{{ include "honcho.fullname" . }}-api:{{ .Values.service.port }}/health

--- a/charts/honcho/values.yaml
+++ b/charts/honcho/values.yaml
@@ -1,0 +1,244 @@
+replicaCount: 1
+
+nameOverride: ""
+fullnameOverride: ""
+revisionHistoryLimit: 3
+
+image:
+  repository: ghcr.io/plastic-labs/honcho
+  pullPolicy: IfNotPresent
+  tag: "v3.0.7"
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  automount: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 100
+  runAsGroup: 101
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  runAsUser: 100
+  runAsGroup: 101
+
+config:
+  env:
+    LOG_LEVEL: INFO
+    DB_POOL_PRE_PING: "true"
+    DB_POOL_SIZE: "10"
+    DB_MAX_OVERFLOW: "20"
+    CACHE_ENABLED: "true"
+    VECTOR_STORE_TYPE: pgvector
+    VECTOR_STORE_MIGRATED: "false"
+    AUTH_USE_AUTH: "false"
+    METRICS_ENABLED: "true"
+    METRICS_NAMESPACE: honcho
+    SENTRY_ENABLED: "false"
+    TELEMETRY_ENABLED: "false"
+
+runtimeSecret:
+  enabled: false
+  name: ""
+
+extraEnv: []
+extraEnvFrom: []
+
+waitForDependencies:
+  enabled: true
+  image: busybox:1.36
+
+database:
+  host: ""
+  port: 5432
+
+cnpg:
+  enabled: false
+  fullnameOverride: ""
+  description: Dedicated PostgreSQL pgvector cluster for Honcho
+  imageName: ghcr.io/cloudnative-pg/postgresql:17
+  imagePullSecrets: []
+  instances: 2
+  database: honcho
+  owner: honcho
+  credentialsSecret:
+    name: ""
+  postInitApplicationSQL:
+    - CREATE EXTENSION IF NOT EXISTS vector;
+  storage:
+    storageClass: ""
+    size: 20Gi
+  walStorage:
+    storageClass: ""
+    size: 10Gi
+  monitoring:
+    enablePodMonitor: true
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 4Gi
+  backup: {}
+  postgresql: {}
+
+redis:
+  enabled: true
+  fullnameOverride: ""
+  image:
+    repository: redis
+    tag: "8.2"
+    pullPolicy: IfNotPresent
+  service:
+    port: 6379
+  auth:
+    enabled: false
+    secretName: ""
+    secretKey: REDIS_PASSWORD
+  persistence:
+    enabled: false
+    storageClass: ""
+    size: 2Gi
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    fsGroup: 999
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+migration:
+  enabled: true
+  command:
+    - /app/.venv/bin/python
+    - scripts/provision_db.py
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+api:
+  replicaCount: 1
+  command:
+    - fastapi
+    - run
+    - --host
+    - 0.0.0.0
+    - src/main.py
+  startupProbe:
+    httpGet:
+      path: /health
+      port: http
+    failureThreshold: 30
+    periodSeconds: 5
+    timeoutSeconds: 3
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: http
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+
+deriver:
+  replicaCount: 1
+  command:
+    - /app/.venv/bin/python
+    - -m
+    - src.deriver
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 4Gi
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: honcho.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+monitoring:
+  podMonitor:
+    enabled: false
+    namespace: ""
+    labels: {}
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 25s
+
+networkPolicy:
+  enabled: false
+  defaultDeny: false
+  allowExternalHttps: true
+  dnsIpBlocks: []
+  apiIngressFrom:
+    - {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/docs/v3/contributing/self-hosting.mdx
+++ b/docs/v3/contributing/self-hosting.mdx
@@ -116,6 +116,37 @@ docker compose logs deriver --tail 20
 
 For a full end-to-end test, see [Verify Your Setup](#verify-your-setup) below.
 
+## Kubernetes Helm Chart
+
+Honcho also includes a Helm chart for Kubernetes deployments. The chart deploys
+the API server, deriver worker, optional Redis, and a migration Job. It expects a
+PostgreSQL database with the `pgvector` extension.
+
+Create a runtime Secret with your database connection and LLM provider settings:
+
+```bash
+kubectl create namespace honcho
+kubectl create secret generic honcho-runtime \
+  --namespace honcho \
+  --from-literal=DB_CONNECTION_URI='postgresql+psycopg://postgres:postgres@postgres.example.com:5432/postgres' \
+  --from-literal=LLM_OPENAI_API_KEY='sk-...' \
+  --from-literal=AUTH_JWT_SECRET='replace-with-a-random-secret'
+```
+
+Install the chart:
+
+```bash
+helm install honcho ./charts/honcho \
+  --namespace honcho \
+  --set runtimeSecret.enabled=true \
+  --set runtimeSecret.name=honcho-runtime \
+  --set database.host=postgres.example.com
+```
+
+See [`charts/honcho/README.md`](../../../charts/honcho/README.md) for chart
+values, optional CloudNativePG support, ingress, NetworkPolicy, and monitoring
+configuration.
+
 ## Manual Setup
 
 For more control over your environment, you can set up everything manually.


### PR DESCRIPTION
## Summary

Closes #514.

This adds a first-party Helm chart under `charts/honcho` for Kubernetes deployments. The chart deploys:

- Honcho API Deployment and Service
- Deriver worker Deployment
- Optional Redis Deployment and Service
- Helm-hook migration Job for `scripts/provision_db.py`
- Optional Ingress, PodMonitor, PodDisruptionBudget, NetworkPolicy, and CloudNativePG database template

The chart keeps cluster-specific integrations disabled by default. Runtime secrets are supplied through an existing Kubernetes Secret, and CloudNativePG support is opt-in so the default chart can be used with managed PostgreSQL or existing in-cluster databases.

This is intentionally scoped differently from #531: that PR adds raw Kubernetes manifests, while this PR addresses the Helm chart request directly with configurable values and chart documentation.

## Validation

- `helm lint --strict charts/honcho`
- `helm template honcho charts/honcho --set runtimeSecret.enabled=true --set runtimeSecret.name=honcho-runtime --set database.host=postgres.example.com`
- `helm template honcho charts/honcho --set cnpg.enabled=true --set cnpg.credentialsSecret.name=honcho-db-credentials --set runtimeSecret.enabled=true --set runtimeSecret.name=honcho-runtime`
- `helm template honcho charts/honcho --set redis.enabled=false --set runtimeSecret.enabled=true --set runtimeSecret.name=honcho-runtime --set database.host=postgres.example.com --set networkPolicy.enabled=true`
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added official Kubernetes Helm chart for deploying Honcho applications, including API server, worker processes, optional caching, and database migration support.
  * Chart supports ingress routing, network policies, pod disruption budgets, and metrics monitoring configuration.

* **Documentation**
  * Added Kubernetes self-hosting guide with Helm installation and configuration instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->