### PR TITLE
fix: treat null observe_others as True in deriver and schema default

### DIFF
--- a/src/deriver/enqueue.py
+++ b/src/deriver/enqueue.py
@@ -364,7 +364,7 @@ async def generate_queue_records(
                 schemas.SessionPeerConfig(**peer_conf[1]) if peer_conf[1] else None
             )
 
-            if session_peer_config is None or not session_peer_config.observe_others:
+            if session_peer_config is None or session_peer_config.observe_others is False:
                 continue
 
             observers.append(peer_name)

--- a/src/schemas/configuration.py
+++ b/src/schemas/configuration.py
@@ -215,6 +215,6 @@ class PeerConfig(BaseModel):
 class SessionPeerConfig(PeerConfig):
     # TODO: Update description - should say "Whether this peer forms representations of other peers in the session"
     observe_others: bool | None = Field(
-        default=None,
+        default=True,
         description="Whether this peer should form a session-level theory-of-mind representation of other peers in the session",
     )


### PR DESCRIPTION
## Problem

When a peer is added to a session **without explicit `observe_others` configuration**, the `SessionPeerConfig` schema defaults to `None`. The deriver's enqueue logic then evaluates `not None` as `True`, incorrectly **skipping cross-peer observation creation** for that peer.

### Affected scenario
Multi-peer setups (e.g., Hermes agent + Frappe agent sharing a workspace) where cross-peer observations are essential for building theory-of-mind representations across AI peers.

### Root cause
Two issues working together:
1. **Schema** (`src/schemas/configuration.py:217`): `observe_others` defaults to `None`
2. **Deriver** (`src/deriver/enqueue.py:367`): `not None` → `True` → skips observation

### Steps to reproduce
1. Create a workspace with multiple peers
2. Add peers to a session without explicit `observe_others` config (or pass empty `{}`)
3. Post messages as one peer
4. Deriver skips creating observations about the other peer — `observe_others` is `null` in the database, and `not null` evaluates to `True` in Python

### Evidence
Tested on Honcho v3.0.9 (commit `340175a`):

```sql
-- Before fix: new peers get null
SELECT peer_name, configuration FROM session_peers WHERE session_name = 'akrida';

  peer_name   |                configuration
--------------+----------------------------------------------
 frappe       | {"observe_me": true, "observe_others": true}   -- manually fixed
 hermes       | {"observe_me": true, "observe_others": true}   -- manually fixed
 test-peer-01 | {"observe_me": null, "observe_others": null}   -- NEW peer, empty config
```

## Fix

Two complementary changes:

### 1. Schema default: `None` → `True`
`src/schemas/configuration.py` — peers should default to observing others when no explicit config is provided. This aligns with the principle of least surprise in multi-peer sessions.

### 2. Deriver logic: `not x` → `x is False`
`src/deriver/enqueue.py` — defense-in-depth. Any residual `None` values (from existing databases) are treated as permissive rather than restrictive. Only explicit `False` blocks cross-peer observation.

## After fix
- Peers default to observing others ✅
- Explicit `False` still blocks observation as intended ✅
- Existing databases with `null` values become permissive ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observer-selection logic to properly distinguish between explicitly disabled settings and other configuration values, fixing edge cases with non-standard value types.
  * Updated default peer observation configuration from disabled to enabled in session settings, allowing connected peers to observe each other by default and improving overall session visibility and monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->