### PR TITLE
fix: use json_object instead of json_schema in structured output fallback

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -381,13 +381,12 @@ class OpenAIBackend:
         response_format: type[BaseModel],
     ) -> Any:
         structured_params = dict(params)
-        structured_params["response_format"] = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": response_format.__name__,
-                "schema": response_format.model_json_schema(),
-            },
-        }
+        structured_params.pop("response_format", None)
+        structured_params["response_format"] = {"type": "json_object"}
+        # Inject schema hint so the model returns the correct JSON shape
+        schema = response_format.model_json_schema()
+        schema_msg = {"role": "system", "content": f"Respond in JSON matching this schema: {json.dumps(schema)}"}
+        structured_params["messages"] = [schema_msg] + structured_params.get("messages", [])
         return await self._client.chat.completions.create(**structured_params)
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fixes #797

Changes `_create_structured_response()` in `src/llm/backends/openai.py` to use `json_object` mode instead of `json_schema` when retrying after `chat.completions.parse()` failure.

## Problem

When `chat.completions.parse()` fails (e.g., provider returns non-JSON), the fallback `_create_structured_response()` retries with `json_schema` format. Providers that silently ignore `json_schema` (Z.AI, and likely other OpenAI-compatible proxies) return plain text/markdown, causing the deriver to produce zero observations indefinitely.

## Fix

- Pop the stale `response_format` (Pydantic model class) from params before setting `json_object`
- Set `response_format` to `{"type": "json_object"}` (universally supported)
- Inject the Pydantic schema as a system message so the model returns the correct JSON shape
- The existing `repair_response_model_json()` handles parsing into the Pydantic model

## Testing

Tested on self-hosted Honcho v3.0.9 with Z.AI GLM-5.1:

- **Before patch**: Deriver generates zero observations on every cycle (markdown returned for `json_schema`)
- **After patch**: Deriver correctly extracts 6 observations from a 2-message test conversation, stored and retrievable via the representation/search API

## Changes

- `src/llm/backends/openai.py`: `_create_structured_response()` method (7 lines removed, 6 added)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAI structured output request formatting for enhanced compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->