### PR TITLE
fix: restrict assistant-prefill to genuine Claude models

### DIFF
--- a/src/llm/backends/anthropic.py
+++ b/src/llm/backends/anthropic.py
@@ -274,6 +274,14 @@ class AnthropicBackend:
 
     @staticmethod
     def _supports_assistant_prefill(model: str) -> bool:
+        # Assistant-prefill (seeding the reply with "{") is an Anthropic-native
+        # capability for forcing structured output. Only genuine Claude models
+        # honor it. Third-party models served through Anthropic-COMPATIBLE
+        # endpoints (e.g. MiniMax) ignore the prefilled assistant turn and stop
+        # after emitting a few tokens, yielding truncated JSON like '{"explicit": ['
+        # that parses to an empty result. Restrict prefill to real Claude models.
+        if not model.startswith("claude-"):
+            return False
         # Claude 4-class models reject assistant-prefill and require the
         # conversation to end with a user message.
         return not model.startswith(


### PR DESCRIPTION
## Summary

`AnthropicBackend._supports_assistant_prefill()` returned `True` for **any** model whose name didn't match the Claude-4 exclusion list. That included third-party models served through *Anthropic-compatible* endpoints (e.g. MiniMax via `https://api.minimax.io/anthropic`).

Assistant-prefill — seeding the reply with `{` to force structured JSON output — is an Anthropic-native capability. Only genuine Claude models honor it. Compatible-endpoint models **ignore** the prefilled assistant turn and stop after a few tokens, emitting truncated JSON like `{"explicit": [` that parses to an empty result.

The practical impact: when Honcho is self-hosted against a non-Claude Anthropic-compatible backend, the **deriver silently produces zero observations** — memory formation breaks with no error, just empty structured output.

## Fix

Gate assistant-prefill on the model actually being a Claude model:

```python
if not model.startswith("claude-"):
    return False
```

8 lines, scoped to `_supports_assistant_prefill`. Genuine Claude behavior is unchanged.

## Verification

Tested end-to-end on a self-hosted stack routing all agents through MiniMax (`MiniMax-M3`):

| Stage | Path exercised | Result |
|---|---|---|
| Ingest | API → session → message queue | message created (201) |
| **Derive** | **queue → MiniMax structured output (the fixed path)** | **6 observations, 0 truncation** |
| Store | pgvector write, `(observer, observed)` keying | 6 conclusions persisted |
| Recall (vector) | TEI embeddings + HNSW semantic search | correct conclusion ranked #1 |
| Recall (agentic) | dialectic `/chat` MiniMax tool loop | correct natural-language answer |

Before the fix, the same deriver path produced truncated JSON → 0 observations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where third-party Anthropic-compatible endpoints could produce truncated or invalid JSON responses when using non-Claude models. This update significantly improves system reliability and response accuracy across different model implementations, ensuring more consistent behavior when working with compatible services and alternative providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->