### PR TITLE
fix: handle Gemini transport in simple_batch_embed individually

### DIFF
--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -422,17 +422,18 @@ class _EmbeddingClient:
             item in analytics."""
             result: dict[str, dict[int, list[float]]] = defaultdict(dict)
             if isinstance(self.client, genai.Client):
-                response = await self.client.aio.models.embed_content(
-                    model=self.model,
-                    contents=[item.text for item in batch],
-                    config={"output_dimensionality": self.vector_dimensions},
-                )
-                if response.embeddings:
-                    for item, embedding in zip(batch, response.embeddings, strict=True):
-                        if embedding.values:
-                            result[item.text_id][item.chunk_index] = (
-                                self._validate_embedding_dimensions(embedding.values)
+                for item in batch:
+                    response = await self.client.aio.models.embed_content(
+                        model=self.model,
+                        contents=item.text,
+                        config={"output_dimensionality": self.vector_dimensions},
+                    )
+                    if response.embeddings and response.embeddings[0].values:
+                        result[item.text_id][item.chunk_index] = (
+                            self._validate_embedding_dimensions(
+                                response.embeddings[0].values
                             )
+                        )
             else:  # openai
                 openai_kwargs: dict[str, Any] = {
                     "model": self.model,

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -428,12 +428,16 @@ class _EmbeddingClient:
                         contents=item.text,
                         config={"output_dimensionality": self.vector_dimensions},
                     )
-                    if response.embeddings and response.embeddings[0].values:
-                        result[item.text_id][item.chunk_index] = (
-                            self._validate_embedding_dimensions(
-                                response.embeddings[0].values
-                            )
+                    if not response.embeddings or not response.embeddings[0].values:
+                        raise ValueError(
+                            f"Gemini returned empty embeddings for text_id={item.text_id!r},"
+                            f" chunk_index={item.chunk_index}"
                         )
+                    result[item.text_id][item.chunk_index] = (
+                        self._validate_embedding_dimensions(
+                            response.embeddings[0].values
+                        )
+                    )
             else:  # openai
                 openai_kwargs: dict[str, Any] = {
                     "model": self.model,

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -444,3 +444,67 @@ def test_prepare_chunks_returns_ordered_chunks(
     assert len(out["long"]) > 1
     # Order preserved
     assert isinstance(out["long"][0], str)
+
+
+@pytest.mark.asyncio
+async def test_gemini_simple_batch_embed_processes_items_individually(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gemini transport must send one API call per item, not a single batched
+    call, because the genai SDK treats list[str] as a multi-part content
+    input and collapses it to a single embedding vector."""
+    calls: list[dict[str, Any]] = []
+    embeddings_per_call = [[0.2] * 12, [0.3] * 12, [0.4] * 12]
+
+    class FakeGeminiModels:
+        async def embed_content(
+            self,
+            *,
+            model: str,
+            contents: str | list[str],
+            config: dict[str, Any],
+        ) -> SimpleNamespace:
+            call_idx = len(calls)
+            calls.append(
+                {
+                    "model": model,
+                    "contents": contents,
+                    "config": config,
+                }
+            )
+            return SimpleNamespace(
+                embeddings=[
+                    SimpleNamespace(values=embeddings_per_call[call_idx])
+                ],
+            )
+
+    class FakeGeminiClient:
+        def __init__(self, *, api_key: str | None, http_options: Any) -> None:
+            self.aio: Any = SimpleNamespace(models=FakeGeminiModels())
+
+    monkeypatch.setattr("src.embedding_client.genai.Client", FakeGeminiClient)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="gemini",
+            model="gemini-embedding-001",
+            api_key="gemini-key",
+        ),
+        vector_dimensions=12,
+        max_input_tokens=4096,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+    result = await client.simple_batch_embed(["alpha", "beta", "gamma"])
+
+    assert len(result) == 3
+    assert result[0] == [0.2] * 12
+    assert result[1] == [0.3] * 12
+    assert result[2] == [0.4] * 12
+
+    # Each call must be a single string, not a list.
+    assert len(calls) == 3
+    assert calls[0]["contents"] == "alpha"
+    assert calls[1]["contents"] == "beta"
+    assert calls[2]["contents"] == "gamma"


### PR DESCRIPTION
## Summary
- Fixed simple_batch_embed() to process Gemini transport items individually instead of as a batch
- Added regression test for multi-item batch with Gemini transport

Fixes #764

## Root Cause
The Google genai Python SDK `embed_content()` method treats a `list[str]` as a single multi-part content input and collapses it into one embedding vector. This is not a batch operation. The OpenAI path correctly returns one embedding per input string.

## Fix
In `_process_batch()`, when the Gemini transport is detected, iterate over each item individually instead of passing all texts at once.

## Test Plan
- [x] `uv run pytest tests/llm/test_embedding_client.py` passes (17 tests)
- [x] Multi-item batch with Gemini transport returns correct number of embeddings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gemini embedding provider now sends and validates individual embedding requests per item, preventing empty-item results and improving consistency.

* **Tests**
  * Added test verifying per-item embedding requests and that results are returned in the correct order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->