### PR TITLE
fix: disable PyJWT built-in exp validation for ISO string exp

### DIFF
--- a/src/security.py
+++ b/src/security.py
@@ -88,7 +88,10 @@ def verify_jwt(token: str) -> JWTParams:
         if not settings.AUTH.JWT_SECRET:
             raise ValueError("AUTH_JWT_SECRET is not set, cannot verify JWT.")
         decoded = jwt.decode(
-            token, settings.AUTH.JWT_SECRET.encode("utf-8"), algorithms=["HS256"]
+            token,
+            settings.AUTH.JWT_SECRET.encode("utf-8"),
+            algorithms=["HS256"],
+            options={"verify_exp": False},
         )
         if "t" in decoded:
             params.t = decoded["t"]


### PR DESCRIPTION
## Problem

Honcho stores JWT expiry (`exp`) as an ISO 8601 string (e.g. `'2036-01-01T00:00:00Z'`) in `JWTParams`, and already has a manual expiry check via `parse_datetime_iso()`.

However, PyJWT's `jwt.decode()` defaults to `verify_exp=True`, which validates `exp` as a Unix integer per RFC 7519. When it encounters an ISO string, it raises:

```
DecodeError: Expiration Time claim (exp) must be an integer.
```

This exception was caught and re-raised as `AuthenticationException('Invalid JWT')`, making **all scoped tokens with an expiry unverifiable** — i.e., any token generated with an `--expires` flag by the `/v1/keys` endpoint or `generate_jwt.py` would always be rejected.

## Fix

Pass `options={'verify_exp': False}` to `jwt.decode()` to skip PyJWT's built-in check. Honcho's own manual expiry check (already present immediately after the `jwt.decode()` call) continues to enforce expiration correctly.

## Testing

Verified manually:
- Valid token with future ISO expiry → accepted ✓
- Token with past ISO expiry → rejected with `AuthenticationException: JWT expired` ✓  
- Token with no expiry → accepted ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JWT token expiration validation behavior to ensure proper handling of expired authentication tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->