### PR TITLE
feat: embed messages immediately on create with reconciler fallback

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -696,6 +696,9 @@ class EmbeddingSettings(HonchoSettings):
     VECTOR_DIMENSIONS: Annotated[int, Field(default=1536, gt=0)] = 1536
     MAX_INPUT_TOKENS: Annotated[int, Field(default=8192, gt=0)] = 8192
     MAX_TOKENS_PER_REQUEST: Annotated[int, Field(default=300_000, gt=0)] = 300_000
+    # Caps concurrent message-embedding fan-out on the API request path (the
+    # immediate-embed background task). The reconciler is unaffected.
+    MAX_CONCURRENT_EMBEDDINGS: Annotated[int, Field(default=10, gt=0, le=100)] = 10
 
     @model_validator(mode="before")
     @classmethod

--- a/src/reconciler/embed_now.py
+++ b/src/reconciler/embed_now.py
@@ -1,0 +1,305 @@
+"""
+Immediate message-embedding fast path.
+
+``create_messages`` writes ``MessageEmbedding`` rows as ``sync_state='pending'``
+with no vector and defers embedding to the reconciler, which runs on a fixed
+interval. To keep freshly created messages searchable within seconds (not
+minutes), the message routers schedule ``embed_messages_now`` as a FastAPI
+background task right after the response is sent. The reconciler remains the
+fallback for anything this path leaves pending (failures, process restarts, or
+rows it could not claim).
+
+The fast path never holds a DB session across the embedding network call: it
+claims and leases rows in one short transaction, embeds with no session open,
+then persists in a second short transaction. Running concurrently with the
+reconciler is safe because the claim uses ``FOR UPDATE SKIP LOCKED`` and leases
+rows by stamping ``last_sync_at``, which the reconciler's backoff filter then
+skips.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import and_, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import models
+from src.config import settings
+from src.dependencies import tracked_db
+from src.embedding_client import embedding_client
+from src.exceptions import VectorStoreError
+from src.reconciler.sync_vectors import (
+    _backoff_eligible,  # pyright: ignore[reportPrivateUsage]
+    build_message_vector_record,
+    compute_chunk_positions,
+)
+from src.telemetry.events import EmbeddingCallPurpose
+from src.utils.types import embedding_call_purpose
+from src.vector_store import VectorRecord, VectorStore, get_external_vector_store
+
+logger = logging.getLogger(__name__)
+
+_embed_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_embed_semaphore() -> asyncio.Semaphore:
+    """Lazily create the embed-concurrency semaphore.
+
+    Built on first use (not at import time) so it binds to the running event
+    loop rather than whatever loop happened to exist at import.
+    """
+    global _embed_semaphore
+    if _embed_semaphore is None:
+        _embed_semaphore = asyncio.Semaphore(
+            settings.EMBEDDING.MAX_CONCURRENT_EMBEDDINGS
+        )
+    return _embed_semaphore
+
+
+def reset_embed_semaphore() -> None:
+    """Test hook: drop the cached semaphore so the next call rebuilds it on the
+    current event loop and current config."""
+    global _embed_semaphore
+    _embed_semaphore = None
+
+
+@dataclass(frozen=True)
+class _ClaimedChunk:
+    """Plain snapshot of a claimed ``MessageEmbedding`` row.
+
+    Captured before the claim transaction commits — after commit the ORM object
+    is detached and attribute access would lazy-load against a closed session.
+    """
+
+    id: int
+    message_id: str
+    content: str
+    workspace_name: str
+    session_name: str | None
+    peer_name: str | None
+
+
+async def embed_messages_now(message_ids: list[str]) -> None:
+    """Embed freshly created messages immediately, leaving the reconciler as the
+    fallback for anything left pending.
+
+    Args:
+        message_ids: ``Message.public_id`` values (what
+            ``MessageEmbedding.message_id`` references). Messages without
+            embeddable content simply have no pending rows to claim.
+    """
+    if not message_ids:
+        return
+
+    claimed = await _claim_and_lease(message_ids)
+    if not claimed:
+        return
+
+    vectors = await _embed_chunks(claimed)
+    if vectors is None:
+        # Embedding failed; rows stay pending + leased, reconciler will retry.
+        return
+
+    await _persist(message_ids, claimed, vectors)
+
+
+async def _claim_and_lease(message_ids: list[str]) -> list[_ClaimedChunk]:
+    """Phase 1 (short txn): claim eligible pending rows with FOR UPDATE SKIP
+    LOCKED, lease them by stamping ``last_sync_at``, and snapshot their data.
+
+    ``sync_attempts`` is intentionally left untouched: the reconciler owns retry
+    accounting and the eventual ``sync_state='failed'`` backstop, so a transient
+    embedding failure on this best-effort path never burns that budget.
+    """
+    async with tracked_db("embed_now_claim") as db:
+        rows_stmt = (
+            select(models.MessageEmbedding)
+            .where(
+                and_(
+                    models.MessageEmbedding.message_id.in_(message_ids),
+                    models.MessageEmbedding.sync_state == "pending",
+                    _backoff_eligible(models.MessageEmbedding.last_sync_at),
+                )
+            )
+            .order_by(models.MessageEmbedding.message_id, models.MessageEmbedding.id)
+            .with_for_update(skip_locked=True)
+        )
+        rows = list((await db.execute(rows_stmt)).scalars().all())
+        if not rows:
+            return []
+
+        claimed = [
+            _ClaimedChunk(
+                id=row.id,
+                message_id=row.message_id,
+                content=row.content,
+                workspace_name=row.workspace_name,
+                session_name=row.session_name,
+                peer_name=row.peer_name,
+            )
+            for row in rows
+        ]
+
+        await db.execute(
+            update(models.MessageEmbedding)
+            .where(models.MessageEmbedding.id.in_([c.id for c in claimed]))
+            .values(last_sync_at=func.now())
+        )
+        await db.commit()
+        return claimed
+
+
+async def _embed_chunks(claimed: list[_ClaimedChunk]) -> list[list[float]] | None:
+    """Phase 2 (no DB session): embed the claimed chunk contents under the
+    concurrency semaphore. Returns vectors in input order, or None on failure."""
+    workspaces = {c.workspace_name for c in claimed}
+    try:
+        async with _get_embed_semaphore():
+            with embedding_call_purpose(
+                EmbeddingCallPurpose.MESSAGE_CREATE.value,
+                workspace_name=workspaces.pop() if len(workspaces) == 1 else None,
+                parent_category="api",
+            ):
+                return await embedding_client.simple_batch_embed(
+                    [c.content for c in claimed]
+                )
+    except Exception:
+        logger.exception(
+            "Immediate embedding failed for %s chunk(s); reconciler will retry",
+            len(claimed),
+        )
+        return None
+
+
+async def _persist(
+    message_ids: list[str],
+    claimed: list[_ClaimedChunk],
+    vectors: list[list[float]],
+) -> None:
+    """Phase 3 (short txn): persist vectors and mark rows synced. On failure,
+    rows stay pending (already leased) and the reconciler heals them."""
+    if len(vectors) != len(claimed):
+        logger.warning(
+            "Embedding count %s != claimed chunk count %s; skipping immediate persist, reconciler will heal",
+            len(vectors),
+            len(claimed),
+        )
+        return
+
+    vector_by_id = {c.id: vec for c, vec in zip(claimed, vectors, strict=True)}
+    # True for pgvector OR during migration (dual-write to both stores).
+    store_in_postgres = (
+        settings.VECTOR_STORE.TYPE == "pgvector" or not settings.VECTOR_STORE.MIGRATED
+    )
+    external = get_external_vector_store()
+
+    async with tracked_db("embed_now_persist") as db:
+        if external is None:
+            await _persist_pgvector(db, claimed, vector_by_id)
+        else:
+            await _persist_external(
+                db, message_ids, claimed, vector_by_id, store_in_postgres, external
+            )
+        await db.commit()
+
+
+async def _persist_pgvector(
+    db: AsyncSession,
+    claimed: list[_ClaimedChunk],
+    vector_by_id: dict[int, list[float]],
+) -> None:
+    """pgvector-only mode: write the vector and mark synced per row. The
+    ``sync_state='pending'`` guard keeps us idempotent if the reconciler synced
+    a row in the gap."""
+    for c in claimed:
+        await db.execute(
+            update(models.MessageEmbedding)
+            .where(
+                and_(
+                    models.MessageEmbedding.id == c.id,
+                    models.MessageEmbedding.sync_state == "pending",
+                )
+            )
+            .values(
+                sync_state="synced",
+                last_sync_at=func.now(),
+                sync_attempts=0,
+                embedding=vector_by_id[c.id],
+            )
+        )
+
+
+async def _persist_external(
+    db: AsyncSession,
+    message_ids: list[str],
+    claimed: list[_ClaimedChunk],
+    vector_by_id: dict[int, list[float]],
+    store_in_postgres: bool,
+    external: VectorStore,
+) -> None:
+    """External-store mode: upsert vectors per namespace, then mark synced.
+    Chunk positions come from the shared helper (full sibling ordering) so vector
+    ids match whatever the reconciler writes for any chunk we skipped."""
+    chunk_position = await compute_chunk_positions(db, message_ids)
+
+    by_namespace: dict[str, list[_ClaimedChunk]] = {}
+    for c in claimed:
+        ns = external.get_vector_namespace("message", c.workspace_name)
+        by_namespace.setdefault(ns, []).append(c)
+
+    for namespace, chunks in by_namespace.items():
+        records: list[VectorRecord] = []
+        synced_chunks: list[_ClaimedChunk] = []
+        for c in chunks:
+            pos = chunk_position.get(c.id)
+            if pos is None:
+                continue
+            records.append(
+                build_message_vector_record(
+                    message_id=c.message_id,
+                    chunk_position=pos,
+                    session_name=c.session_name,
+                    peer_name=c.peer_name,
+                    embedding=vector_by_id[c.id],
+                )
+            )
+            synced_chunks.append(c)
+
+        if not records:
+            continue
+
+        try:
+            await external.upsert_many(namespace, records)
+        except VectorStoreError:
+            logger.warning(
+                "Vector store unavailable during immediate embed of namespace %s; reconciler will retry",
+                namespace,
+            )
+            continue
+        except Exception:
+            logger.exception(
+                "Unexpected error during immediate embed of namespace %s; reconciler will retry",
+                namespace,
+            )
+            continue
+
+        for c in synced_chunks:
+            values: dict[str, Any] = {
+                "sync_state": "synced",
+                "last_sync_at": func.now(),
+                "sync_attempts": 0,
+            }
+            if store_in_postgres:
+                values["embedding"] = vector_by_id[c.id]
+            await db.execute(
+                update(models.MessageEmbedding)
+                .where(
+                    and_(
+                        models.MessageEmbedding.id == c.id,
+                        models.MessageEmbedding.sync_state == "pending",
+                    )
+                )
+                .values(**values)
+            )

--- a/src/reconciler/sync_vectors.py
+++ b/src/reconciler/sync_vectors.py
@@ -204,6 +204,63 @@ async def _bump_message_embedding_sync_attempts(
         )
 
 
+async def compute_chunk_positions(
+    db: AsyncSession, message_ids: list[str]
+) -> dict[int, int]:
+    """Map each MessageEmbedding row id to its 0-indexed chunk position within
+    its message.
+
+    Positions are derived from the full set of sibling rows for each message,
+    ordered by ``(message_id, id)`` — never from a partial subset — so the
+    ``{message_id}_{chunk_position}`` vector id stays stable no matter which
+    rows a given caller claimed. Shared by the reconciler and the immediate
+    embed path so the two writers always agree on vector ids.
+    """
+    if not message_ids:
+        return {}
+
+    sibling_stmt = (
+        select(models.MessageEmbedding.id, models.MessageEmbedding.message_id)
+        .where(models.MessageEmbedding.message_id.in_(message_ids))
+        .order_by(models.MessageEmbedding.message_id, models.MessageEmbedding.id)
+    )
+    sibling_rows = (await db.execute(sibling_stmt)).all()
+
+    embs_by_message: dict[str, list[int]] = {}
+    for emb_id, msg_id in sibling_rows:
+        embs_by_message.setdefault(msg_id, []).append(emb_id)
+
+    chunk_position: dict[int, int] = {}
+    for emb_ids in embs_by_message.values():
+        for pos, emb_id in enumerate(emb_ids):
+            chunk_position[emb_id] = pos
+    return chunk_position
+
+
+def build_message_vector_record(
+    *,
+    message_id: str,
+    chunk_position: int,
+    session_name: str | None,
+    peer_name: str | None,
+    embedding: list[float],
+) -> VectorRecord:
+    """Build the external-store record for one message-embedding chunk.
+
+    Single source of the ``{message_id}_{chunk_position}`` vector id and the
+    metadata shape, shared by the reconciler and the immediate embed path.
+    """
+    return VectorRecord(
+        id=f"{message_id}_{chunk_position}",
+        embedding=[float(x) for x in embedding],
+        metadata={
+            "message_id": message_id,
+            "session_name": session_name,
+            "peer_name": peer_name,
+        },
+    )
+
+
 async def _sync_documents(
     db: AsyncSession,
     documents: list[models.Document],
@@ -374,9 +431,7 @@ async def _sync_message_embeddings(
             workspaces = {emb.workspace_name for emb in embs_needing_embed}
             with embedding_call_purpose(
                 EmbeddingCallPurpose.MESSAGE_CREATE.value,
-                workspace_name=workspaces.pop()
-                if len(workspaces) == 1
-                else None,
+                workspace_name=workspaces.pop() if len(workspaces) == 1 else None,
                 parent_category="reconciliation",
             ):
                 new_embeddings = await embedding_client.simple_batch_embed(contents)
@@ -443,21 +498,7 @@ async def _sync_message_embeddings(
     # 2. Removing MessageEmbedding table entirely if it becomes unnecessary
     # See: https://github.com/plastic-labs/honcho/issues/XXX
     message_ids = list({emb.message_id for emb in embeddings})
-    sibling_stmt = (
-        select(models.MessageEmbedding.id, models.MessageEmbedding.message_id)
-        .where(models.MessageEmbedding.message_id.in_(message_ids))
-        .order_by(models.MessageEmbedding.message_id, models.MessageEmbedding.id)
-    )
-    sibling_rows = (await db.execute(sibling_stmt)).all()
-
-    embs_by_message: dict[str, list[int]] = {}
-    for emb_id, msg_id in sibling_rows:
-        embs_by_message.setdefault(msg_id, []).append(emb_id)
-
-    chunk_position: dict[int, int] = {}
-    for emb_ids in embs_by_message.values():
-        for pos, emb_id in enumerate(emb_ids):
-            chunk_position[emb_id] = pos
+    chunk_position = await compute_chunk_positions(db, message_ids)
 
     # Step 3: Build vector records and upsert to external store (all cases)
     by_namespace: dict[str, list[models.MessageEmbedding]] = {}
@@ -479,14 +520,12 @@ async def _sync_message_embeddings(
                 continue
 
             vector_records.append(
-                VectorRecord(
-                    id=f"{emb.message_id}_{chunk_position[emb.id]}",
-                    embedding=[float(x) for x in embedding],
-                    metadata={
-                        "message_id": emb.message_id,
-                        "session_name": emb.session_name,
-                        "peer_name": emb.peer_name,
-                    },
+                build_message_vector_record(
+                    message_id=emb.message_id,
+                    chunk_position=chunk_position[emb.id],
+                    session_name=emb.session_name,
+                    peer_name=emb.peer_name,
+                    embedding=embedding,
                 )
             )
             embs_to_sync.append(emb)

--- a/src/routers/messages.py
+++ b/src/routers/messages.py
@@ -21,6 +21,7 @@ from src.config import settings
 from src.dependencies import db
 from src.deriver import enqueue
 from src.exceptions import FileTooLargeError, ResourceNotFoundException
+from src.reconciler.embed_now import embed_messages_now
 from src.security import require_auth
 from src.telemetry import prometheus_metrics
 from src.telemetry.events import FileUploadedEvent, MessageCreatedEvent, emit
@@ -140,6 +141,13 @@ async def create_messages_for_session(
         # Enqueue all messages in one call
         background_tasks.add_task(enqueue, payloads)
 
+        # Embed immediately so messages are searchable within seconds; the
+        # reconciler is the fallback for anything left pending.
+        if settings.EMBED_MESSAGES and created_messages:
+            background_tasks.add_task(
+                embed_messages_now, [m.public_id for m in created_messages]
+            )
+
         return created_messages
     except ValueError as e:
         logger.warning(f"Failed to create messages for session {session_id}: {str(e)}")
@@ -206,6 +214,14 @@ async def create_messages_with_file(
     ]
 
     background_tasks.add_task(enqueue, payloads)
+
+    # Embed immediately so messages are searchable within seconds; the
+    # reconciler is the fallback for anything left pending.
+    if settings.EMBED_MESSAGES and created_messages:
+        background_tasks.add_task(
+            embed_messages_now, [m.public_id for m in created_messages]
+        )
+
     logger.debug(
         "Batch of %s messages created from file uploads and queued for processing",
         len(created_messages),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -797,7 +797,7 @@ def mock_tracked_db(request: pytest.FixtureRequest):
         yield
         return
 
-    from contextlib import asynccontextmanager
+    from contextlib import ExitStack, asynccontextmanager
 
     db_engine = request.getfixturevalue("db_engine")
     session_factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
@@ -807,28 +807,35 @@ def mock_tracked_db(request: pytest.FixtureRequest):
         async with session_factory() as session:
             yield session
 
-    with (
-        patch("src.dependencies.tracked_db", mock_tracked_db_context),
-        patch("src.deriver.queue_manager.tracked_db", mock_tracked_db_context),
-        patch("src.deriver.consumer.tracked_db", mock_tracked_db_context),
-        patch("src.deriver.enqueue.tracked_db", mock_tracked_db_context),
-        patch("src.routers.peers.tracked_db", mock_tracked_db_context),
-        patch("src.crud.representation.tracked_db", mock_tracked_db_context),
-        patch("src.dreamer.orchestrator.tracked_db", mock_tracked_db_context),
-        patch("src.dreamer.dream_scheduler.tracked_db", mock_tracked_db_context),
-        patch("src.dialectic.chat.tracked_db", mock_tracked_db_context),
-        patch("src.utils.summarizer.tracked_db", mock_tracked_db_context),
-        patch("src.webhooks.events.tracked_db", mock_tracked_db_context),
-        patch("src.webhooks.webhook_delivery.tracked_db", mock_tracked_db_context),
-        patch("src.utils.agent_tools.tracked_db", mock_tracked_db_context),
-        patch("src.utils.search.tracked_db", mock_tracked_db_context),
-        patch("src.crud.document.tracked_db", mock_tracked_db_context),
-        patch("src.crud.message.tracked_db", mock_tracked_db_context),
-        patch("src.reconciler.sync_vectors.tracked_db", mock_tracked_db_context),
-        patch("src.dialectic.core.tracked_db", mock_tracked_db_context),
-        patch("src.dreamer.specialists.tracked_db", mock_tracked_db_context),
-        patch("src.dreamer.surprisal.tracked_db", mock_tracked_db_context),
-    ):
+    # Each module imports tracked_db by name, so patch every import site.
+    # Use ExitStack (not a parenthesized `with`) to stay under CPython's
+    # 20-statically-nested-block limit as this list grows.
+    tracked_db_targets = [
+        "src.dependencies.tracked_db",
+        "src.deriver.queue_manager.tracked_db",
+        "src.deriver.consumer.tracked_db",
+        "src.deriver.enqueue.tracked_db",
+        "src.routers.peers.tracked_db",
+        "src.crud.representation.tracked_db",
+        "src.dreamer.orchestrator.tracked_db",
+        "src.dreamer.dream_scheduler.tracked_db",
+        "src.dialectic.chat.tracked_db",
+        "src.utils.summarizer.tracked_db",
+        "src.webhooks.events.tracked_db",
+        "src.webhooks.webhook_delivery.tracked_db",
+        "src.utils.agent_tools.tracked_db",
+        "src.utils.search.tracked_db",
+        "src.crud.document.tracked_db",
+        "src.crud.message.tracked_db",
+        "src.reconciler.sync_vectors.tracked_db",
+        "src.reconciler.embed_now.tracked_db",
+        "src.dialectic.core.tracked_db",
+        "src.dreamer.specialists.tracked_db",
+        "src.dreamer.surprisal.tracked_db",
+    ]
+    with ExitStack() as stack:
+        for target in tracked_db_targets:
+            stack.enter_context(patch(target, mock_tracked_db_context))
         yield
 
 

--- a/tests/deriver/test_embed_now.py
+++ b/tests/deriver/test_embed_now.py
@@ -1,0 +1,235 @@
+"""
+Tests for the immediate message-embedding fast path (src/reconciler/embed_now.py).
+
+These exercise embed_messages_now end-to-end against the test database: it opens
+its own tracked_db sessions (patched to the test engine in conftest), so each test
+creates committed fixture rows and asserts on the result via the provided session.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from nanoid import generate as generate_nanoid
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from src import models
+from src.reconciler.embed_now import embed_messages_now, reset_embed_semaphore
+from src.vector_store import VectorStore
+
+
+async def _create_message_with_pending_chunks(
+    db_session: AsyncSession,
+    workspace: models.Workspace,
+    peer: models.Peer,
+    chunk_contents: list[str],
+) -> tuple[str, list[int]]:
+    """Create a message plus one pending MessageEmbedding row per chunk.
+
+    Returns (message public_id, ordered embedding row ids).
+    """
+    session = models.Session(name=str(generate_nanoid()), workspace_name=workspace.name)
+    db_session.add(session)
+    await db_session.commit()
+
+    message_id = str(generate_nanoid())
+    message = models.Message(
+        public_id=message_id,
+        session_name=session.name,
+        workspace_name=workspace.name,
+        peer_name=peer.name,
+        content=" ".join(chunk_contents),
+        seq_in_session=1,
+    )
+    db_session.add(message)
+    await db_session.commit()
+
+    rows = [
+        models.MessageEmbedding(
+            content=chunk,
+            message_id=message_id,
+            workspace_name=workspace.name,
+            session_name=session.name,
+            peer_name=peer.name,
+            sync_state="pending",
+            embedding=None,
+        )
+        for chunk in chunk_contents
+    ]
+    db_session.add_all(rows)
+    await db_session.commit()
+    for row in rows:
+        await db_session.refresh(row)
+    return message_id, [row.id for row in rows]
+
+
+@pytest.fixture(autouse=True)
+def reset_semaphore_fixture():
+    """Rebuild the module semaphore per test so it binds to the active loop."""
+    reset_embed_semaphore()
+    yield
+    reset_embed_semaphore()
+
+
+@pytest.mark.asyncio
+class TestEmbedMessagesNow:
+    async def test_pgvector_happy_path_marks_synced(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ) -> None:
+        """pgvector-only mode: rows get a vector and flip to synced immediately."""
+        workspace, peer = sample_data
+        message_id, emb_ids = await _create_message_with_pending_chunks(
+            db_session, workspace, peer, ["hello world"]
+        )
+
+        await embed_messages_now([message_id])
+
+        for emb_id in emb_ids:
+            row = await db_session.get(models.MessageEmbedding, emb_id)
+            assert row is not None
+            await db_session.refresh(row)
+            assert row.sync_state == "synced"
+            assert row.embedding is not None
+            assert row.sync_attempts == 0
+
+    async def test_no_message_ids_is_noop(self) -> None:
+        """Empty input returns without touching the DB or embedding."""
+        with patch(
+            "src.embedding_client.embedding_client.simple_batch_embed"
+        ) as mock_embed:
+            await embed_messages_now([])
+        mock_embed.assert_not_called()
+
+    async def test_already_synced_rows_not_reclaimed(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ) -> None:
+        """A second run finds no pending rows and does not re-embed."""
+        workspace, peer = sample_data
+        message_id, _ = await _create_message_with_pending_chunks(
+            db_session, workspace, peer, ["first content"]
+        )
+        await embed_messages_now([message_id])
+
+        with patch(
+            "src.embedding_client.embedding_client.simple_batch_embed"
+        ) as mock_embed:
+            await embed_messages_now([message_id])
+        mock_embed.assert_not_called()
+
+    async def test_embed_failure_leaves_rows_pending_and_leased(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ) -> None:
+        """Embedding failure must leave rows pending + leased, attempts untouched,
+        so the reconciler owns retry accounting."""
+        workspace, peer = sample_data
+        message_id, emb_ids = await _create_message_with_pending_chunks(
+            db_session, workspace, peer, ["will fail"]
+        )
+
+        with patch(
+            "src.embedding_client.embedding_client.simple_batch_embed",
+            new=AsyncMock(side_effect=RuntimeError("provider down")),
+        ):
+            await embed_messages_now([message_id])
+
+        for emb_id in emb_ids:
+            row = await db_session.get(models.MessageEmbedding, emb_id)
+            assert row is not None
+            await db_session.refresh(row)
+            assert row.sync_state == "pending"
+            assert row.embedding is None
+            assert row.sync_attempts == 0  # lease only, no attempt bump
+            assert row.last_sync_at is not None  # leased
+
+    async def test_external_store_upserts_with_chunk_positioned_ids(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+        mock_vector_store: VectorStore,
+    ) -> None:
+        """External-store mode: upsert each chunk with id {message_id}_{position}
+        and mark rows synced."""
+        workspace, peer = sample_data
+        message_id, emb_ids = await _create_message_with_pending_chunks(
+            db_session, workspace, peer, ["chunk a", "chunk b", "chunk c"]
+        )
+
+        with patch(
+            "src.reconciler.embed_now.get_external_vector_store",
+            return_value=mock_vector_store,
+        ):
+            await embed_messages_now([message_id])
+
+        upsert_mock: AsyncMock = mock_vector_store.upsert_many  # pyright: ignore[reportAssignmentType]
+        upsert_mock.assert_awaited()
+        upserted_ids = {
+            record.id for call in upsert_mock.await_args_list for record in call.args[1]
+        }
+        assert upserted_ids == {
+            f"{message_id}_0",
+            f"{message_id}_1",
+            f"{message_id}_2",
+        }
+
+        for emb_id in emb_ids:
+            row = await db_session.get(models.MessageEmbedding, emb_id)
+            assert row is not None
+            await db_session.refresh(row)
+            assert row.sync_state == "synced"
+
+    async def test_locked_chunk_skipped_keeps_positions_stable(
+        self,
+        db_session: AsyncSession,
+        db_engine: AsyncEngine,
+        sample_data: tuple[models.Workspace, models.Peer],
+        mock_vector_store: VectorStore,
+    ) -> None:
+        """If a sibling chunk is locked by another txn, SKIP LOCKED skips it but
+        chunk positions still come from the full sibling ordering — so the claimed
+        chunks keep their {message_id}_0 / _2 ids (not _0 / _1)."""
+        workspace, peer = sample_data
+        message_id, emb_ids = await _create_message_with_pending_chunks(
+            db_session, workspace, peer, ["chunk a", "chunk b", "chunk c"]
+        )
+        locked_id = emb_ids[1]  # middle chunk -> position 1
+
+        # Hold a row lock on the middle chunk from an independent transaction.
+        lock_factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
+        lock_session = lock_factory()
+        await lock_session.execute(
+            select(models.MessageEmbedding)
+            .where(models.MessageEmbedding.id == locked_id)
+            .with_for_update()
+        )
+        try:
+            with patch(
+                "src.reconciler.embed_now.get_external_vector_store",
+                return_value=mock_vector_store,
+            ):
+                await embed_messages_now([message_id])
+        finally:
+            await lock_session.rollback()
+            await lock_session.close()
+
+        upsert_mock: AsyncMock = mock_vector_store.upsert_many  # pyright: ignore[reportAssignmentType]
+        upserted_ids = {
+            record.id for call in upsert_mock.await_args_list for record in call.args[1]
+        }
+        assert upserted_ids == {f"{message_id}_0", f"{message_id}_2"}
+
+        # The locked chunk stays pending; the other two are synced.
+        locked_row = await db_session.get(models.MessageEmbedding, locked_id)
+        assert locked_row is not None
+        await db_session.refresh(locked_row)
+        assert locked_row.sync_state == "pending"
+        for emb_id in (emb_ids[0], emb_ids[2]):
+            row = await db_session.get(models.MessageEmbedding, emb_id)
+            assert row is not None
+            await db_session.refresh(row)
+            assert row.sync_state == "synced"

--- a/tests/routes/test_messages.py
+++ b/tests/routes/test_messages.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -44,6 +44,57 @@ async def test_create_message(
     assert message["session_id"] == test_session.name
     assert message["metadata"] == {"message_key": "message_value"}
     assert "id" in message
+
+
+@pytest.mark.asyncio
+async def test_create_message_schedules_immediate_embed(
+    client: TestClient, db_session: AsyncSession, sample_data: tuple[Workspace, Peer]
+):
+    """Creating messages should schedule the immediate-embed background task with
+    the created messages' public ids."""
+    test_workspace, test_peer = sample_data
+    test_session = models.Session(
+        workspace_name=test_workspace.name, name=str(generate_nanoid())
+    )
+    db_session.add(test_session)
+    await db_session.commit()
+
+    with patch(
+        "src.routers.messages.embed_messages_now", new=AsyncMock()
+    ) as mock_embed_now:
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions/{test_session.name}/messages",
+            json={"messages": [{"content": "hello", "peer_id": test_peer.name}]},
+        )
+    assert response.status_code == 201
+    public_id = response.json()[0]["id"]
+    mock_embed_now.assert_awaited_once_with([public_id])
+
+
+@pytest.mark.asyncio
+async def test_create_message_skips_embed_when_disabled(
+    client: TestClient, db_session: AsyncSession, sample_data: tuple[Workspace, Peer]
+):
+    """When EMBED_MESSAGES is disabled, the immediate-embed task is not scheduled."""
+    test_workspace, test_peer = sample_data
+    test_session = models.Session(
+        workspace_name=test_workspace.name, name=str(generate_nanoid())
+    )
+    db_session.add(test_session)
+    await db_session.commit()
+
+    with (
+        patch("src.config.settings.EMBED_MESSAGES", False),
+        patch(
+            "src.routers.messages.embed_messages_now", new=AsyncMock()
+        ) as mock_embed_now,
+    ):
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/sessions/{test_session.name}/messages",
+            json={"messages": [{"content": "hello", "peer_id": test_peer.name}]},
+        )
+    assert response.status_code == 201
+    mock_embed_now.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds embed_messages_now background task so newly created messages are searchable within seconds instead of waiting up to the reconciler interval. Three-phase claim/lease → embed → persist never holds a DB session across the embedding call; the reconciler remains the fallback for failures and stragglers.