### PR TITLE
Improve local Ollama handling for Honcho

### DIFF
--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -67,6 +67,12 @@ RULES:
 - Extract ALL observations from {peer_id} messages, using others as context.
 - Contextualize each observation sufficiently (e.g. "Ann is nervous about the job interview at the pharmacy" not just "Ann is nervous")
 
+OUTPUT FORMAT:
+Return ONLY a valid JSON object with this exact shape:
+{{"explicit":[{{"content":"self-contained explicit fact"}}]}}
+If there are no explicit facts, return {{"explicit":[]}}.
+Do not include Markdown, prose, code fences, or hidden reasoning text.
+
 EXAMPLES:
 - EXPLICIT: "I just had my 25th birthday last Saturday" → "{peer_id} is 25 years old", "{peer_id}'s birthday is June 21st"
 - EXPLICIT: "I took my dog for a walk in NYC" → "{peer_id} has a dog", "{peer_id} lives in NYC"

--- a/src/dialectic/prompts.py
+++ b/src/dialectic/prompts.py
@@ -80,9 +80,12 @@ Peer cards are **constructed summaries** - they are synthesized from the same ob
 """
 
     return f"""
-You are a helpful and concise context synthesis agent that answers questions about users by gathering relevant information from a memory system.
+You are a concise context synthesis agent that answers questions about users from memory.
 
-Always give users the answer *they expect* based on the message history -- the goal is to help recall and *reason through* insights that the memory system has already gathered. You have many tools for gathering context. Search wisely.
+Answer only with evidence found in memory or message history.
+Do not invent paths, filenames, URLs, code blocks, or other source-tree details.
+If evidence is missing or weak, say so plainly instead of guessing.
+Keep the response short unless the user explicitly asks for detail.
 
 {perspective_section}
 {peer_card_explanation}
@@ -231,7 +234,7 @@ If after thorough searching you find NOTHING relevant:
 
 **Remember:** A clear, direct "I don't know" or "I have no information about X" is always the RIGHT answer when the information truly does not exist in memory. Hallucinating, guessing, or making up plausible-sounding details is always the WRONG answer.
 
-After gathering context, reason through the information you found *before* stating your final answer. For comparison questions, explicitly compare the values. Only after you've verified your reasoning should you state your conclusion. Do NOT be pedantic, rather, be helpful and try to give the answer that the asker would expect -- they're the one who knows the most about themselves. Try to 'read their mind' -- understand the information they're really after and share it with them! Be **as specific as possible** given the information you have.
+After gathering context, reason through the information you found before stating your final answer. For comparison questions, explicitly compare the values. Be specific only where the evidence supports it.
 
 Do not explain your tool usage - just provide the synthesized answer.
 """

--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -62,6 +62,30 @@ def _local_ollama_base_url(client: Any) -> str | None:
     return base_url
 
 
+def _ollama_native_options(
+    max_tokens: int,
+    temperature: float | None,
+    stop: list[str] | None,
+    extra_params: dict[str, Any] | None,
+) -> dict[str, Any]:
+    options: dict[str, Any] = {"num_predict": max_tokens}
+    if temperature is not None:
+        options["temperature"] = temperature
+    if stop:
+        options["stop"] = stop
+    if extra_params:
+        for key in (
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "presence_penalty",
+            "seed",
+        ):
+            if key in extra_params:
+                options[key] = extra_params[key]
+    return options
+
+
 def extract_openai_reasoning_content(response: Any) -> str | None:
     try:
         message = response.choices[0].message
@@ -179,6 +203,7 @@ class OpenAIBackend:
                 stop=stop,
                 response_format=response_format,
                 json_mode=bool(extra_params and extra_params.get("json_mode")),
+                extra_params=extra_params,
             )
 
         if isinstance(response_format, type):
@@ -269,12 +294,14 @@ class OpenAIBackend:
         stop: list[str] | None,
         response_format: type[BaseModel] | dict[str, Any] | None,
         json_mode: bool,
+        extra_params: dict[str, Any] | None,
     ) -> CompletionResult:
-        options: dict[str, Any] = {"num_predict": max_tokens}
-        if temperature is not None:
-            options["temperature"] = temperature
-        if stop:
-            options["stop"] = stop
+        options = _ollama_native_options(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            stop=stop,
+            extra_params=extra_params,
+        )
 
         payload: dict[str, Any] = {
             "model": model,

--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
+import httpx
 from openai import BadRequestError, LengthFinishReasonError
 from pydantic import BaseModel, ValidationError
 
@@ -33,6 +34,32 @@ def _uses_max_completion_tokens(model: str) -> bool:
         if m == prefix or m.startswith(prefix + "-"):
             return True
     return False
+
+
+def _prefers_json_object_structured_output(model: str, client: Any) -> bool:
+    """Use json_object for local Ollama structured calls.
+
+    Ollama's OpenAI-compatible shim can return empty content for json_schema
+    with local models. json_object plus local validation is more reliable.
+    """
+    base_url = str(getattr(client, "base_url", "")).lower()
+    model_name = model.lower()
+    return (
+        "11434" in base_url
+        or "11435" in base_url
+        or "ollama" in base_url
+        or model_name.startswith(("qwen", "llama", "mistral", "gemma"))
+    )
+
+
+def _local_ollama_base_url(client: Any) -> str | None:
+    base_url = str(getattr(client, "base_url", "")).rstrip("/")
+    lowered = base_url.lower()
+    if not ("11434" in lowered or "11435" in lowered or "ollama" in lowered):
+        return None
+    if lowered.endswith("/v1"):
+        return base_url[:-3]
+    return base_url
 
 
 def extract_openai_reasoning_content(response: Any) -> str | None:
@@ -141,7 +168,37 @@ class OpenAIBackend:
             extra_params=extra_params,
         )
 
+        ollama_base_url = _local_ollama_base_url(self._client)
+        if ollama_base_url and not tools and tool_choice is None:
+            return await self._complete_with_ollama_native_chat(
+                base_url=ollama_base_url,
+                model=model,
+                messages=messages,
+                max_tokens=max_output_tokens or max_tokens,
+                temperature=temperature,
+                stop=stop,
+                response_format=response_format,
+                json_mode=bool(extra_params and extra_params.get("json_mode")),
+            )
+
         if isinstance(response_format, type):
+            if (
+                extra_params
+                and extra_params.get("json_mode")
+                and _prefers_json_object_structured_output(model, self._client)
+            ):
+                params["response_format"] = {"type": "json_object"}
+                response = await self._client.chat.completions.create(**params)
+                content = self._parse_or_repair_structured_content(
+                    response,
+                    response_format,
+                    model,
+                )
+                return self._normalize_response(
+                    response,
+                    content_override=content,
+                )
+
             params["response_format"] = response_format
             try:
                 response = await self._client.chat.completions.parse(**params)
@@ -200,6 +257,50 @@ class OpenAIBackend:
 
         response = await self._client.chat.completions.create(**params)
         return self._normalize_response(response)
+
+    async def _complete_with_ollama_native_chat(
+        self,
+        *,
+        base_url: str,
+        model: str,
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        temperature: float | None,
+        stop: list[str] | None,
+        response_format: type[BaseModel] | dict[str, Any] | None,
+        json_mode: bool,
+    ) -> CompletionResult:
+        options: dict[str, Any] = {"num_predict": max_tokens}
+        if temperature is not None:
+            options["temperature"] = temperature
+        if stop:
+            options["stop"] = stop
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "think": False,
+            "options": options,
+        }
+        if response_format is not None or json_mode:
+            payload["format"] = "json"
+
+        async with httpx.AsyncClient(timeout=180) as client:
+            response = await client.post(f"{base_url}/api/chat", json=payload)
+            response.raise_for_status()
+        data = response.json()
+        raw_content = data.get("message", {}).get("content") or ""
+        content: Any = raw_content
+        if isinstance(response_format, type):
+            content = repair_response_model_json(raw_content, response_format, model)
+        return CompletionResult(
+            content=content,
+            input_tokens=int(data.get("prompt_eval_count") or 0),
+            output_tokens=int(data.get("eval_count") or 0),
+            finish_reason=data.get("done_reason") or "stop",
+            raw_response=data,
+        )
 
     async def stream(
         self,

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -187,6 +187,70 @@ async def test_openai_backend_passes_thinking_budget_via_extra_body() -> None:
         raise AssertionError("Expected OpenAI create call")
     call = await_args.kwargs
     assert call["extra_body"] == {"reasoning": {"max_tokens": 256}}
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_merges_extra_params_into_native_ollama_options() -> None:
+    client = Mock()
+    client.base_url = "http://localhost:11434/v1"
+    client.chat.completions.create = AsyncMock()
+
+    response_payload = {
+        "message": {"content": "ok"},
+        "prompt_eval_count": 12,
+        "eval_count": 3,
+        "done_reason": "stop",
+    }
+    response = SimpleNamespace(
+        raise_for_status=Mock(),
+        json=Mock(return_value=response_payload),
+    )
+
+    httpx_client = AsyncMock()
+    httpx_client.__aenter__.return_value = httpx_client
+    httpx_client.__aexit__.return_value = None
+    httpx_client.post = AsyncMock(return_value=response)
+
+    with patch("src.llm.backends.openai.httpx.AsyncClient", return_value=httpx_client):
+        backend = OpenAIBackend(client)
+        result = await backend.complete(
+            model="qwen3.5:9b-fixed",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            temperature=0.2,
+            stop=["END"],
+            extra_params={
+                "top_p": 0.9,
+                "top_k": 40,
+                "frequency_penalty": 0.1,
+                "presence_penalty": 0.2,
+                "seed": 1234,
+                "json_mode": True,
+                "cache_policy": object(),
+            },
+        )
+
+    assert result.content == "ok"
+    assert result.input_tokens == 12
+    assert result.output_tokens == 3
+    assert client.chat.completions.create.await_count == 0
+
+    await_args = httpx_client.post.await_args
+    if await_args is None:
+        raise AssertionError("Expected native Ollama post call")
+    call = await_args.kwargs
+    assert call["json"]["think"] is False
+    assert call["json"]["format"] == "json"
+    assert call["json"]["options"] == {
+        "num_predict": 100,
+        "temperature": 0.2,
+        "stop": ["END"],
+        "top_p": 0.9,
+        "top_k": 40,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.2,
+        "seed": 1234,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from src.llm.backends.openai import OpenAIBackend
+from src.llm.backends.openai import OpenAIBackend, _local_ollama_base_url
 
 
 @pytest.mark.asyncio
@@ -238,6 +238,8 @@ async def test_openai_backend_merges_extra_params_into_native_ollama_options() -
     await_args = httpx_client.post.await_args
     if await_args is None:
         raise AssertionError("Expected native Ollama post call")
+    expected_url = f"{_local_ollama_base_url(client)}/api/chat"
+    assert await_args.args[0] == expected_url
     call = await_args.kwargs
     assert call["json"]["think"] is False
     assert call["json"]["format"] == "json"


### PR DESCRIPTION
This patch tightens Honcho's local-model handling in three places:\n\n- deriver prompts now require JSON-only explicit facts\n- dialectic prompts are stricter about evidence and avoid invented source-tree details\n- the OpenAI backend falls back to Ollama's native /api/chat with think:false for local models, and uses json_object for local structured calls\n\nValidation:\n- python3 -m compileall on the three modified modules passed\n\nContext: this is intended to make local Ollama behavior more deterministic for self-hosted deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added routing to support local Ollama-style models for inference.

* **Improvements**
  * Prompt for explicit-fact extraction now enforces a strict JSON-only OUTPUT FORMAT.
  * Agent system prompt tightened: concise context synthesis, evidence-only answers, explicit notice when evidence is weak/missing, and brevity-by-default.

* **Tests**
  * Added tests verifying native Ollama request/response behavior and merged request options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->