### PR TITLE
fix(migrations): dynamic embedding dimenstions

### DIFF
--- a/migrations/versions/119a52b73c60_support_external_embeddings.py
+++ b/migrations/versions/119a52b73c60_support_external_embeddings.py
@@ -25,6 +25,7 @@ from alembic import op
 from pgvector.sqlalchemy import Vector
 
 from migrations.utils import column_exists, constraint_exists, get_schema, index_exists
+from src.config import settings
 
 # revision identifiers, used by Alembic.
 revision: str = "119a52b73c60"
@@ -42,7 +43,7 @@ def upgrade() -> None:
     op.alter_column(
         "message_embeddings",
         "embedding",
-        existing_type=Vector(1536),
+        existing_type=Vector(settings.EMBEDDING.VECTOR_DIMENSIONS),
         nullable=True,
         schema=schema,
     )
@@ -50,7 +51,7 @@ def upgrade() -> None:
     op.alter_column(
         "documents",
         "embedding",
-        existing_type=Vector(1536),
+        existing_type=Vector(settings.EMBEDDING.VECTOR_DIMENSIONS),
         nullable=True,
         schema=schema,
     )

--- a/migrations/versions/917195d9b5e9_add_messageembedding_table.py
+++ b/migrations/versions/917195d9b5e9_add_messageembedding_table.py
@@ -28,7 +28,7 @@ def upgrade() -> None:
         "message_embeddings",
         sa.Column("id", sa.BigInteger(), sa.Identity(), nullable=False),
         sa.Column("content", sa.Text(), nullable=False),
-        sa.Column("embedding", Vector(1536), nullable=False),
+        sa.Column("embedding", Vector(settings.EMBEDDING.VECTOR_DIMENSIONS), nullable=False),
         sa.Column("message_id", sa.Text(), nullable=False),
         sa.Column("workspace_name", sa.Text(), nullable=False),
         sa.Column("session_name", sa.Text(), nullable=True),

--- a/migrations/versions/a1b2c3d4e5f6_initial_schema.py
+++ b/migrations/versions/a1b2c3d4e5f6_initial_schema.py
@@ -363,7 +363,7 @@ def upgrade() -> None:
             server_default="{}",
         ),
         sa.Column("content", sa.Text(), nullable=False),
-        sa.Column("embedding", Vector(1536), nullable=True),  # pyright: ignore
+        sa.Column("embedding", Vector(settings.EMBEDDING.VECTOR_DIMENSIONS), nullable=True),  # pyright: ignore
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),

--- a/src/config.py
+++ b/src/config.py
@@ -28,7 +28,7 @@ EmbeddingDimensionsMode = Literal["auto", "always", "never"]
 
 # OpenAI-compatible models that reject the `dimensions=` request parameter.
 _EMBEDDING_KNOWN_REJECTING_MODELS: frozenset[str] = frozenset(
-    {"text-embedding-ada-002"}
+    {"text-embedding-ada-002", "mistral-embed"}
 )
 
 


### PR DESCRIPTION
Derive embedding dimenstions from settings instead of hardcoded values

Replace hardcoded Vector(1536) with Vector(settings.EMBEDDING.VECTOR_DIMENSTIONS) in three migration files so the database schema automatically matches the configured EMBEDDING_VECTOR_DIMENSTIONS value from .env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for external embeddings with configurable vector dimensions.

* **Refactor**
  * Database migrations and storage now use the configured embedding dimension instead of hard-coded values.

* **Bug Fix**
  * Configuration updated to handle embedding transports/models that reject a dimensions parameter (improves compatibility).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->