### PR TITLE
feat(dreamer): biographical-refresh pass to reconcile stale peer-card facts

### DIFF
--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -1,0 +1,39 @@
+name: Rebuild and redeploy
+
+on:
+  push:
+    branches: [samdu/customizations]
+  workflow_dispatch: {}
+
+jobs:
+  rebuild:
+    runs-on: honcho
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kubectl + crane + jq
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/bin"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+          curl -fsSL "https://dl.k8s.io/release/v1.33.4/bin/linux/amd64/kubectl" -o "$HOME/bin/kubectl"
+          chmod +x "$HOME/bin/kubectl"
+          curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v0.20.5/go-containerregistry_Linux_x86_64.tar.gz" \
+            | tar -xzC "$HOME/bin" crane
+          curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64" -o "$HOME/bin/jq"
+          chmod +x "$HOME/bin/jq"
+
+      - name: Rebuild image
+        run: ./rebuild.sh
+
+      - name: Rollout restart
+        run: |
+          for d in honcho-api honcho-deriver; do
+            if kubectl -n apps get deployment "${d}" >/dev/null 2>&1; then
+              kubectl -n apps rollout restart deployment/"${d}"
+              kubectl -n apps rollout status deployment/"${d}" --timeout=300s
+            else
+              echo "deployment/${d} not present in apps ns; skipping rollout"
+            fi
+          done

--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -2,7 +2,7 @@ name: Rebuild and redeploy
 
 on:
   push:
-    branches: [samdu/customizations]
+    branches: [main]
   workflow_dispatch: {}
 
 jobs:

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build the honcho image via in-cluster BuildKit and push to the local registry.
+#
+# Runs identically from a laptop or from the honcho runner scale set in the
+# `arc-runners` namespace. Source is always the checkout containing this
+# script — no separate git clone step.
+#
+# Usage: ./rebuild.sh [--tag TAG] [--force] [--restart]
+#
+#   --tag TAG     Docker tag to publish (default: latest)
+#   --force       Rebuild even if the image's SHA label already matches HEAD
+#   --restart     Rollout-restart the honcho-api and honcho-deriver Deployments
+#                 after a successful build. Convenience for laptop runs; CI uses
+#                 a separate step.
+
+cd "$(dirname "$0")"
+
+REGISTRY="192.168.1.216:5000"
+IMAGE="honcho"
+TAG="latest"
+FORCE="false"
+RESTART="false"
+ARCHITECTURES=("amd64" "arm64")
+NAMESPACE="buildkit"
+TIMESTAMP=$(date +%s)
+BUILDKIT_IMAGE="moby/buildkit:v0.29.0"
+
+WALL_START=$(date +%s)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag) TAG="$2"; shift 2 ;;
+        --force) FORCE="true"; shift ;;
+        --restart) RESTART="true"; shift ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+missing=()
+for tool in kubectl crane git jq tar gzip; do
+    command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+done
+if (( ${#missing[@]} > 0 )); then
+    echo "ERROR: missing required tool(s): ${missing[*]}" >&2
+    echo "  On macOS: brew install ${missing[*]}" >&2
+    exit 1
+fi
+
+CRANE_DOCKER_CONFIG="$(mktemp -d)"
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "${CRANE_DOCKER_CONFIG}" "${BUILD_DIR}"' EXIT
+export DOCKER_CONFIG="${CRANE_DOCKER_CONFIG}"
+
+if ! kubectl get ns "${NAMESPACE}" >/dev/null 2>&1; then
+    echo "ERROR: cannot reach namespace '${NAMESPACE}' with current kubectl context." >&2
+    echo "  Current context: $(kubectl config current-context 2>/dev/null || echo '<none>')" >&2
+    exit 1
+fi
+
+SOURCE_SHA="$(git -C "${SCRIPT_DIR}" rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+echo "==> Building ${IMAGE} (${SOURCE_SHA}) on ${ARCHITECTURES[*]}"
+
+# SHA short-circuit: if the existing image was built from this exact HEAD,
+# skip unless --force.
+if [[ "${FORCE}" != "true" && "${SOURCE_SHA}" != "unknown" ]]; then
+    existing_sha=$(crane config --insecure "${REGISTRY}/${IMAGE}:${TAG}-${ARCHITECTURES[0]}" 2>/dev/null \
+        | jq -r '.config.Labels["org.opencontainers.image.revision"] // ""' 2>/dev/null \
+        || true)
+    if [[ "${existing_sha}" == "${SOURCE_SHA}" ]]; then
+        echo "==> ${REGISTRY}/${IMAGE}:${TAG} already built at ${SOURCE_SHA}; nothing to do (--force overrides)"
+        exit 0
+    fi
+    if [[ -n "${existing_sha}" ]]; then
+        echo "    Existing image built from ${existing_sha}; rebuilding to ${SOURCE_SHA}"
+    fi
+fi
+
+# Honcho's repo is much bigger than the Dockerfile context needs. The
+# Dockerfile only references: src/, migrations/, scripts/, docker/,
+# alembic.ini, config.toml*, plus uv.lock and pyproject.toml. Ship only
+# those to keep the ConfigMap under its 1MiB limit.
+echo "==> Packaging build context (filtered to Dockerfile-relevant paths)"
+CONTEXT_INCLUDES=(
+    Dockerfile
+    uv.lock
+    pyproject.toml
+    alembic.ini
+    src
+    migrations
+    scripts
+    docker
+)
+for glob in config.toml config.toml.example; do
+    [[ -e "${SCRIPT_DIR}/${glob}" ]] && CONTEXT_INCLUDES+=("${glob}")
+done
+
+# COPYFILE_DISABLE=1 keeps macOS `tar` from silently shipping AppleDouble
+# `._<filename>` metadata alongside real files. Inside the image, Alembic
+# scans `migrations/versions/*.py` and tries to load those companions as
+# Python — which errors with "source code string cannot contain null
+# bytes" and crashloops honcho-api. Harmless on Linux; essential on
+# macOS builds.
+COPYFILE_DISABLE=1 tar -C "${SCRIPT_DIR}" -czf "${BUILD_DIR}/context.tar.gz" "${CONTEXT_INCLUDES[@]}"
+CONTEXT_SIZE=$(du -k "${BUILD_DIR}/context.tar.gz" | cut -f1)
+echo "    Context size: ${CONTEXT_SIZE}KB"
+
+if (( CONTEXT_SIZE > 1000 )); then
+    echo "ERROR: context tarball (${CONTEXT_SIZE}KB) exceeds ConfigMap 1MiB limit." >&2
+    echo "  Trim the source tree or use a PVC-based context." >&2
+    exit 1
+fi
+
+CONTEXT_CM="${IMAGE}-build-context-${TIMESTAMP}"
+kubectl -n "${NAMESPACE}" create configmap "${CONTEXT_CM}" \
+    --from-file=context.tar.gz="${BUILD_DIR}/context.tar.gz"
+
+cleanup() {
+    kubectl -n "${NAMESPACE}" delete configmap "${CONTEXT_CM}" --ignore-not-found 2>/dev/null || true
+    for arch in "${ARCHITECTURES[@]}"; do
+        kubectl -n "${NAMESPACE}" delete job "buildkit-${IMAGE}-${arch}-${TIMESTAMP}" --ignore-not-found 2>/dev/null || true
+    done
+    rm -rf "${CRANE_DOCKER_CONFIG}" "${BUILD_DIR}"
+}
+trap cleanup EXIT
+
+# Submit one Job per arch, targeting the per-arch buildkitd Service.
+declare -a JOB_NAMES=()
+for arch in "${ARCHITECTURES[@]}"; do
+    job_name="buildkit-${IMAGE}-${arch}-${TIMESTAMP}"
+    JOB_NAMES+=("${job_name}")
+    arch_tag="${IMAGE}:${TAG}-${arch}"
+    cache_ref="${REGISTRY}/${IMAGE}/buildkit-cache:${arch}"
+
+    echo "==> Submitting ${arch} build job ${job_name}"
+    cat <<EOF | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${job_name}
+  namespace: ${NAMESPACE}
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: extract-context
+          image: busybox:latest
+          command: ["/bin/sh","-c"]
+          args: ["set -ex; mkdir -p /workspace; tar -C /workspace -xzf /context/context.tar.gz; ls /workspace | head"]
+          volumeMounts:
+            - { name: workspace, mountPath: /workspace }
+            - { name: context, mountPath: /context }
+      containers:
+        - name: buildctl
+          image: ${BUILDKIT_IMAGE}
+          command: ["buildctl"]
+          args:
+            - "--addr"
+            - "tcp://buildkitd-${arch}.buildkit.svc:1234"
+            - "build"
+            - "--frontend"
+            - "dockerfile.v0"
+            - "--local"
+            - "context=/workspace"
+            - "--local"
+            - "dockerfile=/workspace"
+            - "--opt"
+            - "platform=linux/${arch}"
+            - "--opt"
+            - "label:org.opencontainers.image.revision=${SOURCE_SHA}"
+            - "--output"
+            - "type=image,name=${REGISTRY}/${arch_tag},push=true,registry.insecure=true"
+            - "--export-cache"
+            - "type=registry,ref=${cache_ref},mode=max,registry.insecure=true"
+            - "--import-cache"
+            - "type=registry,ref=${cache_ref},registry.insecure=true,ignoreerror=true"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - { name: workspace, mountPath: /workspace }
+      volumes:
+        - name: workspace
+          emptyDir: {}
+        - name: context
+          configMap:
+            name: ${CONTEXT_CM}
+EOF
+done
+
+echo ""
+echo "==> Streaming concurrent builds"
+declare -a PIDS=()
+for i in "${!ARCHITECTURES[@]}"; do
+    arch="${ARCHITECTURES[$i]}"
+    job_name="${JOB_NAMES[$i]}"
+    (
+        # kubectl wait returns immediately if no resources match yet, so
+        # wait for the pod to exist before waiting for it to be ready, and
+        # give the completion wait enough headroom for a cold-cache build
+        # with a rewritten uv.lock (~10min on these arches).
+        kubectl wait --for=create pod -l "job-name=${job_name}" \
+            -n "${NAMESPACE}" --timeout=120s >/dev/null 2>&1 || true
+        kubectl wait --for=condition=ready pod -l "job-name=${job_name}" \
+            -n "${NAMESPACE}" --timeout=300s >/dev/null 2>&1 || true
+        kubectl logs -f "job/${job_name}" -n "${NAMESPACE}" 2>&1 \
+            | sed "s/^/[${arch}] /" || true
+        if kubectl wait --for=condition=complete "job/${job_name}" \
+                -n "${NAMESPACE}" --timeout=1200s >/dev/null 2>&1; then
+            echo "[${arch}] build complete"
+        else
+            echo "[${arch}] build FAILED" >&2
+            kubectl logs "job/${job_name}" -n "${NAMESPACE}" --tail=50 2>/dev/null \
+                | sed "s/^/[${arch}-err] /" >&2 || true
+            exit 1
+        fi
+    ) &
+    PIDS+=($!)
+done
+
+FAILED=0
+for pid in "${PIDS[@]}"; do
+    wait "${pid}" || FAILED=1
+done
+(( FAILED )) && exit 1
+
+echo ""
+echo "==> Creating multi-arch manifest"
+ARCH_REFS=()
+for arch in "${ARCHITECTURES[@]}"; do
+    ARCH_REFS+=("${REGISTRY}/${IMAGE}:${TAG}-${arch}")
+done
+crane index append --insecure \
+    --tag "${REGISTRY}/${IMAGE}:${TAG}" \
+    --manifest "${ARCH_REFS[0]}" \
+    --manifest "${ARCH_REFS[1]}" \
+    --flatten
+
+WALL_END=$(date +%s)
+echo ""
+echo "==> Done in $(( WALL_END - WALL_START ))s"
+echo "    Pushed: ${REGISTRY}/${IMAGE}:${TAG} (${SOURCE_SHA})"
+
+if [[ "${RESTART}" == "true" ]]; then
+    echo ""
+    echo "==> Restarting honcho-api and honcho-deriver Deployments"
+    kubectl -n apps rollout restart deployment/honcho-api deployment/honcho-deriver
+    kubectl -n apps rollout status deployment/honcho-api --timeout=180s
+    kubectl -n apps rollout status deployment/honcho-deriver --timeout=180s
+fi

--- a/src/config.py
+++ b/src/config.py
@@ -759,6 +759,20 @@ class DeriverSettings(HonchoSettings):
     # Whether to deduplicate documents when creating them
     DEDUPLICATE: bool = True
 
+    # Cosine distance threshold below which a new observation is treated as a
+    # duplicate of an existing one. Tighter values (0.05) only catch near-identical
+    # wording; looser values (0.20+) catch genuine paraphrases at some risk of
+    # conflating distinct events that share infrastructure.
+    DEDUPLICATE_MAX_DISTANCE: Annotated[float, Field(default=0.20, ge=0.0, le=1.0)] = (
+        0.20
+    )
+
+    # Peer names this deployment never forms a representation OF (observe_me forced
+    # false), regardless of per-peer or per-session config. Use for assistant/agent
+    # peers whose own turns would otherwise be distilled into useless self-observations.
+    # Set via env as JSON, e.g. DERIVER_UNOBSERVED_PEERS='["claude"]'.
+    UNOBSERVED_PEERS: list[str] = Field(default_factory=list)
+
     LOG_OBSERVATIONS: bool = False
 
     MAX_INPUT_TOKENS: Annotated[int, Field(default=25000, gt=0, le=25000)] = 25000

--- a/src/config.py
+++ b/src/config.py
@@ -1285,6 +1285,14 @@ class AppSettings(HonchoSettings):
 
     MAX_MESSAGE_SIZE: Annotated[int, Field(default=25_000, gt=0)] = 25_000
     EMBED_MESSAGES: bool = True
+    FILTER_TOOL_BREADCRUMBS: bool = Field(
+        default=True,
+        description=(
+            "Skip persisting tool-run breadcrumb messages (e.g. '[Tool] Ran: ...') "
+            "at ingestion. These dominate the message store by volume and dilute "
+            "search and distillation."
+        ),
+    )
     LANGFUSE_HOST: str | None = None
     LANGFUSE_PUBLIC_KEY: str | None = None
 

--- a/src/config.py
+++ b/src/config.py
@@ -1142,6 +1142,38 @@ class SurprisalSettings(BaseModel):
     INCLUDE_LEVELS: list[str] = ["explicit", "deductive"]
 
 
+class BiographicalRefreshSettings(BaseModel):
+    """Settings for the biographical-refresh pass.
+
+    A focused reconciliation pass that runs as part of the dream cycle: it diffs
+    the stored peer card (the biographical Profile) against recent messages
+    authored by the observed peer and supersedes facts that have gone stale
+    (e.g. a card that still says "close to accepting a role" long after messages
+    confirmed the role was accepted). It is a single structured-output LLM call,
+    not an agentic loop — predictable cost, runs at most once per dream.
+
+    Reuses DreamSettings.DEDUCTION_MODEL_CONFIG for the LLM call; no separate
+    model config is required.
+    """
+
+    ENABLED: bool = True
+
+    # Cap on how many recent messages (authored by the observed peer) to pull as
+    # the reconciliation signal. Also bounded by MAX_INPUT_TOKENS.
+    MAX_RECENT_MESSAGES: Annotated[int, Field(default=100, gt=0, le=1000)] = 100
+
+    # Token budget for the recent-message block fed to the LLM. The most recent
+    # messages are kept until this budget is reached.
+    MAX_INPUT_TOKENS: Annotated[int, Field(default=16_000, gt=0, le=200_000)] = 16_000
+
+    # Skip the pass when the card has fewer than this many entries — there is
+    # nothing meaningful to reconcile against.
+    MIN_CARD_ENTRIES: Annotated[int, Field(default=1, gt=0, le=40)] = 1
+
+    # Cap on output tokens for the reconciliation call.
+    MAX_OUTPUT_TOKENS: Annotated[int, Field(default=4_096, gt=0, le=32_000)] = 4_096
+
+
 class DreamSettings(HonchoSettings):
     model_config = SettingsConfigDict(  # pyright: ignore
         env_prefix="DREAM_", env_nested_delimiter="__", extra="ignore"
@@ -1187,6 +1219,11 @@ class DreamSettings(HonchoSettings):
 
     # Surprisal-based sampling subsystem
     SURPRISAL: SurprisalSettings = Field(default_factory=SurprisalSettings)
+
+    # Biographical-refresh pass (peer card vs recent messages reconciliation)
+    BIOGRAPHICAL_REFRESH: BiographicalRefreshSettings = Field(
+        default_factory=BiographicalRefreshSettings
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/src/crud/document.py
+++ b/src/crud/document.py
@@ -989,7 +989,7 @@ async def is_rejected_duplicate(
         query=doc.content,
         observer=observer,
         observed=observed,
-        max_distance=0.05,
+        max_distance=settings.DERIVER.DEDUPLICATE_MAX_DISTANCE,
         top_k=1,
         embedding=doc.embedding,
     )

--- a/src/deriver/enqueue.py
+++ b/src/deriver/enqueue.py
@@ -265,6 +265,12 @@ def get_effective_observe_me(
     Returns:
         True if observe_me is enabled, False otherwise
     """
+    # Deployment-level policy: never form a representation of these peers (e.g. the
+    # assistant), regardless of per-peer/session config. Stops the deriver from
+    # distilling an agent's own turns into useless self-observations.
+    if observed in set(settings.DERIVER.UNOBSERVED_PEERS):
+        return False
+
     # If the sender is not in peers_with_configuration, they left after sending a message.
     # We'll use the default behavior of observing the sender by instantiating the default
     # peer-level and session-level configs.

--- a/src/dreamer/biographical_refresh.py
+++ b/src/dreamer/biographical_refresh.py
@@ -1,0 +1,315 @@
+"""
+Biographical-refresh pass.
+
+The stored peer card (the biographical *Profile*) is written by the deduction
+specialist during dreams, but nothing systematically re-checks each card entry
+against newer messages. So a fact can go stale and never get reconciled — e.g.
+the card keeps saying "close to accepting a role" long after the messages
+confirmed the role was accepted (signed contract, got an EIN).
+
+This module adds a focused reconciliation pass that runs as part of the dream
+cycle. It diffs the current peer card against recent messages authored by the
+observed peer and supersedes facts that have gone stale. Like the minimal
+deriver and the summarizer — and unlike the specialists — it is a single
+structured-output LLM call, not an agentic tool loop: predictable cost, runs at
+most once per dream.
+
+Entry point: `run_biographical_refresh`, called from `orchestrator.run_dream`
+after the specialists have run.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from src import crud, models
+from src.config import settings
+from src.dependencies import tracked_db
+from src.llm import honcho_llm_call
+from src.llm.types import LLMTelemetryContext
+from src.schemas.configuration import ResolvedConfiguration
+from src.telemetry.events.llm import CallPurpose
+from src.utils.agent_tools import MAX_PEER_CARD_FACTS, normalize_peer_card_entries
+from src.utils.formatting import format_new_turn_with_timestamp
+from src.utils.tokens import estimate_tokens
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BiographicalRefreshResult:
+    """Outcome of a biographical-refresh pass, for logging/telemetry."""
+
+    # Whether the LLM call completed without raising.
+    success: bool
+    # Whether the card was actually rewritten (a stale fact was superseded).
+    card_updated: bool
+    # Number of entries the model reported as superseded/stale.
+    superseded_count: int
+    input_tokens: int
+    output_tokens: int
+    duration_ms: float
+
+
+class _Reconciliation(BaseModel):
+    """Structured output of the reconciliation call."""
+
+    no_changes: bool = Field(
+        default=False,
+        description=(
+            "True if no entry in the current card is stale, outdated, or "
+            "contradicted by the recent messages. When true, reconciled_card "
+            "is ignored and the card is left untouched."
+        ),
+    )
+    reconciled_card: list[str] = Field(
+        default_factory=list,
+        description=(
+            "The COMPLETE reconciled peer card: re-emit every still-valid entry "
+            "verbatim, rewrite superseded entries to their current value, and "
+            "drop entries that recent messages have made false. Omitting an "
+            "entry deletes it, so only omit facts that are now false. Each entry "
+            "must keep the IDENTITY:/ATTRIBUTE:/RELATIONSHIP:/INSTRUCTION: "
+            "prefix format."
+        ),
+    )
+    superseded: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Short human-readable notes for each change, e.g. "
+            "'close to accepting a role' -> 'works at Carrum (1099 contractor)'. "
+            "For logging only."
+        ),
+    )
+
+
+def _build_prompt(observed: str, peer_card: list[str], formatted_messages: str) -> str:
+    card_block = "\n".join(f"- {entry}" for entry in peer_card)
+    return f"""You are a biographical reconciliation agent. Your only job is to keep \
+the stored Profile of {observed} consistent with what the recent messages show \
+to be true RIGHT NOW.
+
+You are given the CURRENT PROFILE (a list of stable identity facts about \
+{observed}) and the most RECENT MESSAGES authored by {observed}. A fact on the \
+Profile can drift out of date: a plan becomes a completed action, a job search \
+becomes a job, a city someone was "moving to" becomes the city they live in.
+
+## CURRENT PROFILE
+
+{card_block}
+
+## RECENT MESSAGES (most recent last)
+
+{formatted_messages}
+
+## YOUR TASK
+
+Go through each Profile entry and decide whether the recent messages have made it \
+stale, outdated, or false:
+
+- **Still valid** — re-emit the entry verbatim in `reconciled_card`.
+- **Superseded** — the messages show the fact has moved on. Rewrite the entry to \
+its current value (keeping the same prefix), and add a `superseded` note. \
+Example: `ATTRIBUTE: Close to accepting a role at Carrum` becomes \
+`ATTRIBUTE: Works at Carrum as a 1099 contractor` once messages confirm the \
+signed contract and EIN.
+- **Now false** — the messages contradict the fact and there is no replacement. \
+Omit the entry from `reconciled_card`.
+
+## RULES
+
+1. **Conservative.** Only change an entry when the recent messages CLEARLY \
+contradict or supersede it. Ambiguity or silence is not evidence of change — \
+when in doubt, keep the entry verbatim.
+2. **Reconcile, don't author.** Do not add brand-new facts that are merely \
+mentioned in the messages — that is the deriver's job. Only rewrite entries that \
+already exist on the Profile (and only to track a value that genuinely moved).
+3. **Preserve format.** Every entry in `reconciled_card` must start with one of \
+`IDENTITY:`, `ATTRIBUTE:`, `RELATIONSHIP:`, or `INSTRUCTION:` followed by a \
+space. Keep each entry to one concise fact.
+4. **Subject is {observed}.** Never write facts about other participants.
+5. **No churn.** If nothing is stale, set `no_changes` to true and stop. Do not \
+reword entries cosmetically.
+
+Return the complete reconciled card only when at least one entry actually changed."""
+
+
+async def _get_recent_authored_messages(observed: str, workspace_name: str) -> str:
+    """Fetch and format the observed peer's most recent messages.
+
+    Pulls up to MAX_RECENT_MESSAGES authored by `observed` across the workspace,
+    newest first, then keeps the newest ones that fit within MAX_INPUT_TOKENS and
+    renders them oldest-first for the prompt. Returns "" when there are none.
+    """
+    cfg = settings.DREAM.BIOGRAPHICAL_REFRESH
+    async with tracked_db("biographical_refresh.messages") as db:
+        stmt = (
+            select(models.Message)
+            .where(
+                models.Message.workspace_name == workspace_name,
+                models.Message.peer_name == observed,
+            )
+            .order_by(models.Message.id.desc())
+            .limit(cfg.MAX_RECENT_MESSAGES)
+        )
+        result = await db.execute(stmt)
+        recent_newest_first = list(result.scalars().all())
+
+    if not recent_newest_first:
+        return ""
+
+    # Keep the newest messages that fit the token budget, then flip to
+    # chronological order for the prompt.
+    budget = cfg.MAX_INPUT_TOKENS
+    kept: list[models.Message] = []
+    used = 0
+    for msg in recent_newest_first:
+        cost = estimate_tokens(msg.content) or 0
+        if kept and used + cost > budget:
+            break
+        kept.append(msg)
+        used += cost
+
+    kept.reverse()
+    return "\n".join(
+        format_new_turn_with_timestamp(msg.content, msg.created_at, msg.peer_name)
+        for msg in kept
+    )
+
+
+async def run_biographical_refresh(
+    workspace_name: str,
+    observer: str,
+    observed: str,
+    *,
+    configuration: ResolvedConfiguration | None = None,
+    parent_run_id: str | None = None,
+) -> BiographicalRefreshResult | None:
+    """Reconcile the (observer, observed) peer card against recent messages.
+
+    Returns None when the pass is skipped (disabled, peer-card writes disabled,
+    empty/too-small card, or no recent messages). Otherwise returns a result
+    describing the outcome — `card_updated` is True only when a stale fact was
+    actually superseded.
+
+    Uses short-lived DB sessions and never holds one across the LLM call.
+    """
+    cfg = settings.DREAM.BIOGRAPHICAL_REFRESH
+    if not cfg.ENABLED:
+        return None
+
+    # Respect the same gate the specialists use: if peer-card writes are
+    # disabled for this workspace/session, there is nothing to reconcile.
+    if configuration is not None and not configuration.peer_card.create:
+        return None
+
+    start_time = time.perf_counter()
+
+    # 1. Current card (the biographical Profile).
+    async with tracked_db("biographical_refresh.card") as db:
+        peer_card = await crud.get_peer_card(
+            db, workspace_name, observer=observer, observed=observed
+        )
+
+    if not peer_card or len(peer_card) < cfg.MIN_CARD_ENTRIES:
+        return None
+
+    # 2. Recent messages authored by the observed peer.
+    formatted_messages = await _get_recent_authored_messages(observed, workspace_name)
+    if not formatted_messages:
+        return None
+
+    # 3. Single structured-output reconciliation call.
+    prompt = _build_prompt(observed, peer_card, formatted_messages)
+    try:
+        response = await honcho_llm_call(
+            model_config=settings.DREAM.DEDUCTION_MODEL_CONFIG,
+            prompt=prompt,
+            max_tokens=cfg.MAX_OUTPUT_TOKENS,
+            track_name="Biographical Refresh",
+            response_model=_Reconciliation,
+            json_mode=True,
+            enable_retry=True,
+            retry_attempts=3,
+            trace_name="biographical_refresh",
+            telemetry=LLMTelemetryContext(
+                workspace_name=workspace_name,
+                call_purpose=CallPurpose.DREAM_BIOGRAPHICAL_REFRESH.value,
+                parent_category="biographical_refresh",
+                run_id=parent_run_id,
+                observer=observer,
+                observed=observed,
+            ),
+        )
+    except Exception:
+        logger.error(
+            "[%s] Biographical refresh LLM call failed for %s/%s/%s",
+            parent_run_id,
+            workspace_name,
+            observer,
+            observed,
+            exc_info=True,
+        )
+        duration_ms = (time.perf_counter() - start_time) * 1000
+        return BiographicalRefreshResult(
+            success=False,
+            card_updated=False,
+            superseded_count=0,
+            input_tokens=0,
+            output_tokens=0,
+            duration_ms=duration_ms,
+        )
+
+    parsed = response.content
+    duration_ms = (time.perf_counter() - start_time) * 1000
+
+    def _result(card_updated: bool, superseded_count: int) -> BiographicalRefreshResult:
+        return BiographicalRefreshResult(
+            success=True,
+            card_updated=card_updated,
+            superseded_count=superseded_count,
+            input_tokens=response.input_tokens,
+            output_tokens=response.output_tokens,
+            duration_ms=duration_ms,
+        )
+
+    if parsed.no_changes:
+        return _result(card_updated=False, superseded_count=0)
+
+    # 4. Normalize/validate with the same rules as `update_peer_card`.
+    normalized, _rejected = normalize_peer_card_entries(parsed.reconciled_card)
+    if len(normalized) > MAX_PEER_CARD_FACTS:
+        normalized = normalized[:MAX_PEER_CARD_FACTS]
+
+    # Guard: never clear the card if the model returned nothing usable, and skip
+    # the write when the reconciled card is identical to the current one.
+    if not normalized or normalized == peer_card:
+        return _result(card_updated=False, superseded_count=0)
+
+    # 5. Persist the reconciled card.
+    async with tracked_db("biographical_refresh.write") as db:
+        await crud.set_peer_card(
+            db,
+            workspace_name,
+            normalized,
+            observer=observer,
+            observed=observed,
+        )
+
+    logger.info(
+        "[%s] Biographical refresh updated peer card for %s/%s/%s "
+        + "(%d -> %d entries, %d superseded)",
+        parent_run_id,
+        workspace_name,
+        observer,
+        observed,
+        len(peer_card),
+        len(normalized),
+        len(parsed.superseded),
+    )
+    return _result(card_updated=True, superseded_count=len(parsed.superseded))

--- a/src/dreamer/orchestrator.py
+++ b/src/dreamer/orchestrator.py
@@ -26,6 +26,7 @@ from sqlalchemy import func, select
 from src import crud, models
 from src.config import settings
 from src.dependencies import tracked_db
+from src.dreamer.biographical_refresh import run_biographical_refresh
 from src.dreamer.specialists import SPECIALISTS, SpecialistResult
 from src.dreamer.surprisal import SurprisalScore  # type: ignore
 from src.exceptions import SurprisalError
@@ -239,6 +240,35 @@ async def run_dream(
         except Exception as e:
             logger.error(f"[{run_id}] Induction specialist failed: {e}", exc_info=True)
             accumulate_metric(task_name, "induction_error", str(e), "blob")
+
+        # Biographical-refresh pass: reconcile the peer card (the biographical
+        # Profile) against recent messages and supersede stale facts. A single
+        # structured-output LLM call, gated by config; failures are isolated so
+        # they never abort the dream.
+        if settings.DREAM.BIOGRAPHICAL_REFRESH.ENABLED:
+            logger.info(f"[{run_id}] Running biographical refresh")
+            try:
+                refresh_result = await run_biographical_refresh(
+                    workspace_name=workspace_name,
+                    observer=observer,
+                    observed=observed,
+                    configuration=configuration,
+                    parent_run_id=run_id,
+                )
+                if refresh_result is not None:
+                    accumulate_metric(
+                        task_name,
+                        "biographical_refresh_card_updated",
+                        refresh_result.card_updated,
+                        "blob",
+                    )
+            except Exception as e:
+                logger.error(
+                    f"[{run_id}] Biographical refresh failed: {e}", exc_info=True
+                )
+                accumulate_metric(
+                    task_name, "biographical_refresh_error", str(e), "blob"
+                )
 
         # Log final metrics
         duration_ms = (time.perf_counter() - start_time) * 1000

--- a/src/routers/messages.py
+++ b/src/routers/messages.py
@@ -25,6 +25,7 @@ from src.security import require_auth
 from src.telemetry import prometheus_metrics
 from src.telemetry.events import FileUploadedEvent, MessageCreatedEvent, emit
 from src.utils.files import process_file_uploads_for_messages
+from src.utils.message_filter import filter_tool_run_breadcrumbs
 
 logger = logging.getLogger(__name__)
 
@@ -94,9 +95,25 @@ async def create_messages_for_session(
 ):
     """Add new message(s) to a session."""
     try:
+        # Drop tool-run breadcrumb noise (e.g. "[Tool] Ran: ...") before it ever
+        # enters the message store. Filtering here keeps the persistence layer,
+        # telemetry, and the enqueue payload below all aligned on the same set of
+        # messages we actually intend to keep.
+        messages_to_create = (
+            filter_tool_run_breadcrumbs(
+                messages.messages, content_of=lambda m: m.content
+            )
+            if settings.FILTER_TOOL_BREADCRUMBS
+            else list(messages.messages)
+        )
+
+        # Every inbound message was a breadcrumb: nothing to persist or enqueue.
+        if not messages_to_create:
+            return []
+
         created_messages = await crud.create_messages(
             db,
-            messages=messages.messages,
+            messages=messages_to_create,
             workspace_name=workspace_id,
             session_name=session_id,
         )
@@ -133,7 +150,7 @@ async def create_messages_for_session(
                 "configuration": original.configuration,
             }
             for message, original in zip(
-                created_messages, messages.messages, strict=True
+                created_messages, messages_to_create, strict=True
             )
         ]
 

--- a/src/telemetry/events/llm.py
+++ b/src/telemetry/events/llm.py
@@ -34,6 +34,7 @@ class CallPurpose(str, Enum):
     DIALECTIC_ANSWER = "dialectic.answer"
     DREAM_DEDUCTION = "dream.deduction"
     DREAM_INDUCTION = "dream.induction"
+    DREAM_BIOGRAPHICAL_REFRESH = "dream.biographical_refresh"
     SUMMARY_SHORT = "summary.short"
     SUMMARY_LONG = "summary.long"
 

--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -64,6 +64,39 @@ def _validate_peer_card_entry(line: str) -> bool:
     return False
 
 
+def normalize_peer_card_entries(items: list[Any]) -> tuple[list[str], list[str]]:
+    """Validate, dedupe, and order-preserve a list of peer card entries.
+
+    Shared by the `update_peer_card` tool handler and the biographical-refresh
+    pass so both enforce identical card rules. Structural validation is
+    form-only (see `_validate_peer_card_entry`); subject-substance correctness
+    is left to the prompt.
+
+    Returns ``(normalized, rejected)`` where ``normalized`` is the list of valid,
+    case-insensitively de-duplicated entries in first-seen order — NOT yet capped
+    to ``MAX_PEER_CARD_FACTS`` (callers apply the cap so they can log truncation
+    in their own context) — and ``rejected`` is the raw lines that failed
+    structural validation.
+    """
+    normalized: list[str] = []
+    seen: set[str] = set()
+    rejected: list[str] = []
+    for item in items:
+        line = str(item).strip()
+        if not line:
+            continue
+        if not _validate_peer_card_entry(line):
+            rejected.append(line)
+            continue
+        # Case-insensitive dedupe with whitespace normalization.
+        normalized_key = " ".join(line.lower().split())
+        if normalized_key in seen:
+            continue
+        seen.add(normalized_key)
+        normalized.append(line)
+    return normalized, rejected
+
+
 def _normalized_observation_input(
     obs: schemas.ObservationInput,
 ) -> schemas.ObservationInput:
@@ -1464,13 +1497,8 @@ async def _handle_update_peer_card(
         return "Peer card content was empty, no update performed."
 
     # Normalize, validate structure, and deduplicate to keep peer cards bounded
-    # and on-spec.
-    normalized_peer_card: list[str] = []
-    seen: set[str] = set()
-    rejected_count = 0
-    # Keep a small sample of rejected entries to surface back to the model so it
-    # can self-correct on a retry. Capped to avoid bloating the tool response.
-    rejected_samples: list[str] = []
+    # and on-spec. Shared with the biographical-refresh pass via
+    # `normalize_peer_card_entries`.
     _REJECTED_SAMPLE_CAP = 3
     _REJECTED_SAMPLE_LINE_LIMIT = 120
     items = (
@@ -1478,27 +1506,14 @@ async def _handle_update_peer_card(
         if isinstance(raw_peer_card_content, list)
         else [str(raw_peer_card_content)]
     )
-    for item in items:
-        line = str(item).strip()
-        if not line:
-            continue
-
-        if not _validate_peer_card_entry(line):
-            rejected_count += 1
-            if len(rejected_samples) < _REJECTED_SAMPLE_CAP:
-                rejected_samples.append(line[:_REJECTED_SAMPLE_LINE_LIMIT])
-            logger.info(
-                "Rejecting peer card entry (no allowed prefix, empty body, or over length cap): %r",
-                line[:80],
-            )
-            continue
-
-        # Case-insensitive dedupe with whitespace normalization.
-        normalized_key = " ".join(line.lower().split())
-        if normalized_key in seen:
-            continue
-        seen.add(normalized_key)
-        normalized_peer_card.append(line)
+    normalized_peer_card, rejected_lines = normalize_peer_card_entries(items)
+    rejected_count = len(rejected_lines)
+    # Keep a small sample of rejected entries to surface back to the model so it
+    # can self-correct on a retry. Capped to avoid bloating the tool response.
+    rejected_samples: list[str] = [
+        line[:_REJECTED_SAMPLE_LINE_LIMIT]
+        for line in rejected_lines[:_REJECTED_SAMPLE_CAP]
+    ]
 
     if rejected_count:
         logger.info(

--- a/src/utils/message_filter.py
+++ b/src/utils/message_filter.py
@@ -1,0 +1,62 @@
+"""Ingestion-time filtering of low-value messages.
+
+Some clients (notably Claude Code session ingestion) emit tool-run breadcrumb
+lines such as ``[Tool] Ran: ...`` as messages. These dominate the message store
+by volume while carrying no durable signal, diluting search and distillation.
+
+This module provides a narrow, conservative predicate that identifies those
+breadcrumbs so the API can skip persisting them. It deliberately matches only
+well-known breadcrumb prefixes to avoid dropping legitimate user/assistant
+content that merely mentions a tool.
+"""
+
+from collections.abc import Callable, Sequence
+from logging import getLogger
+from typing import TypeVar
+
+logger = getLogger(__name__)
+
+# Prefixes that identify a message whose *entire* content is a tool-run
+# breadcrumb rather than conversational content. Matched against the message
+# content after stripping leading whitespace. Extend this tuple if new
+# breadcrumb shapes appear; keep entries specific so legitimate prose that
+# happens to start with one of these words is not caught.
+TOOL_BREADCRUMB_PREFIXES: tuple[str, ...] = ("[Tool] Ran:",)
+
+_T = TypeVar("_T")
+
+
+def is_tool_run_breadcrumb(content: str) -> bool:
+    """Return True if ``content`` is a tool-run breadcrumb, not real content.
+
+    Args:
+        content: The raw message content.
+
+    Returns:
+        True when the message is a known tool-run breadcrumb that should not be
+        persisted to the message store.
+    """
+    if not content:
+        return False
+    return content.lstrip().startswith(TOOL_BREADCRUMB_PREFIXES)
+
+
+def filter_tool_run_breadcrumbs(
+    messages: Sequence[_T],
+    *,
+    content_of: Callable[[_T], str],
+) -> list[_T]:
+    """Drop messages whose content is a tool-run breadcrumb.
+
+    Args:
+        messages: Messages (or message-like objects) to filter.
+        content_of: Callable returning the content string for each message.
+
+    Returns:
+        A new list preserving input order with breadcrumb messages removed.
+    """
+    kept = [m for m in messages if not is_tool_run_breadcrumb(content_of(m))]
+    dropped = len(messages) - len(kept)
+    if dropped:
+        logger.debug("Filtered %d tool-run breadcrumb message(s) at ingestion", dropped)
+    return kept

--- a/tests/test_tool_breadcrumb_filtering.py
+++ b/tests/test_tool_breadcrumb_filtering.py
@@ -1,0 +1,107 @@
+"""Tests for ingestion-time filtering of tool-run breadcrumb messages."""
+
+import pytest
+from httpx import AsyncClient
+
+from src import models
+from src.utils.message_filter import (
+    filter_tool_run_breadcrumbs,
+    is_tool_run_breadcrumb,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for the predicate / filter helper (no DB required)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "[Tool] Ran: Bash(ls -la)",
+        "[Tool] Ran: Read(/etc/hosts)",
+        "  [Tool] Ran: Edit(file.py)",  # leading whitespace still matches
+        "\n[Tool] Ran: Grep(pattern)",
+    ],
+)
+def test_breadcrumbs_are_detected(content: str):
+    assert is_tool_run_breadcrumb(content) is True
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "",
+        "Can you run the tests for me?",
+        "I used the [Tool] Ran: line as an example in my message.",  # not a prefix
+        "The tool ran successfully and printed the output.",
+        "[Tool] output: something",  # different, non-breadcrumb tag
+        "Here's what `[Tool] Ran:` means in Claude Code.",
+    ],
+)
+def test_legitimate_content_is_kept(content: str):
+    assert is_tool_run_breadcrumb(content) is False
+
+
+def test_filter_preserves_order_and_drops_only_breadcrumbs():
+    items = [
+        {"content": "real one"},
+        {"content": "[Tool] Ran: Bash(echo hi)"},
+        {"content": "real two"},
+        {"content": "[Tool] Ran: Read(x)"},
+    ]
+    kept = filter_tool_run_breadcrumbs(items, content_of=lambda m: m["content"])
+    assert [m["content"] for m in kept] == ["real one", "real two"]
+
+
+def test_filter_all_breadcrumbs_returns_empty():
+    items = [
+        {"content": "[Tool] Ran: a"},
+        {"content": "[Tool] Ran: b"},
+    ]
+    assert filter_tool_run_breadcrumbs(items, content_of=lambda m: m["content"]) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration test against the message-create route
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_messages_skips_tool_breadcrumbs(
+    client: AsyncClient, sample_data: tuple[models.Workspace, models.Peer]
+):
+    """A mixed batch persists only the real messages; breadcrumbs are dropped."""
+    test_workspace, test_peer = sample_data
+    response = await client.post(
+        f"/v3/workspaces/{test_workspace.name}/sessions/breadcrumb-session/messages/",
+        json={
+            "messages": [
+                {"content": "Real user message", "peer_id": test_peer.name},
+                {"content": "[Tool] Ran: Bash(ls)", "peer_id": test_peer.name},
+                {"content": "Another real message", "peer_id": test_peer.name},
+            ]
+        },
+    )
+    assert response.status_code in (200, 201)
+    data = response.json()
+    contents = [m["content"] for m in data]
+    assert contents == ["Real user message", "Another real message"]
+
+
+@pytest.mark.asyncio
+async def test_create_messages_all_breadcrumbs_persists_nothing(
+    client: AsyncClient, sample_data: tuple[models.Workspace, models.Peer]
+):
+    """A batch that is entirely breadcrumbs persists nothing and returns []."""
+    test_workspace, test_peer = sample_data
+    response = await client.post(
+        f"/v3/workspaces/{test_workspace.name}/sessions/all-breadcrumb-session/messages/",
+        json={
+            "messages": [
+                {"content": "[Tool] Ran: Bash(ls)", "peer_id": test_peer.name},
+                {"content": "[Tool] Ran: Read(x)", "peer_id": test_peer.name},
+            ]
+        },
+    )
+    assert response.status_code in (200, 201)
+    assert response.json() == []


### PR DESCRIPTION
## What
Adds a biographical-refresh reconciliation pass to the dream cycle. It diffs the stored peer card (the biographical *Profile*) against recent observed-peer messages and supersedes facts that have gone stale — e.g. the card still reading "close to accepting a role" long after the messages confirmed the role was accepted.

## How
- New `src/dreamer/biographical_refresh.py` — `run_biographical_refresh`, a **single structured-output LLM call** (like the minimal deriver / summarizer, not an agentic tool loop). Runs at most once per dream, after the specialists.
- Wired into `orchestrator.run_dream`.
- Gated behind `BIOGRAPHICAL_REFRESH` settings (ENABLED + recent-message / input-token / output-token caps).

## Testing
⚠️ **Not run locally** — the full honcho suite OOM-kills the toolbox pod it was authored in (real Postgres + heavy integration fixtures). Deferred to PR CI. **Do not merge until CI is green and Sam has reviewed** — honcho is the live memory backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)