### PR TITLE
feat(llm): add EMBEDDING_MODEL_CONFIG__INPUT_TYPE for asymmetric embedders

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -21,6 +21,11 @@ LOG_LEVEL=INFO
 # EMBEDDING_MODEL_CONFIG__TRANSPORT=openai
 # EMBEDDING_MODEL_CONFIG__MODEL=text-embedding-3-small
 # EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL=
+# Asymmetric-encoder providers (e.g. some NVIDIA NIM embedding models like
+# `nvidia/llama-nemotron-embed-1b-v2`) require an `input_type` parameter and
+# will fail without it. Set this to the value the provider expects — usually
+# `query` for indexing/search use. Leave unset for plain OpenAI / Gemini.
+# EMBEDDING_MODEL_CONFIG__INPUT_TYPE=query
 # EMBEDDING_MODEL_CONFIG__OVERRIDES__API_KEY_ENV=
 
 # LANGFUSE_HOST=

--- a/src/config.py
+++ b/src/config.py
@@ -301,6 +301,13 @@ class ConfiguredEmbeddingModelSettings(BaseModel):
     transport: EmbeddingTransport = "openai"
     overrides: ModelOverrideSettings = Field(default_factory=ModelOverrideSettings)
     dimensions_mode: EmbeddingDimensionsMode = "auto"
+    # Optional `input_type` to forward to the embedding endpoint. Required by
+    # some asymmetric-encoder providers — notably NVIDIA NIM models such as
+    # `nvidia/llama-nemotron-embed-1b-v2` which fail with HTTP 400 when this
+    # field is missing. Common values: "query", "passage" (NIM), or
+    # provider-specific equivalents. Default `None` preserves the historical
+    # behaviour for plain OpenAI / Gemini, which don't accept this parameter.
+    input_type: str | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -337,6 +344,7 @@ class EmbeddingModelConfig(BaseModel):
     transport: EmbeddingTransport = "openai"
     api_key: str | None = None
     base_url: str | None = None
+    input_type: str | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -459,6 +467,7 @@ def resolve_embedding_model_config(
         transport=configured.transport,
         api_key=api_key,
         base_url=configured.overrides.base_url,
+        input_type=configured.input_type,
     )
 
 

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -152,6 +152,9 @@ class _EmbeddingClient:
         self.model: str = config.model
         self.vector_dimensions: int = vector_dimensions
         self.send_dimensions: bool = send_dimensions
+        # Optional `input_type` to forward to the embedding endpoint. Required
+        # by some asymmetric-encoder providers (notably NVIDIA NIM models).
+        self.input_type: str | None = config.input_type
 
         if self.transport == "gemini":
             if not config.api_key:
@@ -237,6 +240,8 @@ class _EmbeddingClient:
             openai_kwargs: dict[str, Any] = {"model": self.model, "input": [query]}
             if self.send_dimensions:
                 openai_kwargs["dimensions"] = self.vector_dimensions
+            if self.input_type is not None:
+                openai_kwargs["input_type"] = self.input_type
             response = await openai_client.embeddings.create(**openai_kwargs)
             return self._validate_embedding_dimensions(response.data[0].embedding)
 
@@ -290,6 +295,8 @@ class _EmbeddingClient:
                     }
                     if self.send_dimensions:
                         openai_kwargs["dimensions"] = self.vector_dimensions
+                    if self.input_type is not None:
+                        openai_kwargs["input_type"] = self.input_type
                     response = await self.client.embeddings.create(**openai_kwargs)
                     batch_embeddings.extend(
                         [
@@ -455,6 +462,8 @@ class _EmbeddingClient:
                 }
                 if self.send_dimensions:
                     openai_kwargs["dimensions"] = self.vector_dimensions
+                if self.input_type is not None:
+                    openai_kwargs["input_type"] = self.input_type
                 response = await self.client.embeddings.create(**openai_kwargs)
                 for item, embedding_data in zip(batch, response.data, strict=True):
                     result[item.text_id][item.chunk_index] = (

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -328,6 +328,27 @@ def test_resolve_send_dimensions_always_overrides_ada_rejecting_allowlist(
     assert s.resolve_send_dimensions() is True
 
 
+def test_input_type_default_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """By default no input_type is sent — preserves OpenAI / Gemini behaviour."""
+    s = _build_embedding_settings({}, monkeypatch)
+    assert s.MODEL_CONFIG.input_type is None
+
+
+def test_input_type_propagates_through_resolved_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When configured, input_type is preserved end-to-end through resolution."""
+    from src.config import resolve_embedding_model_config
+
+    s = _build_embedding_settings(
+        {"EMBEDDING_MODEL_CONFIG__INPUT_TYPE": "query"},
+        monkeypatch,
+    )
+    assert s.MODEL_CONFIG.input_type == "query"
+    resolved = resolve_embedding_model_config(s.MODEL_CONFIG)
+    assert resolved.input_type == "query"
+
+
 def test_resolve_send_dimensions_never_returns_false_regardless(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Some OpenAI-compatible embedding endpoints — most notably the NVIDIA NIM asymmetric-encoder models — require an `input_type` parameter and fail with HTTP 400 when it's missing:

```
HTTP 400 {"detail": "'input_type' parameter is required for asymmetric models"}
```

Affected models include:

- `nvidia/llama-nemotron-embed-1b-v2`
- other NIM asymmetric retrieval embedders

OpenAI and Gemini don't accept this parameter, so it must remain opt-in (default `None` preserves the existing behaviour).

## Changes

- **`src/config.py`** — add `input_type: str | None = None` to both `ConfiguredEmbeddingModelSettings` (operator-facing) and `EmbeddingModelConfig` (runtime), with full docstring. Propagated through `resolve_embedding_model_config`.
- **`src/embedding_client.py`** — store `self.input_type` from config; forward it as `openai_kwargs["input_type"]` at all three `embeddings.create()` call sites (single-query embed, batched embed with retry, `simple_batch_embed`).
- **`tests/llm/test_embedding_client.py`** — 2 new tests: default is `None`; configured value propagates through resolution.
- **`.env.template`** — document the new option with an example NIM config block.

## Example usage

```env
EMBEDDING_MODEL_CONFIG__TRANSPORT=openai
EMBEDDING_MODEL_CONFIG__MODEL=nvidia/llama-nemotron-embed-1b-v2
EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL=https://integrate.api.nvidia.com/v1
EMBEDDING_MODEL_CONFIG__INPUT_TYPE=query
```

## Compatibility

- **OpenAI / Gemini**: no behaviour change — `input_type` stays unset and is never forwarded.
- **NVIDIA NIM asymmetric models**: previously broken, now configurable via env var.
- The field is a free-form `str` rather than a `Literal` because input-type values vary across providers (`query`/`passage` on NIM, different vocabularies elsewhere). Operators set whatever their provider expects.

## Reproduction (without the patch)

Configuring Honcho against `nvidia/llama-nemotron-embed-1b-v2` previously failed in the deriver:

```
src.deriver.deriver - ERROR - Failed to save representation for observer alice:
Error code: 400 - {'error': "'input_type' parameter is required for asymmetric models"}
```

After the patch, with `EMBEDDING_MODEL_CONFIG__INPUT_TYPE=query` set, representations save correctly.

## Companion PR

[#778](https://github.com/plastic-labs/honcho/pull/778) ships in parallel and adds NIM symmetric models to `_EMBEDDING_KNOWN_REJECTING_MODELS` so they work out of the box. Combined, the two PRs make NVIDIA NIM a first-class embedding provider for Honcho.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced embedding model configuration with support for an optional `input_type` parameter, enabling compatibility with embedding providers that require it (such as certain NVIDIA NIM models).

* **Documentation**
  * Updated configuration templates and guidance on setting the `input_type` parameter for different embedding use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->