### PR TITLE
fix(llm): add NVIDIA NIM embedding models to _EMBEDDING_KNOWN_REJECTING_MODELS

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -27,8 +27,21 @@ EmbeddingTransport = Literal["openai", "gemini"]
 EmbeddingDimensionsMode = Literal["auto", "always", "never"]
 
 # OpenAI-compatible models that reject the `dimensions=` request parameter.
+# This includes OpenAI's own text-embedding-ada-002 plus several
+# OpenAI-compatible providers that don't support the dimensions parameter
+# (NVIDIA NIM endpoints in particular).
 _EMBEDDING_KNOWN_REJECTING_MODELS: frozenset[str] = frozenset(
-    {"text-embedding-ada-002"}
+    {
+        # OpenAI
+        "text-embedding-ada-002",
+        # NVIDIA NIM — none of the OpenAI-compatible embedding endpoints on
+        # integrate.api.nvidia.com accept a `dimensions` parameter.
+        "baai/bge-m3",
+        "nvidia/nv-embed-v1",
+        "nvidia/nv-embedqa-e5-v5",
+        "nvidia/nv-embedqa-mistral-7b-v2",
+        "snowflake/arctic-embed-l",
+    }
 )
 
 


### PR DESCRIPTION
## Summary

NVIDIA NIM (`integrate.api.nvidia.com`) exposes several OpenAI-compatible embedding endpoints, but **none of them accept the `dimensions=` request parameter** that Honcho sends by default. This causes embedding calls to fail with HTTP 400.

This PR adds them to `_EMBEDDING_KNOWN_REJECTING_MODELS` so the `dimensions` parameter is skipped automatically (the same approach as #772 for `mistral-embed`).

## Models added

- `baai/bge-m3` (multilingual, 1024 dim)
- `nvidia/nv-embed-v1`
- `nvidia/nv-embedqa-e5-v5`
- `nvidia/nv-embedqa-mistral-7b-v2`
- `snowflake/arctic-embed-l`

## Reproduction

Configuring any of these models against NIM previously failed:

\`\`\`
EMBEDDING_MODEL_CONFIG__TRANSPORT=openai
EMBEDDING_MODEL_CONFIG__MODEL=baai/bge-m3
EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL=https://integrate.api.nvidia.com/v1
\`\`\`

Calls to `/v1/embeddings` returned:

\`\`\`json
{"detail": {"type": "extra_forbidden", "loc": ["body", "dimensions"], "msg": "Extra inputs are not permitted", "input": 1024}}
\`\`\`

Verified directly via curl against `integrate.api.nvidia.com` — the rejection is at the NIM gateway layer and is consistent across these models.

## After this PR

Honcho automatically skips the `dimensions` parameter for these models. Users can still force the previous behaviour with `EMBEDDING_MODEL_CONFIG__DIMENSIONS_MODE=always`.

## Notes

- Confirmed by deploying Honcho self-hosted on Docker with NIM as the LLM provider for both text generation (`meta/llama-3.3-70b-instruct`) and embeddings (`baai/bge-m3`) after applying this patch.
- `nvidia/llama-nemotron-embed-1b-v2` accepts `dimensions` but **requires** an `input_type` parameter (asymmetric model). That's a separate fix — I'll send a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced embedding model support by improving compatibility with additional OpenAI and OpenAI-compatible embedding providers when handling dimension parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->