### PR TITLE
fix: declare click as honcho-cli dependency

### DIFF
--- a/honcho-cli/pyproject.toml
+++ b/honcho-cli/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
+    "click>=8.0.0",
     "typer>=0.15.0",
     "honcho-ai>=2.0.0",
     "rich>=13.0.0",

--- a/honcho-cli/uv.lock
+++ b/honcho-cli/uv.lock
@@ -91,6 +91,7 @@ name = "honcho-cli"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "honcho-ai" },
     { name = "httpx" },
     { name = "rich" },
@@ -105,6 +106,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0.0" },
     { name = "honcho-ai", specifier = ">=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1305,6 +1305,7 @@ name = "honcho-cli"
 version = "0.1.0"
 source = { editable = "honcho-cli" }
 dependencies = [
+    { name = "click" },
     { name = "honcho-ai" },
     { name = "httpx" },
     { name = "rich" },
@@ -1319,6 +1320,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0.0" },
     { name = "honcho-ai", editable = "sdks/python" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },


### PR DESCRIPTION
Fixes #786.

`honcho_cli._help` imports `click` directly, but `honcho-cli` did not declare `click` as a runtime dependency. Clean tool installs can therefore fail before Typer is able to provide its transitive dependency.

This adds `click>=8.0.0` to `honcho-cli` and updates both lockfiles for the direct dependency metadata only.

Verification on Windows from an ASCII temp path:
- `uv run --package honcho-cli honcho --help`
- `uv run --package honcho-cli python -c "import importlib.metadata as m; print([r for r in (m.requires('honcho-cli') or []) if r.lower().startswith('click')])"`
- `uv run --package honcho-cli --extra dev pytest honcho-cli/tests/test_commands.py::TestInit::test_first_run_writes_exact_shape -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to support enhanced functionality.

---

**Note:** This release contains primarily infrastructure updates with no visible end-user changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->