### PR TITLE
fix(llm) add model to _EMBEDDING_KNOWN_REJECTING_MODELS

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -28,7 +28,7 @@ EmbeddingDimensionsMode = Literal["auto", "always", "never"]
 
 # OpenAI-compatible models that reject the `dimensions=` request parameter.
 _EMBEDDING_KNOWN_REJECTING_MODELS: frozenset[str] = frozenset(
-    {"text-embedding-ada-002"}
+    {"text-embedding-ada-002", "mistral-embed"}
 )
 
 


### PR DESCRIPTION
fix(llm) add model "mistral-embed" to known models rejecting dimenstions parameter in _EMBEDDING_KNOWN_REJECTING_MODELS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed embedding model configuration for Mistral to ensure proper handling of API parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->