### PR TITLE
fix: make deriver metrics port configurable via DERIVER_METRICS_PORT env var

### DIFF
--- a/src/deriver/__main__.py
+++ b/src/deriver/__main__.py
@@ -20,12 +20,13 @@ logger = logging.getLogger(__name__)
 
 
 def start_metrics_server() -> None:
-    """Start the Prometheus metrics HTTP server on port 9090."""
-    start_http_server(9090)
+    """Start the Prometheus metrics HTTP server."""
+    metrics_port = int(os.getenv("DERIVER_METRICS_PORT", "9090"))
+    start_http_server(metrics_port)
     # Expose DB connection-pool stats for this deriver instance.
     register_db_pool_collector("deriver")
     register_db_query_instrumentation("deriver")
-    logger.info("Prometheus metrics server started on port 9090")
+    logger.info(f"Prometheus metrics server started on port {metrics_port}")
 
 
 def setup_logging():


### PR DESCRIPTION
## Problem

The deriver process hardcodes port 9090 for its Prometheus metrics server. In production deployments where Prometheus itself runs on 9090 (e.g., Eevee benchmarking platform), the deriver crashes on startup with `[Errno 98] Address already in use`, causing benchmark jobs to silently fail (timeout after 600s with 0 completed conversations).

## Fix

Make the port configurable via the `DERIVER_METRICS_PORT` environment variable, defaulting to 9090 for backward compatibility.

```python
metrics_port = int(os.getenv("DERIVER_METRICS_PORT", "9090"))
start_http_server(metrics_port)
```

## Usage

Set `DERIVER_METRICS_PORT=9091` (or any free port) in the environment when running the deriver alongside a Prometheus instance on 9090.

Minimal, surgical change — 4 lines modified, no restructuring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Prometheus metrics server port is now configurable via the `DERIVER_METRICS_PORT` environment variable, with a default of 9090.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->