### PR TITLE
feat: add generate_jwt.py script for creating scoped JWTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,26 @@ the `AUTH_JWT_SECRET` environment variable. This is required for `AUTH_USE_AUTH`
 AUTH_JWT_SECRET=<generated_secret>
 ```
 
+Once auth is enabled, use `scripts/generate_jwt.py` to mint tokens for local
+development and scripting:
+
+```bash
+# Admin token (full access, no expiry)
+uv run python scripts/generate_jwt.py --admin
+
+# Admin token expiring in 24 hours
+uv run python scripts/generate_jwt.py --admin --expires 24h
+
+# Workspace-scoped token
+uv run python scripts/generate_jwt.py --workspace my-workspace --expires 30d
+
+# Capture a token for use in curl/scripts
+TOKEN=$(uv run python scripts/generate_jwt.py --admin --print-only)
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/v1/workspaces
+```
+
+Duration units: `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), `y` (years).
+
 5. **Run database migrations**
 
 With the database set up and environment variables configured, run the migrations

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ uv run python scripts/generate_jwt.py --workspace my-workspace --expires 30d
 
 # Capture a token for use in curl/scripts
 TOKEN=$(uv run python scripts/generate_jwt.py --admin --print-only)
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/v1/workspaces
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/v3/workspaces
 ```
 
 Duration units: `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), `y` (years).

--- a/scripts/generate_jwt.py
+++ b/scripts/generate_jwt.py
@@ -105,7 +105,6 @@ def main():
         exp_str = format_datetime_utc(expiry)
 
     params = JWTParams(
-        t="",
         ad=True if args.admin else None,
         w=args.workspace,
         p=args.peer,

--- a/scripts/generate_jwt.py
+++ b/scripts/generate_jwt.py
@@ -64,22 +64,26 @@ def main():
         help="Generate an admin JWT (full access)",
     )
     parser.add_argument(
-        "--workspace", "-w",
+        "--workspace",
+        "-w",
         metavar="NAME",
         help="Scope the JWT to a workspace",
     )
     parser.add_argument(
-        "--peer", "-p",
+        "--peer",
+        "-p",
         metavar="NAME",
         help="Scope the JWT to a peer (requires --workspace)",
     )
     parser.add_argument(
-        "--session", "-s",
+        "--session",
+        "-s",
         metavar="NAME",
         help="Scope the JWT to a session (requires --workspace)",
     )
     parser.add_argument(
-        "--expires", "-e",
+        "--expires",
+        "-e",
         metavar="DURATION",
         type=parse_duration,
         help="Token expiry duration. Units: s=seconds, m=minutes, h=hours, d=days, w=weeks, y=years. E.g. 5h, 30d, 1y",
@@ -92,10 +96,14 @@ def main():
     args = parser.parse_args()
 
     if not args.admin and not any([args.workspace, args.peer, args.session]):
-        parser.error("Specify --admin or at least one of --workspace, --peer, --session")
+        parser.error(
+            "Specify --admin or at least one of --workspace, --peer, --session"
+        )
 
     if args.admin and any([args.workspace, args.peer, args.session]):
-        parser.error("--admin cannot be combined with --workspace, --peer, or --session")
+        parser.error(
+            "--admin cannot be combined with --workspace, --peer, or --session"
+        )
 
     if (args.peer or args.session) and not args.workspace:
         parser.error("--peer and --session require --workspace")
@@ -118,7 +126,7 @@ def main():
     if args.print_only:
         print(token)
     else:
-        scope_parts = []
+        scope_parts: list[str] = []
         if args.admin:
             scope_parts.append("admin")
         if args.workspace:

--- a/scripts/generate_jwt.py
+++ b/scripts/generate_jwt.py
@@ -21,17 +21,15 @@ Examples:
 
 import argparse
 import datetime
+import os
 import re
 import sys
 
 # Allow running from repo root without installing
-import os
-
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from src.security import JWTParams, create_jwt
 from src.utils.formatting import format_datetime_utc
-
 
 DURATION_UNITS = {
     "s": datetime.timedelta(seconds=1),
@@ -95,6 +93,9 @@ def main():
 
     if not args.admin and not any([args.workspace, args.peer, args.session]):
         parser.error("Specify --admin or at least one of --workspace, --peer, --session")
+
+    if args.admin and any([args.workspace, args.peer, args.session]):
+        parser.error("--admin cannot be combined with --workspace, --peer, or --session")
 
     if (args.peer or args.session) and not args.workspace:
         parser.error("--peer and --session require --workspace")

--- a/scripts/generate_jwt.py
+++ b/scripts/generate_jwt.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env uv run python
+"""
+Utility script to generate scoped JWTs for Honcho.
+
+Examples:
+    # Admin JWT (no expiry)
+    uv run python scripts/generate_jwt.py --admin
+
+    # Admin JWT expiring in 24 hours
+    uv run python scripts/generate_jwt.py --admin --expires 24h
+
+    # Workspace-scoped JWT expiring in 30 days
+    uv run python scripts/generate_jwt.py --workspace my-workspace --expires 30d
+
+    # Peer-scoped JWT expiring in 1 year
+    uv run python scripts/generate_jwt.py --workspace my-workspace --peer my-peer --expires 1y
+
+    # Session-scoped JWT
+    uv run python scripts/generate_jwt.py --workspace my-workspace --session my-session --expires 8h
+"""
+
+import argparse
+import datetime
+import re
+import sys
+
+# Allow running from repo root without installing
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.security import JWTParams, create_jwt
+from src.utils.formatting import format_datetime_utc
+
+
+DURATION_UNITS = {
+    "s": datetime.timedelta(seconds=1),
+    "m": datetime.timedelta(minutes=1),
+    "h": datetime.timedelta(hours=1),
+    "d": datetime.timedelta(days=1),
+    "w": datetime.timedelta(weeks=1),
+    "y": datetime.timedelta(days=365),
+}
+
+
+def parse_duration(value: str) -> datetime.timedelta:
+    """Parse a duration string like '5h', '1d', '2w', '1y' into a timedelta."""
+    match = re.fullmatch(r"(\d+)([smhdwy])", value.strip().lower())
+    if not match:
+        raise argparse.ArgumentTypeError(
+            f"Invalid duration '{value}'. Use format like: 30s, 5m, 2h, 7d, 2w, 1y"
+        )
+    amount, unit = int(match.group(1)), match.group(2)
+    return DURATION_UNITS[unit] * amount
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate a scoped JWT for Honcho authentication.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--admin",
+        action="store_true",
+        help="Generate an admin JWT (full access)",
+    )
+    parser.add_argument(
+        "--workspace", "-w",
+        metavar="NAME",
+        help="Scope the JWT to a workspace",
+    )
+    parser.add_argument(
+        "--peer", "-p",
+        metavar="NAME",
+        help="Scope the JWT to a peer (requires --workspace)",
+    )
+    parser.add_argument(
+        "--session", "-s",
+        metavar="NAME",
+        help="Scope the JWT to a session (requires --workspace)",
+    )
+    parser.add_argument(
+        "--expires", "-e",
+        metavar="DURATION",
+        type=parse_duration,
+        help="Token expiry duration. Units: s=seconds, m=minutes, h=hours, d=days, w=weeks, y=years. E.g. 5h, 30d, 1y",
+    )
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help="Only print the token, no labels",
+    )
+    args = parser.parse_args()
+
+    if not args.admin and not any([args.workspace, args.peer, args.session]):
+        parser.error("Specify --admin or at least one of --workspace, --peer, --session")
+
+    if (args.peer or args.session) and not args.workspace:
+        parser.error("--peer and --session require --workspace")
+
+    exp_str: str | None = None
+    if args.expires:
+        expiry = datetime.datetime.now(datetime.timezone.utc) + args.expires
+        exp_str = format_datetime_utc(expiry)
+
+    params = JWTParams(
+        t="",
+        ad=True if args.admin else None,
+        w=args.workspace,
+        p=args.peer,
+        s=args.session,
+        exp=exp_str,
+    )
+
+    token = create_jwt(params)
+
+    if args.print_only:
+        print(token)
+    else:
+        scope_parts = []
+        if args.admin:
+            scope_parts.append("admin")
+        if args.workspace:
+            scope_parts.append(f"workspace={args.workspace}")
+        if args.peer:
+            scope_parts.append(f"peer={args.peer}")
+        if args.session:
+            scope_parts.append(f"session={args.session}")
+
+        print(f"Scope:   {', '.join(scope_parts)}")
+        if exp_str:
+            print(f"Expires: {exp_str}")
+        else:
+            print("Expires: never")
+        print(f"Token:   {token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,7 @@ _RUNTIME_MOCK_TEST_BLOCKLIST_PREFIXES = (
     # LLM transport tests mock providers directly and don't need database/runtime setup.
     "tests/utils/test_length_finish_reason.py",
     "tests/utils/test_clients.py",
+    "tests/test_generate_jwt_script.py",
 )
 
 _LIVE_LLM_MARKER = "live_llm"

--- a/tests/test_generate_jwt_script.py
+++ b/tests/test_generate_jwt_script.py
@@ -1,0 +1,23 @@
+import sys
+
+import pytest
+
+from scripts import generate_jwt
+
+
+def test_admin_cannot_be_combined_with_scoped_flags(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_jwt.py",
+            "--admin",
+            "--workspace",
+            "my-workspace",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        generate_jwt.main()
+
+    assert exc_info.value.code == 2


### PR DESCRIPTION
## Summary

Adds `scripts/generate_jwt.py` — a CLI utility for generating Honcho JWTs locally without needing a running API server or the `/v1/keys` endpoint.

This is useful for:
- **Local development**: bootstrap an admin token to call the API
- **Scripting/automation**: pipe tokens into curl commands or test scripts
- **Debugging**: quickly generate workspace/peer/session-scoped tokens

## Usage

```bash
# Admin JWT (no expiry)
uv run python scripts/generate_jwt.py --admin

# Admin JWT expiring in 24 hours
uv run python scripts/generate_jwt.py --admin --expires 24h

# Workspace-scoped JWT expiring in 30 days
uv run python scripts/generate_jwt.py --workspace my-workspace --expires 30d

# Peer-scoped JWT expiring in 1 year
uv run python scripts/generate_jwt.py --workspace my-ws --peer my-peer --expires 1y

# Session-scoped JWT
uv run python scripts/generate_jwt.py --workspace my-ws --session my-session --expires 8h

# Print only the token (for scripting)
TOKEN=$(uv run python scripts/generate_jwt.py --admin --print-only)
```

## Details

- Uses the existing `JWTParams` / `create_jwt` from `src/security.py` — no new logic
- Duration syntax supports: `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), `y` (years)
- No new dependencies — only stdlib + existing project code
- Works as a standalone script via `uv run` shebang

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI utility to mint scoped JWTs (admin, workspace, peer, session) with selectable expiry, duration units (s, m, h, d, w, y), validation of flag combinations, and an option to output only the raw token.

* **Documentation**
  * Local development guide updated with usage examples and an API curl example showing token usage.

* **Tests**
  * Added test coverage for CLI flag validation and adjusted test config to include the new test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->