### PR TITLE
fix(api): expose conclusion provenance

### DIFF
--- a/src/schemas/api.py
+++ b/src/schemas/api.py
@@ -29,6 +29,7 @@ from src.schemas.configuration import (
     SessionPeerConfig,
     WorkspaceConfiguration,
 )
+from src.utils.types import DocumentLevel
 
 # ---------------------------------------------------------------------------
 # Metadata validation helpers
@@ -446,6 +447,15 @@ class Conclusion(BaseModel):
         serialization_alias="observed_id",
     )
     session_name: str | None = Field(default=None, serialization_alias="session_id")
+    level: DocumentLevel = Field(
+        serialization_alias="conclusion_type",
+        description="How the conclusion was derived",
+    )
+    source_ids: list[str] | None = Field(
+        default=None,
+        serialization_alias="premises",
+        description="Source conclusion IDs used to derive this conclusion",
+    )
     created_at: datetime.datetime
 
     model_config = ConfigDict(  # pyright: ignore

--- a/tests/routes/test_conclusions.py
+++ b/tests/routes/test_conclusions.py
@@ -63,6 +63,8 @@ class TestConclusionRoutes:
             observed=test_peer2.name,
             content="User prefers dark mode",
             session_name=test_session.name,
+            level="deductive",
+            source_ids=["source-dark-mode"],
         )
         doc2 = models.Document(
             workspace_name=test_workspace.name,
@@ -70,6 +72,8 @@ class TestConclusionRoutes:
             observed=test_peer2.name,
             content="User works late at night",
             session_name=test_session.name,
+            level="inductive",
+            source_ids=["source-work-hours"],
         )
         db_session.add_all([doc1, doc2])
         await db_session.commit()
@@ -92,12 +96,29 @@ class TestConclusionRoutes:
         assert "observer_id" in conclusion
         assert "observed_id" in conclusion
         assert "session_id" in conclusion
+        assert "conclusion_type" in conclusion
+        assert "premises" in conclusion
         assert "created_at" in conclusion
 
         # Verify content
         contents = [item["content"] for item in data["items"]]
         assert "User prefers dark mode" in contents
         assert "User works late at night" in contents
+
+        conclusions_by_content = {item["content"]: item for item in data["items"]}
+        assert conclusions_by_content["User prefers dark mode"]["conclusion_type"] == (
+            "deductive"
+        )
+        assert conclusions_by_content["User prefers dark mode"]["premises"] == [
+            "source-dark-mode"
+        ]
+        assert (
+            conclusions_by_content["User works late at night"]["conclusion_type"]
+            == "inductive"
+        )
+        assert conclusions_by_content["User works late at night"]["premises"] == [
+            "source-work-hours"
+        ]
 
     @pytest.mark.asyncio
     async def test_list_conclusions_empty_session(


### PR DESCRIPTION
## Summary

Expose conclusion provenance through the public conclusions API by serializing existing `Document` fields on the `Conclusion` response schema:

- `Document.level` as `conclusion_type`
- `Document.source_ids` as `premises`

This lets API clients such as OpenConcho distinguish explicit, deductive, and inductive conclusions without coupling to Honcho's database schema or guessing missing types as explicit.

Fixes #846.

## Root cause

The database already stores conclusion derivation metadata, but `/v3/workspaces/{workspace_id}/conclusions/list` omitted that metadata from its response schema. Clients using the supported public API therefore could not render derived conclusion types accurately.

## Testing

Validated on the fork branch with:

```text
uv run ruff check src/schemas/api.py tests/routes/test_conclusions.py
uv run ruff format --check src/schemas/api.py tests/routes/test_conclusions.py
uv run basedpyright src/schemas/api.py
uv run pytest tests/routes/test_conclusions.py -q
```

Also deployed this patch in a self-hosted environment and verified the live OpenAPI schema exposes `conclusion_type` and `premises`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conclusion responses now include the conclusion type and associated premises in the API output.
  * These fields are now consistently returned in the serialized response for conclusion lists.

* **Bug Fixes**
  * Improved response coverage to ensure conclusion details are mapped and displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->