### PR TITLE
Fix #839 and #843: add explicit timeout to AsyncOpenAI and emit struc…

### DIFF
--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -6,6 +6,7 @@ from src.config import ConfiguredModelSettings, settings
 from src.crud.representation import RepresentationManager
 from src.dependencies import tracked_db
 from src.llm import honcho_llm_call
+from src.llm.structured_output import StructuredOutputError
 from src.llm.types import LLMTelemetryContext
 from src.models import Message
 from src.schemas import ResolvedConfiguration
@@ -143,24 +144,40 @@ async def process_representation_tasks_batch(
 
     # Single LLM call
     llm_start = time.perf_counter()
-    response = await honcho_llm_call(
-        model_config=model_config,
-        prompt=prompt,
-        max_tokens=max_tokens,
-        response_model=PromptRepresentation,
-        json_mode=True,
-        max_input_tokens=settings.DERIVER.MAX_INPUT_TOKENS,
-        enable_retry=True,
-        retry_attempts=3,
-        trace_name="minimal_deriver",
-        telemetry=LLMTelemetryContext(
-            workspace_name=latest_message.workspace_name,
-            call_purpose=CallPurpose.DERIVER_REPRESENTATION.value,
-            parent_category="representation",
-            observed=observed,
-            track_name="Minimal Deriver",
-        ),
-    )
+    try:
+        response = await honcho_llm_call(
+            model_config=model_config,
+            prompt=prompt,
+            max_tokens=max_tokens,
+            response_model=PromptRepresentation,
+            json_mode=True,
+            max_input_tokens=settings.DERIVER.MAX_INPUT_TOKENS,
+            enable_retry=True,
+            retry_attempts=3,
+            trace_name="minimal_deriver",
+            telemetry=LLMTelemetryContext(
+                workspace_name=latest_message.workspace_name,
+                call_purpose=CallPurpose.DERIVER_REPRESENTATION.value,
+                parent_category="representation",
+                observed=observed,
+                track_name="Minimal Deriver",
+            ),
+        )
+    except StructuredOutputError as e:
+        logger.error(
+            "Deriver parse failure",
+            extra={
+                "work_unit_id": f"{observed}_{latest_message.session_name}",
+                "peer_id": observed,
+                "session_id": latest_message.session_name,
+                "transport": model_config.transport,
+                "model": model_config.model,
+                "structured_output_mode": model_config.structured_output_mode,
+                "parse_failure_reason": e.reason,
+                "raw_response_excerpt": e.raw_content[:500] if e.raw_content else "",
+            }
+        )
+        raise
     llm_duration = (time.perf_counter() - llm_start) * 1000
 
     accumulate_metric(

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -175,6 +175,7 @@ class _EmbeddingClient:
             self.client = AsyncOpenAI(
                 api_key=config.api_key,
                 base_url=config.base_url,
+                timeout=600.0,
             )
             self.max_embedding_tokens = max_input_tokens
             self.max_batch_size = 2048  # OpenAI batch limit

--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -190,28 +190,15 @@ class OpenAIBackend:
                     truncated,
                     content_override=content,
                 )
-            except BadRequestError:
+            except BadRequestError as e:
                 # A 400 means the provider rejected the request shape — most
                 # often it doesn't support OpenAI Structured Outputs (json_schema).
-                # Retrying or re-requesting won't help (it rejects the same shape
-                # again, the latency trap of #797), so return empty rather than
-                # erroring existing flows. The warning is the signal to set
-                # structured_output_mode=json_object. There is no response body to
-                # account for, so token usage is legitimately zero here.
-                logger.warning(
-                    "Structured output via json_schema rejected by model %s; "
+                raise StructuredOutputError(
+                    f"Structured output via json_schema rejected by model {model}; "
                     + "set structured_output_mode=json_object if the provider does "
                     + "not support OpenAI Structured Outputs.",
-                    model,
-                )
-                # empty_structured_output() validates {} against the model, which
-                # itself raises if the model has required fields. Fall back to
-                # empty string content rather than letting that escape the handler.
-                try:
-                    fallback_content: Any = empty_structured_output(response_format)
-                except ValidationError:
-                    fallback_content = ""
-                return CompletionResult(content=fallback_content)
+                    reason="bad_request"
+                ) from e
             parsed = response.choices[0].message.parsed
             if parsed is not None:
                 return self._normalize_response(

--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -71,6 +71,7 @@ def get_openai_client() -> AsyncOpenAI:
         api_key=settings.LLM.OPENAI_API_KEY,
         base_url=settings.LLM.OPENAI_BASE_URL,
         default_headers=_default_headers_for(settings.LLM.OPENAI_BASE_URL),
+        timeout=600.0,
     )
 
 
@@ -96,6 +97,7 @@ def get_openai_override_client(
         api_key=api_key,
         base_url=base_url,
         default_headers=_default_headers_for(base_url),
+        timeout=600.0,
     )
 
 
@@ -133,6 +135,7 @@ if settings.LLM.OPENAI_API_KEY:
         api_key=settings.LLM.OPENAI_API_KEY,
         base_url=settings.LLM.OPENAI_BASE_URL,
         default_headers=_default_headers_for(settings.LLM.OPENAI_BASE_URL),
+        timeout=600.0,
     )
 
 if settings.LLM.GEMINI_API_KEY:

--- a/src/llm/structured_output.py
+++ b/src/llm/structured_output.py
@@ -10,6 +10,10 @@ from src.utils.representation import PromptRepresentation
 
 class StructuredOutputError(ValueError):
     """Raised when structured output cannot be validated or repaired."""
+    def __init__(self, message: str, raw_content: str = "", reason: str = ""):
+        super().__init__(message)
+        self.raw_content = raw_content
+        self.reason = reason
 
 
 def repair_response_model_json(
@@ -43,15 +47,13 @@ def repair_response_model_json(
                         item["premises"] = []
 
         final = json.dumps(repaired_data)
-    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
-        final = ""
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
+        raise StructuredOutputError(f"Failed to repair JSON: {e}", raw_content=raw_content, reason="empty_after_repair") from e
 
     try:
         return response_model.model_validate_json(final)
-    except ValidationError:
-        if response_model is PromptRepresentation:
-            return PromptRepresentation(explicit=[])
-        raise
+    except ValidationError as e:
+        raise StructuredOutputError(f"Validation failed after repair: {e}", raw_content=raw_content, reason="validation_error") from e
 
 
 def validate_structured_output(


### PR DESCRIPTION
…tured logs on unparseable LLM output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of structured output parsing failures with clearer errors and better logging details.
  * Requests that exceed the provider’s structured-output support now fail explicitly instead of silently falling back.
  * Added longer timeout handling for OpenAI-based requests to reduce premature timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->