### PR TITLE
docs(env): add Dialectic base URL override examples to .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -170,12 +170,17 @@ LLM_OPENAI_API_KEY=your-api-key-here
 # DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT=openai
 # DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL=gpt-5.4-mini
 # DIALECTIC_LEVELS__max__MAX_TOOL_ITERATIONS=10
-# Optional overrides:
+# Optional overrides (model and OpenAI-compatible base URL are per-level):
 # DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL=your-model-here
+# DIALECTIC_LEVELS__minimal__MODEL_CONFIG__OVERRIDES__BASE_URL=https://openrouter.ai/api/v1
 # DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL=your-model-here
+# DIALECTIC_LEVELS__low__MODEL_CONFIG__OVERRIDES__BASE_URL=https://openrouter.ai/api/v1
 # DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL=your-model-here
+# DIALECTIC_LEVELS__medium__MODEL_CONFIG__OVERRIDES__BASE_URL=https://openrouter.ai/api/v1
 # DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL=your-model-here
+# DIALECTIC_LEVELS__high__MODEL_CONFIG__OVERRIDES__BASE_URL=https://openrouter.ai/api/v1
 # DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL=your-model-here
+# DIALECTIC_LEVELS__max__MODEL_CONFIG__OVERRIDES__BASE_URL=https://openrouter.ai/api/v1
 # DIALECTIC_LEVELS__max__MODEL_CONFIG__THINKING_EFFORT=medium
 # DIALECTIC_LEVELS__max__MODEL_CONFIG__THINKING_BUDGET_TOKENS=1024
 # Optional backup per level (must set both or neither):


### PR DESCRIPTION
The Dialectic section was the only LLM section in .env.template missing MODEL_CONFIG__OVERRIDES__BASE_URL examples. Without them, users routing to OpenAI-compatible providers (e.g. Siliconflow) weren't aware the per-level override existed and fell back to the default OpenAI endpoint, hitting AuthenticationError. The override already works; this just enumerates it per reasoning level.

Fixes #818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment configuration template to clarify per-level override capabilities. The template now explicitly documents support for both model selection and OpenAI-compatible base URL configuration at each complexity level. Added commented example configurations showing how to customize base URLs alongside model selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->