### PR TITLE
fix(llm): add Kimi coding User-Agent

### DIFF
--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -70,6 +70,12 @@ def get_openai_override_client(
     base_url: str | None, api_key: str | None
 ) -> AsyncOpenAI:
     """OpenAI client for a specific (base_url, api_key) pair. Cached by key."""
+    if base_url and "api.kimi.com/coding" in base_url:
+        return AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            default_headers={"User-Agent": "KimiCLI/1.5"},
+        )
     return AsyncOpenAI(api_key=api_key, base_url=base_url)
 
 

--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from typing import assert_never
+from urllib.parse import urlparse
 
 from anthropic import AsyncAnthropic
 from google import genai
@@ -31,6 +32,8 @@ from .history_adapters import (
     OpenAIHistoryAdapter,
 )
 from .types import ProviderClient
+
+KIMI_CODING_USER_AGENT = "KimiCLI/1.5"
 
 
 @lru_cache(maxsize=1)
@@ -70,13 +73,25 @@ def get_openai_override_client(
     base_url: str | None, api_key: str | None
 ) -> AsyncOpenAI:
     """OpenAI client for a specific (base_url, api_key) pair. Cached by key."""
-    if base_url and "api.kimi.com/coding" in base_url:
+    if _is_kimi_coding_base_url(base_url):
         return AsyncOpenAI(
             api_key=api_key,
             base_url=base_url,
-            default_headers={"User-Agent": "KimiCLI/1.5"},
+            default_headers={"User-Agent": KIMI_CODING_USER_AGENT},
         )
     return AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+
+def _is_kimi_coding_base_url(base_url: str | None) -> bool:
+    """Return whether base_url targets Kimi's coding-compatible endpoint."""
+    if not base_url:
+        return False
+
+    parsed = urlparse(base_url)
+    path = parsed.path.rstrip("/")
+    return parsed.hostname == "api.kimi.com" and (
+        path == "/coding" or path.startswith("/coding/")
+    )
 
 
 @lru_cache(maxsize=128)

--- a/tests/llm/test_registry.py
+++ b/tests/llm/test_registry.py
@@ -1,9 +1,34 @@
-from src.llm.registry import get_openai_override_client
+from src.llm.registry import KIMI_CODING_USER_AGENT, get_openai_override_client
 
 
 def test_kimi_coding_override_client_uses_kimi_cli_user_agent() -> None:
+    """Verify Kimi coding endpoint clients include the KimiCLI User-Agent."""
     get_openai_override_client.cache_clear()
 
     client = get_openai_override_client("https://api.kimi.com/coding/v1", "test-key")
 
-    assert client.default_headers["User-Agent"] == "KimiCLI/1.5"
+    assert client.default_headers.get("User-Agent") == KIMI_CODING_USER_AGENT
+
+
+def test_non_kimi_override_client_has_no_custom_user_agent() -> None:
+    """Verify ordinary OpenAI-compatible endpoints do not get Kimi headers."""
+    get_openai_override_client.cache_clear()
+
+    client = get_openai_override_client("https://api.openai.com/v1", "test-key")
+
+    assert client.default_headers.get("User-Agent") != KIMI_CODING_USER_AGENT
+
+
+def test_kimi_user_agent_rejects_lookalike_urls() -> None:
+    """Verify only api.kimi.com coding paths get the Kimi User-Agent."""
+    get_openai_override_client.cache_clear()
+
+    lookalike_urls = [
+        "https://malicious-api.kimi.com/coding/v1",
+        "https://evil.example/api.kimi.com/coding/v1",
+        "https://api.kimi.com/coding-proxy/v1",
+    ]
+
+    for url in lookalike_urls:
+        client = get_openai_override_client(url, "test-key")
+        assert client.default_headers.get("User-Agent") != KIMI_CODING_USER_AGENT

--- a/tests/llm/test_registry.py
+++ b/tests/llm/test_registry.py
@@ -1,0 +1,9 @@
+from src.llm.registry import get_openai_override_client
+
+
+def test_kimi_coding_override_client_uses_kimi_cli_user_agent() -> None:
+    get_openai_override_client.cache_clear()
+
+    client = get_openai_override_client("https://api.kimi.com/coding/v1", "test-key")
+
+    assert client.default_headers["User-Agent"] == "KimiCLI/1.5"


### PR DESCRIPTION
## Summary

- add a narrow Kimi coding endpoint compatibility header for OpenAI override clients targeting `api.kimi.com/coding`
- add a focused test proving the override client sets `User-Agent: KimiCLI/1.5` only for that endpoint path

## Why

Kimi's coding endpoint is OpenAI-compatible in request shape, but local testing showed it rejects generic SDK requests unless they include the coding-client User-Agent. This keeps the compatibility behavior scoped to Kimi's coding base URL rather than changing headers for other OpenAI-compatible providers.

## Testing

- `uv run ruff check src/llm/registry.py tests/llm/test_registry.py`
- `uv run pytest tests/llm/test_registry.py`

## Disclosure

Assisted-by: OpenClaw:gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clients connecting to Kimi coding API endpoints will send a KimiCLI/1.5 User-Agent header to ensure correct handling by those endpoints.

* **Tests**
  * Added tests verifying the Kimi User-Agent is applied for genuine Kimi coding endpoints, is not applied to non-Kimi OpenAI-compatible URLs, and rejects lookalike/partial-match URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->