### PR TITLE
fix(llm): make structured-output extraction robust on OpenAI-compatible providers

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
@@ -16,6 +17,103 @@ from src.llm.structured_output import (
 )
 
 logger = logging.getLogger(__name__)
+
+_THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+
+
+def _json_payload(text: str) -> str | None:
+    """Return ``text`` if it parses as a JSON object/array, else None."""
+    try:
+        if isinstance(json.loads(text), (dict, list)):
+            return text
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return None
+
+
+def _strip_reasoning_and_fences(text: str | None) -> str:
+    """Reduce a model response to its first complete JSON value.
+
+    OpenAI-compatible providers that don't honor ``response_format`` as a hard
+    grammar (Ollama, many self-hosted llama.cpp builds, chain-of-thought models
+    like GLM / MiniMax / DeepSeek) wrap structured output in ``<think>…</think>``
+    blocks and/or ```json fences, and sometimes append a natural-language
+    explanation after the JSON. ``repair_response_model_json`` then fails with
+    ``Expecting value: line 1 column 1 (char 0)`` and the deriver produces zero
+    observations. If no JSON structure is present the text is returned
+    unchanged."""
+    text = text or ""
+    # 1. Already a JSON object/array — return untouched. Done first so a value
+    #    that legitimately contains "<think>" or stray braces is never mangled.
+    payload = _json_payload(text)
+    if payload is not None:
+        return payload
+    # 2. Strip closed <think>…</think> blocks (and the surrounding fence/prose
+    #    they sit in), then retry.
+    cleaned = _THINK_RE.sub("", text).strip()
+    if (payload := _json_payload(cleaned)) is not None:
+        return cleaned
+    # 3. Extract the first complete JSON value starting at the first { or [.
+    #    raw_decode is string-aware and stops at the end of that value, so it
+    #    ignores ```json fences, trailing prose (incl. stray braces/brackets),
+    #    and unclosed reasoning that precedes real JSON.
+    start = min(
+        (i for i in (cleaned.find("{"), cleaned.find("[")) if i != -1),
+        default=-1,
+    )
+    if start != -1:
+        try:
+            _, end = json.JSONDecoder().raw_decode(cleaned, start)
+            return cleaned[start:end]
+        except (json.JSONDecodeError, ValueError):
+            # Truncated/invalid — hand the tail to repair_response_model_json.
+            return cleaned[start:]
+    return cleaned
+
+
+def _inject_schema_hint(
+    messages: list[dict[str, Any]],
+    response_format: type[BaseModel],
+) -> list[dict[str, Any]]:
+    """Append the target JSON schema to the system message.
+
+    ``json_object`` mode (unlike native ``json_schema``) does not tell the model
+    which fields to emit, so weaker / local models return empty or free-text
+    JSON. Injecting the schema makes the fallback reliable."""
+    try:
+        schema = json.dumps(response_format.model_json_schema())
+    except Exception as exc:
+        logger.warning(
+            "Could not serialize schema for %s; json_object fallback proceeds "
+            + "without a schema hint: %s",
+            getattr(response_format, "__name__", response_format),
+            exc,
+        )
+        return messages
+    hint = (
+        "You must respond with a single JSON object that conforms exactly to "
+        + "this JSON schema. Output only the JSON object — no prose, no markdown "
+        + "code fences, no <think> tags.\n\nSchema:\n"
+        + schema
+    )
+    # Shallow copy is sufficient: we replace a message's content, never mutate
+    # the original dicts or their nested values in place.
+    messages = [dict(m) for m in messages]
+    sys_idx = next(
+        (i for i, m in enumerate(messages) if m.get("role") == "system"), None
+    )
+    if sys_idx is None:
+        messages.insert(0, {"role": "system", "content": hint})
+        return messages
+    content = messages[sys_idx].get("content", "")
+    if isinstance(content, str):
+        messages[sys_idx]["content"] = f"{content}\n\n{hint}" if content else hint
+    elif isinstance(content, list):
+        # Multi-modal content: append the hint as an additional text part.
+        messages[sys_idx]["content"] = [*content, {"type": "text", "text": hint}]
+    else:
+        messages[sys_idx]["content"] = hint
+    return messages
 
 
 def _uses_max_completion_tokens(model: str) -> bool:
@@ -149,7 +247,7 @@ class OpenAIBackend:
                 truncated = exc.completion
                 raw_content = truncated.choices[0].message.content or ""
                 content = repair_response_model_json(
-                    raw_content,
+                    _strip_reasoning_and_fences(raw_content),
                     response_format,
                     model,
                 )
@@ -175,7 +273,7 @@ class OpenAIBackend:
             raw_content = response.choices[0].message.content or ""
             if parsed is None and raw_content:
                 content = repair_response_model_json(
-                    raw_content,
+                    _strip_reasoning_and_fences(raw_content),
                     response_format,
                     model,
                 )
@@ -381,13 +479,14 @@ class OpenAIBackend:
         response_format: type[BaseModel],
     ) -> Any:
         structured_params = dict(params)
-        structured_params["response_format"] = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": response_format.__name__,
-                "schema": response_format.model_json_schema(),
-            },
-        }
+        # The native attempt already failed, often because the provider rejects
+        # or ignores json_schema. Retry with json_object (widely supported) and
+        # inject the schema so the model still knows the target shape; the
+        # response is repaired/validated by the caller.
+        structured_params["response_format"] = {"type": "json_object"}
+        structured_params["messages"] = _inject_schema_hint(
+            structured_params["messages"], response_format
+        )
         return await self._client.chat.completions.create(**structured_params)
 
     @staticmethod
@@ -398,7 +497,8 @@ class OpenAIBackend:
     ) -> BaseModel | str:
         raw_content = response.choices[0].message.content or ""
         if raw_content:
-            return repair_response_model_json(raw_content, response_format, model)
+            cleaned = _strip_reasoning_and_fences(raw_content)
+            return repair_response_model_json(cleaned, response_format, model)
         refusal = getattr(response.choices[0].message, "refusal", None)
         if refusal:
             return refusal

--- a/tests/llm/test_backends/test_openai_structured_output.py
+++ b/tests/llm/test_backends/test_openai_structured_output.py
@@ -1,0 +1,124 @@
+"""Unit tests for the OpenAI-backend structured-output helpers."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pydantic import BaseModel
+
+from src.llm.backends.openai import (
+    _inject_schema_hint,  # pyright: ignore[reportPrivateUsage]
+    _strip_reasoning_and_fences,  # pyright: ignore[reportPrivateUsage]
+)
+
+
+class _Obs(BaseModel):
+    facts: list[str] = []
+
+
+# --------------------------------------------------------------------------- #
+# _strip_reasoning_and_fences
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # empty <think></think> + ```json fence (typical local llama.cpp output)
+        ('<think>\n\n</think>\n\n```json\n{"a": 1}\n```', '{"a": 1}'),
+        # closed reasoning block, JSON, then trailing prose
+        ('<think>r</think>{"ok": true} done.', '{"ok": true}'),
+        # bare ``` fence without the json language tag
+        ('```\n{"z": 9}\n```', '{"z": 9}'),
+        # already-valid object / array — fast path, returned untouched
+        ('{"facts": ["x", "y"]}', '{"facts": ["x", "y"]}'),
+        ('[{"a": 1}, {"b": 2}]', '[{"a": 1}, {"b": 2}]'),
+        # brace/bracket inside a string value must not confuse extraction
+        ('{"n": "a } b ] c"}', '{"n": "a } b ] c"}'),
+        # C-1 regression: a string value literally containing "<think>" must be
+        # preserved (fast path runs before any <think> stripping)
+        ('{"note": "a <think> tag in text"}', '{"note": "a <think> tag in text"}'),
+        # C1: object followed by prose containing the OTHER bracket type
+        ('{"k": "v"} list: [1, 2]', '{"k": "v"}'),
+        # M1: object followed by prose containing the SAME closing bracket
+        ('{"items": [1,2,3]} the value is 4}', '{"items": [1,2,3]}'),
+        # array first, trailing prose containing a stray "}"
+        ('[1, 2] and a dict: {"k": "v"}', "[1, 2]"),
+        # unclosed <think> (truncated) followed by recoverable JSON
+        ('<think>partial reasoning\n{"ok": true}', '{"ok": true}'),
+        # pure prose with no JSON is returned unchanged
+        ("I cannot help with that.", "I cannot help with that."),
+        # None / empty
+        (None, ""),
+        ("", ""),
+    ],
+)
+def test_strip_reasoning_and_fences(raw: str | None, expected: str) -> None:
+    assert _strip_reasoning_and_fences(raw) == expected
+
+
+# --------------------------------------------------------------------------- #
+# _inject_schema_hint
+# --------------------------------------------------------------------------- #
+def test_inject_appends_to_existing_system_message():
+    messages = [
+        {"role": "system", "content": "Extract facts."},
+        {"role": "user", "content": "hi"},
+    ]
+    out = _inject_schema_hint(messages, _Obs)
+    assert out[0]["role"] == "system"
+    assert out[0]["content"].startswith("Extract facts.")
+    assert "JSON schema" in out[0]["content"]
+    assert "facts" in out[0]["content"]  # schema body present
+    assert out[1] == {"role": "user", "content": "hi"}
+
+
+def test_inject_inserts_system_when_absent():
+    messages = [{"role": "user", "content": "hi"}]
+    out = _inject_schema_hint(messages, _Obs)
+    assert out[0]["role"] == "system"
+    assert "JSON schema" in out[0]["content"]
+    assert out[1] == {"role": "user", "content": "hi"}
+
+
+def test_inject_targets_system_even_when_not_first():
+    messages = [
+        {"role": "user", "content": "u1"},
+        {"role": "system", "content": "sys"},
+    ]
+    out = _inject_schema_hint(messages, _Obs)
+    assert out[0] == {"role": "user", "content": "u1"}
+    assert out[1]["role"] == "system"
+    assert out[1]["content"].startswith("sys")
+    assert "facts" in out[1]["content"]
+
+
+def test_inject_into_multimodal_system_content_appends_text_part():
+    messages = [{"role": "system", "content": [{"type": "text", "text": "sys"}]}]
+    out = _inject_schema_hint(messages, _Obs)
+    content = out[0]["content"]
+    assert isinstance(content, list)
+    assert content[0] == {"type": "text", "text": "sys"}
+    assert content[-1]["type"] == "text"
+    assert "facts" in content[-1]["text"]
+
+
+def test_inject_does_not_mutate_caller_messages():
+    messages = [{"role": "system", "content": "orig"}]
+    snapshot = {"role": "system", "content": "orig"}
+    _inject_schema_hint(messages, _Obs)
+    assert messages[0] == snapshot  # caller's list/dicts untouched
+
+
+def test_inject_serialize_failure_logs_and_passes_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class BadSchema:
+        @staticmethod
+        def model_json_schema() -> dict[str, object]:
+            raise RuntimeError("boom")
+
+    messages = [{"role": "user", "content": "hi"}]
+    with caplog.at_level(logging.WARNING):
+        out = _inject_schema_hint(messages, BadSchema)  # pyright: ignore[reportArgumentType]
+    assert out == messages  # no hint added, call proceeds
+    assert "without a schema hint" in caplog.text


### PR DESCRIPTION
## Problem

The OpenAI backend always requests structured output via native `json_schema`
(`chat.completions.parse()`, with `_create_structured_response` as the fallback).
Many OpenAI-compatible providers either reject `json_schema` outright or silently
ignore it and return text / markdown / chain-of-thought-wrapped JSON. Either way
`repair_response_model_json()` fails with `Expecting value: line 1 column 1
(char 0)` and the **deriver silently produces zero observations on every cycle**.

Reported across several environments:
- #716 — Ollama / OpenAI-compatible (GLM, Kimi): json_schema ignored + reasoning-content wrapping
- #771 — chain-of-thought models (MiniMax-M3): `<think>` + markdown fence breaks the parser
- #797 — `_create_structured_response` fallback retries with the same `json_schema` that just failed
- #743 — `json_object` prompt doesn't tell the model to emit JSON / the schema
- also #663, #780

## Fix

Keep native `json_schema` as the **first attempt** — no change for providers that
support it (OpenAI, Anthropic, capable proxies). Harden only the failure/repair
paths:

1. **Reasoning/fence stripping** — `_strip_reasoning_and_fences()` reduces a
   response to its first complete JSON value before repair. It is parse-first
   (a valid JSON object/array — even one whose string values contain `<think>`
   or stray braces — is returned untouched), then strips `<think>…</think>`
   blocks, then does a string-aware `json.JSONDecoder().raw_decode` from the
   first `{`/`[` so it ignores ```json fences and trailing prose. Applied in the
   `LengthFinishReasonError` path, the `parsed is None` path, and
   `_parse_or_repair_structured_content`.
2. **json_object fallback** — `_create_structured_response` (already the
   `BadRequestError`/`ValidationError` fallback) now retries with
   `{"type": "json_object"}` instead of the `json_schema` that just failed, and
   injects the schema into the system prompt (`_inject_schema_hint`) so the model
   still knows the target shape. The caller repairs/validates the result.

No new config. Behavior is unchanged for providers that succeed natively; the
only added cost for broken providers is one already-failing native attempt.

## Testing

- Unit tests for `_strip_reasoning_and_fences` (14 cases) and
  `_inject_schema_hint` (6 cases), covering the regressions above (string values
  containing `<think>`/braces, object-then-prose, array-first, truncated
  reasoning, multimodal system content, schema-serialize failure).
- Verified end-to-end against a self-hosted llama.cpp server (Qwen3-27B): the
  deriver went from 0 → correct observations.

## Known limitations / out of scope

- **Deeply-nested JSON followed by prose** that happens to end with a matching
  close char is a residual edge; `raw_decode` handles the common cases, a full
  balanced parse is possible follow-up.
- **Injected schema is unbounded** — very large pydantic schemas can crowd small
  context windows.
- **The streaming path still uses `json_schema`** (out of scope here; the
  non-streaming deriver/dialectic is where all four issues live).
- **The `json_object` fallback forwards the original params** (incl. any
  reasoning/thinking-budget fields); a provider that also rejects those could
  `400` in the fallback. This is pre-existing behavior, called out for awareness.

Closes #716, closes #771, closes #743, closes #797.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of structured JSON responses from OpenAI, including better processing of wrapped outputs with reasoning tags and markdown formatting.

* **Tests**
  * Added comprehensive test coverage for structured output processing helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->