### PR TITLE
fix: private ip address check for webhook creation

### DIFF
--- a/src/schemas/api.py
+++ b/src/schemas/api.py
@@ -681,10 +681,17 @@ class WebhookEndpointCreate(WebhookEndpointBase):
         if parsed.hostname:
             try:
                 ip_address = ipaddress.ip_address(parsed.hostname)
-                if ip_address.is_private:
-                    raise ValueError("Private IP addresses are not allowed")
-            except ValueError:  # Not an IP address, might be a hostname
-                pass
+            except ValueError:  # Not an IP literal — a hostname, leave it alone
+                ip_address = None
+            if ip_address is not None and (
+                ip_address.is_private
+                or ip_address.is_loopback
+                or ip_address.is_link_local
+                or ip_address.is_reserved
+                or ip_address.is_multicast
+                or ip_address.is_unspecified
+            ):
+                raise ValueError("Private/internal IP addresses are not allowed")
 
         return v
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated webhook endpoint URL validation to restrict certain categories of IP addresses (private, loopback, link-local, reserved, multicast, and unspecified) while allowing standard hostname-based URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->