### PR TITLE
fix(agent_tools): strip display-format "id:" prefix from source_ids and get_reasoning_chain lookups

### DIFF
--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -1303,7 +1303,7 @@ def _normalize_observation_id(obs_id: str) -> str:
     obs_id = obs_id.strip()
     if obs_id.lower().startswith("id:"):
         obs_id = obs_id[3:]
-    return obs_id
+    return obs_id.strip()
 
 
 async def _handle_create_observations_impl(

--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -1290,6 +1290,22 @@ class ToolContext:
     parent_category: str | None = None  # Parent category for CloudEvents
 
 
+def _normalize_observation_id(obs_id: str) -> str:
+    """Strip the display-format ``id:`` prefix from a model-supplied observation ID.
+
+    Observations are presented to agents as ``[id:xxx]`` (see
+    ``Representation.str_with_ids``), and despite tool-schema instructions to
+    pass the bare ID, models sometimes copy the prefix verbatim. Since document
+    IDs are nanoids whose alphabet includes ``-`` and ``_``, only the ``id:``
+    prefix and surrounding whitespace are stripped — anything more aggressive
+    could mangle legitimate IDs.
+    """
+    obs_id = obs_id.strip()
+    if obs_id.lower().startswith("id:"):
+        obs_id = obs_id[3:]
+    return obs_id
+
+
 async def _handle_create_observations_impl(
     ctx: ToolContext,
     tool_input: dict[str, Any],
@@ -1309,6 +1325,13 @@ async def _handle_create_observations_impl(
             obs["level"] = forced_level
         else:
             obs.setdefault("level", default_level)
+        # Models sometimes copy the display-format "id:" prefix into source_ids;
+        # normalize so provenance links reference real document IDs.
+        source_ids = obs.get("source_ids")
+        if isinstance(source_ids, list):
+            obs["source_ids"] = [
+                _normalize_observation_id(s) for s in source_ids if isinstance(s, str)
+            ]
 
     # Validate observations individually so valid ones are still processed
     observations: list[schemas.ObservationInput] = []
@@ -2203,6 +2226,7 @@ async def _handle_get_reasoning_chain(
     observation_id = tool_input.get("observation_id")
     if not observation_id:
         return "ERROR: 'observation_id' is required"
+    observation_id = _normalize_observation_id(observation_id)
 
     direction = tool_input.get("direction", "both")
     if direction not in ("premises", "conclusions", "both"):

--- a/tests/utils/test_agent_tools.py
+++ b/tests/utils/test_agent_tools.py
@@ -520,6 +520,7 @@ class TestNormalizeObservationId:
             ("id:doc_abc123", "doc_abc123"),
             ("ID:doc_abc123", "doc_abc123"),
             ("  id:doc_abc123  ", "doc_abc123"),
+            ("id: doc_abc123", "doc_abc123"),
             # nanoid alphabet includes '-' and '_'; these must survive untouched
             ("3-bwp1hxCRkRbUh_nrqn0", "3-bwp1hxCRkRbUh_nrqn0"),
             ("id:3-bwp1hxCRkRbUh_nrqn0", "3-bwp1hxCRkRbUh_nrqn0"),

--- a/tests/utils/test_agent_tools.py
+++ b/tests/utils/test_agent_tools.py
@@ -34,6 +34,7 @@ from src.utils.agent_tools import (
     _handle_search_messages,  # pyright: ignore[reportPrivateUsage]
     _handle_search_messages_temporal,  # pyright: ignore[reportPrivateUsage]
     _handle_update_peer_card,  # pyright: ignore[reportPrivateUsage]
+    _normalize_observation_id,  # pyright: ignore[reportPrivateUsage]
     _validate_peer_card_entry,  # pyright: ignore[reportPrivateUsage]
     create_observations,
     create_tool_executor,
@@ -245,6 +246,40 @@ class TestCreateObservations:
         doc = (await db_session.execute(stmt)).scalar_one_or_none()
         assert doc is not None
         assert doc.level == "deductive"
+        assert doc.source_ids == ["premise1", "premise2"]
+
+    async def test_source_ids_display_prefix_is_stripped(
+        self,
+        db_session: AsyncSession,
+        make_tool_context: Callable[..., ToolContext],
+    ):
+        """Models sometimes copy the '[id:xxx]' display format into source_ids;
+        the prefix must be stripped so provenance links reference real IDs."""
+        ctx = make_tool_context(current_messages=None)
+
+        result = await _handle_create_observations(
+            ctx,
+            {
+                "observations": [
+                    {
+                        "content": "Inferred preference for early mornings",
+                        "source_ids": ["id:premise1", "ID:premise2"],
+                        "premises": [
+                            "User schedules meetings before 9am",
+                            "User mentions waking at 5:30",
+                        ],
+                    },
+                ]
+            },
+        )
+
+        assert "Created 1 observations" in result
+
+        stmt = select(models.Document).where(
+            models.Document.content == "Inferred preference for early mornings"
+        )
+        doc = (await db_session.execute(stmt)).scalar_one_or_none()
+        assert doc is not None
         assert doc.source_ids == ["premise1", "premise2"]
 
     async def test_empty_observations_list_returns_error(
@@ -473,6 +508,26 @@ class TestCreateObservations:
         assert len(result.failed) == 0
         batch_embed.assert_not_awaited()
         create_documents.assert_not_awaited()
+
+
+class TestNormalizeObservationId:
+    """Unit tests for _normalize_observation_id."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("doc_abc123", "doc_abc123"),
+            ("id:doc_abc123", "doc_abc123"),
+            ("ID:doc_abc123", "doc_abc123"),
+            ("  id:doc_abc123  ", "doc_abc123"),
+            # nanoid alphabet includes '-' and '_'; these must survive untouched
+            ("3-bwp1hxCRkRbUh_nrqn0", "3-bwp1hxCRkRbUh_nrqn0"),
+            ("id:3-bwp1hxCRkRbUh_nrqn0", "3-bwp1hxCRkRbUh_nrqn0"),
+            ("_leading_underscore", "_leading_underscore"),
+        ],
+    )
+    def test_normalization(self, raw: str, expected: str):
+        assert _normalize_observation_id(raw) == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Observations are presented to agents in `[id:xxx]` display format (`Representation.str_with_ids` and several tool outputs in `agent_tools.py`). Despite the tool schemas instructing models to pass the bare ID, models — especially smaller local ones — sometimes copy the prefix verbatim. In our self-hosted deployment (dream specialists on a 14B model via Ollama), 16 of 16 failed `delete_observations` calls over a 24h window carried the `id:` prefix.

#746 fixes this for `delete_observations` (where the failure is at least logged). This PR covers the two remaining entry points where the same model behavior corrupts data **silently**:

- **`source_ids` on `create_observations_*`** — prefixed IDs are stored as-is in document metadata, leaving broken provenance links (we observed e.g. `source_ids: ['id:wIXfBLbxZzZtoZPrZi6Dx', ...]` in production)
- **`observation_id` on `get_reasoning_chain`** — prefixed IDs fail the lookup with "not found"

Adds a small `_normalize_observation_id()` helper that strips only the `id:` prefix (case-insensitive) and surrounding whitespace. Deliberately nothing more aggressive: document IDs are nanoids whose alphabet includes `-` and `_` (real IDs from our deployment: `3-bwp1hxCRkRbUh_nrqn0`, `ndvEfEbsicL4TSUkiy8T_`), so trimming those characters would mangle legitimate IDs.

`delete_observations` is intentionally untouched to avoid conflicting with #746. Happy to rebase onto its `_normalize_observation_ids` helper if/when it lands.

Related to #719.

## Testing

- Unit tests for the helper, including nanoid edge cases (`-`/`_` preserved)
- Handler-level test asserting `id:`-prefixed `source_ids` are stored stripped (mirrors the existing deductive-creation test)
- `ruff check` and `ruff format --check` pass

---

### Additional context

Found while investigating duplicate dream cycles (#794) — the concurrent dreams surfaced a burst of `Failed to delete observation id:...` warnings that led here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized observation identifiers so IDs provided with display prefixes (e.g., "id:...") are stripped and trimmed, ensuring provenance lookups and reasoning-chain traversal work reliably.
* **Tests**
  * Added tests verifying normalization behavior for prefixed IDs, case-insensitivity, whitespace trimming, and allowed character handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->