### PR TITLE
fix(llm): pass OpenAI provider extra options

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -322,6 +322,14 @@ class OpenAIBackend:
             ):
                 if key in extra_params:
                     params[key] = extra_params[key]
+            if "extra_body" in extra_params:
+                params.setdefault("extra_body", {}).update(extra_params["extra_body"])
+            if "thinking" in extra_params:
+                params.setdefault("extra_body", {})["thinking"] = extra_params[
+                    "thinking"
+                ]
+            if "extra_headers" in extra_params:
+                params["extra_headers"] = extra_params["extra_headers"]
         return params
 
     def _normalize_response(

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -228,6 +228,52 @@ async def test_openai_backend_skips_extra_body_when_thinking_budget_zero() -> No
 
 
 @pytest.mark.asyncio
+async def test_openai_backend_passes_provider_extra_body_headers_and_thinking() -> None:
+    client = Mock()
+    client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        content="ok",
+                        tool_calls=[],
+                        reasoning_details=[],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                prompt_tokens_details=None,
+            ),
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    await backend.complete(
+        model="kimi-for-coding",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        extra_params={
+            "extra_body": {"custom": "value"},
+            "thinking": {"type": "disabled"},
+            "extra_headers": {"X-Test": "yes"},
+        },
+    )
+
+    await_args = client.chat.completions.create.await_args
+    if await_args is None:
+        raise AssertionError("Expected OpenAI create call")
+    call = await_args.kwargs
+    assert call["extra_body"] == {
+        "custom": "value",
+        "thinking": {"type": "disabled"},
+    }
+    assert call["extra_headers"] == {"X-Test": "yes"}
+
+
+@pytest.mark.asyncio
 async def test_openai_backend_converts_anthropic_style_tools() -> None:
     client = Mock()
     client.chat.completions.create = AsyncMock(


### PR DESCRIPTION
## Summary

- forward configured `extra_body`, `thinking`, and `extra_headers` from `OpenAIBackend` into chat-completions calls
- add focused coverage proving those provider-specific options reach the OpenAI-compatible SDK call

## Why

Some OpenAI-compatible providers expose useful or required request options outside Honcho's current hard-coded parameter allowlist. Honcho can carry these provider settings in config, but the OpenAI backend currently drops them before making the SDK call.

This PR keeps the behavior generic and provider-neutral: if a provider config supplies `extra_body`, `thinking`, or `extra_headers`, pass them through to the OpenAI-compatible request.

## Testing

- `uv run ruff check src/llm/backends/openai.py tests/llm/test_backends/test_openai.py`
- `uv run pytest tests/llm/test_backends/test_openai.py`

## Disclosure

Assisted-by: OpenClaw:gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAI backend now accepts provider-specific request customizations: custom request body content, a thinking directive, and custom headers.

* **Tests**
  * Added test coverage to verify provider-specific request customizations are passed through correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->