### PR TITLE
fix: stop mislabeling transient embedding errors as token-limit errors

### DIFF
--- a/src/crud/document.py
+++ b/src/crud/document.py
@@ -16,7 +16,7 @@ from src.crud.collection import get_or_create_collection
 from src.crud.peer import get_peer
 from src.crud.session import get_session
 from src.dependencies import tracked_db
-from src.embedding_client import embedding_client
+from src.embedding_client import EmbeddingTokenLimitError, embedding_client
 from src.exceptions import (
     ResourceNotFoundException,
     ValidationException,
@@ -350,7 +350,7 @@ async def query_documents(
     if embedding is None:
         try:
             embedding = await embedding_client.embed(query)
-        except ValueError as e:
+        except EmbeddingTokenLimitError as e:
             raise ValidationException(
                 "Query exceeds maximum token limit of "
                 + f"{settings.EMBEDDING.MAX_INPUT_TOKENS}."
@@ -798,7 +798,7 @@ async def create_observations(
     contents = [obs.content for obs in observations]
     try:
         embeddings = await embedding_client.simple_batch_embed(contents)
-    except ValueError as e:
+    except EmbeddingTokenLimitError as e:
         raise ValidationException(str(e)) from e
 
     # Create document objects and track embeddings for vector store

--- a/src/crud/document.py
+++ b/src/crud/document.py
@@ -18,7 +18,7 @@ from src.crud.collection import get_or_create_collection
 from src.crud.peer import get_peer, reject_scope_observed
 from src.crud.session import get_session
 from src.dependencies import tracked_db
-from src.embedding_client import embedding_client
+from src.embedding_client import EmbeddingTokenLimitError, embedding_client
 from src.exceptions import (
     ResourceNotFoundException,
     ValidationException,
@@ -362,7 +362,7 @@ async def query_documents(
     if embedding is None:
         try:
             embedding = await embedding_client.embed(query)
-        except ValueError as e:
+        except EmbeddingTokenLimitError as e:
             raise ValidationException(
                 "Query exceeds maximum token limit of "
                 + f"{settings.EMBEDDING.MAX_INPUT_TOKENS}."
@@ -987,7 +987,7 @@ async def create_observations(
         embeddings = await embedding_client.simple_batch_embed(
             contents, on_oversize="truncate"
         )
-    except ValueError as e:
+    except EmbeddingTokenLimitError as e:
         raise ValidationException(str(e)) from e
 
     # Create document objects and track embeddings for vector store

--- a/src/crud/representation.py
+++ b/src/crud/representation.py
@@ -13,7 +13,7 @@ from src import crud, exceptions, models, schemas
 from src.config import settings
 from src.dependencies import tracked_db
 from src.dreamer.dream_scheduler import check_and_schedule_dream
-from src.embedding_client import embedding_client
+from src.embedding_client import EmbeddingTokenLimitError, embedding_client
 from src.schemas import ResolvedConfiguration
 from src.telemetry.events import EmbeddingCallPurpose
 from src.telemetry.logging import accumulate_metric
@@ -106,7 +106,7 @@ class RepresentationManager:
                 embeddings = await embedding_client.simple_batch_embed(
                     observation_texts
                 )
-        except ValueError as e:
+        except EmbeddingTokenLimitError as e:
             raise exceptions.ValidationException(
                 "Observation content exceeds maximum token limit of "
                 + f"{settings.EMBEDDING.MAX_INPUT_TOKENS}."

--- a/src/crud/representation.py
+++ b/src/crud/representation.py
@@ -13,7 +13,7 @@ from src import crud, exceptions, models, schemas
 from src.config import settings
 from src.dependencies import tracked_db
 from src.dreamer.dream_scheduler import check_and_schedule_dream
-from src.embedding_client import embedding_client
+from src.embedding_client import EmbeddingTokenLimitError, embedding_client
 from src.schemas import ResolvedConfiguration
 from src.telemetry.events import EmbeddingCallPurpose
 from src.telemetry.logging import accumulate_metric
@@ -109,7 +109,7 @@ class RepresentationManager:
                 embeddings = await embedding_client.simple_batch_embed(
                     observation_texts, on_oversize="truncate"
                 )
-        except ValueError as e:
+        except EmbeddingTokenLimitError as e:
             raise exceptions.ValidationException(
                 "Observation content exceeds maximum token limit of "
                 + f"{settings.EMBEDDING.MAX_INPUT_TOKENS}."

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -18,6 +18,16 @@ logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
+class EmbeddingTokenLimitError(ValueError):
+    """Raised when text submitted for embedding exceeds the configured token limit.
+
+    A subclass of ``ValueError`` for backwards compatibility with existing
+    ``except ValueError`` handlers, but distinct enough that callers can
+    catch it specifically without also swallowing unrelated embedding
+    failures (e.g. transient empty responses from the provider).
+    """
+
+
 async def _emit_embedding_call(
     *,
     provider: str,
@@ -201,7 +211,7 @@ class _EmbeddingClient:
         token_count = len(self.encoding.encode(query))
 
         if token_count > self.max_embedding_tokens:
-            raise ValueError(
+            raise EmbeddingTokenLimitError(
                 f"Query exceeds maximum token limit of {self.max_embedding_tokens} tokens (got {token_count} tokens)"
             )
 
@@ -259,12 +269,25 @@ class _EmbeddingClient:
             List of embedding vectors corresponding to input texts
 
         Raises:
-            ValueError: If any text exceeds token limits
+            EmbeddingTokenLimitError: If any text exceeds token limits
         """
         embeddings: list[list[float]] = []
 
         for i in range(0, len(texts), self.max_batch_size):
             batch = texts[i : i + self.max_batch_size]
+
+            # Check each text against the token limit before calling the
+            # provider. We can't rely on the provider's error message to
+            # identify token-limit failures (messages vary by provider and
+            # may not mention "tokens" at all), so we check ourselves and
+            # let any other provider error propagate unchanged.
+            token_counts = [len(self.encoding.encode(t)) for t in batch]
+            for token_count in token_counts:
+                if token_count > self.max_embedding_tokens:
+                    raise EmbeddingTokenLimitError(
+                        "Text content exceeds maximum token limit of "
+                        + f"{self.max_embedding_tokens} tokens (got {token_count} tokens)."
+                    )
 
             async def _embed_batch(batch: list[str] = batch) -> list[list[float]]:
                 """One provider call for one batch. Lifted into a closure so
@@ -299,25 +322,14 @@ class _EmbeddingClient:
                     )
                 return batch_embeddings
 
-            try:
-                # Pre-compute the tiktoken estimate ONCE for telemetry; the
-                # batch contents don't change between attempts.
-                tokens_estimate = sum(len(self.encoding.encode(t)) for t in batch)
-                batch_embeddings = await _emit_embedding_call(
-                    provider=self.transport,
-                    model=self.model,
-                    texts=batch,
-                    input_tokens_estimate=tokens_estimate,
-                    fn=_embed_batch,
-                )
-                embeddings.extend(batch_embeddings)
-            except Exception as e:
-                # Check if it's a token limit error and re-raise as ValueError for consistency
-                if "token" in str(e).lower():
-                    raise ValueError(
-                        f"Text content exceeds maximum token limit of {self.max_embedding_tokens}."
-                    ) from e
-                raise
+            batch_embeddings = await _emit_embedding_call(
+                provider=self.transport,
+                model=self.model,
+                texts=batch,
+                input_tokens_estimate=sum(token_counts),
+                fn=_embed_batch,
+            )
+            embeddings.extend(batch_embeddings)
 
         return embeddings
 

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -159,6 +159,17 @@ def _publish_embedding_event(
         logger.debug("Failed to emit EmbeddingCallCompletedEvent", exc_info=True)
 
 
+class EmbeddingTokenLimitError(ValueError):
+    """Raised when input text genuinely exceeds the model's token limit.
+
+    Subclasses ``ValueError`` so existing broad handlers keep working, while
+    letting callers tell a real "content too long" condition apart from a
+    transient provider or configuration failure (dimension mismatch, empty
+    response, upstream error). Only the pre-flight token checks raise this;
+    provider failures keep raising plain ``ValueError``.
+    """
+
+
 class BatchItem(NamedTuple):
     """A single item in a batch with its metadata."""
 
@@ -272,7 +283,7 @@ class _EmbeddingClient:
         token_count = len(self.encoding.encode(query))
 
         if token_count > self.max_embedding_tokens:
-            raise ValueError(
+            raise EmbeddingTokenLimitError(
                 f"Query exceeds maximum token limit of {self.max_embedding_tokens} tokens (got {token_count} tokens)"
             )
 
@@ -358,8 +369,8 @@ class _EmbeddingClient:
             List of embedding vectors, one per input text (in order)
 
         Raises:
-            ValueError: If any text exceeds token limits and `on_oversize` is
-                ``"raise"``
+            EmbeddingTokenLimitError: If any text exceeds token limits and
+                `on_oversize` is ``"raise"``
         """
         if not texts:
             return []
@@ -380,7 +391,7 @@ class _EmbeddingClient:
                         tokens,
                     )
                 else:
-                    raise ValueError(
+                    raise EmbeddingTokenLimitError(
                         f"Text at index {idx} exceeds maximum token limit of "
                         + f"{self.max_embedding_tokens} tokens (got {len(token_ids)} tokens)"
                     )

--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src import crud, models, schemas
 from src.config import settings
 from src.dependencies import tracked_db
-from src.embedding_client import embedding_client
+from src.embedding_client import EmbeddingTokenLimitError, embedding_client
 from src.exceptions import ResourceNotFoundException
 from src.models import Document
 from src.schemas import ResolvedConfiguration
@@ -1884,11 +1884,15 @@ async def _handle_search_memory(
             parent_category=ctx.parent_category,
         ):
             query_embedding = await embedding_client.embed(query)
-    except ValueError:
+    except EmbeddingTokenLimitError:
         return (
             "ERROR: Query exceeds maximum token limit of "
             + f"{settings.EMBEDDING.MAX_INPUT_TOKENS}. Please use a shorter query."
         )
+    except ValueError as e:
+        # Provider/config failure, not an oversized query. Keep returning a
+        # string so the tool loop can continue, but don't blame the query.
+        return f"ERROR: Embedding the query failed: {e}"
 
     # Base telemetry metadata; results_count gets filled in below.
     search_meta: dict[str, Any] = {

--- a/src/utils/search.py
+++ b/src/utils/search.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src import models
 from src.config import settings
 from src.dependencies import tracked_db
-from src.embedding_client import embedding_client
+from src.embedding_client import EmbeddingTokenLimitError, embedding_client
 from src.exceptions import ValidationException
 from src.models import session_peers_table
 from src.telemetry.events import EmbeddingCallPurpose
@@ -388,7 +388,7 @@ async def search(
                 parent_category="api",
             ):
                 query_embedding = await embedding_client.embed(query)
-        except ValueError as e:
+        except EmbeddingTokenLimitError as e:
             raise ValidationException(
                 f"Query exceeds maximum token limit of {settings.EMBEDDING.MAX_INPUT_TOKENS}."
             ) from e

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -4,7 +4,10 @@ from typing import Any
 import pytest
 
 from src.config import EmbeddingModelConfig
-from src.embedding_client import _EmbeddingClient  # pyright: ignore[reportPrivateUsage]
+from src.embedding_client import (  # pyright: ignore[reportPrivateUsage]
+    EmbeddingTokenLimitError,
+    _EmbeddingClient,
+)
 
 
 class FakeOpenAIEmbeddingsAPI:
@@ -239,6 +242,77 @@ async def test_openai_simple_batch_embed_forwards_dimensions(
     assert len(fake.calls) == 1
     assert fake.calls[0]["dimensions"] == 768
     assert fake.calls[0]["input"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_simple_batch_embed_raises_token_limit_error_without_provider_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, fake = _build_openai_client(
+        monkeypatch,
+        embedding=[0.1] * 768,
+        model="text-embedding-3-small",
+        send_dimensions=True,
+        vector_dimensions=768,
+    )
+
+    oversized_text = "word " * 9000  # well over the 8192 token limit
+
+    with pytest.raises(EmbeddingTokenLimitError, match=r"got \d+ tokens"):
+        await client.simple_batch_embed(["short text", oversized_text])
+
+    # Pre-check should reject before ever calling the provider.
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_simple_batch_embed_propagates_non_token_errors_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class EmptyResponseEmbeddingsAPI:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        async def create(
+            self,
+            *,
+            model: str,
+            input: str | list[str],
+            **kwargs: Any,
+        ) -> SimpleNamespace:
+            call: dict[str, Any] = {"model": model, "input": input}
+            call.update(kwargs)
+            self.calls.append(call)
+            # Mirrors the OpenAI SDK's parser when a provider (e.g. OpenRouter)
+            # returns HTTP 200 with an empty `data: []` body.
+            raise ValueError("No embedding data received")
+
+    fake_embeddings = EmptyResponseEmbeddingsAPI()
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: EmptyResponseEmbeddingsAPI = fake_embeddings
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai",
+            model="text-embedding-3-small",
+            api_key="test-key",
+        ),
+        vector_dimensions=768,
+        max_input_tokens=8192,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+    with pytest.raises(ValueError, match="No embedding data received") as exc_info:
+        await client.simple_batch_embed(["a", "b"])
+
+    # The error must propagate as-is, not be relabeled as a token-limit error.
+    assert not isinstance(exc_info.value, EmbeddingTokenLimitError)
+    assert len(fake_embeddings.calls) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -14,6 +14,7 @@ from src.config import (
 from src.embedding_client import (
     BatchItem,
     EmbeddingClient,
+    EmbeddingTokenLimitError,
     _EmbeddingClient,  # pyright: ignore[reportPrivateUsage]
 )
 
@@ -1173,3 +1174,70 @@ async def test_gemini_process_batch_wraps_contents_as_content_part(
     assert all(isinstance(c, genai_types.Content) for c in contents)
     assert contents[0].parts[0].text == "hello"
     assert contents[1].parts[0].text == "world"
+
+
+# --- Token-limit classification (issue #568) -------------------------------
+#
+# Only genuine "content too long" conditions may raise
+# EmbeddingTokenLimitError. Provider/config failures must stay plain
+# ValueError so callers don't rewrite them as token-limit errors.
+
+
+def test_embedding_token_limit_error_is_value_error() -> None:
+    """Subclassing ValueError keeps pre-existing broad handlers working."""
+    assert issubclass(EmbeddingTokenLimitError, ValueError)
+
+
+@pytest.mark.asyncio
+async def test_embed_raises_token_limit_error_before_calling_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, fake_embeddings = _build_openai_client(
+        monkeypatch,
+        embedding=[0.1, 0.2],
+        model="text-embedding-3-small",
+        send_dimensions=False,
+        vector_dimensions=2,
+    )
+
+    with pytest.raises(EmbeddingTokenLimitError):
+        await client.embed("word " * 20_000)
+
+    assert fake_embeddings.calls == [], "provider must not be called on oversize input"
+
+
+@pytest.mark.asyncio
+async def test_simple_batch_embed_raises_token_limit_error_before_calling_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, fake_embeddings = _build_openai_client(
+        monkeypatch,
+        embedding=[0.1, 0.2],
+        model="text-embedding-3-small",
+        send_dimensions=False,
+        vector_dimensions=2,
+    )
+
+    with pytest.raises(EmbeddingTokenLimitError):
+        await client.simple_batch_embed(["fine", "word " * 20_000])
+
+    assert fake_embeddings.calls == [], "provider must not be called on oversize input"
+
+
+@pytest.mark.asyncio
+async def test_provider_dimension_mismatch_is_not_a_token_limit_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wrong-width vector is a provider/config fault, not an oversized input."""
+    client, _ = _build_openai_client(
+        monkeypatch,
+        embedding=[0.1, 0.2, 0.3],  # 3 wide, client expects 2
+        model="text-embedding-3-small",
+        send_dimensions=False,
+        vector_dimensions=2,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        await client.embed("short query")
+
+    assert not isinstance(excinfo.value, EmbeddingTokenLimitError)


### PR DESCRIPTION
## Summary

- Several call sites (`save_representation`, `query_documents`, `create_observations`) catch a generic `ValueError`/`Exception` from the embedding client and unconditionally rewrite the message to "...exceeds maximum token limit of N", regardless of the actual cause.
- `simple_batch_embed` (used by the deriver's `save_representation`) had no token pre-check at all, unlike `embed()`, which already does `len(self.encoding.encode(text)) > self.max_embedding_tokens` before calling the provider.
- As a result, transient provider errors — e.g. some OpenAI-compatible providers (observed via OpenRouter) occasionally return HTTP 200 with an empty `data: []` body, which the OpenAI SDK's response parser turns into `ValueError("No embedding data received")` — get relabeled as token-limit errors. This makes it impossible to distinguish "your content is too long" from "the embedding provider had a transient hiccup, please retry" from logs/error messages alone.

## Changes

- Add `EmbeddingTokenLimitError(ValueError)` in `src/embedding_client.py` — a distinguishable subclass (still a `ValueError` for backwards compatibility) raised only when content genuinely exceeds the configured token limit.
- `simple_batch_embed` now performs the same pre-check as `embed()` (count tokens via `self.encoding.encode`, compare to `self.max_embedding_tokens`) *before* calling the provider, raising `EmbeddingTokenLimitError` with the actual token count. Any other provider error now propagates unchanged.
- Narrow the `except` clauses in `src/crud/representation.py` (`save_representation`) and `src/crud/document.py` (`query_documents`, `create_observations`) from `except ValueError` to `except EmbeddingTokenLimitError`, so non-token-limit errors surface with their real message/type instead of being mislabeled.

## Test plan

- [x] `uv run pytest tests/llm/test_embedding_client.py -q` — 15 passed (added 2 new regression tests: pre-check raises `EmbeddingTokenLimitError` without a provider call when content is oversized; a non-token `ValueError` such as `"No embedding data received"` propagates unchanged through `simple_batch_embed`)
- [x] `uv run pytest tests/crud/test_representation_manager.py tests/deriver/test_deriver_processing.py -q` — 18 passed, no regressions
- [x] `uv run ruff check src/` — clean
- [x] `uv run basedpyright` on changed files — 0 errors, 0 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of oversized embedding inputs and search queries.
  * Users now receive clearer guidance when content or queries exceed the configured token limit.
  * Other embedding and provider errors are now distinguished from input-size validation issues.

* **Tests**
  * Added coverage for token-limit detection across individual and batch embedding workflows.
  * Verified that unrelated embedding failures continue to be reported appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->