### PR TITLE
feat: added goose as mcp connector

### DIFF
--- a/docs/v3/guides/integrations/mcp.mdx
+++ b/docs/v3/guides/integrations/mcp.mdx
@@ -224,6 +224,32 @@ Add to `~/.config/zed/settings.json`:
 Zed uses `context_servers` instead of `mcpServers`. Native HTTP support requires Zed v0.214.5 or later.
 </Note>
 
+### Goose
+
+[Goose](https://goose-docs.ai/) supports remote MCP servers natively over Streamable HTTP.
+
+The easiest way is to run `goose configure`, choose **Add Extension → Remote Extension (Streamable HTTP)**, and enter the name `honcho`, the URI `https://mcp.honcho.dev`, and the headers `Authorization: Bearer hch-your-key-here` and `X-Honcho-User-Name: YourName`.
+
+Or edit your `config.yaml` directly (on Linux, `~/.config/goose/config.yaml`):
+
+```yaml
+extensions:
+  honcho:
+    enabled: true
+    type: streamable_http
+    name: honcho
+    description: Honcho persistent memory & personalization
+    uri: https://mcp.honcho.dev
+    headers:
+      Authorization: "Bearer hch-your-key-here"
+      X-Honcho-User-Name: "YourName"
+    timeout: 60
+```
+
+<Tip>
+To teach Goose the recommended memory flow, save the [instructions](https://raw.githubusercontent.com/plastic-labs/honcho/refs/heads/main/mcp/instructions.md) into a `.goosehints` file in your Goose config directory (or a project root). This is Goose's equivalent of Claude Desktop's "Project Instructions". Not sure of your config path? Run `goose info`.
+</Tip>
+
 ---
 
 ## Optional Configuration


### PR DESCRIPTION
Added [Goose](https://goose-docs.ai/) as an integration for honcho's MCP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section to the MCP integrations guide covering Goose client setup for remote MCP via Streamable HTTP, including a quick CLI option, manual `config.yaml` steps with a YAML example, and guidance for locating Goose’s config path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->