### PR TITLE
fix(embedding): request float encoding for OpenAI-compatible embeddings

### DIFF
--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -234,7 +234,11 @@ class _EmbeddingClient:
         openai_client = self.client
 
         async def _call_openai() -> list[float]:
-            openai_kwargs: dict[str, Any] = {"model": self.model, "input": [query]}
+            openai_kwargs: dict[str, Any] = {
+                "model": self.model,
+                "input": [query],
+                "encoding_format": "float",
+            }
             if self.send_dimensions:
                 openai_kwargs["dimensions"] = self.vector_dimensions
             response = await openai_client.embeddings.create(**openai_kwargs)
@@ -287,6 +291,7 @@ class _EmbeddingClient:
                     openai_kwargs: dict[str, Any] = {
                         "input": batch,
                         "model": self.model,
+                        "encoding_format": "float",
                     }
                     if self.send_dimensions:
                         openai_kwargs["dimensions"] = self.vector_dimensions
@@ -452,6 +457,7 @@ class _EmbeddingClient:
                 openai_kwargs: dict[str, Any] = {
                     "model": self.model,
                     "input": [item.text for item in batch],
+                    "encoding_format": "float",
                 }
                 if self.send_dimensions:
                     openai_kwargs["dimensions"] = self.vector_dimensions

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -60,7 +60,11 @@ async def test_openai_embedding_client_uses_configured_model_and_dimensions(
 
     assert embedding == [0.1] * 8
     assert fake_embeddings.calls == [
-        {"model": "text-embedding-3-small", "input": ["hello world"]}
+        {
+            "model": "text-embedding-3-small",
+            "input": ["hello world"],
+            "encoding_format": "float",
+        }
     ]
 
 
@@ -200,6 +204,7 @@ async def test_openai_embed_forwards_dimensions_when_send_dimensions_true(
         {
             "model": "text-embedding-3-small",
             "input": ["hello"],
+            "encoding_format": "float",
             "dimensions": 768,
         }
     ]
@@ -219,7 +224,13 @@ async def test_openai_embed_omits_dimensions_when_send_dimensions_false(
 
     await client.embed("hello")
 
-    assert fake.calls == [{"model": "text-embedding-3-small", "input": ["hello"]}]
+    assert fake.calls == [
+        {
+            "model": "text-embedding-3-small",
+            "input": ["hello"],
+            "encoding_format": "float",
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -238,6 +249,7 @@ async def test_openai_simple_batch_embed_forwards_dimensions(
 
     assert len(fake.calls) == 1
     assert fake.calls[0]["dimensions"] == 768
+    assert fake.calls[0]["encoding_format"] == "float"
     assert fake.calls[0]["input"] == ["a", "b"]
 
 
@@ -257,6 +269,7 @@ async def test_openai_batch_embed_forwards_dimensions(
 
     assert len(fake.calls) == 1
     assert fake.calls[0]["dimensions"] == 768
+    assert fake.calls[0]["encoding_format"] == "float"
 
 
 def _build_embedding_settings(


### PR DESCRIPTION
## **Description**

This PR fixes OpenAI-compatible embedding providers that return encoded string embeddings unless `encoding_format="float"` is explicitly requested.

Honcho expects embeddings as `list[float]`. Without this parameter, some compatible providers can return an embedding payload that fails downstream parsing, for example when the provider attempts to unmarshal string embeddings into float arrays.

Submitted by:
TT SRE Team

---

### **Additional context**

The change applies `encoding_format="float"` to all OpenAI embedding request paths:

- single embedding requests
- simple batch embedding requests
- chunked batch embedding requests

This keeps behavior unchanged for OpenAI-compatible APIs that already default to float embeddings, while making the request explicit for providers that require the parameter.

## **Changelog**

### **Added**

### **Changed**

### **Deprecated**

### **Removed**

### **Fixed**

- Request float-formatted embeddings from OpenAI-compatible embedding APIs.
- Add unit test coverage to assert `encoding_format="float"` is forwarded for single and batch embedding paths.

### **Security**

## Testing

- `uv run ruff check src/embedding_client.py tests/llm/test_embedding_client.py`
- `uv run pytest -n 0 -s tests/llm/test_embedding_client.py`

Result:

- [x]  `ruff`: passed
- [x]   `pytest`: 13 passed, 2 warnings from third-party dependencies



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI embedding requests now explicitly specify float encoding format, ensuring consistent and proper formatting across all embedding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->