### PR TITLE
feat: OpenAI OAuth device code flow (ChatGPT Plus / Codex)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,4 @@ grafana-data/
 
 # Claude Code addon stuff
 .omc
+secrets/

--- a/scripts/honcho_oauth_setup.py
+++ b/scripts/honcho_oauth_setup.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
-"""OAuth setup for Honcho using the OpenAI Codex CLI.
+"""OAuth setup for Honcho using the OpenAI ChatGPT Plus device code flow.
 
-The Codex CLI handles the browser-based OAuth flow correctly (including
-Cloudflare challenges on auth.openai.com).  This script delegates
-authentication to it, then reads the resulting refresh token and prints
-the .env snippet to add.
+Opens a browser-based login at auth.openai.com/codex/device, polls for
+authorization, exchanges the code for tokens, and prints the .env snippet
+to add.
 
-Requirements:
-    Install the Codex CLI via snap:     sudo snap install codex
-    Or via npm:                         npm install -g @openai/codex
+Requirements: Python 3.11+ with httpx (already a Honcho dependency).
 
 Usage:
     uv run python scripts/honcho_oauth_setup.py
@@ -16,144 +13,150 @@ Usage:
 
 from __future__ import annotations
 
-import json
-import os
-import shutil
-import subprocess
 import sys
-from pathlib import Path
+import time
+import webbrowser
+
+import httpx
+
+_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+_DEVICE_CODE_URL = "https://auth.openai.com/api/accounts/deviceauth/usercode"
+_POLL_URL = "https://auth.openai.com/api/accounts/deviceauth/token"
+_TOKEN_URL = "https://auth.openai.com/oauth/token"
+_REDIRECT_URI = "https://auth.openai.com/deviceauth/callback"
+_AUTH_PAGE = "https://auth.openai.com/codex/device"
+_MAX_POLL_SECONDS = 900  # 15 minutes
 
 
-# Locations where the Codex CLI stores its auth file, in preference order.
-# The snap revision directory (e.g. ~/snap/codex/34/) is discovered at runtime.
-_AUTH_FILE_CANDIDATES: list[Path] = [
-    Path.home() / ".codex" / "auth.json",
-]
-
-
-def _find_snap_auth_file() -> Path | None:
-    """Return the auth.json from the active snap revision, if present."""
-    snap_base = Path.home() / "snap" / "codex"
-    if not snap_base.exists():
-        return None
-    # Each revision is a numeric subdirectory; pick the highest (newest).
-    revisions = sorted(
-        (d for d in snap_base.iterdir() if d.name.isdigit()),
-        key=lambda d: int(d.name),
-        reverse=True,
+def _request_device_code(client: httpx.Client) -> tuple[str, str, int]:
+    """Return (device_auth_id, user_code, poll_interval_seconds)."""
+    resp = client.post(_DEVICE_CODE_URL, json={"client_id": _CLIENT_ID})
+    resp.raise_for_status()
+    data = resp.json()
+    return (
+        data["device_auth_id"],
+        data["user_code"],
+        max(int(data.get("interval", 5)), 3),
     )
-    for rev in revisions:
-        candidate = rev / "auth.json"
-        if candidate.exists():
-            return candidate
-    return None
 
 
-def _find_auth_file() -> Path | None:
-    snap = _find_snap_auth_file()
-    if snap:
-        return snap
-    for candidate in _AUTH_FILE_CANDIDATES:
-        if candidate.exists():
-            return candidate
-    return None
+def _poll_for_auth_code(
+    client: httpx.Client,
+    device_auth_id: str,
+    user_code: str,
+    interval: int,
+) -> tuple[str, str]:
+    """Poll until the user completes login.
 
-
-def _read_refresh_token(auth_file: Path) -> str:
-    data = json.loads(auth_file.read_text())
-    token: str = data.get("tokens", {}).get("refresh_token", "")
-    if not token:
-        print(f"No refresh_token found in {auth_file}")
-        print("File contents:", json.dumps(data, indent=2)[:500])
-        sys.exit(1)
-    return token
-
-
-def _codex_is_installed() -> bool:
-    return shutil.which("codex") is not None
-
-
-def _codex_login_status() -> bool:
-    """Return True if Codex reports being logged in."""
-    result = subprocess.run(
-        ["codex", "login", "status"],
-        capture_output=True,
-        text=True,
+    Returns (authorization_code, code_verifier) provided by the server.
+    """
+    deadline = time.time() + _MAX_POLL_SECONDS
+    dots = 0
+    while time.time() < deadline:
+        time.sleep(interval)
+        resp = client.post(
+            _POLL_URL,
+            json={"device_auth_id": device_auth_id, "user_code": user_code},
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            return data["authorization_code"], data["code_verifier"]
+        # 403/404 means still pending — keep waiting
+        dots = (dots + 1) % 4
+        print(f"\rWaiting for browser login{'.' * dots}   ", end="", flush=True)
+    raise TimeoutError(
+        f"No login detected after {_MAX_POLL_SECONDS // 60} minutes. "
+        "Please run the script again."
     )
-    return result.returncode == 0
 
 
-def _run_codex_device_auth() -> None:
-    """Invoke `codex login --device-auth` interactively (inherits stdin/stdout)."""
-    print("Running: codex login --device-auth")
-    print()
-    result = subprocess.run(["codex", "login", "--device-auth"])
-    if result.returncode != 0:
-        print("\ncodex login failed. Please run it manually and try again.")
-        sys.exit(1)
+def _exchange_code(
+    client: httpx.Client,
+    authorization_code: str,
+    code_verifier: str,
+) -> str:
+    """Exchange authorization_code for a refresh token."""
+    resp = client.post(
+        _TOKEN_URL,
+        data={
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": _REDIRECT_URI,
+            "client_id": _CLIENT_ID,
+            "code_verifier": code_verifier,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    refresh_token: str = data["refresh_token"]
+    return refresh_token
 
 
 def main() -> None:
     print()
     print("=" * 60)
-    print("  Honcho OAuth Setup (via OpenAI Codex CLI)")
+    print("  Honcho OAuth Setup (ChatGPT Plus / Codex)")
     print("=" * 60)
     print()
 
-    # 1. Ensure Codex CLI is available.
-    if not _codex_is_installed():
-        print("The Codex CLI is not installed.")
-        print()
-        print("Install it with one of:")
-        print("  sudo snap install codex          # Ubuntu / Snap")
-        print("  npm install -g @openai/codex     # Node.js")
-        print()
-        print("Then re-run this script.")
-        sys.exit(1)
+    with httpx.Client(timeout=30.0) as client:
+        # Step 1: request a device code
+        try:
+            device_auth_id, user_code, interval = _request_device_code(client)
+        except httpx.HTTPStatusError as exc:
+            print(f"Failed to request device code: {exc}")
+            sys.exit(1)
 
-    # 2. Authenticate if needed.
-    auth_file = _find_auth_file()
-    if auth_file is None or not _codex_login_status():
-        print("You are not logged in to the Codex CLI.")
-        print("Starting device authentication — follow the prompts below.")
+        # Step 2: direct the user to the login page
+        print(f"Open this URL in your browser to log in with your ChatGPT Plus account:")
         print()
-        _run_codex_device_auth()
+        print(f"  {_AUTH_PAGE}")
         print()
-        auth_file = _find_auth_file()
+        print(f"When prompted, enter this code:  {user_code}")
+        print()
 
-    if auth_file is None:
-        print("Could not locate Codex auth file after login.")
-        print("Expected locations:")
-        print("  ~/.codex/auth.json")
-        print("  ~/snap/codex/<revision>/auth.json")
-        sys.exit(1)
+        opened = webbrowser.open(_AUTH_PAGE)
+        if opened:
+            print("(Browser opened automatically.)")
+        print()
 
-    # 3. Read the refresh token.
-    refresh_token = _read_refresh_token(auth_file)
+        # Step 3: poll for completion
+        try:
+            authorization_code, code_verifier = _poll_for_auth_code(
+                client, device_auth_id, user_code, interval
+            )
+        except (TimeoutError, httpx.HTTPStatusError, KeyError) as exc:
+            print(f"\nError waiting for login: {exc}")
+            sys.exit(1)
 
-    print(f"Found credentials: {auth_file}")
-    print()
+        print("\r" + " " * 50 + "\r", end="")  # clear waiting line
+        print("Login detected! Exchanging code for tokens...")
+        print()
+
+        # Step 4: exchange for refresh token
+        try:
+            refresh_token = _exchange_code(client, authorization_code, code_verifier)
+        except httpx.HTTPStatusError as exc:
+            print(f"Token exchange failed: {exc}\n{exc.response.text[:500]}")
+            sys.exit(1)
+
     print("=" * 60)
     print("  Authentication successful!")
     print("=" * 60)
     print()
     print("Add these lines to your .env file, then rebuild/restart Honcho:")
     print()
-    print("  # Remove or comment out LLM_OPENAI_API_KEY and LLM_OPENAI_BASE_URL")
-    print("  # (or keep them for OpenRouter fallback — see note below)")
     print("  LLM_OPENAI_AUTH_MODE=oauth")
     print(f"  LLM_OPENAI_REFRESH_TOKEN={refresh_token}")
     print()
-    print("NOTE: The OAuth token authenticates against api.openai.com (not")
-    print("OpenRouter).  If your model configs use OpenRouter-specific models")
-    print("(google/gemini-*, deepseek/*, etc.) via OVERRIDES__BASE_URL, those")
-    print("overrides continue to use their own base URL.  They will need an")
-    print("explicit API key (set OVERRIDES__API_KEY_ENV to an env var that")
-    print("holds your OpenRouter key) if you remove LLM_OPENAI_API_KEY.")
+    print("The OAuth client targets https://chatgpt.com/backend-api/codex")
+    print("(OpenAI Responses API, included with ChatGPT Plus — no API credits needed).")
     print()
-    print("For a fully OAuth-only setup, switch those models to OpenAI-native")
-    print("equivalents (gpt-4.1-mini, o3-mini, etc.) and remove the OpenRouter")
-    print("base URL overrides.")
+    print("NOTE: Model configs with an explicit OVERRIDES__BASE_URL still use")
+    print("that provider directly and need their own API key. To route a feature")
+    print("through ChatGPT Plus, remove its OVERRIDES__BASE_URL override and set")
+    print("its MODEL to a supported model (e.g. gpt-5.4-mini, gpt-4.1-mini).")
 
 
 if __name__ == "__main__":

--- a/scripts/honcho_oauth_setup.py
+++ b/scripts/honcho_oauth_setup.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Interactive OAuth setup for Honcho using the OpenAI device code flow (RFC 8628).
+
+Run this script once to authenticate with your ChatGPT / OpenAI Codex account
+and obtain a refresh token that Honcho can use to make LLM calls without a
+separate API key.
+
+Usage:
+    python scripts/honcho_oauth_setup.py
+
+After authenticating, add the printed values to your .env file and restart Honcho.
+"""
+
+import asyncio
+import sys
+
+import httpx
+
+_DEVICE_CODE_URL = "https://auth.openai.com/oauth/device/code"
+_TOKEN_URL = "https://auth.openai.com/oauth/token"
+_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+_SCOPES = "openid profile email offline_access"
+_AUDIENCE = "https://api.openai.com/v1"
+
+
+async def main() -> None:
+    async with httpx.AsyncClient() as client:
+        # Step 1: Request device and user codes.
+        resp = await client.post(
+            _DEVICE_CODE_URL,
+            data={
+                "client_id": _CLIENT_ID,
+                "scope": _SCOPES,
+                "audience": _AUDIENCE,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=30.0,
+        )
+        if resp.status_code != 200:
+            print(f"Error requesting device code: {resp.status_code} {resp.text}")
+            sys.exit(1)
+
+        device_data = resp.json()
+        device_code: str = device_data["device_code"]
+        user_code: str = device_data["user_code"]
+        verification_uri: str = device_data["verification_uri"]
+        interval: int = device_data.get("interval", 5)
+        expires_in: int = device_data.get("expires_in", 300)
+
+        print()
+        print("=" * 60)
+        print("  Honcho OAuth Setup")
+        print("=" * 60)
+        print()
+        print(f"  1. Open this URL in your browser:")
+        print(f"     {verification_uri}")
+        print()
+        print(f"  2. Enter this code when prompted:")
+        print(f"     {user_code}")
+        print()
+        print(f"  (Code expires in {expires_in // 60} minutes)")
+        print()
+        print("Waiting for authentication", end="", flush=True)
+
+        # Step 2: Poll the token endpoint until the user completes auth.
+        elapsed = 0
+        while elapsed < expires_in:
+            await asyncio.sleep(interval)
+            elapsed += interval
+
+            token_resp = await client.post(
+                _TOKEN_URL,
+                data={
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                    "device_code": device_code,
+                    "client_id": _CLIENT_ID,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=30.0,
+            )
+            token_data = token_resp.json()
+
+            if token_resp.status_code == 200:
+                refresh_token: str = token_data.get("refresh_token", "")
+                if not refresh_token:
+                    print()
+                    print()
+                    print("Authentication succeeded but no refresh token was returned.")
+                    print("Make sure the 'offline_access' scope is enabled for this client.")
+                    sys.exit(1)
+
+                print()
+                print()
+                print("=" * 60)
+                print("  Authentication successful!")
+                print("=" * 60)
+                print()
+                print("Add the following lines to your .env file, then restart Honcho:")
+                print()
+                print("  LLM_OPENAI_AUTH_MODE=oauth")
+                print(f"  LLM_OPENAI_REFRESH_TOKEN={refresh_token}")
+                print()
+                print("You can also unset LLM_OPENAI_API_KEY if you no longer need it.")
+                return
+
+            error = token_data.get("error", "unknown_error")
+            if error == "authorization_pending":
+                print(".", end="", flush=True)
+            elif error == "slow_down":
+                interval += 5
+                print(".", end="", flush=True)
+            elif error == "expired_token":
+                print()
+                print()
+                print("The device code expired. Please run this script again.")
+                sys.exit(1)
+            else:
+                print()
+                print()
+                description = token_data.get("error_description", "")
+                print(f"Authentication error: {error}")
+                if description:
+                    print(f"  {description}")
+                sys.exit(1)
+
+        print()
+        print()
+        print("Timed out waiting for authentication. Please run this script again.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/honcho_oauth_setup.py
+++ b/scripts/honcho_oauth_setup.py
@@ -109,7 +109,7 @@ def main() -> None:
             sys.exit(1)
 
         # Step 2: direct the user to the login page
-        print(f"Open this URL in your browser to log in with your ChatGPT Plus account:")
+        print("Open this URL in your browser to log in with your ChatGPT Plus account:")
         print()
         print(f"  {_AUTH_PAGE}")
         print()

--- a/scripts/honcho_oauth_setup.py
+++ b/scripts/honcho_oauth_setup.py
@@ -1,132 +1,199 @@
 #!/usr/bin/env python3
-"""Interactive OAuth setup for Honcho using the OpenAI device code flow (RFC 8628).
+"""OAuth setup for Honcho using PKCE authorization code flow (RFC 7636).
 
-Run this script once to authenticate with your ChatGPT / OpenAI Codex account
-and obtain a refresh token that Honcho can use to make LLM calls without a
-separate API key.
+The script:
+  1. Generates a PKCE challenge locally (no network call needed)
+  2. Prints the OpenAI authorization URL for you to open in a browser
+  3. Starts a local HTTP server on localhost to catch the redirect
+  4. Exchanges the authorization code for an access + refresh token
+  5. Prints the .env lines to add, then exits
 
 Usage:
-    python scripts/honcho_oauth_setup.py
-
-After authenticating, add the printed values to your .env file and restart Honcho.
+    uv run python scripts/honcho_oauth_setup.py
 """
 
+from __future__ import annotations
+
 import asyncio
+import base64
+import hashlib
+import http.server
+import os
+import secrets
 import sys
+import threading
+import urllib.parse
 
 import httpx
 
-_DEVICE_CODE_URL = "https://auth.openai.com/oauth/device/code"
-_TOKEN_URL = "https://auth.openai.com/oauth/token"
 _CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+_AUTH_URL = "https://auth.openai.com/authorize"
+_TOKEN_URL = "https://auth.openai.com/oauth/token"
 _SCOPES = "openid profile email offline_access"
 _AUDIENCE = "https://api.openai.com/v1"
+_REDIRECT_PORT = 54321
+_REDIRECT_URI = f"http://localhost:{_REDIRECT_PORT}/callback"
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = base64.urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode()
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()
+    ).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _build_auth_url(state: str, code_challenge: str) -> str:
+    return _AUTH_URL + "?" + urllib.parse.urlencode({
+        "response_type": "code",
+        "client_id": _CLIENT_ID,
+        "redirect_uri": _REDIRECT_URI,
+        "scope": _SCOPES,
+        "audience": _AUDIENCE,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    })
+
+
+# Shared result written by the HTTP handler, read by the async main loop.
+_auth_result: dict[str, str] = {}
+_auth_event = threading.Event()
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        parsed = urllib.parse.urlparse(self.path)
+        params = dict(urllib.parse.parse_qsl(parsed.query))
+
+        if "code" in params:
+            _auth_result["code"] = params["code"]
+            _auth_result["state"] = params.get("state", "")
+            html = (
+                b"<html><body style='font-family:sans-serif;padding:2rem'>"
+                b"<h2>&#x2705; Authentication successful</h2>"
+                b"<p>You can close this tab and return to the terminal.</p>"
+                b"</body></html>"
+            )
+        else:
+            error = params.get("error", "unknown_error")
+            desc = params.get("error_description", "")
+            _auth_result["error"] = error
+            _auth_result["error_description"] = desc
+            html = (
+                f"<html><body style='font-family:sans-serif;padding:2rem'>"
+                f"<h2>&#x274C; Authentication failed</h2>"
+                f"<p>{error}: {desc}</p>"
+                f"</body></html>"
+            ).encode()
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(html)
+        _auth_event.set()
+
+    def log_message(self, *_args: object) -> None:
+        pass  # suppress request logs
 
 
 async def main() -> None:
+    code_verifier, code_challenge = _pkce_pair()
+    state = secrets.token_urlsafe(16)
+    auth_url = _build_auth_url(state, code_challenge)
+
+    # Start the local redirect server before printing the URL so the port is
+    # ready by the time the browser follows the redirect.
+    try:
+        server = http.server.HTTPServer(("localhost", _REDIRECT_PORT), _CallbackHandler)
+    except OSError as exc:
+        print(f"Could not bind to localhost:{_REDIRECT_PORT}: {exc}")
+        print("Is another process using that port? Kill it and try again.")
+        sys.exit(1)
+
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    print()
+    print("=" * 60)
+    print("  Honcho OAuth Setup")
+    print("=" * 60)
+    print()
+    print("Open this URL in your browser to log in with your ChatGPT")
+    print("Plus / OpenAI Codex account:")
+    print()
+    print(f"  {auth_url}")
+    print()
+    print("After you log in the browser will redirect to localhost and")
+    print("this script will finish automatically.")
+    print()
+    print("Waiting for browser redirect", end="", flush=True)
+
+    # Poll until the callback handler fires, printing dots to show activity.
+    while not _auth_event.wait(timeout=1.0):
+        print(".", end="", flush=True)
+
+    server.shutdown()
+    print()
+
+    if "error" in _auth_result:
+        print()
+        print(f"Authentication failed: {_auth_result['error']}")
+        desc = _auth_result.get("error_description")
+        if desc:
+            print(f"  {desc}")
+        sys.exit(1)
+
+    if _auth_result.get("state") != state:
+        print()
+        print("State mismatch — possible CSRF. Aborting.")
+        sys.exit(1)
+
+    auth_code = _auth_result["code"]
+    print("Code received. Exchanging for tokens...", end="", flush=True)
+
     async with httpx.AsyncClient() as client:
-        # Step 1: Request device and user codes.
         resp = await client.post(
-            _DEVICE_CODE_URL,
+            _TOKEN_URL,
             data={
+                "grant_type": "authorization_code",
                 "client_id": _CLIENT_ID,
-                "scope": _SCOPES,
-                "audience": _AUDIENCE,
+                "code": auth_code,
+                "redirect_uri": _REDIRECT_URI,
+                "code_verifier": code_verifier,
             },
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             timeout=30.0,
         )
-        if resp.status_code != 200:
-            print(f"Error requesting device code: {resp.status_code} {resp.text}")
-            sys.exit(1)
 
-        device_data = resp.json()
-        device_code: str = device_data["device_code"]
-        user_code: str = device_data["user_code"]
-        verification_uri: str = device_data["verification_uri"]
-        interval: int = device_data.get("interval", 5)
-        expires_in: int = device_data.get("expires_in", 300)
-
+    if resp.status_code != 200:
         print()
-        print("=" * 60)
-        print("  Honcho OAuth Setup")
-        print("=" * 60)
-        print()
-        print(f"  1. Open this URL in your browser:")
-        print(f"     {verification_uri}")
-        print()
-        print(f"  2. Enter this code when prompted:")
-        print(f"     {user_code}")
-        print()
-        print(f"  (Code expires in {expires_in // 60} minutes)")
-        print()
-        print("Waiting for authentication", end="", flush=True)
-
-        # Step 2: Poll the token endpoint until the user completes auth.
-        elapsed = 0
-        while elapsed < expires_in:
-            await asyncio.sleep(interval)
-            elapsed += interval
-
-            token_resp = await client.post(
-                _TOKEN_URL,
-                data={
-                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-                    "device_code": device_code,
-                    "client_id": _CLIENT_ID,
-                },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-                timeout=30.0,
-            )
-            token_data = token_resp.json()
-
-            if token_resp.status_code == 200:
-                refresh_token: str = token_data.get("refresh_token", "")
-                if not refresh_token:
-                    print()
-                    print()
-                    print("Authentication succeeded but no refresh token was returned.")
-                    print("Make sure the 'offline_access' scope is enabled for this client.")
-                    sys.exit(1)
-
-                print()
-                print()
-                print("=" * 60)
-                print("  Authentication successful!")
-                print("=" * 60)
-                print()
-                print("Add the following lines to your .env file, then restart Honcho:")
-                print()
-                print("  LLM_OPENAI_AUTH_MODE=oauth")
-                print(f"  LLM_OPENAI_REFRESH_TOKEN={refresh_token}")
-                print()
-                print("You can also unset LLM_OPENAI_API_KEY if you no longer need it.")
-                return
-
-            error = token_data.get("error", "unknown_error")
-            if error == "authorization_pending":
-                print(".", end="", flush=True)
-            elif error == "slow_down":
-                interval += 5
-                print(".", end="", flush=True)
-            elif error == "expired_token":
-                print()
-                print()
-                print("The device code expired. Please run this script again.")
-                sys.exit(1)
-            else:
-                print()
-                print()
-                description = token_data.get("error_description", "")
-                print(f"Authentication error: {error}")
-                if description:
-                    print(f"  {description}")
-                sys.exit(1)
-
-        print()
-        print()
-        print("Timed out waiting for authentication. Please run this script again.")
+        print(f"Token exchange failed ({resp.status_code}):")
+        print(resp.text[:500])
         sys.exit(1)
+
+    data = resp.json()
+    refresh_token: str = data.get("refresh_token", "")
+
+    if not refresh_token:
+        print()
+        print("Token exchange succeeded but no refresh_token was returned.")
+        print("The 'offline_access' scope may not be enabled for this client.")
+        print(f"Response keys: {list(data.keys())}")
+        sys.exit(1)
+
+    print(" done.")
+    print()
+    print("=" * 60)
+    print("  Authentication successful!")
+    print("=" * 60)
+    print()
+    print("Add these lines to your .env file, then rebuild/restart Honcho:")
+    print()
+    print("  LLM_OPENAI_AUTH_MODE=oauth")
+    print(f"  LLM_OPENAI_REFRESH_TOKEN={refresh_token}")
+    print()
+    print("You can remove LLM_OPENAI_API_KEY once you've confirmed OAuth works.")
 
 
 if __name__ == "__main__":

--- a/scripts/honcho_oauth_setup.py
+++ b/scripts/honcho_oauth_setup.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-"""OAuth setup for Honcho using PKCE authorization code flow (RFC 7636).
+"""OAuth setup for Honcho using the OpenAI Codex CLI.
 
-The script:
-  1. Generates a PKCE challenge locally (no network call needed)
-  2. Prints the OpenAI authorization URL for you to open in a browser
-  3. Starts a local HTTP server on localhost to catch the redirect
-  4. Exchanges the authorization code for an access + refresh token
-  5. Prints the .env lines to add, then exits
+The Codex CLI handles the browser-based OAuth flow correctly (including
+Cloudflare challenges on auth.openai.com).  This script delegates
+authentication to it, then reads the resulting refresh token and prints
+the .env snippet to add.
+
+Requirements:
+    Install the Codex CLI via snap:     sudo snap install codex
+    Or via npm:                         npm install -g @openai/codex
 
 Usage:
     uv run python scripts/honcho_oauth_setup.py
@@ -14,175 +16,122 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
-import base64
-import hashlib
-import http.server
+import json
 import os
-import secrets
+import shutil
+import subprocess
 import sys
-import threading
-import urllib.parse
-
-import httpx
-
-_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
-_AUTH_URL = "https://auth.openai.com/authorize"
-_TOKEN_URL = "https://auth.openai.com/oauth/token"
-_SCOPES = "openid profile email offline_access"
-_AUDIENCE = "https://api.openai.com/v1"
-_REDIRECT_PORT = 54321
-_REDIRECT_URI = f"http://localhost:{_REDIRECT_PORT}/callback"
+from pathlib import Path
 
 
-def _pkce_pair() -> tuple[str, str]:
-    verifier = base64.urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode()
-    challenge = base64.urlsafe_b64encode(
-        hashlib.sha256(verifier.encode()).digest()
-    ).rstrip(b"=").decode()
-    return verifier, challenge
+# Locations where the Codex CLI stores its auth file, in preference order.
+# The snap revision directory (e.g. ~/snap/codex/34/) is discovered at runtime.
+_AUTH_FILE_CANDIDATES: list[Path] = [
+    Path.home() / ".codex" / "auth.json",
+]
 
 
-def _build_auth_url(state: str, code_challenge: str) -> str:
-    return _AUTH_URL + "?" + urllib.parse.urlencode({
-        "response_type": "code",
-        "client_id": _CLIENT_ID,
-        "redirect_uri": _REDIRECT_URI,
-        "scope": _SCOPES,
-        "audience": _AUDIENCE,
-        "state": state,
-        "code_challenge": code_challenge,
-        "code_challenge_method": "S256",
-    })
+def _find_snap_auth_file() -> Path | None:
+    """Return the auth.json from the active snap revision, if present."""
+    snap_base = Path.home() / "snap" / "codex"
+    if not snap_base.exists():
+        return None
+    # Each revision is a numeric subdirectory; pick the highest (newest).
+    revisions = sorted(
+        (d for d in snap_base.iterdir() if d.name.isdigit()),
+        key=lambda d: int(d.name),
+        reverse=True,
+    )
+    for rev in revisions:
+        candidate = rev / "auth.json"
+        if candidate.exists():
+            return candidate
+    return None
 
 
-# Shared result written by the HTTP handler, read by the async main loop.
-_auth_result: dict[str, str] = {}
-_auth_event = threading.Event()
+def _find_auth_file() -> Path | None:
+    snap = _find_snap_auth_file()
+    if snap:
+        return snap
+    for candidate in _AUTH_FILE_CANDIDATES:
+        if candidate.exists():
+            return candidate
+    return None
 
 
-class _CallbackHandler(http.server.BaseHTTPRequestHandler):
-    def do_GET(self) -> None:
-        parsed = urllib.parse.urlparse(self.path)
-        params = dict(urllib.parse.parse_qsl(parsed.query))
-
-        if "code" in params:
-            _auth_result["code"] = params["code"]
-            _auth_result["state"] = params.get("state", "")
-            html = (
-                b"<html><body style='font-family:sans-serif;padding:2rem'>"
-                b"<h2>&#x2705; Authentication successful</h2>"
-                b"<p>You can close this tab and return to the terminal.</p>"
-                b"</body></html>"
-            )
-        else:
-            error = params.get("error", "unknown_error")
-            desc = params.get("error_description", "")
-            _auth_result["error"] = error
-            _auth_result["error_description"] = desc
-            html = (
-                f"<html><body style='font-family:sans-serif;padding:2rem'>"
-                f"<h2>&#x274C; Authentication failed</h2>"
-                f"<p>{error}: {desc}</p>"
-                f"</body></html>"
-            ).encode()
-
-        self.send_response(200)
-        self.send_header("Content-Type", "text/html")
-        self.end_headers()
-        self.wfile.write(html)
-        _auth_event.set()
-
-    def log_message(self, *_args: object) -> None:
-        pass  # suppress request logs
+def _read_refresh_token(auth_file: Path) -> str:
+    data = json.loads(auth_file.read_text())
+    token: str = data.get("tokens", {}).get("refresh_token", "")
+    if not token:
+        print(f"No refresh_token found in {auth_file}")
+        print("File contents:", json.dumps(data, indent=2)[:500])
+        sys.exit(1)
+    return token
 
 
-async def main() -> None:
-    code_verifier, code_challenge = _pkce_pair()
-    state = secrets.token_urlsafe(16)
-    auth_url = _build_auth_url(state, code_challenge)
+def _codex_is_installed() -> bool:
+    return shutil.which("codex") is not None
 
-    # Start the local redirect server before printing the URL so the port is
-    # ready by the time the browser follows the redirect.
-    try:
-        server = http.server.HTTPServer(("localhost", _REDIRECT_PORT), _CallbackHandler)
-    except OSError as exc:
-        print(f"Could not bind to localhost:{_REDIRECT_PORT}: {exc}")
-        print("Is another process using that port? Kill it and try again.")
+
+def _codex_login_status() -> bool:
+    """Return True if Codex reports being logged in."""
+    result = subprocess.run(
+        ["codex", "login", "status"],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _run_codex_device_auth() -> None:
+    """Invoke `codex login --device-auth` interactively (inherits stdin/stdout)."""
+    print("Running: codex login --device-auth")
+    print()
+    result = subprocess.run(["codex", "login", "--device-auth"])
+    if result.returncode != 0:
+        print("\ncodex login failed. Please run it manually and try again.")
         sys.exit(1)
 
-    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
-    server_thread.start()
 
+def main() -> None:
     print()
     print("=" * 60)
-    print("  Honcho OAuth Setup")
+    print("  Honcho OAuth Setup (via OpenAI Codex CLI)")
     print("=" * 60)
     print()
-    print("Open this URL in your browser to log in with your ChatGPT")
-    print("Plus / OpenAI Codex account:")
-    print()
-    print(f"  {auth_url}")
-    print()
-    print("After you log in the browser will redirect to localhost and")
-    print("this script will finish automatically.")
-    print()
-    print("Waiting for browser redirect", end="", flush=True)
 
-    # Poll until the callback handler fires, printing dots to show activity.
-    while not _auth_event.wait(timeout=1.0):
-        print(".", end="", flush=True)
-
-    server.shutdown()
-    print()
-
-    if "error" in _auth_result:
+    # 1. Ensure Codex CLI is available.
+    if not _codex_is_installed():
+        print("The Codex CLI is not installed.")
         print()
-        print(f"Authentication failed: {_auth_result['error']}")
-        desc = _auth_result.get("error_description")
-        if desc:
-            print(f"  {desc}")
+        print("Install it with one of:")
+        print("  sudo snap install codex          # Ubuntu / Snap")
+        print("  npm install -g @openai/codex     # Node.js")
+        print()
+        print("Then re-run this script.")
         sys.exit(1)
 
-    if _auth_result.get("state") != state:
+    # 2. Authenticate if needed.
+    auth_file = _find_auth_file()
+    if auth_file is None or not _codex_login_status():
+        print("You are not logged in to the Codex CLI.")
+        print("Starting device authentication — follow the prompts below.")
         print()
-        print("State mismatch — possible CSRF. Aborting.")
+        _run_codex_device_auth()
+        print()
+        auth_file = _find_auth_file()
+
+    if auth_file is None:
+        print("Could not locate Codex auth file after login.")
+        print("Expected locations:")
+        print("  ~/.codex/auth.json")
+        print("  ~/snap/codex/<revision>/auth.json")
         sys.exit(1)
 
-    auth_code = _auth_result["code"]
-    print("Code received. Exchanging for tokens...", end="", flush=True)
+    # 3. Read the refresh token.
+    refresh_token = _read_refresh_token(auth_file)
 
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            _TOKEN_URL,
-            data={
-                "grant_type": "authorization_code",
-                "client_id": _CLIENT_ID,
-                "code": auth_code,
-                "redirect_uri": _REDIRECT_URI,
-                "code_verifier": code_verifier,
-            },
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            timeout=30.0,
-        )
-
-    if resp.status_code != 200:
-        print()
-        print(f"Token exchange failed ({resp.status_code}):")
-        print(resp.text[:500])
-        sys.exit(1)
-
-    data = resp.json()
-    refresh_token: str = data.get("refresh_token", "")
-
-    if not refresh_token:
-        print()
-        print("Token exchange succeeded but no refresh_token was returned.")
-        print("The 'offline_access' scope may not be enabled for this client.")
-        print(f"Response keys: {list(data.keys())}")
-        sys.exit(1)
-
-    print(" done.")
+    print(f"Found credentials: {auth_file}")
     print()
     print("=" * 60)
     print("  Authentication successful!")
@@ -190,11 +139,22 @@ async def main() -> None:
     print()
     print("Add these lines to your .env file, then rebuild/restart Honcho:")
     print()
+    print("  # Remove or comment out LLM_OPENAI_API_KEY and LLM_OPENAI_BASE_URL")
+    print("  # (or keep them for OpenRouter fallback — see note below)")
     print("  LLM_OPENAI_AUTH_MODE=oauth")
     print(f"  LLM_OPENAI_REFRESH_TOKEN={refresh_token}")
     print()
-    print("You can remove LLM_OPENAI_API_KEY once you've confirmed OAuth works.")
+    print("NOTE: The OAuth token authenticates against api.openai.com (not")
+    print("OpenRouter).  If your model configs use OpenRouter-specific models")
+    print("(google/gemini-*, deepseek/*, etc.) via OVERRIDES__BASE_URL, those")
+    print("overrides continue to use their own base URL.  They will need an")
+    print("explicit API key (set OVERRIDES__API_KEY_ENV to an env var that")
+    print("holds your OpenRouter key) if you remove LLM_OPENAI_API_KEY.")
+    print()
+    print("For a fully OAuth-only setup, switch those models to OpenAI-native")
+    print("equivalents (gpt-4.1-mini, o3-mini, etc.) and remove the OpenRouter")
+    print("base URL overrides.")
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/src/config.py
+++ b/src/config.py
@@ -723,6 +723,11 @@ class LLMSettings(HonchoSettings):
     OPENAI_AUTH_MODE: Literal["api_key", "oauth"] = "api_key"
     OPENAI_REFRESH_TOKEN: str | None = None
     OPENAI_CLIENT_ID: str = "app_EMoamEEZ73f0CkXaXp7hrann"
+    # Base URL used when OPENAI_AUTH_MODE=oauth.  Defaults to the ChatGPT/Codex
+    # Responses API backend (included with ChatGPT Plus, no billing credits needed).
+    # The Responses API endpoint (/responses) on this host is not Cloudflare-protected
+    # and accepts standard OAuth bearer tokens from the Codex device code flow.
+    OPENAI_OAUTH_BASE_URL: str = "https://chatgpt.com/backend-api/codex"
 
     # General LLM settings
     DEFAULT_MAX_TOKENS: Annotated[int, Field(default=1000, gt=0, le=100_000)] = 2500

--- a/src/config.py
+++ b/src/config.py
@@ -722,6 +722,11 @@ class LLMSettings(HonchoSettings):
     # obtain a refresh token interactively.
     OPENAI_AUTH_MODE: Literal["api_key", "oauth"] = "api_key"
     OPENAI_REFRESH_TOKEN: str | None = None
+    # Path to a file that stores the current refresh token.  On startup the
+    # manager reads it (taking precedence over OPENAI_REFRESH_TOKEN when the file
+    # exists) so a previously rotated token survives container restarts.  On every
+    # rotation the manager writes the new token back to this file.
+    OPENAI_REFRESH_TOKEN_FILE: str | None = None
     OPENAI_CLIENT_ID: str = "app_EMoamEEZ73f0CkXaXp7hrann"
     # Base URL used when OPENAI_AUTH_MODE=oauth.  Defaults to the ChatGPT/Codex
     # Responses API backend (included with ChatGPT Plus, no billing credits needed).

--- a/src/config.py
+++ b/src/config.py
@@ -716,6 +716,14 @@ class LLMSettings(HonchoSettings):
     OPENAI_BASE_URL: str | None = None
     GEMINI_BASE_URL: str | None = None
 
+    # OpenAI OAuth settings (device code flow / refresh token).
+    # Set OPENAI_AUTH_MODE=oauth and supply OPENAI_REFRESH_TOKEN to use OAuth
+    # instead of a static API key.  Run `scripts/honcho_oauth_setup.py` to
+    # obtain a refresh token interactively.
+    OPENAI_AUTH_MODE: Literal["api_key", "oauth"] = "api_key"
+    OPENAI_REFRESH_TOKEN: str | None = None
+    OPENAI_CLIENT_ID: str = "app_EMoamEEZ73f0CkXaXp7hrann"
+
     # General LLM settings
     DEFAULT_MAX_TOKENS: Annotated[int, Field(default=1000, gt=0, le=100_000)] = 2500
 

--- a/src/deriver/__main__.py
+++ b/src/deriver/__main__.py
@@ -84,6 +84,10 @@ async def run_deriver():
     finally:
         if oauth_refresh_task is not None:
             oauth_refresh_task.cancel()
+            try:
+                await oauth_refresh_task
+            except asyncio.CancelledError:
+                pass
         # Shutdown telemetry (flush CloudEvents buffer)
         await shutdown_telemetry()
 

--- a/src/deriver/__main__.py
+++ b/src/deriver/__main__.py
@@ -7,6 +7,7 @@ from prometheus_client import start_http_server
 
 from src.config import settings
 from src.db import engine, register_db_query_instrumentation
+from src.llm.registry import initialize_oauth
 from src.startup import validate_embedding_schema
 from src.telemetry import (
     initialize_telemetry_async,
@@ -66,13 +67,23 @@ async def run_deriver():
     # Initialize async telemetry (CloudEvents emitter)
     await initialize_telemetry_async()
 
+    oauth_refresh_task: asyncio.Task[None] | None = None
+
     try:
         # Fail fast if the embedding schema does not match settings — same
         # gate the API runs in its lifespan. Inside the try block so the
         # telemetry buffer is still flushed if validation raises.
         await validate_embedding_schema(engine)
+
+        # Initialize OAuth token manager if configured; start background refresh.
+        oauth_manager = await initialize_oauth()
+        if oauth_manager is not None:
+            oauth_refresh_task = asyncio.create_task(oauth_manager.run_refresh_loop())
+
         await main()
     finally:
+        if oauth_refresh_task is not None:
+            oauth_refresh_task.cancel()
         # Shutdown telemetry (flush CloudEvents buffer)
         await shutdown_telemetry()
 

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -11,6 +11,7 @@ from .api import honcho_llm_call
 from .backend import CompletionResult, ProviderBackend, StreamChunk, ToolCallResult
 from .credentials import default_transport_api_key, resolve_credentials
 from .executor import honcho_llm_call_inner
+from .oauth import OAuthOpenAI, OAuthTokenManager
 from .registry import (
     CLIENTS,
     backend_for_provider,
@@ -23,6 +24,7 @@ from .registry import (
     get_openai_client,
     get_openai_override_client,
     history_adapter_for_provider,
+    initialize_oauth,
 )
 from .types import (
     HonchoLLMCallResponse,
@@ -42,6 +44,8 @@ __all__ = [
     "HonchoLLMCallStreamChunk",
     "IterationCallback",
     "IterationData",
+    "OAuthOpenAI",
+    "OAuthTokenManager",
     "ProviderBackend",
     "ProviderClient",
     "ReasoningEffortType",
@@ -62,5 +66,6 @@ __all__ = [
     "history_adapter_for_provider",
     "honcho_llm_call",
     "honcho_llm_call_inner",
+    "initialize_oauth",
     "resolve_credentials",
 ]

--- a/src/llm/backends/openai_responses.py
+++ b/src/llm/backends/openai_responses.py
@@ -42,6 +42,9 @@ def _enforce_strict_schema(schema: dict[str, Any]) -> dict[str, Any]:
                 k: _enforce_strict_schema(v)
                 for k, v in schema["properties"].items()
             }
+            # Strict mode requires every property key to appear in required.
+            # Optional fields use anyOf [..., null] so they can still be null.
+            schema["required"] = list(schema["properties"].keys())
     if "$defs" in schema:
         schema["$defs"] = {
             k: _enforce_strict_schema(v)

--- a/src/llm/backends/openai_responses.py
+++ b/src/llm/backends/openai_responses.py
@@ -28,6 +28,30 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _enforce_strict_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively add additionalProperties: false to all object types.
+
+    The Responses API strict mode requires this on every object in the schema;
+    Pydantic's model_json_schema() does not include it by default.
+    """
+    schema = dict(schema)
+    if schema.get("type") == "object":
+        schema["additionalProperties"] = False
+        if "properties" in schema:
+            schema["properties"] = {
+                k: _enforce_strict_schema(v)
+                for k, v in schema["properties"].items()
+            }
+    if "$defs" in schema:
+        schema["$defs"] = {
+            k: _enforce_strict_schema(v)
+            for k, v in schema["$defs"].items()
+        }
+    if "items" in schema:
+        schema["items"] = _enforce_strict_schema(schema["items"])
+    return schema
+
+
 def _content_to_str(content: Any) -> str:
     if content is None:
         return ""
@@ -335,7 +359,9 @@ class OpenAIResponsesBackend:
                     "format": {
                         "type": "json_schema",
                         "name": response_format.__name__,
-                        "schema": response_format.model_json_schema(),
+                        "schema": _enforce_strict_schema(
+                            response_format.model_json_schema()
+                        ),
                         "strict": True,
                     }
                 }

--- a/src/llm/backends/openai_responses.py
+++ b/src/llm/backends/openai_responses.py
@@ -1,0 +1,377 @@
+"""OpenAI Responses API backend for ChatGPT Plus / Codex OAuth.
+
+Calls https://chatgpt.com/backend-api/codex/responses using an OAuth bearer
+token from an OAuthTokenManager.  The endpoint differs from the standard
+OpenAI Chat Completions API in three ways:
+  - Always streams (stream=True is required)
+  - Stateless (store=False required)
+  - Uses the Responses API wire format (instructions + input instead of messages)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+from pydantic import BaseModel
+
+from src.llm.backend import CompletionResult, StreamChunk, ToolCallResult
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Message / tool format translation helpers
+# ---------------------------------------------------------------------------
+
+
+def _content_to_str(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "".join(parts)
+    return str(content)
+
+
+def _split_messages(
+    messages: list[dict[str, Any]],
+) -> tuple[str, list[dict[str, Any]]]:
+    """Convert Chat Completions messages to Responses API (instructions, input).
+
+    - system → instructions (concatenated)
+    - assistant with tool_calls → function_call input items
+    - tool results → function_call_output input items
+    - user/assistant text → kept as role+content items
+    """
+    instruction_parts: list[str] = []
+    input_items: list[dict[str, Any]] = []
+
+    for msg in messages:
+        role = msg.get("role", "")
+        content = msg.get("content")
+
+        if role == "system":
+            text = _content_to_str(content)
+            if text:
+                instruction_parts.append(text)
+
+        elif role == "assistant":
+            tool_calls = msg.get("tool_calls")
+            if tool_calls:
+                if content:
+                    text = _content_to_str(content)
+                    if text:
+                        input_items.append({"role": "assistant", "content": text})
+                for tc in tool_calls:
+                    input_items.append(
+                        {
+                            "type": "function_call",
+                            "call_id": tc["id"],
+                            "name": tc["function"]["name"],
+                            "arguments": tc["function"]["arguments"],
+                        }
+                    )
+            else:
+                input_items.append(
+                    {"role": "assistant", "content": _content_to_str(content)}
+                )
+
+        elif role == "tool":
+            input_items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": msg.get("tool_call_id", ""),
+                    "output": _content_to_str(content),
+                }
+            )
+
+        else:
+            input_items.append(
+                {"role": role, "content": _content_to_str(content)}
+            )
+
+    return "\n\n".join(instruction_parts), input_items
+
+
+def _convert_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert Honcho / Chat Completions tool defs to Responses API format.
+
+    Responses API puts name/description/parameters at the top level of the
+    tool object, unlike Chat Completions which nests them under "function".
+    """
+    result: list[dict[str, Any]] = []
+    for tool in tools:
+        if tool.get("type") == "function":
+            fn = tool.get("function", {})
+            result.append(
+                {
+                    "type": "function",
+                    "name": fn.get("name", ""),
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }
+            )
+        else:
+            # Anthropic-style (name/description/input_schema at top level)
+            result.append(
+                {
+                    "type": "function",
+                    "name": tool.get("name", ""),
+                    "description": tool.get("description", ""),
+                    "parameters": tool.get("input_schema", {}),
+                }
+            )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Backend
+# ---------------------------------------------------------------------------
+
+
+class OpenAIResponsesBackend:
+    """Provider backend for the ChatGPT Plus / Codex Responses API.
+
+    Requires an OAuthTokenManager for bearer-token refresh.  Makes direct
+    httpx calls so it controls the exact wire format; the standard OpenAI SDK
+    is not used here because /chat/completions is Cloudflare-protected on the
+    chatgpt.com host while /responses is not.
+    """
+
+    def __init__(self, token_manager: Any, base_url: str) -> None:
+        self._token_manager = token_manager
+        self._url = base_url.rstrip("/") + "/responses"
+
+    # ------------------------------------------------------------------
+    # ProviderBackend interface
+    # ------------------------------------------------------------------
+
+    async def complete(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        temperature: float | None = None,
+        stop: list[str] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        response_format: type[BaseModel] | dict[str, Any] | None = None,
+        thinking_budget_tokens: int | None = None,
+        thinking_effort: str | None = None,
+        max_output_tokens: int | None = None,
+        extra_params: dict[str, Any] | None = None,
+    ) -> CompletionResult:
+        body = self._build_body(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            thinking_effort=thinking_effort,
+        )
+
+        text_parts: list[str] = []
+        tool_calls: list[ToolCallResult] = []
+        input_tokens = 0
+        output_tokens = 0
+        finish_reason = "stop"
+        pending_fcs: dict[int, dict[str, Any]] = {}
+
+        async for event in self._iter_events(body):
+            etype = event.get("type", "")
+
+            if etype == "response.output_text.delta":
+                text_parts.append(event.get("delta", ""))
+
+            elif etype == "response.output_item.added":
+                item = event.get("item", {})
+                if item.get("type") == "function_call":
+                    idx = event.get("output_index", 0)
+                    pending_fcs[idx] = {
+                        "id": item.get("call_id") or item.get("id", ""),
+                        "name": item.get("name", ""),
+                        "arguments": item.get("arguments", ""),
+                    }
+
+            elif etype == "response.function_call_arguments.delta":
+                idx = event.get("output_index", 0)
+                if idx in pending_fcs:
+                    pending_fcs[idx]["arguments"] += event.get("delta", "")
+
+            elif etype == "response.output_item.done":
+                item = event.get("item", {})
+                if item.get("type") == "function_call":
+                    idx = event.get("output_index", 0)
+                    fc = pending_fcs.pop(idx, None)
+                    if fc:
+                        args_str = fc["arguments"] or item.get("arguments", "")
+                        try:
+                            args: dict[str, Any] = (
+                                json.loads(args_str) if args_str else {}
+                            )
+                        except json.JSONDecodeError:
+                            args = {}
+                        tool_calls.append(
+                            ToolCallResult(id=fc["id"], name=fc["name"], input=args)
+                        )
+                        finish_reason = "tool_calls"
+
+            elif etype == "response.completed":
+                usage = (event.get("response") or {}).get("usage") or {}
+                input_tokens = usage.get("input_tokens", 0)
+                output_tokens = usage.get("output_tokens", 0)
+
+            elif etype == "response.failed":
+                error = (event.get("response") or {}).get("error") or {}
+                raise RuntimeError(
+                    f"Codex Responses API error: {error.get('message', event)}"
+                )
+
+        content: Any = "".join(text_parts)
+        if response_format is not None and isinstance(response_format, type):
+            try:
+                content = response_format.model_validate_json(content)
+            except Exception:
+                pass  # caller's repair logic handles raw string
+
+        return CompletionResult(
+            content=content,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            finish_reason=finish_reason,
+            tool_calls=tool_calls,
+        )
+
+    async def stream(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        temperature: float | None = None,
+        stop: list[str] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        response_format: type[BaseModel] | dict[str, Any] | None = None,
+        thinking_budget_tokens: int | None = None,
+        thinking_effort: str | None = None,
+        max_output_tokens: int | None = None,
+        extra_params: dict[str, Any] | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        body = self._build_body(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            thinking_effort=thinking_effort,
+        )
+
+        output_tokens = 0
+
+        async for event in self._iter_events(body):
+            etype = event.get("type", "")
+            if etype == "response.output_text.delta":
+                yield StreamChunk(content=event.get("delta", ""))
+            elif etype == "response.completed":
+                usage = (event.get("response") or {}).get("usage") or {}
+                output_tokens = usage.get("output_tokens", 0)
+            elif etype == "response.failed":
+                error = (event.get("response") or {}).get("error") or {}
+                raise RuntimeError(
+                    f"Codex Responses API error: {error.get('message', event)}"
+                )
+
+        yield StreamChunk(is_done=True, finish_reason="stop", output_tokens=output_tokens)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_body(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]],
+        temperature: float | None,
+        tools: list[dict[str, Any]] | None,
+        tool_choice: str | dict[str, Any] | None,
+        response_format: type[BaseModel] | dict[str, Any] | None,
+        thinking_effort: str | None,
+    ) -> dict[str, Any]:
+        instructions, input_items = _split_messages(messages)
+        body: dict[str, Any] = {
+            "model": model,
+            "instructions": instructions,
+            "input": input_items,
+            "stream": True,
+            "store": False,
+        }
+        if temperature is not None:
+            body["temperature"] = temperature
+        if tools:
+            body["tools"] = _convert_tools(tools)
+            if tool_choice is not None:
+                body["tool_choice"] = tool_choice
+        if thinking_effort:
+            body["reasoning"] = {"effort": thinking_effort}
+        if response_format is not None:
+            if isinstance(response_format, type):
+                body["text"] = {
+                    "format": {
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": response_format.__name__,
+                            "schema": response_format.model_json_schema(),
+                            "strict": True,
+                        },
+                    }
+                }
+            elif isinstance(response_format, dict):
+                fmt_type = response_format.get("type")
+                if fmt_type in ("json_object", "json_schema"):
+                    body["text"] = {"format": response_format}
+        return body
+
+    async def _iter_events(
+        self, body: dict[str, Any]
+    ) -> AsyncIterator[dict[str, Any]]:
+        await self._token_manager.refresh_if_needed()
+        headers = {
+            "Authorization": f"Bearer {self._token_manager.access_token}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=httpx.Timeout(600.0)) as client:
+            async with client.stream(
+                "POST", self._url, json=body, headers=headers
+            ) as resp:
+                if not resp.is_success:
+                    await resp.aread()
+                    raise RuntimeError(
+                        f"Codex Responses API {resp.status_code}: {resp.text[:500]}"
+                    )
+                async for line in resp.aiter_lines():
+                    line = line.strip()
+                    if not line or not line.startswith("data: "):
+                        continue
+                    data_str = line[6:]
+                    if data_str == "[DONE]":
+                        return
+                    try:
+                        yield json.loads(data_str)
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "Responses API: invalid JSON in SSE: %.100s", data_str
+                        )

--- a/src/llm/backends/openai_responses.py
+++ b/src/llm/backends/openai_responses.py
@@ -329,20 +329,31 @@ class OpenAIResponsesBackend:
             body["reasoning"] = {"effort": thinking_effort}
         if response_format is not None:
             if isinstance(response_format, type):
+                # Responses API: name/schema/strict are flat inside text.format,
+                # unlike Chat Completions which nests them under "json_schema".
                 body["text"] = {
                     "format": {
                         "type": "json_schema",
-                        "json_schema": {
-                            "name": response_format.__name__,
-                            "schema": response_format.model_json_schema(),
-                            "strict": True,
-                        },
+                        "name": response_format.__name__,
+                        "schema": response_format.model_json_schema(),
+                        "strict": True,
                     }
                 }
             elif isinstance(response_format, dict):
                 fmt_type = response_format.get("type")
-                if fmt_type in ("json_object", "json_schema"):
-                    body["text"] = {"format": response_format}
+                if fmt_type == "json_object":
+                    body["text"] = {"format": {"type": "json_object"}}
+                elif fmt_type == "json_schema":
+                    # Unwrap Chat Completions nesting if present
+                    nested = response_format.get("json_schema", response_format)
+                    body["text"] = {
+                        "format": {
+                            "type": "json_schema",
+                            "name": nested.get("name", "schema"),
+                            "schema": nested.get("schema", nested),
+                            "strict": nested.get("strict", True),
+                        }
+                    }
         return body
 
     async def _iter_events(

--- a/src/llm/oauth.py
+++ b/src/llm/oauth.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -38,7 +39,15 @@ class OAuthTokenManager:
         self,
         refresh_token: str,
         client_id: str = _DEFAULT_CLIENT_ID,
+        token_file: str | None = None,
     ) -> None:
+        self._token_file = Path(token_file) if token_file else None
+        # If a token file exists, it holds the most recently rotated token and
+        # takes precedence over the value passed in (which may be stale).
+        if self._token_file and self._token_file.exists():
+            stored = self._token_file.read_text().strip()
+            if stored:
+                refresh_token = stored
         self._refresh_token = refresh_token
         self._client_id = client_id
         self._access_token: str = ""
@@ -73,6 +82,12 @@ class OAuthTokenManager:
             ) from exc
         if "refresh_token" in data:
             self._refresh_token = data["refresh_token"]
+            if self._token_file is not None:
+                # Write atomically so a crash mid-write doesn't corrupt the file.
+                tmp = self._token_file.with_suffix(".tmp")
+                tmp.write_text(self._refresh_token)
+                tmp.replace(self._token_file)
+                logger.debug("Persisted rotated refresh token to %s", self._token_file)
         expires_in: int = data.get("expires_in", 600)
         self._expires_at = time.time() + expires_in
         logger.info(

--- a/src/llm/oauth.py
+++ b/src/llm/oauth.py
@@ -1,0 +1,111 @@
+"""OAuth token management for OpenAI-compatible providers.
+
+Implements RFC 8628 device code flow for initial authentication and
+automatic access-token refresh using a stored refresh token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+import httpx
+from openai import AsyncOpenAI
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_URL = "https://auth.openai.com/oauth/token"
+_DEVICE_CODE_URL = "https://auth.openai.com/oauth/device/code"
+_DEFAULT_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+_SCOPES = "openid profile email offline_access"
+_AUDIENCE = "https://api.openai.com/v1"
+
+# Refresh the token when fewer than this many seconds remain before expiry.
+_REFRESH_BUFFER_SECONDS = 300
+
+
+class OAuthTokenManager:
+    """Holds an OAuth access token and refreshes it automatically.
+
+    Instantiate once at startup (after calling ``refresh()`` to obtain the
+    initial token), then pass to ``OAuthOpenAI``.  A background task should
+    call ``run_refresh_loop()`` to keep the token alive.
+    """
+
+    def __init__(
+        self,
+        refresh_token: str,
+        client_id: str = _DEFAULT_CLIENT_ID,
+    ) -> None:
+        self._refresh_token = refresh_token
+        self._client_id = client_id
+        self._access_token: str = ""
+        self._expires_at: float = 0.0
+        self._lock = asyncio.Lock()
+
+    @property
+    def access_token(self) -> str:
+        return self._access_token
+
+    async def refresh(self) -> None:
+        """Exchange the refresh token for a new access token."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                _TOKEN_URL,
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": self._refresh_token,
+                    "client_id": self._client_id,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=30.0,
+            )
+            resp.raise_for_status()
+            data: dict[str, Any] = resp.json()
+
+        self._access_token = data["access_token"]
+        if "refresh_token" in data:
+            self._refresh_token = data["refresh_token"]
+        expires_in: int = data.get("expires_in", 600)
+        self._expires_at = time.time() + expires_in
+        logger.info(
+            "OAuth access token refreshed; expires in %ds", expires_in
+        )
+
+    async def refresh_if_needed(self) -> None:
+        """Refresh only when within the buffer window of expiry."""
+        if time.time() < self._expires_at - _REFRESH_BUFFER_SECONDS:
+            return
+        async with self._lock:
+            if time.time() < self._expires_at - _REFRESH_BUFFER_SECONDS:
+                return
+            await self.refresh()
+
+    async def run_refresh_loop(self) -> None:
+        """Background task: check every 60 seconds and refresh as needed."""
+        while True:
+            try:
+                await self.refresh_if_needed()
+            except Exception:
+                logger.exception("OAuth token refresh failed; will retry")
+            await asyncio.sleep(60)
+
+
+class OAuthOpenAI(AsyncOpenAI):
+    """AsyncOpenAI variant that reads its bearer token from an OAuthTokenManager.
+
+    The ``auth_headers`` property is evaluated per-request, so a single cached
+    instance automatically picks up refreshed tokens without cache invalidation.
+    """
+
+    def __init__(self, token_manager: OAuthTokenManager, **kwargs: Any) -> None:
+        # Pass a non-empty placeholder so the SDK does not raise at construction.
+        kwargs.setdefault("api_key", "__oauth__")
+        super().__init__(**kwargs)
+        self._token_manager = token_manager
+
+    @property
+    def auth_headers(self) -> dict[str, str]:  # type: ignore[override]
+        return {"Authorization": f"Bearer {self._token_manager.access_token}"}

--- a/src/llm/oauth.py
+++ b/src/llm/oauth.py
@@ -65,7 +65,12 @@ class OAuthTokenManager:
             resp.raise_for_status()
             data: dict[str, Any] = resp.json()
 
-        self._access_token = data["access_token"]
+        try:
+            self._access_token = data["access_token"]
+        except (KeyError, TypeError) as exc:
+            raise ValueError(
+                f"OAuth token response missing 'access_token': {data}"
+            ) from exc
         if "refresh_token" in data:
             self._refresh_token = data["refresh_token"]
         expires_in: int = data.get("expires_in", 600)

--- a/src/llm/oauth.py
+++ b/src/llm/oauth.py
@@ -96,8 +96,10 @@ class OAuthTokenManager:
 class OAuthOpenAI(AsyncOpenAI):
     """AsyncOpenAI variant that reads its bearer token from an OAuthTokenManager.
 
-    The ``auth_headers`` property is evaluated per-request, so a single cached
-    instance automatically picks up refreshed tokens without cache invalidation.
+    Both ``_bearer_auth`` (openai >= 2.x) and ``auth_headers`` (openai < 2.x)
+    are overridden so the correct hook is called regardless of SDK version.
+    The properties are evaluated per-request, so a single cached instance
+    automatically picks up refreshed tokens without cache invalidation.
     """
 
     def __init__(self, token_manager: OAuthTokenManager, **kwargs: Any) -> None:
@@ -107,5 +109,9 @@ class OAuthOpenAI(AsyncOpenAI):
         self._token_manager = token_manager
 
     @property
-    def auth_headers(self) -> dict[str, str]:  # type: ignore[override]
+    def _bearer_auth(self) -> dict[str, str]:  # openai >= 2.x
+        return {"Authorization": f"Bearer {self._token_manager.access_token}"}
+
+    @property
+    def auth_headers(self) -> dict[str, str]:  # type: ignore[override]  # openai < 2.x
         return {"Authorization": f"Bearer {self._token_manager.access_token}"}

--- a/src/llm/oauth.py
+++ b/src/llm/oauth.py
@@ -44,11 +44,8 @@ class OAuthTokenManager:
         self._token_file = Path(token_file) if token_file else None
         # If a token file exists, it holds the most recently rotated token and
         # takes precedence over the value passed in (which may be stale).
-        if self._token_file and self._token_file.exists():
-            stored = self._token_file.read_text().strip()
-            if stored:
-                refresh_token = stored
-        self._refresh_token = refresh_token
+        stored = self._read_token_file()
+        self._refresh_token = stored if stored else refresh_token
         self._client_id = client_id
         self._access_token: str = ""
         self._expires_at: float = 0.0
@@ -58,8 +55,25 @@ class OAuthTokenManager:
     def access_token(self) -> str:
         return self._access_token
 
+    def _read_token_file(self) -> str | None:
+        if self._token_file and self._token_file.exists():
+            stored = self._token_file.read_text().strip()
+            if stored:
+                return stored
+        return None
+
     async def refresh(self) -> None:
-        """Exchange the refresh token for a new access token."""
+        """Exchange the refresh token for a new access token.
+
+        Refresh tokens rotate on use, and multiple processes (API server,
+        deriver worker) each hold an independent in-memory copy while sharing
+        one token file. Re-reading the file here picks up a sibling's
+        already-rotated token instead of retrying one the auth server has
+        already invalidated.
+        """
+        stored = self._read_token_file()
+        if stored and stored != self._refresh_token:
+            self._refresh_token = stored
         async with httpx.AsyncClient() as client:
             resp = await client.post(
                 _TOKEN_URL,
@@ -90,9 +104,7 @@ class OAuthTokenManager:
                 logger.debug("Persisted rotated refresh token to %s", self._token_file)
         expires_in: int = data.get("expires_in", 600)
         self._expires_at = time.time() + expires_in
-        logger.info(
-            "OAuth access token refreshed; expires in %ds", expires_in
-        )
+        logger.info("OAuth access token refreshed; expires in %ds", expires_in)
 
     async def refresh_if_needed(self) -> None:
         """Refresh only when within the buffer window of expiry."""

--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -78,7 +78,12 @@ def get_openai_client() -> AsyncOpenAI:
     Returns an OAuthOpenAI instance when OPENAI_AUTH_MODE=oauth and
     initialize_oauth() has been called to populate _oauth_manager.
     """
-    if settings.LLM.OPENAI_AUTH_MODE == "oauth" and _oauth_manager is not None:
+    if settings.LLM.OPENAI_AUTH_MODE == "oauth":
+        if _oauth_manager is None:
+            raise RuntimeError(
+                "OAuth mode is enabled but initialize_oauth() has not been called. "
+                "Ensure the application lifespan has started before making LLM calls."
+            )
         # Pass base_url explicitly so the SDK does not read OPENAI_BASE_URL from
         # the environment (which may point to a proxy like OpenRouter).
         return OAuthOpenAI(

--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -30,6 +30,7 @@ from .history_adapters import (
     HistoryAdapter,
     OpenAIHistoryAdapter,
 )
+from .oauth import OAuthOpenAI, OAuthTokenManager
 from .types import ProviderClient
 
 # Client-level ``default_headers`` applied to OpenAI-compatible clients, keyed by
@@ -54,6 +55,11 @@ def _default_headers_for(base_url: str | None) -> dict[str, str]:
     return {}
 
 
+# Singleton OAuth manager — set by initialize_oauth() in the app lifespan.
+# None when OPENAI_AUTH_MODE=api_key (the default).
+_oauth_manager: OAuthTokenManager | None = None
+
+
 @lru_cache(maxsize=1)
 def get_anthropic_client() -> AsyncAnthropic:
     """Default Anthropic client built from settings.LLM.ANTHROPIC_API_KEY."""
@@ -66,7 +72,16 @@ def get_anthropic_client() -> AsyncAnthropic:
 
 @lru_cache(maxsize=1)
 def get_openai_client() -> AsyncOpenAI:
-    """Default OpenAI client built from settings.LLM.OPENAI_API_KEY."""
+    """Default OpenAI client built from settings.LLM.OPENAI_API_KEY.
+
+    Returns an OAuthOpenAI instance when OPENAI_AUTH_MODE=oauth and
+    initialize_oauth() has been called to populate _oauth_manager.
+    """
+    if settings.LLM.OPENAI_AUTH_MODE == "oauth" and _oauth_manager is not None:
+        return OAuthOpenAI(
+            token_manager=_oauth_manager,
+            base_url=settings.LLM.OPENAI_BASE_URL,
+        )
     return AsyncOpenAI(
         api_key=settings.LLM.OPENAI_API_KEY,
         base_url=settings.LLM.OPENAI_BASE_URL,
@@ -115,6 +130,41 @@ def get_gemini_override_client(
     """Gemini client for a specific (base_url, api_key) pair. Cached by key."""
     http_options = genai_types.HttpOptions(base_url=base_url) if base_url else None
     return genai.Client(api_key=api_key, http_options=http_options)
+
+
+async def initialize_oauth() -> OAuthTokenManager | None:
+    """Set up the OAuth token manager and wire it into CLIENTS.
+
+    Call once during application startup (lifespan / deriver main).  Returns
+    the manager so the caller can start the background refresh loop.  No-ops
+    and returns None when OPENAI_AUTH_MODE != "oauth".
+    """
+    global _oauth_manager
+
+    if settings.LLM.OPENAI_AUTH_MODE != "oauth":
+        return None
+
+    if not settings.LLM.OPENAI_REFRESH_TOKEN:
+        raise ValueError(
+            "LLM_OPENAI_REFRESH_TOKEN must be set when LLM_OPENAI_AUTH_MODE=oauth. "
+            "Run `python scripts/honcho_oauth_setup.py` to obtain one."
+        )
+
+    manager = OAuthTokenManager(
+        refresh_token=settings.LLM.OPENAI_REFRESH_TOKEN,
+        client_id=settings.LLM.OPENAI_CLIENT_ID,
+    )
+    await manager.refresh()
+    _oauth_manager = manager
+
+    CLIENTS["openai"] = OAuthOpenAI(
+        token_manager=manager,
+        base_url=settings.LLM.OPENAI_BASE_URL,
+    )
+    # Clear the lru_cache so get_openai_client() returns the OAuth variant.
+    get_openai_client.cache_clear()
+
+    return manager
 
 
 # Module-level default-client registry, populated at import time. Tests patch
@@ -214,6 +264,8 @@ def get_backend(config: ModelConfig) -> ProviderBackend:
 
 __all__ = [
     "CLIENTS",
+    "OAuthOpenAI",
+    "OAuthTokenManager",
     "backend_for_provider",
     "client_for_model_config",
     "get_anthropic_client",
@@ -224,4 +276,5 @@ __all__ = [
     "get_openai_client",
     "get_openai_override_client",
     "history_adapter_for_provider",
+    "initialize_oauth",
 ]

--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -161,6 +161,7 @@ async def initialize_oauth() -> OAuthTokenManager | None:
     manager = OAuthTokenManager(
         refresh_token=settings.LLM.OPENAI_REFRESH_TOKEN,
         client_id=settings.LLM.OPENAI_CLIENT_ID,
+        token_file=settings.LLM.OPENAI_REFRESH_TOKEN_FILE,
     )
     await manager.refresh()
     _oauth_manager = manager

--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -78,10 +78,10 @@ def get_openai_client() -> AsyncOpenAI:
     initialize_oauth() has been called to populate _oauth_manager.
     """
     if settings.LLM.OPENAI_AUTH_MODE == "oauth" and _oauth_manager is not None:
-        return OAuthOpenAI(
-            token_manager=_oauth_manager,
-            base_url=settings.LLM.OPENAI_BASE_URL,
-        )
+        # OAuth tokens are scoped to api.openai.com; ignore LLM_OPENAI_BASE_URL
+        # so proxy URLs (OpenRouter etc.) don't bleed into the OAuth client.
+        # Per-feature configs that need a proxy should set their own base_url override.
+        return OAuthOpenAI(token_manager=_oauth_manager)
     return AsyncOpenAI(
         api_key=settings.LLM.OPENAI_API_KEY,
         base_url=settings.LLM.OPENAI_BASE_URL,
@@ -157,10 +157,8 @@ async def initialize_oauth() -> OAuthTokenManager | None:
     await manager.refresh()
     _oauth_manager = manager
 
-    CLIENTS["openai"] = OAuthOpenAI(
-        token_manager=manager,
-        base_url=settings.LLM.OPENAI_BASE_URL,
-    )
+    # No base_url: OAuth tokens are for api.openai.com only.
+    CLIENTS["openai"] = OAuthOpenAI(token_manager=manager)
     # Clear the lru_cache so get_openai_client() returns the OAuth variant.
     get_openai_client.cache_clear()
 

--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -23,6 +23,7 @@ from .backend import ProviderBackend
 from .backends.anthropic import AnthropicBackend
 from .backends.gemini import GeminiBackend
 from .backends.openai import OpenAIBackend
+from .backends.openai_responses import OpenAIResponsesBackend
 from .credentials import default_transport_api_key
 from .history_adapters import (
     AnthropicHistoryAdapter,
@@ -78,12 +79,11 @@ def get_openai_client() -> AsyncOpenAI:
     initialize_oauth() has been called to populate _oauth_manager.
     """
     if settings.LLM.OPENAI_AUTH_MODE == "oauth" and _oauth_manager is not None:
-        # OAuth tokens are scoped to api.openai.com.  Pass the URL explicitly so
-        # the SDK does not read OPENAI_BASE_URL from the environment (which may
-        # point to a proxy like OpenRouter).
+        # Pass base_url explicitly so the SDK does not read OPENAI_BASE_URL from
+        # the environment (which may point to a proxy like OpenRouter).
         return OAuthOpenAI(
             token_manager=_oauth_manager,
-            base_url="https://api.openai.com/v1",
+            base_url=settings.LLM.OPENAI_OAUTH_BASE_URL,
         )
     return AsyncOpenAI(
         api_key=settings.LLM.OPENAI_API_KEY,
@@ -163,7 +163,7 @@ async def initialize_oauth() -> OAuthTokenManager | None:
     # Explicit base_url overrides OPENAI_BASE_URL env var (which may point to a proxy).
     CLIENTS["openai"] = OAuthOpenAI(
         token_manager=manager,
-        base_url="https://api.openai.com/v1",
+        base_url=settings.LLM.OPENAI_OAUTH_BASE_URL,
     )
     # Clear the lru_cache so get_openai_client() returns the OAuth variant.
     get_openai_client.cache_clear()
@@ -238,6 +238,16 @@ def backend_for_provider(
     if provider == "anthropic":
         return AnthropicBackend(client)
     if provider == "openai":
+        # OAuthOpenAI pointing at chatgpt.com/backend-api/codex uses the
+        # Responses API (/responses), which is not Cloudflare-blocked, instead
+        # of /chat/completions, which is.
+        if isinstance(client, OAuthOpenAI) and "chatgpt.com/backend-api" in str(
+            client.base_url
+        ):
+            return OpenAIResponsesBackend(
+                token_manager=client._token_manager,  # pyright: ignore[reportPrivateUsage]
+                base_url=str(client.base_url),
+            )
         return OpenAIBackend(client)
     if provider == "gemini":
         return GeminiBackend(client)

--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -78,10 +78,13 @@ def get_openai_client() -> AsyncOpenAI:
     initialize_oauth() has been called to populate _oauth_manager.
     """
     if settings.LLM.OPENAI_AUTH_MODE == "oauth" and _oauth_manager is not None:
-        # OAuth tokens are scoped to api.openai.com; ignore LLM_OPENAI_BASE_URL
-        # so proxy URLs (OpenRouter etc.) don't bleed into the OAuth client.
-        # Per-feature configs that need a proxy should set their own base_url override.
-        return OAuthOpenAI(token_manager=_oauth_manager)
+        # OAuth tokens are scoped to api.openai.com.  Pass the URL explicitly so
+        # the SDK does not read OPENAI_BASE_URL from the environment (which may
+        # point to a proxy like OpenRouter).
+        return OAuthOpenAI(
+            token_manager=_oauth_manager,
+            base_url="https://api.openai.com/v1",
+        )
     return AsyncOpenAI(
         api_key=settings.LLM.OPENAI_API_KEY,
         base_url=settings.LLM.OPENAI_BASE_URL,
@@ -157,8 +160,11 @@ async def initialize_oauth() -> OAuthTokenManager | None:
     await manager.refresh()
     _oauth_manager = manager
 
-    # No base_url: OAuth tokens are for api.openai.com only.
-    CLIENTS["openai"] = OAuthOpenAI(token_manager=manager)
+    # Explicit base_url overrides OPENAI_BASE_URL env var (which may point to a proxy).
+    CLIENTS["openai"] = OAuthOpenAI(
+        token_manager=manager,
+        base_url="https://api.openai.com/v1",
+    )
     # Clear the lru_cache so get_openai_client() returns the OAuth variant.
     get_openai_client.cache_clear()
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import re
 import time
@@ -22,6 +23,7 @@ from src.cache.client import close_cache, init_cache
 from src.config import settings
 from src.db import engine, register_db_query_instrumentation, request_context
 from src.exceptions import HonchoException
+from src.llm.registry import initialize_oauth
 from src.routers import (
     conclusions,
     keys,
@@ -149,9 +151,18 @@ async def lifespan(_: FastAPI):
             "Error initializing cache in api process; proceeding without cache: %s", e
         )
 
+    # Initialize OAuth token manager if configured; start background refresh.
+    oauth_manager = await initialize_oauth()
+    oauth_refresh_task: asyncio.Task[None] | None = None
+    if oauth_manager is not None:
+        oauth_refresh_task = asyncio.create_task(oauth_manager.run_refresh_loop())
+
     try:
         yield
     finally:
+        if oauth_refresh_task is not None:
+            oauth_refresh_task.cancel()
+
         # Import here to avoid circular import at module load time
         from src.vector_store import close_external_vector_store
 

--- a/src/main.py
+++ b/src/main.py
@@ -162,6 +162,10 @@ async def lifespan(_: FastAPI):
     finally:
         if oauth_refresh_task is not None:
             oauth_refresh_task.cancel()
+            try:
+                await oauth_refresh_task
+            except asyncio.CancelledError:
+                pass
 
         # Import here to avoid circular import at module load time
         from src.vector_store import close_external_vector_store

--- a/tests/llm/test_oauth.py
+++ b/tests/llm/test_oauth.py
@@ -168,12 +168,16 @@ def test_oauth_openai_auth_headers_reflects_current_token() -> None:
 
     openai_client = OAuthOpenAI(token_manager=manager, base_url="http://localhost/v1")
 
+    # auth_headers — openai < 2.x path
     assert openai_client.auth_headers == {"Authorization": "Bearer initial-token"}
+    # _bearer_auth — openai >= 2.x path
+    assert openai_client._bearer_auth == {"Authorization": "Bearer initial-token"}  # pyright: ignore[reportPrivateUsage]
 
-    # Simulate a token refresh.
+    # Simulate a token refresh — both properties must reflect the new token.
     manager._access_token = "refreshed-token"  # pyright: ignore[reportPrivateUsage]
 
     assert openai_client.auth_headers == {"Authorization": "Bearer refreshed-token"}
+    assert openai_client._bearer_auth == {"Authorization": "Bearer refreshed-token"}  # pyright: ignore[reportPrivateUsage]
 
 
 def test_oauth_openai_does_not_require_api_key_env_var() -> None:

--- a/tests/llm/test_oauth.py
+++ b/tests/llm/test_oauth.py
@@ -1,0 +1,185 @@
+"""Tests for src/llm/oauth.py — OAuthTokenManager and OAuthOpenAI."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.llm.oauth import OAuthOpenAI, OAuthTokenManager
+
+
+# ---------------------------------------------------------------------------
+# OAuthTokenManager
+# ---------------------------------------------------------------------------
+
+
+def _make_token_response(
+    access_token: str = "access-123",
+    expires_in: int = 600,
+    refresh_token: str | None = None,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "access_token": access_token,
+        "expires_in": expires_in,
+    }
+    if refresh_token is not None:
+        data["refresh_token"] = refresh_token
+    return data
+
+
+def _mock_httpx_post(response_data: dict[str, Any], status_code: int = 200) -> Any:
+    """Return an async context manager mock whose .post() returns a fake response."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = response_data
+    mock_resp.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    return mock_client
+
+
+@pytest.mark.asyncio
+async def test_refresh_updates_access_token() -> None:
+    manager = OAuthTokenManager(refresh_token="rt-abc", client_id="client-1")
+    assert manager.access_token == ""
+
+    with patch(
+        "src.llm.oauth.httpx.AsyncClient",
+        return_value=_mock_httpx_post(_make_token_response("new-token", 3600)),
+    ):
+        await manager.refresh()
+
+    assert manager.access_token == "new-token"
+
+
+@pytest.mark.asyncio
+async def test_refresh_updates_refresh_token_when_rotated() -> None:
+    manager = OAuthTokenManager(refresh_token="rt-old", client_id="client-1")
+
+    with patch(
+        "src.llm.oauth.httpx.AsyncClient",
+        return_value=_mock_httpx_post(
+            _make_token_response("tok", refresh_token="rt-new")
+        ),
+    ):
+        await manager.refresh()
+
+    # Access the private attribute to verify rotation.
+    assert manager._refresh_token == "rt-new"  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_refresh_if_needed_skips_when_token_is_fresh() -> None:
+    manager = OAuthTokenManager(refresh_token="rt-abc", client_id="client-1")
+    # Manually set a far-future expiry so the token appears fresh.
+    manager._access_token = "existing-token"  # pyright: ignore[reportPrivateUsage]
+    manager._expires_at = time.time() + 3600  # pyright: ignore[reportPrivateUsage]
+
+    mock_client = _mock_httpx_post(_make_token_response())
+    with patch("src.llm.oauth.httpx.AsyncClient", return_value=mock_client):
+        await manager.refresh_if_needed()
+
+    mock_client.post.assert_not_called()
+    assert manager.access_token == "existing-token"
+
+
+@pytest.mark.asyncio
+async def test_refresh_if_needed_refreshes_when_near_expiry() -> None:
+    manager = OAuthTokenManager(refresh_token="rt-abc", client_id="client-1")
+    manager._access_token = "old-token"  # pyright: ignore[reportPrivateUsage]
+    # Expire in 60 s — within the 300 s buffer.
+    manager._expires_at = time.time() + 60  # pyright: ignore[reportPrivateUsage]
+
+    with patch(
+        "src.llm.oauth.httpx.AsyncClient",
+        return_value=_mock_httpx_post(_make_token_response("refreshed-token")),
+    ):
+        await manager.refresh_if_needed()
+
+    assert manager.access_token == "refreshed-token"
+
+
+@pytest.mark.asyncio
+async def test_refresh_if_needed_is_race_safe() -> None:
+    """Concurrent refresh_if_needed calls should only trigger one HTTP request."""
+    manager = OAuthTokenManager(refresh_token="rt-abc", client_id="client-1")
+    # Expired token.
+    manager._expires_at = time.time() - 1  # pyright: ignore[reportPrivateUsage]
+
+    call_count = 0
+
+    async def fake_refresh() -> None:
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0)
+        manager._access_token = "token"  # pyright: ignore[reportPrivateUsage]
+        manager._expires_at = time.time() + 3600  # pyright: ignore[reportPrivateUsage]
+
+    with patch.object(manager, "refresh", side_effect=fake_refresh):
+        await asyncio.gather(
+            manager.refresh_if_needed(),
+            manager.refresh_if_needed(),
+            manager.refresh_if_needed(),
+        )
+
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_refresh_loop_calls_refresh_if_needed() -> None:
+    manager = OAuthTokenManager(refresh_token="rt-abc", client_id="client-1")
+    call_count = 0
+
+    async def fake_refresh_if_needed() -> None:
+        nonlocal call_count
+        call_count += 1
+
+    with patch.object(manager, "refresh_if_needed", side_effect=fake_refresh_if_needed):
+        with patch("src.llm.oauth.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            # Let the loop run for 2 iterations then cancel.
+            async def stop_after_two(*_: Any) -> None:
+                if call_count >= 2:
+                    raise asyncio.CancelledError
+
+            mock_sleep.side_effect = stop_after_two
+
+            with pytest.raises(asyncio.CancelledError):
+                await manager.run_refresh_loop()
+
+    assert call_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# OAuthOpenAI
+# ---------------------------------------------------------------------------
+
+
+def test_oauth_openai_auth_headers_reflects_current_token() -> None:
+    manager = OAuthTokenManager(refresh_token="rt-abc", client_id="client-1")
+    manager._access_token = "initial-token"  # pyright: ignore[reportPrivateUsage]
+
+    openai_client = OAuthOpenAI(token_manager=manager, base_url="http://localhost/v1")
+
+    assert openai_client.auth_headers == {"Authorization": "Bearer initial-token"}
+
+    # Simulate a token refresh.
+    manager._access_token = "refreshed-token"  # pyright: ignore[reportPrivateUsage]
+
+    assert openai_client.auth_headers == {"Authorization": "Bearer refreshed-token"}
+
+
+def test_oauth_openai_does_not_require_api_key_env_var() -> None:
+    """OAuthOpenAI must construct without a real api_key."""
+    manager = OAuthTokenManager(refresh_token="rt-abc", client_id="client-1")
+    manager._access_token = "tok"  # pyright: ignore[reportPrivateUsage]
+
+    client = OAuthOpenAI(token_manager=manager, base_url="https://api.openai.com/v1")
+    assert client is not None


### PR DESCRIPTION
## Summary

Adds OAuth authentication support for OpenAI using the device code flow, allowing Honcho to run LLM features against a **ChatGPT Plus subscription** instead of OpenAI API credits.

### Key insight: use the Responses API, not Chat Completions

The ChatGPT Plus OAuth token works against \`chatgpt.com/backend-api/codex/responses\` — the same endpoint used by the Codex CLI and Hermes. The \`/chat/completions\` endpoint on the same host is Cloudflare-protected for non-browser clients. \`api.openai.com/v1\` requires API billing credits that the ChatGPT Plus subscription does not include.

### Files changed

- **\`src/llm/oauth.py\`** — \`OAuthTokenManager\` manages refresh-token grant cycle with automatic background renewal; \`OAuthOpenAI\` subclasses \`AsyncOpenAI\` and overrides the bearer auth property to inject the live token per-request
- **\`src/llm/backends/openai_responses.py\`** *(new)* — direct \`httpx\` backend for the Responses API. Translates Honcho's Chat Completions message format to the Responses API wire format (\`instructions\` + \`input\` items), handles SSE streaming, tool calls via \`function_call\`/\`function_call_output\` items, and Pydantic structured output. Always sets \`stream: true\` and \`store: false\` as required by the endpoint.
- **\`src/llm/registry.py\`** — \`initialize_oauth()\` wires the token manager into \`CLIENTS["openai"]\`; \`backend_for_provider()\` routes \`OAuthOpenAI\` clients pointing at \`chatgpt.com/backend-api\` through \`OpenAIResponsesBackend\` instead of the standard OpenAI backend; uses \`settings.LLM.OPENAI_OAUTH_BASE_URL\`
- **\`src/config.py\`** — new \`LLMSettings\` fields: \`LLM_OPENAI_AUTH_MODE\` (\`api_key\` | \`oauth\`), \`LLM_OPENAI_REFRESH_TOKEN\`, \`LLM_OPENAI_CLIENT_ID\`, \`LLM_OPENAI_OAUTH_BASE_URL\` (default: \`https://chatgpt.com/backend-api/codex\`)
- **\`src/main.py\`** / **\`src/deriver/__main__.py\`** — call \`initialize_oauth()\` at startup and run the background token-refresh task for the process lifetime
- **\`scripts/honcho_oauth_setup.py\`** — self-contained device code setup script (no Codex CLI required). Drives the flow directly via \`httpx\`: POST \`/api/accounts/deviceauth/usercode\` → display code → poll \`/api/accounts/deviceauth/token\` → exchange at \`/oauth/token\`. The server generates and returns the \`code_verifier\` (non-standard; not client-side PKCE).
- **\`tests/llm/test_oauth.py\`** — unit tests covering token refresh, rotation, near-expiry detection, lock-based race safety, background loop, and bearer auth dynamic read

### Behavior

- Default behavior (\`LLM_OPENAI_AUTH_MODE=api_key\`) is unchanged — no OAuth code runs
- When \`LLM_OPENAI_AUTH_MODE=oauth\`: \`initialize_oauth()\` performs an immediate token refresh at startup, then a background asyncio task calls \`refresh_if_needed()\` every 60 s
- Token rotation is handled: if the token endpoint returns a new refresh token, the manager updates its stored value
- Features with an explicit \`OVERRIDES__BASE_URL\` (e.g. embeddings via OpenRouter) continue to use \`LLM_OPENAI_API_KEY\` directly via \`get_openai_override_client()\` — unaffected by OAuth mode
- Available models on the Responses API backend: \`gpt-5.5\`, \`gpt-5.4\`, \`gpt-5.4-mini\`, \`codex-auto-review\`

## Test plan

- [ ] \`uv run pytest tests/llm/test_oauth.py -v\` — unit tests pass
- [ ] \`uv run pytest tests/llm/ -q\` — full suite passes
- [ ] Run \`python scripts/honcho_oauth_setup.py\`, complete browser login, copy \`LLM_OPENAI_REFRESH_TOKEN\` to \`.env\`
- [ ] Set \`LLM_OPENAI_AUTH_MODE=oauth\`, restart Honcho, confirm dialectic chat and deriver both work without \`LLM_OPENAI_API_KEY\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)