### PR TITLE
feat: add queue purge endpoint for stranded work units (#799)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,14 @@ from src.routers import (
     keys,
     messages,
     peers,
+    queue,
+    sessions,
+    webhooks,
+    workspaces,
+    conclusions,
+    keys,
+    messages,
+    peers,
     sessions,
     webhooks,
     workspaces,
@@ -201,6 +209,7 @@ app.include_router(messages.router, prefix="/v3")
 app.include_router(conclusions.router, prefix="/v3")
 app.include_router(keys.router, prefix="/v3")
 app.include_router(webhooks.router, prefix="/v3")
+app.include_router(queue.router, prefix="/v3")
 
 # Prometheus metrics endpoint
 app.add_route("/metrics", metrics_endpoint, methods=["GET"])

--- a/src/routers/queue.py
+++ b/src/routers/queue.py
@@ -10,11 +10,12 @@ import logging
 from typing import Literal
 
 from fastapi import APIRouter, Depends, Path, Query
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src import db, models
-from src.dependencies import require_auth
+from src import models
+from src.dependencies import db
+from src.security import require_auth
 
 logger = logging.getLogger(__name__)
 
@@ -24,14 +25,16 @@ router = APIRouter()
 @router.delete(
     "/{workspace_id}/queue",
     status_code=200,
-    dependencies=[
-        Depends(require_auth(workspace_name="workspace_id"))
-    ],
+    dependencies=[Depends(require_auth(workspace_name="workspace_id"))],
 )
 async def purge_stranded_work_units(
     workspace_id: str = Path(...),
-    session_id: str | None = Query(None, description="Optional: purge only for specific session"),
-    status: Literal["all", "unprocessed"] = Query("unprocessed", description="Which items to purge"),
+    session_id: str | None = Query(
+        None, description="Optional: purge only for specific session"
+    ),
+    status: Literal["all", "unprocessed"] = Query(
+        "unprocessed", description="Which items to purge"
+    ),
     db: AsyncSession = db,
 ):
     """
@@ -55,13 +58,13 @@ async def purge_stranded_work_units(
             conditions.append(models.QueueItem.session_id == session_id)
 
         if status == "unprocessed":
-            conditions.append(models.QueueItem.processed == False)
+            conditions.append(~models.QueueItem.processed)
 
-        # Count items to be purged
-        count_query = select(models.QueueItem).where(*conditions)
-        result = await db.execute(count_query)
-        items_to_purge = result.scalars().all()
-        count = len(items_to_purge)
+        # Count items to be purged using SQL COUNT (avoid loading ORM rows)
+        count_query = (
+            select(func.count()).select_from(models.QueueItem).where(*conditions)
+        )
+        count = (await db.execute(count_query)).scalar() or 0
 
         if count == 0:
             return {

--- a/src/routers/queue.py
+++ b/src/routers/queue.py
@@ -1,0 +1,94 @@
+"""Queue purge endpoint for stranded work units.
+
+Adds an API endpoint to cancel/purge work units that are stranded
+in the queue after their associated sessions have been soft-deleted.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Path, Query
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import db, models
+from src.dependencies import require_auth
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.delete(
+    "/{workspace_id}/queue",
+    status_code=200,
+    dependencies=[
+        Depends(require_auth(workspace_name="workspace_id"))
+    ],
+)
+async def purge_stranded_work_units(
+    workspace_id: str = Path(...),
+    session_id: str | None = Query(None, description="Optional: purge only for specific session"),
+    status: Literal["all", "unprocessed"] = Query("unprocessed", description="Which items to purge"),
+    db: AsyncSession = db,
+):
+    """
+    Purge stranded work units from the queue.
+
+    When sessions are soft-deleted, their associated work units remain
+    in the queue permanently. This endpoint cleans them up.
+
+    Args:
+        workspace_id: The workspace to purge queue items for
+        session_id: Optional session ID to limit purge scope
+        status: "unprocessed" (default) or "all" to include processed items
+    """
+    try:
+        # Build filter conditions
+        conditions = [
+            models.QueueItem.workspace_name == workspace_id,
+        ]
+
+        if session_id:
+            conditions.append(models.QueueItem.session_id == session_id)
+
+        if status == "unprocessed":
+            conditions.append(models.QueueItem.processed == False)
+
+        # Count items to be purged
+        count_query = select(models.QueueItem).where(*conditions)
+        result = await db.execute(count_query)
+        items_to_purge = result.scalars().all()
+        count = len(items_to_purge)
+
+        if count == 0:
+            return {
+                "message": "No stranded work units found",
+                "purged_count": 0,
+            }
+
+        # Delete the items
+        delete_query = delete(models.QueueItem).where(*conditions)
+        await db.execute(delete_query)
+        await db.commit()
+
+        logger.info(
+            "Purged %d stranded work units for workspace %s (session: %s)",
+            count,
+            workspace_id,
+            session_id or "all",
+        )
+
+        return {
+            "message": f"Purged {count} stranded work units",
+            "purged_count": count,
+            "workspace_id": workspace_id,
+            "session_id": session_id,
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to purge queue: {e}")
+        await db.rollback()
+        raise

--- a/tests/routes/test_queue_purge.py
+++ b/tests/routes/test_queue_purge.py
@@ -1,0 +1,177 @@
+"""Tests for the queue purge endpoint (DELETE /v3/{workspace_id}/queue)."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import models
+from src.models import Peer, Workspace
+
+
+def _make_queue_item(
+    workspace_name: str,
+    *,
+    session_id: str | None = None,
+    processed: bool = False,
+) -> models.QueueItem:
+    """Helper to construct an unsaved QueueItem with the minimum required fields."""
+    return models.QueueItem(
+        workspace_name=workspace_name,
+        session_id=session_id,
+        work_unit_key=f"test:wu:{session_id or 'ws'}:{processed}",
+        task_type="representation",
+        payload={"task_type": "representation"},
+        processed=processed,
+    )
+
+
+class TestQueuePurge:
+    """Test suite for DELETE /v3/{workspace_id}/queue"""
+
+    @pytest.mark.asyncio
+    async def test_purge_empty_workspace_returns_zero(
+        self,
+        client: TestClient,
+        sample_data: tuple[Workspace, Peer],
+    ) -> None:
+        """No matching items → purged_count=0, message says so."""
+        workspace, _ = sample_data
+        response = client.delete(f"/v3/workspaces/{workspace.name}/queue")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["purged_count"] == 0
+        assert "No stranded" in body["message"]
+
+    @pytest.mark.asyncio
+    async def test_purge_unprocessed_only(
+        self,
+        client: TestClient,
+        db_session: AsyncSession,
+        sample_data: tuple[Workspace, Peer],
+    ) -> None:
+        """status='unprocessed' (default) deletes only unprocessed rows."""
+        workspace, _ = sample_data
+        # 2 unprocessed, 1 processed
+        for _ in range(2):
+            db_session.add(_make_queue_item(workspace.name, processed=False))
+        db_session.add(_make_queue_item(workspace.name, processed=True))
+        await db_session.commit()
+
+        response = client.delete(f"/v3/workspaces/{workspace.name}/queue")
+        assert response.status_code == 200
+        assert response.json()["purged_count"] == 2
+
+        # 1 processed row remains
+        remaining = (
+            await db_session.execute(
+                models.QueueItem.__table__.select().where(
+                    models.QueueItem.workspace_name == workspace.name
+                )
+            )
+        ).fetchall()
+        assert len(remaining) == 1
+        assert remaining[0].processed is True
+
+    @pytest.mark.asyncio
+    async def test_purge_all_includes_processed(
+        self,
+        client: TestClient,
+        db_session: AsyncSession,
+        sample_data: tuple[Workspace, Peer],
+    ) -> None:
+        """status='all' purges both processed and unprocessed rows."""
+        workspace, _ = sample_data
+        for _ in range(3):
+            db_session.add(_make_queue_item(workspace.name, processed=False))
+        for _ in range(2):
+            db_session.add(_make_queue_item(workspace.name, processed=True))
+        await db_session.commit()
+
+        response = client.delete(
+            f"/v3/workspaces/{workspace.name}/queue",
+            params={"status": "all"},
+        )
+        assert response.status_code == 200
+        assert response.json()["purged_count"] == 5
+
+        remaining = (
+            await db_session.execute(
+                models.QueueItem.__table__.select().where(
+                    models.QueueItem.workspace_name == workspace.name
+                )
+            )
+        ).fetchall()
+        assert len(remaining) == 0
+
+    @pytest.mark.asyncio
+    async def test_purge_filtered_by_session(
+        self,
+        client: TestClient,
+        db_session: AsyncSession,
+        sample_data: tuple[Workspace, Peer],
+    ) -> None:
+        """session_id query param narrows the purge to one session only."""
+        workspace, _ = sample_data
+        sess_a = models.Session(workspace_name=workspace.name, name="sess_a")
+        sess_b = models.Session(workspace_name=workspace.name, name="sess_b")
+        db_session.add_all([sess_a, sess_b])
+        await db_session.flush()
+
+        for _ in range(2):
+            db_session.add(_make_queue_item(workspace.name, session_id="sess_a"))
+        for _ in range(3):
+            db_session.add(_make_queue_item(workspace.name, session_id="sess_b"))
+        await db_session.commit()
+
+        response = client.delete(
+            f"/v3/workspaces/{workspace.name}/queue",
+            params={"session_id": "sess_a"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["purged_count"] == 2
+        assert body["session_id"] == "sess_a"
+
+        # sess_b rows still present
+        remaining = (
+            await db_session.execute(
+                models.QueueItem.__table__.select().where(
+                    models.QueueItem.workspace_name == workspace.name
+                )
+            )
+        ).fetchall()
+        assert len(remaining) == 3
+        assert all(r.session_id == "sess_b" for r in remaining)
+
+    @pytest.mark.asyncio
+    async def test_purge_only_targets_workspace(
+        self,
+        client: TestClient,
+        db_session: AsyncSession,
+        sample_data: tuple[Workspace, Peer],
+    ) -> None:
+        """Cross-workspace isolation: a purge on workspace A must not touch workspace B."""
+        ws_a, _ = sample_data
+        ws_b = models.Workspace(name="other-ws")
+        db_session.add(ws_b)
+        await db_session.flush()
+
+        for _ in range(2):
+            db_session.add(_make_queue_item(ws_a.name, processed=False))
+        for _ in range(3):
+            db_session.add(_make_queue_item(ws_b.name, processed=False))
+        await db_session.commit()
+
+        response = client.delete(f"/v3/workspaces/{ws_a.name}/queue")
+        assert response.status_code == 200
+        assert response.json()["purged_count"] == 2
+
+        # ws_b rows still present
+        remaining = (
+            await db_session.execute(
+                models.QueueItem.__table__.select().where(
+                    models.QueueItem.workspace_name == ws_b.name
+                )
+            )
+        ).fetchall()
+        assert len(remaining) == 3


### PR DESCRIPTION
## What

Add `DELETE /v3/{workspace_id}/queue` endpoint to purge stranded work units from the queue.

## Why

From [#799](https://github.com/plastic-labs/honcho/issues/799): When sessions are soft-deleted via `DELETE /v3/workspaces/{workspace_id}/sessions/{session_id}`, any pending work units queued for the deriver remain permanently in the queue. The deriver does not process them (the session no longer exists), and there is no API endpoint to purge or cancel these stranded work units.

## How

### New file: `src/routers/queue.py`

```python
@router.delete("/{workspace_id}/queue")
async def purge_stranded_work_units(
    workspace_id: str,
    session_id: str | None = None,
    status: Literal["all", "unprocessed"] = "unprocessed",
):
    # Count and delete stranded work units
    # Returns: {message, purged_count, workspace_id, session_id}
```

### Features

- **Filter by session**: Optional `session_id` parameter to purge only for specific session
- **Filter by status**: `unprocessed` (default) or `all` to include processed items
- **Safe**: Only deletes items matching the filter, returns count of purged items
- **Logged**: All purge operations are logged for audit

## Usage

```bash
# Purge all unprocessed items for a workspace
curl -X DELETE /v3/my-workspace/queue

# Purge items for specific session
curl -X DELETE /v3/my-workspace/queue?session_id=sess_123

# Purge all items (including processed)
curl -X DELETE /v3/my-workspace/queue?status=all
```

## Testing

```bash
pytest tests/ -v -k "queue"
```

Closes #799

Signed-off-by: zsxh1990 <zsxh1990@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new authenticated API endpoint to purge stranded queue items from a workspace under the existing `/v3` namespace.
  * Supports optional filtering by `session_id` and `status` (defaulting to unprocessed-only, with an option to purge all).
  * Returns a detailed purge summary, including counts and identifiers.
* **Tests**
  * Added coverage for empty workspaces, default vs. all-status purging, session-specific filtering, and ensuring items in other workspaces remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->