### PR TITLE
fix: translate canonical tool_choice in OpenAI backend for cross-provider fallback

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -352,8 +352,9 @@ class OpenAIBackend:
             params["stop"] = stop
         if tools:
             params["tools"] = self._convert_tools(tools)
-            if tool_choice is not None:
-                params["tool_choice"] = tool_choice
+            converted_tool_choice = self._convert_tool_choice(tool_choice)
+            if converted_tool_choice is not None:
+                params["tool_choice"] = converted_tool_choice
         if extra_params:
             for key in (
                 "top_p",
@@ -507,6 +508,29 @@ class OpenAIBackend:
             return empty_structured_output(response_format)
         except ValidationError:
             return ""
+
+    @staticmethod
+    def _convert_tool_choice(
+        tool_choice: str | dict[str, Any] | None,
+    ) -> str | dict[str, Any] | None:
+        # Translate Honcho's canonical tool_choice vocabulary to OpenAI's. This
+        # mirrors the Anthropic/Gemini backends so a single TOOL_CHOICE value
+        # works regardless of which provider a fallback chain lands on. Notably
+        # OpenAI has no "any" — it spells the same intent "required".
+        if tool_choice is None:
+            return None
+        if isinstance(tool_choice, dict):
+            if "name" in tool_choice:
+                return {
+                    "type": "function",
+                    "function": {"name": tool_choice["name"]},
+                }
+            return tool_choice
+        if tool_choice in {"any", "required"}:
+            return "required"
+        if tool_choice in {"auto", "none"}:
+            return tool_choice
+        return {"type": "function", "function": {"name": tool_choice}}
 
     @staticmethod
     def _convert_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -504,6 +504,67 @@ async def test_openai_backend_converts_anthropic_style_tools() -> None:
     assert call["tool_choice"] == "required"
 
 
+async def test_openai_backend_translates_canonical_any_tool_choice_to_required() -> (
+    None
+):
+    """Regression: a Gemini→OpenAI fallback passes canonical "any", which OpenAI
+    rejects as an invalid param. The backend must translate it to "required"."""
+    client = Mock()
+    client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        content="ok",
+                        tool_calls=[],
+                        reasoning_details=[],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                prompt_tokens_details=None,
+            ),
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    await backend.complete(
+        model="gpt-4.1",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        tools=[
+            {
+                "name": "get_weather",
+                "description": "Lookup weather",
+                "input_schema": {"type": "object", "properties": {}},
+            }
+        ],
+        tool_choice="any",
+    )
+
+    assert _await_kwargs(client.chat.completions.create)["tool_choice"] == "required"
+
+
+@pytest.mark.parametrize(
+    ("canonical", "expected"),
+    [
+        ("any", "required"),
+        ("required", "required"),
+        ("auto", "auto"),
+        ("none", "none"),
+        (None, None),
+        ("search", {"type": "function", "function": {"name": "search"}}),
+        ({"name": "search"}, {"type": "function", "function": {"name": "search"}}),
+        ({"type": "function"}, {"type": "function"}),
+    ],
+)
+def test_openai_convert_tool_choice(canonical: Any, expected: Any) -> None:
+    assert OpenAIBackend._convert_tool_choice(canonical) == expected  # pyright: ignore[reportPrivateUsage]
+
+
 @pytest.mark.parametrize(
     "model",
     [


### PR DESCRIPTION
## Problem

`tool_choice` is meant to be a single canonical value set per dialectic level (`TOOL_CHOICE`), with each backend translating it to its provider's native vocabulary at call time. The Anthropic and Gemini backends do this via `_convert_tool_choice`; the **OpenAI backend passed the value through raw**.

On a mixed-provider fallback chain — primary Gemini, backup OpenAI — a canonical `"any"` reached OpenAI unchanged. OpenAI's API only accepts `none` / `auto` / `required` (or a function dict), so it rejected the request as an invalid param. This surfaced in production as `invalid params` errors only when the fallback actually crossed transports.

## Fix

Give the OpenAI backend its own `_convert_tool_choice`, mirroring the Anthropic and Gemini backends, so one canonical `TOOL_CHOICE` resolves correctly no matter which provider a fallback lands on:

- `"any"` / `"required"` → `"required"` (OpenAI's spelling of the same intent)
- `"auto"` / `"none"` → pass through
- a tool-name string or `{"name": ...}` dict → `{"type": "function", "function": {"name": ...}}`
- an already-shaped dict → pass through; `None` → `None`

Wired into `_build_params`, the single choke point for both the streaming and non-streaming paths.

Translation stays **in the backend** rather than in config, because the fallback chain doesn't know at config-time which provider it will hit.

## Tests

- Regression test reproducing the incident: canonical `"any"` → request sends `"required"`.
- Parametrized unit test covering every branch of the converter.

The existing test passing `"required"` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool selection settings so calls are translated into the format expected by OpenAI when tools are used.
  * Fixed a case where the `"any"` tool choice now maps correctly to `"required"` for compatible API calls.

* **Tests**
  * Added coverage for tool-choice conversion across common string values and structured inputs.
  * Added a regression test to verify the translated tool choice is sent correctly during completion requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->