### PR TITLE
fix(parser): handle empty or markdown-only LLM responses

### DIFF
--- a/src/utils/json_parser.py
+++ b/src/utils/json_parser.py
@@ -355,11 +355,26 @@ def simple_bracket_repair(json_str: str) -> str:
 def validate_and_repair_json(json_str: str) -> str:
     """Main function with comprehensive repair strategies"""
     raw = json_str.strip() if json_str else ""
-    # L1: Basic empty check
-    if not raw or not (raw.startswith("[") or raw.startswith("{") or raw.startswith("```")):
-        logger.info(f"[PARSER-GUARD] Non-JSON content detected, bypassing: {repr(raw)[:200]}...")
+    # Detect empty markdown fence-only responses (e.g. "```json\n```" or "``` ```")
+    empty_fence_only = bool(
+        re.fullmatch(
+            r"```(?:json)?\s*```",
+            raw,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+    )
+    if not raw or empty_fence_only:
+        logger.info("[PARSER-GUARD] Empty model output detected; returning []")
         return "[]"
-    
+    # Guard against non-JSON hallucinations (e.g. model returns pure-text explanation
+    # instead of structured output). Log a warning rather than swallowing silently.
+    if not (raw.startswith("[") or raw.startswith("{") or raw.startswith("```")):
+        logger.warning(
+            "[PARSER-GUARD] Non-JSON model output detected (length=%d); coercing to []",
+            len(raw),
+        )
+        return "[]"
+
     json_str = raw
 
     # Try parsing with repair library
@@ -377,7 +392,11 @@ def validate_and_repair_json(json_str: str) -> str:
         return repaired
 
     except json.JSONDecodeError as repair_error:
-        logger.error(f"❌ Repair failed: {repair_error}. RAW CONTENT: {repr(json_str)}")
+        logger.error(
+            "❌ Repair failed: %s (length=%d)",
+            repair_error,
+            len(json_str) if json_str else 0,
+        )
         raise ValueError(
             f"Could not repair JSON. Original error: {repair_error.msg}, "
             + f"Repair error: {repair_error.msg}"

--- a/src/utils/json_parser.py
+++ b/src/utils/json_parser.py
@@ -354,7 +354,13 @@ def simple_bracket_repair(json_str: str) -> str:
 
 def validate_and_repair_json(json_str: str) -> str:
     """Main function with comprehensive repair strategies"""
-    json_str = json_str.strip()
+    # Clean up empty strings or markdown empty blocks
+    cleaned = json_str.strip() if json_str else ""
+    cleaned = re.sub(r'^```json\s*```$', '', cleaned, flags=re.MULTILINE).strip()
+    if not cleaned or cleaned == '```' or cleaned == '``````':
+        return "[]"
+        
+    json_str = cleaned
 
     # Try parsing with repair library
     good_json = repair_json(json_str)

--- a/src/utils/json_parser.py
+++ b/src/utils/json_parser.py
@@ -370,7 +370,8 @@ def validate_and_repair_json(json_str: str) -> str:
     # instead of structured output). Log a warning rather than swallowing silently.
     if not (raw.startswith("[") or raw.startswith("{") or raw.startswith("```")):
         logger.warning(
-            "[PARSER-GUARD] Non-JSON model output detected (length=%d); coercing to []",
+            "[PARSER-GUARD] Non-JSON model output detected "
+            "(length=%d); coercing to []",
             len(raw),
         )
         return "[]"

--- a/src/utils/json_parser.py
+++ b/src/utils/json_parser.py
@@ -354,13 +354,13 @@ def simple_bracket_repair(json_str: str) -> str:
 
 def validate_and_repair_json(json_str: str) -> str:
     """Main function with comprehensive repair strategies"""
-    # Clean up empty strings or markdown empty blocks
-    cleaned = json_str.strip() if json_str else ""
-    cleaned = re.sub(r'^```json\s*```$', '', cleaned, flags=re.MULTILINE).strip()
-    if not cleaned or cleaned == '```' or cleaned == '``````':
+    raw = json_str.strip() if json_str else ""
+    # L1: Basic empty check
+    if not raw or not (raw.startswith("[") or raw.startswith("{") or raw.startswith("```")):
+        logger.info(f"[PARSER-GUARD] Non-JSON content detected, bypassing: {repr(raw)[:200]}...")
         return "[]"
-        
-    json_str = cleaned
+    
+    json_str = raw
 
     # Try parsing with repair library
     good_json = repair_json(json_str)
@@ -377,7 +377,7 @@ def validate_and_repair_json(json_str: str) -> str:
         return repaired
 
     except json.JSONDecodeError as repair_error:
-        logger.error(f"❌ Repair failed: {repair_error}")
+        logger.error(f"❌ Repair failed: {repair_error}. RAW CONTENT: {repr(json_str)}")
         raise ValueError(
             f"Could not repair JSON. Original error: {repair_error.msg}, "
             + f"Repair error: {repair_error.msg}"


### PR DESCRIPTION
When certain LLMs (like `gemini-3-flash` or other lightweight models) generate zero observations, they frequently drift from the required JSON schema. Instead of returning a valid empty JSON array `[]`, they often return:
1. Completely empty strings or pure whitespace.
2. Empty markdown code blocks (e.g., ```json\n```).
3. Pure-text hallucinated explanations (e.g., "*Based on the messages provided, there are no facts...*").

Previously, `validate_and_repair_json` would strip the string but then attempt to parse the invalid result, crashing with `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`.

**This PR:**
- Adds a pre-processing guard using `re.fullmatch` to intercept truly empty outputs (including empty markdown fences), gracefully returning `[]`.
- Intercepts non-JSON hallucinated text (outputs not starting with `[`, `{`, or ```) with a WARNING log, coercing to `[]` rather than silently swallowing or crashing.
- Replaces `repr()` with payload length in error logging to prevent PII (raw model outputs) from leaking into persistent logs on parse failures, addressing CodeRabbit review feedback.