### PR TITLE
fix: correct import pattern for `typing.Self` within honcho python SDK for python 3.10

### DIFF
--- a/sdks/python/src/honcho/types.py
+++ b/sdks/python/src/honcho/types.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import AsyncIterator, Iterator
-from typing import Self
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
 
 __all__ = [
     "DialecticStreamResponse",


### PR DESCRIPTION
## Description

This PR corrects the pattern for importing `typing.Self` in Python 3.10 environments within `sdks/python/src/honcho/types.py` to prevent `ImportError` when importing the honcho Python
SDK.

## Changes

Simple change of:

```python
from collections.abc import AsyncIterator, Iterator
from typing import Self
```

to:

```python
import sys
from collections.abc import AsyncIterator, Iterator

if sys.version_info < (3, 11):
    from typing_extensions import Self
else:
    from typing import Self
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python version compatibility by ensuring `Self` type support works across supported runtime versions.
  * Preserved existing stream response behavior while avoiding import issues on older Python releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->