### PR TITLE
fix(trees): filter unsupported k kwarg in create_tree to prevent TypeError

### DIFF
--- a/src/dreamer/trees/__init__.py
+++ b/src/dreamer/trees/__init__.py
@@ -18,6 +18,10 @@ def create_tree(tree_type: str, **kwargs: Any) -> SurprisalTree:
     """
     Factory function to create different tree types.
 
+    Only forwards keyword arguments that each tree constructor accepts.
+    This prevents ``TypeError`` when ``k=`` (passed by ``_build_tree``) is
+    forwarded to tree types that do not use a k-NN parameter.
+
     Args:
         tree_type: Type of tree to create ('rptree', 'kdtree', 'balltree',
                    'covertree', 'lsh', 'graph', 'prototype')
@@ -30,18 +34,22 @@ def create_tree(tree_type: str, **kwargs: Any) -> SurprisalTree:
         ValueError: If tree_type is not recognized
     """
     if tree_type == "rptree":
+        kwargs.pop("k", None)
         return RPTree(**kwargs)
     elif tree_type == "kdtree":
         return SklearnTreeWrapper(tree_type="kd", **kwargs)
     elif tree_type == "balltree":
         return SklearnTreeWrapper(tree_type="ball", **kwargs)
     elif tree_type == "covertree":
+        kwargs.pop("k", None)
         return CoverTree(**kwargs)
     elif tree_type == "lsh":
+        kwargs.pop("k", None)
         return LSHSurprisal(**kwargs)
     elif tree_type == "graph":
         return GraphSurprisal(**kwargs)
     elif tree_type == "prototype":
+        kwargs.pop("k", None)
         return PrototypeSurprisal(**kwargs)
     else:
         raise ValueError(f"Unknown tree type: {tree_type}")

--- a/src/dreamer/trees/__init__.py
+++ b/src/dreamer/trees/__init__.py
@@ -18,9 +18,10 @@ def create_tree(tree_type: str, **kwargs: Any) -> SurprisalTree:
     """
     Factory function to create different tree types.
 
-    Only forwards keyword arguments that each tree constructor accepts.
-    This prevents ``TypeError`` when ``k=`` (passed by ``_build_tree``) is
-    forwarded to tree types that do not use a k-NN parameter.
+    Strips the ``k`` parameter before passing kwargs to tree types that
+    do not use a k-NN parameter (RPTree, CoverTree, LSHSurprisal,
+    PrototypeSurprisal). All other keyword arguments are forwarded
+    unchanged.
 
     Args:
         tree_type: Type of tree to create ('rptree', 'kdtree', 'balltree',


### PR DESCRIPTION
## Summary

`create_tree()` in `trees/__init__.py` now filters out the `k` keyword argument before forwarding to tree types that do not accept it. This prevents a `TypeError` when `_build_tree()` in `surprisal.py` passes `k=settings.DREAM.SURPRISAL.TREE_K` to all tree constructors.

### Affected tree types (previously crashing with k=):
- `RPTree`
- `CoverTree`
- `LSHSurprisal`
- `PrototypeSurprisal`

### Unaffected tree types (already accepted k=):
- `SklearnTreeWrapper` (kdtree / balltree)
- `GraphSurprisal`

Fixes #698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tree construction so incompatible keyword parameters (notably a "k" parameter) are filtered for certain tree types, preventing initialization errors.
  * Preserved forwarding of accepted parameters for other tree backends so their behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->