### PR TITLE
fix(agent_tools): normalize stringified observation_ids in delete_observations (#719)

### DIFF
--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import weakref
 from collections.abc import Callable
@@ -2064,11 +2065,56 @@ async def _handle_get_peer_card(ctx: ToolContext, tool_input: dict[str, Any]) ->
     )
 
 
+def _normalize_observation_ids(raw: Any) -> list[str]:
+    """Coerce a delete_observations ``observation_ids`` argument into ``list[str]``.
+
+    The tool schema asks for ``list[str]``, but LLM/tool-call output sometimes
+    provides a stringified list (e.g. ``"[doc_abc123]"``, ``"[id:doc_abc123]"``,
+    or a JSON-encoded array). A bare string passed into SQLAlchemy's ``.in_()``
+    either raises or silently iterates character-by-character, so it is
+    normalized here before reaching the delete path. See issue #719.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, (list, tuple, set)):
+        items: list[Any] = list(raw)
+    elif isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return []
+        try:
+            parsed = json.loads(text)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, list):
+            items = parsed
+        elif isinstance(parsed, str):
+            items = [parsed]
+        else:
+            inner = text
+            if inner.startswith("[") and inner.endswith("]"):
+                inner = inner[1:-1]
+            items = list(inner.split(","))
+    else:
+        items = [raw]
+
+    normalized: list[str] = []
+    for item in items:
+        if not isinstance(item, str):
+            item = str(item)
+        cleaned = item.strip().strip("\"'").strip()
+        if cleaned.lower().startswith("id:"):
+            cleaned = cleaned[3:].strip()
+        if cleaned:
+            normalized.append(cleaned)
+    return normalized
+
+
 async def _handle_delete_observations(
     ctx: ToolContext, tool_input: dict[str, Any]
 ) -> "str | ToolResult":
     """Handle delete_observations tool."""
-    observation_ids = tool_input.get("observation_ids", [])
+    observation_ids = _normalize_observation_ids(tool_input.get("observation_ids", []))
     if not observation_ids:
         return "ERROR: observation_ids list is empty"
 

--- a/tests/utils/test_agent_tools.py
+++ b/tests/utils/test_agent_tools.py
@@ -21,6 +21,7 @@ from src.utils.agent_tools import (
     ToolContext,
     _handle_create_observations,  # pyright: ignore[reportPrivateUsage]
     _handle_delete_observations,  # pyright: ignore[reportPrivateUsage]
+    _normalize_observation_ids,  # pyright: ignore[reportPrivateUsage]
     _handle_extract_preferences,  # pyright: ignore[reportPrivateUsage]
     _handle_finish_consolidation,  # pyright: ignore[reportPrivateUsage]
     _handle_get_messages_by_date_range,  # pyright: ignore[reportPrivateUsage]
@@ -590,6 +591,59 @@ class TestDeleteObservations:
         assert event.conclusion_count == 3
         # RETURNING order is not guaranteed; compare as multiset.
         assert sorted(event.levels) == sorted(["explicit", "deductive", "inductive"])
+
+class TestNormalizeObservationIds:
+    """Unit tests for _normalize_observation_ids (issue #719)."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (["doc_abc123", "doc_def456"], ["doc_abc123", "doc_def456"]),
+            ('["doc_abc123", "doc_def456"]', ["doc_abc123", "doc_def456"]),
+            ("[doc_abc123]", ["doc_abc123"]),
+            ("[id:doc_abc123]", ["doc_abc123"]),
+            ("[doc_abc123, doc_def456]", ["doc_abc123", "doc_def456"]),
+            ("doc_abc123", ["doc_abc123"]),
+            (["id:doc_abc123"], ["doc_abc123"]),
+            ("", []),
+            ([], []),
+            (None, []),
+        ],
+    )
+    def test_normalizes_stringified_and_list_inputs(
+        self, raw: Any, expected: list[str]
+    ):
+        assert _normalize_observation_ids(raw) == expected
+
+
+@pytest.mark.asyncio
+class TestDeleteObservationsStringifiedIds:
+    """Regression test for issue #719: stringified observation_ids must not crash."""
+
+    async def test_delete_accepts_stringified_id_list(
+        self,
+        db_session: AsyncSession,
+        tool_test_data: Any,
+        make_tool_context: Callable[..., ToolContext],
+    ):
+        """A bracketed-string observation_ids payload deletes the same row as a real list."""
+        _, _, _, _, _, documents = tool_test_data
+        ctx = make_tool_context(include_observation_ids=True)
+
+        doc_id = documents[0].id
+        # LLM/tool-call output sometimes emits a stringified list rather than a JSON array.
+        result = await _handle_delete_observations(
+            ctx, {"observation_ids": f"[{doc_id}]"}
+        )
+
+        assert "Deleted 1 observations" in result
+
+        db_session.expire(documents[0])
+        stmt = select(models.Document).where(models.Document.id == doc_id)
+        doc = (await db_session.execute(stmt)).scalar_one_or_none()
+        assert doc is not None
+        assert doc.deleted_at is not None
+
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`_handle_delete_observations` (`src/utils/agent_tools.py`) passes `tool_input["observation_ids"]` straight into `crud.delete_documents(document_ids=...)`, which feeds SQLAlchemy's `.in_()`. The tool schema asks for `list[str]`, but in agentic dream/dialectic loops the model/tool-call output sometimes emits a **stringified list** instead of a real array:

```json
{"observation_ids": "[doc_abc123]"}
{"observation_ids": "[id:doc_abc123]"}
```

When a bare string reaches `.in_()` it either raises or silently iterates character-by-character, crashing (or corrupting) the tool loop. This is especially likely when the model copies IDs from earlier tool output formatted as `[id:...]`.

Fixes #719.

## Fix

Add `_normalize_observation_ids()` to coerce the argument into `list[str]` before it reaches the delete path. It handles:

- real `list`/`tuple`/`set` (unchanged passthrough)
- JSON-encoded array strings (`'["a","b"]'`)
- bracketed non-JSON strings (`"[a]"`, `"[a, b]"`)
- bare single-id strings (`"a"`)
- `id:` prefixes and stray quotes/brackets
- empty / `None` -> `[]`

The handler then calls `_normalize_observation_ids(tool_input.get("observation_ids", []))`. Real-list callers are unaffected.

## Tests

- `TestNormalizeObservationIds`: parametrized unit tests covering all input shapes above (including the two exact payloads from the issue).
- `TestDeleteObservationsStringifiedIds`: handler-level regression test asserting a `"[<doc_id>]"` string soft-deletes the same row a real list would.

Both files pass `python -m py_compile`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced observation deletion to reliably accept and process observation IDs in multiple formats, improving robustness when handling edge cases, malformed inputs, and various string representations.

* **Tests**
  * Added comprehensive test coverage for observation ID parsing and deletion operations, validating support for various input formats and soft-deletion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/honcho/pull/746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->