### PR TITLE
fix(llm): guard OpenAI backend against malformed provider responses

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -18,6 +18,36 @@ from src.llm.structured_output import (
 logger = logging.getLogger(__name__)
 
 
+def _first_choice(response: Any) -> Any:
+    """Return the first choice from an OpenAI(-compatible) chat response.
+
+    OpenAI-compatible gateways (OpenRouter, vLLM, DashScope, LiteLLM, ...)
+    sometimes return a technically-successful HTTP response whose body is
+    missing ``choices`` or carries an empty list. Indexing
+    ``response.choices[0]`` directly turns that into a raw
+    ``AttributeError``/``IndexError``/``TypeError`` deep in the backend; raise a
+    controlled ``ValidationException`` instead so callers treat it as a provider
+    failure (and can fall back) rather than crashing.
+    """
+    choices = getattr(response, "choices", None)
+    if not choices:
+        raise ValidationException(
+            "OpenAI-compatible response did not include any choices"
+        )
+    return choices[0]
+
+
+def _first_message(response: Any) -> Any:
+    """Return the ``message`` of the first choice, guarding against malformed
+    OpenAI-compatible responses (see :func:`_first_choice`)."""
+    message = getattr(_first_choice(response), "message", None)
+    if message is None:
+        raise ValidationException(
+            "OpenAI-compatible response choice did not include a message"
+        )
+    return message
+
+
 def _uses_max_completion_tokens(model: str) -> bool:
     """OpenAI reasoning models (gpt-5 family + o-series) require
     ``max_completion_tokens`` instead of the classic ``max_tokens`` parameter.
@@ -171,8 +201,9 @@ class OpenAIBackend:
                     fallback_response,
                     content_override=content,
                 )
-            parsed = response.choices[0].message.parsed
-            raw_content = response.choices[0].message.content or ""
+            message = _first_message(response)
+            parsed = getattr(message, "parsed", None)
+            raw_content = getattr(message, "content", None) or ""
             if parsed is None and raw_content:
                 content = repair_response_model_json(
                     raw_content,
@@ -181,7 +212,7 @@ class OpenAIBackend:
                 )
                 return self._normalize_response(response, content_override=content)
             if parsed is None:
-                refusal = getattr(response.choices[0].message, "refusal", None)
+                refusal = getattr(message, "refusal", None)
                 if refusal:
                     return self._normalize_response(
                         response,
@@ -330,10 +361,15 @@ class OpenAIBackend:
         *,
         content_override: Any | None = None,
     ) -> CompletionResult:
-        usage = response.usage
-        finish_reason = response.choices[0].finish_reason
+        usage = getattr(response, "usage", None)
+        choice = _first_choice(response)
+        finish_reason = getattr(choice, "finish_reason", None)
         tool_calls: list[ToolCallResult] = []
-        message = response.choices[0].message
+        message = getattr(choice, "message", None)
+        if message is None:
+            raise ValidationException(
+                "OpenAI-compatible response choice did not include a message"
+            )
         if getattr(message, "tool_calls", None):
             for tool_call in message.tool_calls:
                 tool_input: dict[str, Any] = {}
@@ -362,7 +398,7 @@ class OpenAIBackend:
         return CompletionResult(
             content=content_override
             if content_override is not None
-            else (message.content or ""),
+            else (getattr(message, "content", None) or ""),
             input_tokens=usage.prompt_tokens if usage else 0,
             output_tokens=usage.completion_tokens if usage else 0,
             cache_creation_input_tokens=cache_creation,
@@ -396,10 +432,11 @@ class OpenAIBackend:
         response_format: type[BaseModel],
         model: str,
     ) -> BaseModel | str:
-        raw_content = response.choices[0].message.content or ""
+        message = _first_message(response)
+        raw_content = getattr(message, "content", None) or ""
         if raw_content:
             return repair_response_model_json(raw_content, response_format, model)
-        refusal = getattr(response.choices[0].message, "refusal", None)
+        refusal = getattr(message, "refusal", None)
         if refusal:
             return refusal
         raise ValidationException(

--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -158,6 +158,12 @@ class OpenAIBackend:
         max_output_tokens: int | None = None,
         extra_params: dict[str, Any] | None = None,
     ) -> CompletionResult:
+        """Run a single chat completion and return a normalized result.
+
+        Handles the structured-output ``parse()`` path (with repair/fallback)
+        when ``response_format`` is a Pydantic model, and the plain
+        ``create()`` path otherwise.
+        """
         params = self._build_params(
             model=model,
             messages=messages,
@@ -361,6 +367,8 @@ class OpenAIBackend:
         *,
         content_override: Any | None = None,
     ) -> CompletionResult:
+        """Convert a raw OpenAI(-compatible) response into a ``CompletionResult``,
+        extracting content, tool calls, usage, and reasoning details."""
         usage = getattr(response, "usage", None)
         choice = _first_choice(response)
         finish_reason = getattr(choice, "finish_reason", None)
@@ -432,6 +440,8 @@ class OpenAIBackend:
         response_format: type[BaseModel],
         model: str,
     ) -> BaseModel | str:
+        """Repair structured content from a fallback response, returning the
+        repaired model, a refusal string, or raising if neither is available."""
         message = _first_message(response)
         raw_content = getattr(message, "content", None) or ""
         if raw_content:

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -2,7 +2,9 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from pydantic import BaseModel
 
+from src.exceptions import ValidationException
 from src.llm.backends.openai import OpenAIBackend
 
 
@@ -288,6 +290,90 @@ async def test_openai_backend_converts_anthropic_style_tools() -> None:
         }
     ]
     assert call["tool_choice"] == "required"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        SimpleNamespace(choices=[], usage=None),
+        SimpleNamespace(choices=None, usage=None),
+        SimpleNamespace(usage=None),
+        SimpleNamespace(
+            choices=[SimpleNamespace(finish_reason="stop", message=None)],
+            usage=None,
+        ),
+    ],
+)
+async def test_openai_backend_raises_controlled_error_on_malformed_response(
+    response: SimpleNamespace,
+) -> None:
+    """OpenAI-compatible gateways can return technically-successful responses
+    with no choices / no message. These must surface as a controlled
+    ValidationException rather than a raw AttributeError/IndexError/TypeError."""
+    client = Mock()
+    client.chat.completions.create = AsyncMock(return_value=response)
+
+    backend = OpenAIBackend(client)
+    with pytest.raises(ValidationException):
+        await backend.complete(
+            model="some-proxy-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+        )
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_tolerates_missing_usage() -> None:
+    """A response missing the ``usage`` attribute entirely should still return a
+    result with token counts defaulted to 0, not crash."""
+    client = Mock()
+    client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(content="ok", tool_calls=[]),
+                )
+            ],
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    result = await backend.complete(
+        model="some-proxy-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+    )
+
+    assert result.content == "ok"
+    assert result.input_tokens == 0
+    assert result.output_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_raises_controlled_error_on_malformed_structured_response() -> (
+    None
+):
+    """The structured-output ``parse()`` path must also guard against empty
+    ``choices`` from OpenAI-compatible providers."""
+
+    class _Schema(BaseModel):
+        value: str
+
+    client = Mock()
+    client.chat.completions.parse = AsyncMock(
+        return_value=SimpleNamespace(choices=[], usage=None)
+    )
+
+    backend = OpenAIBackend(client)
+    with pytest.raises(ValidationException):
+        await backend.complete(
+            model="some-proxy-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            response_format=_Schema,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -349,6 +349,8 @@ async def test_openai_backend_tolerates_missing_usage() -> None:
     assert result.content == "ok"
     assert result.input_tokens == 0
     assert result.output_tokens == 0
+    assert result.cache_creation_input_tokens == 0
+    assert result.cache_read_input_tokens == 0
 
 
 @pytest.mark.asyncio
@@ -359,6 +361,8 @@ async def test_openai_backend_raises_controlled_error_on_malformed_structured_re
     ``choices`` from OpenAI-compatible providers."""
 
     class _Schema(BaseModel):
+        """Minimal structured-output schema used to exercise the parse path."""
+
         value: str
 
     client = Mock()


### PR DESCRIPTION
## Description

Closes #676.

The OpenAI chat backend (`src/llm/backends/openai.py`) assumed every response is a well-formed `ChatCompletion` with at least one choice and a `usage` attribute. OpenAI-*compatible* gateways (OpenRouter, vLLM, DashScope, LiteLLM, new-api, Groq-compatible layers, ...) sometimes return a technically-successful HTTP response whose body is missing `choices`, carries an empty list, or has a null `message`/`usage`. In those cases the backend crashed with a raw `AttributeError`/`IndexError`/`TypeError` deep inside `response.choices[0].message` / `response.usage` instead of surfacing a controlled provider error.

## Changes

- Add two small helpers — `_first_choice()` and `_first_message()` — that raise a controlled `ValidationException` when `choices` is `None`/empty or the first choice has no `message`.
- Route the three trusting spots through them:
  - `complete()` structured `parse()` path (`.message.parsed` / `.content` / `.refusal`)
  - `_normalize_response()` (`response.usage`, `choices[0].finish_reason`, `choices[0].message`)
  - `_parse_or_repair_structured_content()`
- Missing `usage` now degrades to zero token counts via `getattr(...)` rather than raising (the `CompletionResult` already handled a falsy `usage`).

The malformed/empty case now fails as a `ValidationException` that points at the provider response, so callers can treat it as a provider failure (and fall back) instead of crashing.

### Scope

This intentionally covers the robustness/crash-defense half of #676. The broader structured-output fallback-chain expansion (`json_schema → json_object → no response_format`) overlaps with the JSON-mode work in #663/#751 and is left out to keep this change focused and easy to review.

## Tests

Added cases to `tests/llm/test_backends/test_openai.py` covering the response shapes called out in the issue:

- `choices=[]`, `choices=None`, no `usage` attribute, and `message=None` → controlled `ValidationException`
- response missing `usage` entirely → returns a result with token counts defaulted to `0`
- malformed structured (`parse()`) response with empty `choices` → controlled `ValidationException`

`uv run pytest tests/llm/test_backends/test_openai.py` → 27 passed. `ruff check`, `ruff format --check`, and `basedpyright` on the touched files are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened parsing of OpenAI-style responses to reliably detect missing or empty choices/messages and raise controlled validation errors.
  * Preserved existing fallback/repair behavior when parsed output is absent but raw content exists; improved safe extraction of finish reasons and content overrides.
  * Improved structured-output repair to handle malformed inputs more robustly.

* **Tests**
  * Added tests covering malformed responses, missing usage/token defaults, and structured-output validation error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->