### PR TITLE
fix(llm): coerce None output_tokens to 0 in completion_result_to_response

### DIFF
--- a/src/llm/executor.py
+++ b/src/llm/executor.py
@@ -167,7 +167,7 @@ def completion_result_to_response(
     return HonchoLLMCallResponse(
         content=result.content,
         input_tokens=result.input_tokens,
-        output_tokens=result.output_tokens,
+        output_tokens=result.output_tokens or 0,
         cache_creation_input_tokens=result.cache_creation_input_tokens,
         cache_read_input_tokens=result.cache_read_input_tokens,
         finish_reasons=[result.finish_reason] if result.finish_reason else [],


### PR DESCRIPTION
## Problem
`completion_result_to_response()` (src/llm/executor.py) assigns
`output_tokens=result.output_tokens` directly, but
`HonchoLLMCallResponse.output_tokens` is typed `int`. Some providers return
`output_tokens=None` for certain completions — reproduced with **Gemini** on
tool-loop completions. The `None` then fails Pydantic validation and raises,
aborting the call.

In practice this manifests in the **Dreamer**: a dream is scheduled, the
deduction phase completes, and then the **induction** phase crashes before any
inductive conclusions are persisted (the dream queue never drains).

## Fix
Coerce `None -> 0`:
```python
output_tokens=result.output_tokens or 0,
```
Token accounting degrades gracefully (under-counts rather than crashing) for
providers/paths that omit an output-token count. Provider-agnostic — lives in
the shared executor path, not a Gemini-specific branch.

## Repro
Run a Gemini-backed dream (`DREAM_*_MODEL_CONFIG__TRANSPORT=gemini`) with enough
explicit conclusions to trigger induction; without this guard the induction
specialist call raises a ValidationError on HonchoLLMCallResponse.

## Validation
Applied against a local 3.0.x deployment: a full dream cycle then completes
end-to-end — deductive AND inductive conclusions persist and the peer card
updates (verified on a live workspace).

## Notes
Happy to add a focused unit test for completion_result_to_response with
output_tokens=None if you'd prefer it bundled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed inconsistent handling of output token counts in LLM responses to ensure proper normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->