### PR TITLE
fix: conditionally pass k kwarg in create_tree() for non-KNN tree types

### DIFF
--- a/src/dreamer/surprisal.py
+++ b/src/dreamer/surprisal.py
@@ -384,9 +384,15 @@ def _build_tree(embeddings: np.ndarray) -> SurprisalTree:
         # Return empty tree (will handle gracefully in caller)
         return create_tree(settings.DREAM.SURPRISAL.TREE_TYPE)
 
+    # Only KNN-based tree types (kdtree, balltree, graph) accept k.
+    # Other types (rptree, covertree, lsh, prototype) do not.
+    tree_kwargs = {}
+    if settings.DREAM.SURPRISAL.TREE_TYPE in ("kdtree", "balltree", "graph"):
+        tree_kwargs["k"] = settings.DREAM.SURPRISAL.TREE_K
+
     tree = create_tree(
         tree_type=settings.DREAM.SURPRISAL.TREE_TYPE,
-        k=settings.DREAM.SURPRISAL.TREE_K,
+        **tree_kwargs,
     )
 
     tree.batch_insert(embeddings)

--- a/tests/dreamer/test_trees.py
+++ b/tests/dreamer/test_trees.py
@@ -22,4 +22,4 @@ def test_create_tree_all_types_with_default_k(tree_type: str) -> None:
     tree.batch_insert(embeddings)
     score = tree.surprisal(embeddings[0])
     assert isinstance(score, float)
-    assert not np.isnan(score)
+    assert np.isfinite(score)

--- a/tests/dreamer/test_trees.py
+++ b/tests/dreamer/test_trees.py
@@ -1,0 +1,25 @@
+"""Tests for the create_tree factory function."""
+
+import numpy as np
+import pytest
+
+from src.dreamer.trees import create_tree
+
+ALL_TREE_TYPES = ["rptree", "kdtree", "balltree", "covertree", "lsh", "graph", "prototype"]
+
+
+@pytest.mark.parametrize("tree_type", ALL_TREE_TYPES)
+def test_create_tree_all_types_with_default_k(tree_type: str) -> None:
+    """create_tree() should not crash for any tree type when k is passed conditionally."""
+    # KNN-based types accept k; non-KNN types should not receive it.
+    if tree_type in ("kdtree", "balltree", "graph"):
+        tree = create_tree(tree_type=tree_type, k=5)
+    else:
+        tree = create_tree(tree_type=tree_type)
+
+    # Every tree must expose batch_insert and surprisal.
+    embeddings = np.random.randn(20, 8).astype(np.float32)
+    tree.batch_insert(embeddings)
+    score = tree.surprisal(embeddings[0])
+    assert isinstance(score, float)
+    assert not np.isnan(score)


### PR DESCRIPTION
## Summary
- Added guard in create_tree() to only pass k kwarg to tree constructors that accept it (kdtree, balltree, graph)
- Added parameterized test covering all 7 tree types with default k to prevent regression

## Root Cause
The `_build_tree()` function in `src/dreamer/surprisal.py` unconditionally passed `k` to all tree constructors via `create_tree()`. However, only 3 of 7 tree types (kdtree, balltree, graph) accept the `k` parameter. The other 4 types (rptree, covertree, lsh, prototype) do not, causing a `TypeError` crash.

## Fix
Added a guard in `_build_tree()` that only passes `k` when the tree type is kdtree, balltree, or graph.

## Test Plan
- [x] Manual verification: all 7 tree types work correctly
- [x] Parameterized test `test_create_tree_all_types_with_default_k` covers all 7 tree types

Fixes #698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incompatible parameters from being sent to tree implementations during initialization, avoiding constructor errors for non-KNN tree types.

* **Tests**
  * Added tests covering all supported tree types, ensuring proper creation, data insertion, and valid surprisal outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->