### PR TITLE
fix(mcp): strip WWW-Authenticate header to prevent spurious OAuth popups in JetBrains

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -13,6 +13,17 @@ const CORS_HEADERS = {
   "Access-Control-Allow-Headers": CORS_ALLOWED_HEADERS,
 };
 
+function stripOAuthChallenge(response: Response): Response {
+  if (!response.headers.has("WWW-Authenticate")) return response;
+  const headers = new Headers(response.headers);
+  headers.delete("WWW-Authenticate");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 export default {
   async fetch(
     request: Request,
@@ -46,7 +57,7 @@ export default {
           headers: CORS_ALLOWED_HEADERS,
         },
       });
-      return await handler(request, env, executionCtx);
+      return stripOAuthChallenge(await handler(request, env, executionCtx));
     } catch (e) {
       const message =
         e instanceof Error ? e.message : "Internal server error";


### PR DESCRIPTION
## Problem

Reported in #792: every time a JetBrains IDE (WebStorm, IntelliJ) opens a project with the Honcho MCP server configured, the AI Assistant panel shows:

> **The authorization server 'https://mcp.honcho.dev' does not support automatic client registration.**

The connection works fine (Bearer token auth succeeds), but the popup fires on every IDE launch because `createMcpHandler` from the `agents` package emits a `WWW-Authenticate: Bearer` header on 401 responses as part of the MCP OAuth spec. JetBrains' MCP client is RFC-compliant — it sees that header, follows OAuth discovery, and hits dynamic client registration, which Honcho doesn't implement.

## Fix

Add a `stripOAuthChallenge` helper that removes `WWW-Authenticate` from any response returned by `createMcpHandler`. Honcho uses static Bearer token auth only — the header is an unintentional side effect of the agents package, not an advertised capability.

The helper is a no-op on responses that don't carry the header, so there's no impact on normal responses.

## Changes

- `mcp/src/index.ts` — wrap the handler response in `stripOAuthChallenge`; no other files touched

## Testing

Verified the fix by checking that the `WWW-Authenticate` header is stripped on 401 responses. JetBrains AI Assistant should no longer trigger the OAuth registration popup on project open.

— Jean "Claude"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response handling by filtering authentication-related headers from responses before they are returned to the caller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->