### PR TITLE
fix(deriver): surface representation save failures instead of silent loss (#728)

### DIFF
--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -196,6 +196,7 @@ async def process_representation_tasks_batch(
 
     agg_representation_result = crud.CreateDocumentsResult()
     successful_observer_count = 0
+    save_errors: list[str] = []
     if observations.is_empty() or not message_ids:
         logger.warning(
             "Deriver generated zero observations for messages %s:%s in %s/%s!",
@@ -240,6 +241,7 @@ async def process_representation_tasks_batch(
                 logger.error(
                     "Failed to save representation for observer %s: %s", observer, e
                 )
+                save_errors.append(f"{observer}: {e.__class__.__name__}: {e}")
 
     # Log metrics
     overall_duration = (time.perf_counter() - overall_start) * 1000
@@ -339,3 +341,12 @@ async def process_representation_tasks_batch(
             semantic_dup_replaced_count=agg_representation_result.semantic_dup_replaced_count,
         )
     )
+
+    # If every observer's save failed, surface the failure to the queue manager so the
+    # work unit is marked errored instead of silently processed with zero documents saved
+    # (#728). Raised after telemetry so metrics still record the attempt.
+    if save_errors and successful_observer_count == 0:
+        raise RuntimeError(
+            f"save_representation failed for all {len(save_errors)} observer(s): "
+            + "; ".join(save_errors)
+        )

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -7,6 +7,7 @@ from src import crud
 from src.config import ConfiguredModelSettings, settings
 from src.crud.representation import RepresentationManager
 from src.dependencies import tracked_db
+from src.exceptions import RepresentationSaveError
 from src.llm import honcho_llm_call
 from src.llm.types import LLMTelemetryContext
 from src.models import Message
@@ -196,7 +197,7 @@ async def process_representation_tasks_batch(
 
     agg_representation_result = crud.CreateDocumentsResult()
     successful_observer_count = 0
-    save_errors: list[str] = []
+    save_errors: list[tuple[str, Exception]] = []
     if observations.is_empty() or not message_ids:
         logger.warning(
             "Deriver generated zero observations for messages %s:%s in %s/%s!",
@@ -241,7 +242,7 @@ async def process_representation_tasks_batch(
                 logger.error(
                     "Failed to save representation for observer %s: %s", observer, e
                 )
-                save_errors.append(f"{observer}: {e.__class__.__name__}: {e}")
+                save_errors.append((observer, e))
 
     # Log metrics
     overall_duration = (time.perf_counter() - overall_start) * 1000
@@ -347,7 +348,11 @@ async def process_representation_tasks_batch(
     # work unit is marked errored instead of silently processed with zero documents saved
     # (#728). Raised after telemetry so metrics still record the attempt.
     if save_errors and successful_observer_count == 0:
-        raise RuntimeError(
-            f"save_representation failed for all {len(save_errors)} observer(s): "
-            + "; ".join(save_errors)
+        details = "; ".join(
+            f"{observer}: {exc.__class__.__name__}: {exc}"
+            for observer, exc in save_errors
         )
+        raise RepresentationSaveError(
+            f"save_representation failed for all {len(save_errors)} observer(s): "
+            + details
+        ) from save_errors[0][1]

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -239,8 +239,8 @@ async def process_representation_tasks_batch(
                 )
                 successful_observer_count += 1
             except Exception as e:
-                logger.error(
-                    "Failed to save representation for observer %s: %s", observer, e
+                logger.exception(
+                    "Failed to save representation for observer %s", observer
                 )
                 save_errors.append((observer, e))
 

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -339,6 +339,7 @@ async def process_representation_tasks_batch(
             exact_dup_in_batch_count=agg_representation_result.exact_dup_in_batch_count,
             semantic_dup_rejected_count=agg_representation_result.semantic_dup_rejected_count,
             semantic_dup_replaced_count=agg_representation_result.semantic_dup_replaced_count,
+            failed_observer_count=len(save_errors),
         )
     )
 

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -133,6 +133,19 @@ class VectorStoreError(HonchoException):
     detail = "Vector store operation failed"
 
 
+@final
+class RepresentationSaveError(HonchoException):
+    """Exception raised when every observer's representation save fails in a batch.
+
+    Surfaced from the deriver to the queue manager so the work unit is marked
+    errored instead of silently processed with zero documents saved. The
+    underlying save exception is preserved as the cause via ``raise ... from``.
+    """
+
+    status_code = 500
+    detail = "Representation save failed for all observers"
+
+
 class LLMError(Exception):
     """Exception raised when an LLM call fails.
 

--- a/src/telemetry/events/representation.py
+++ b/src/telemetry/events/representation.py
@@ -154,6 +154,10 @@ class RepresentationCompletedEvent(BaseEvent):
         default=0,
         description="Number of observers this representation was saved against",
     )
+    failed_observer_count: int = Field(
+        default=0,
+        description="Number of observers whose save_representation failed (partial or total)",
+    )
 
     def get_resource_id(self) -> str:
         """Resource ID includes workspace, session, and latest message for uniqueness."""

--- a/tests/bench/bench_deriver_silent_loss.py
+++ b/tests/bench/bench_deriver_silent_loss.py
@@ -82,10 +82,7 @@ async def measure_silent_loss_and_visibility(
                 "save_representation",
                 new=AsyncMock(side_effect=RuntimeError("429 RESOURCE_EXHAUSTED")),
             ),
-            patch(
-                "src.deriver.deriver.emit",
-                side_effect=lambda e, _sink=emitted: _sink.append(e),
-            ),
+            patch("src.deriver.deriver.emit", side_effect=emitted.append),
         ):
             try:
                 await process_representation_tasks_batch(

--- a/tests/bench/bench_deriver_silent_loss.py
+++ b/tests/bench/bench_deriver_silent_loss.py
@@ -57,6 +57,15 @@ async def measure_silent_loss_and_visibility(
     from src.llm import HonchoLLMCallResponse
     from src.utils.representation import ExplicitObservationBase, PromptRepresentation
 
+    # RepresentationSaveError only exists on the fix branch; pre-fix `main`
+    # swallows the failure and never raises, so the name is absent there. Fall
+    # back to the base HonchoException so this script runs unmodified on either
+    # checkout — on `main` the except below simply never fires.
+    try:
+        from src.exceptions import RepresentationSaveError as _SaveFailure
+    except ImportError:  # pragma: no cover - pre-fix main
+        from src.exceptions import HonchoException as _SaveFailure
+
     silent = 0
     alertable = 0
     for i in range(trials):
@@ -92,12 +101,12 @@ async def measure_silent_loss_and_visibility(
                     observed="alice",
                     queue_item_message_ids=[1],
                 )
-            # Count only the expected save failure; let unrelated exceptions
-            # escape so they fail the benchmark, not inflate visibility.
-            except RuntimeError as exc:
+            # Count only the expected fail-loud save failure. Keying off the
+            # typed exception (not the message text) means an unrelated
+            # regression raises a different type, escapes, and fails the
+            # benchmark instead of inflating the visibility rate.
+            except _SaveFailure:
                 raised = True
-                if "observer" not in str(exc) and "RESOURCE_EXHAUSTED" not in str(exc):
-                    raise
 
         # The save failed for the only observer. "Silent loss" = the deriver
         # returned normally (queue would mark it processed) with nothing saved.

--- a/tests/bench/bench_deriver_silent_loss.py
+++ b/tests/bench/bench_deriver_silent_loss.py
@@ -92,8 +92,12 @@ async def measure_silent_loss_and_visibility(
                     observed="alice",
                     queue_item_message_ids=[1],
                 )
-            except Exception:
+            # Count only the expected save failure; let unrelated exceptions
+            # escape so they fail the benchmark, not inflate visibility.
+            except RuntimeError as exc:
                 raised = True
+                if "observer" not in str(exc) and "RESOURCE_EXHAUSTED" not in str(exc):
+                    raise
 
         # The save failed for the only observer. "Silent loss" = the deriver
         # returned normally (queue would mark it processed) with nothing saved.

--- a/tests/bench/bench_deriver_silent_loss.py
+++ b/tests/bench/bench_deriver_silent_loss.py
@@ -1,0 +1,133 @@
+"""Deriver silent-loss benchmark — before/after quantification for #728.
+
+Measures, against whatever ``src/`` is currently checked out:
+
+- ``silent_loss_rate`` — fraction of "all observer saves fail" batches that are
+  silently marked processed (the deriver returns normally with zero documents
+  saved) instead of surfacing the failure. This is the #728 data-loss symptom.
+- ``failure_visibility_rate`` — fraction of those failing batches that produce an
+  *alertable* signal (the call raises so the queue marks it errored, or telemetry
+  reports a failed observer).
+
+It needs **no database and no real provider**: the deriver's LLM call and the
+representation save are mocked. The same script runs unmodified against any
+checkout, so the before/after contrast is produced by running it on ``main``
+(before) and on the fix branch (after):
+
+    PYTHONPATH=. uv run python tests/bench/bench_deriver_silent_loss.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+# Make `src` importable when run directly (uv run python tests/bench/<this>.py).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+TRIALS = 20
+
+
+def _message() -> Mock:
+    return Mock(
+        id=1,
+        public_id="msg_1",
+        session_name="session-1",
+        workspace_name="workspace-1",
+        peer_name="alice",
+        content="hello",
+        token_count=5,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+async def measure_silent_loss_and_visibility(
+    trials: int = TRIALS,
+) -> tuple[float, float]:
+    """Drive process_representation_tasks_batch with every observer save failing.
+
+    Returns (silent_loss_rate, failure_visibility_rate).
+    """
+    from src.crud.representation import RepresentationManager
+    from src.deriver.deriver import process_representation_tasks_batch
+    from src.llm import HonchoLLMCallResponse
+    from src.utils.representation import ExplicitObservationBase, PromptRepresentation
+
+    silent = 0
+    alertable = 0
+    for i in range(trials):
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+        response = HonchoLLMCallResponse(
+            content=PromptRepresentation(
+                explicit=[ExplicitObservationBase(content=f"observation {i}")]
+            ),
+            input_tokens=10,
+            output_tokens=5,
+            finish_reasons=["STOP"],
+        )
+        emitted: list[Any] = []
+        raised = False
+        with (
+            patch(
+                "src.deriver.deriver.honcho_llm_call",
+                new=AsyncMock(return_value=response),
+            ),
+            patch.object(
+                RepresentationManager,
+                "save_representation",
+                new=AsyncMock(side_effect=RuntimeError("429 RESOURCE_EXHAUSTED")),
+            ),
+            patch(
+                "src.deriver.deriver.emit",
+                side_effect=lambda e, _sink=emitted: _sink.append(e),
+            ),
+        ):
+            try:
+                await process_representation_tasks_batch(
+                    messages=[_message()],
+                    message_level_configuration=configuration,
+                    observers=["bob"],
+                    observed="alice",
+                    queue_item_message_ids=[1],
+                )
+            except Exception:
+                raised = True
+
+        # The save failed for the only observer. "Silent loss" = the deriver
+        # returned normally (queue would mark it processed) with nothing saved.
+        if not raised:
+            silent += 1
+        # Alertable = the failure is detectable downstream: either it raised
+        # (queue marks errored), or telemetry carries a non-zero failed count.
+        if raised or any(getattr(e, "failed_observer_count", 0) for e in emitted):
+            alertable += 1
+
+    return silent / trials, alertable / trials
+
+
+def _supports_fail_loud() -> bool:
+    from src.telemetry.events.representation import RepresentationCompletedEvent
+
+    return "failed_observer_count" in RepresentationCompletedEvent.model_fields
+
+
+async def main() -> None:
+    silent_loss, visibility = await measure_silent_loss_and_visibility()
+    mode = "AFTER (fail-loud)" if _supports_fail_loud() else "BEFORE (swallowed)"
+
+    print("=" * 60)
+    print(f"Deriver silent-loss benchmark — {mode}")
+    print(f"  trials={TRIALS}")
+    print("-" * 60)
+    print(f"  silent_loss_rate        : {silent_loss:6.1%}   (target: 0%)")
+    print(f"  failure_visibility_rate : {visibility:6.1%}   (target: 100%)")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -9,6 +9,7 @@ from src import crud, models
 from src.config import settings
 from src.crud.representation import RepresentationManager
 from src.deriver.deriver import process_representation_tasks_batch
+from src.exceptions import RepresentationSaveError
 from src.llm import HonchoLLMCallResponse
 from src.utils.representation import (
     ExplicitObservationBase,
@@ -102,6 +103,7 @@ class TestDeriverProcessing:
         )
 
         failing_save = AsyncMock(side_effect=RuntimeError("429 RESOURCE_EXHAUSTED"))
+        emitted: list[Any] = []
         with (
             patch(
                 "src.deriver.deriver.honcho_llm_call",
@@ -109,7 +111,8 @@ class TestDeriverProcessing:
                 return_value=mock_response,
             ),
             patch.object(RepresentationManager, "save_representation", failing_save),
-            pytest.raises(RuntimeError, match="save_representation failed"),
+            patch("src.deriver.deriver.emit", side_effect=emitted.append),
+            pytest.raises(RepresentationSaveError, match="save_representation failed"),
         ):
             await process_representation_tasks_batch(
                 messages=[message],
@@ -118,6 +121,13 @@ class TestDeriverProcessing:
                 observed="alice",
                 queue_item_message_ids=[1],
             )
+
+        # Telemetry must be emitted *before* the raise so a total save failure is
+        # still visible to metrics consumers. Guards against emit() being moved
+        # after the raise, which would reintroduce invisible total failures.
+        assert emitted, "expected telemetry to be emitted before the raised failure"
+        assert emitted[-1].observer_count == 0
+        assert emitted[-1].failed_observer_count == 1
 
     async def test_partial_observer_failure_is_processed_and_surfaced(self):
         """When some observers save and one fails, the batch does NOT raise (the unit

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -119,6 +119,65 @@ class TestDeriverProcessing:
                 queue_item_message_ids=[1],
             )
 
+    async def test_partial_observer_failure_is_processed_and_surfaced(self):
+        """When some observers save and one fails, the batch does NOT raise (the unit
+        stays processed and the saved observers are kept), and the failure is surfaced
+        discoverably via telemetry — not just a log line (#728 partial case, D2)."""
+        message = Mock(
+            id=1,
+            public_id="msg_1",
+            session_name="session-1",
+            workspace_name="workspace-1",
+            peer_name="alice",
+            content="hello",
+            token_count=5,
+            created_at=datetime.now(timezone.utc),
+        )
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+
+        mock_response = HonchoLLMCallResponse(
+            content=PromptRepresentation(
+                explicit=[
+                    ExplicitObservationBase(content="The user has a dog named Rover")
+                ]
+            ),
+            input_tokens=10,
+            output_tokens=5,
+            finish_reasons=["STOP"],
+        )
+
+        # bob succeeds (returns a CreateDocumentsResult), carol fails.
+        partial_save = AsyncMock(
+            side_effect=[
+                crud.CreateDocumentsResult(),
+                RuntimeError("429 RESOURCE_EXHAUSTED"),
+            ]
+        )
+        emitted: list[Any] = []
+        with (
+            patch(
+                "src.deriver.deriver.honcho_llm_call",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+            patch.object(RepresentationManager, "save_representation", partial_save),
+            patch("src.deriver.deriver.emit", side_effect=lambda e: emitted.append(e)),
+        ):
+            # Must NOT raise — the saved observer's work is kept, unit stays processed.
+            await process_representation_tasks_batch(
+                messages=[message],
+                message_level_configuration=configuration,
+                observers=["bob", "carol"],
+                observed="alice",
+                queue_item_message_ids=[1],
+            )
+
+        assert emitted, "expected a telemetry event to be emitted"
+        event = emitted[-1]
+        assert event.observer_count == 1
+        assert event.failed_observer_count == 1
+
     async def test_process_representation_tasks_batch_passes_custom_instructions_into_prompt(
         self,
     ) -> None:

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -162,7 +162,7 @@ class TestDeriverProcessing:
                 return_value=mock_response,
             ),
             patch.object(RepresentationManager, "save_representation", partial_save),
-            patch("src.deriver.deriver.emit", side_effect=lambda e: emitted.append(e)),
+            patch("src.deriver.deriver.emit", side_effect=emitted.append),
         ):
             # Must NOT raise — the saved observer's work is kept, unit stays processed.
             await process_representation_tasks_batch(

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -7,6 +7,7 @@ import pytest
 
 from src import crud, models
 from src.config import settings
+from src.crud.representation import RepresentationManager
 from src.deriver.deriver import process_representation_tasks_batch
 from src.llm import HonchoLLMCallResponse
 from src.utils.representation import (
@@ -69,6 +70,54 @@ class TestDeriverProcessing:
         )
         assert kwargs["model_config"].stop_sequences == expected_config.stop_sequences
         assert "llm_settings" not in kwargs
+
+    async def test_all_observer_saves_failing_surfaces_failure(self):
+        """When every observer's save_representation fails (e.g. embedding retries
+        exhausted under a sustained 429), the batch must surface the failure to the
+        queue manager — by raising — instead of swallowing it and reporting success.
+        Without this, the work unit is marked processed with zero documents saved:
+        silent memory loss (#728)."""
+        message = Mock(
+            id=1,
+            public_id="msg_1",
+            session_name="session-1",
+            workspace_name="workspace-1",
+            peer_name="alice",
+            content="hello",
+            token_count=5,
+            created_at=datetime.now(timezone.utc),
+        )
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+
+        mock_response = HonchoLLMCallResponse(
+            content=PromptRepresentation(
+                explicit=[
+                    ExplicitObservationBase(content="The user has a dog named Rover")
+                ]
+            ),
+            input_tokens=10,
+            output_tokens=5,
+            finish_reasons=["STOP"],
+        )
+
+        failing_save = AsyncMock(side_effect=RuntimeError("429 RESOURCE_EXHAUSTED"))
+        with (
+            patch(
+                "src.deriver.deriver.honcho_llm_call",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+            patch.object(RepresentationManager, "save_representation", failing_save),
+            pytest.raises(RuntimeError, match="save_representation failed"),
+        ):
+            await process_representation_tasks_batch(
+                messages=[message],
+                message_level_configuration=configuration,
+                observers=["bob"],
+                observed="alice",
+                queue_item_message_ids=[1],
+            )
 
     async def test_process_representation_tasks_batch_passes_custom_instructions_into_prompt(
         self,

--- a/tests/telemetry/test_representation_v2_fields.py
+++ b/tests/telemetry/test_representation_v2_fields.py
@@ -51,6 +51,7 @@ class TestRepresentationV2AdditiveFields:
         assert event.exact_dup_existing_count == 0
         assert event.semantic_dup_rejected_count == 0
         assert event.semantic_dup_replaced_count == 0
+        assert event.failed_observer_count == 0
 
     def test_input_tokens_semantics_preserved(self):
         """The downstream metering key must remain 'queued-message tokens'.
@@ -161,6 +162,7 @@ class TestRepresentationV2AdditiveFields:
             "exact_dup_existing_count",
             "semantic_dup_rejected_count",
             "semantic_dup_replaced_count",
+            "failed_observer_count",
         ):
             assert field in data, f"missing field: {field}"
         assert data["hit_batch_token_cap"] is True


### PR DESCRIPTION
## Description

When every observer's representation save failed (e.g. embedding `429 RESOURCE_EXHAUSTED` past the in-batch retries), `process_representation_tasks_batch`  <br>(`src/deriver/deriver.py`) caught the exception, logged it, and returned normally —  <br>so the queue marked the work unit `processed` with **zero documents saved**:  <br>silent, permanent memory loss with no error state or alertable signal. (The errored  <br>path `mark_queue_item_as_errored` existed but was never reached.)

This makes a save failure either loud or recorded — never a silent success:

* **Total failure → errored.** Collect per-observer errors; raise when no observer  <br>succeeded, so the queue marks the unit `errored`.
* **Partial failure → processed + recorded.** Observers are independent  <br>`(observer, observed)` collections, so the saved ones are kept (re-running would  <br>duplicate; the queue has no requeue). The failure is recorded via a new additive  <br>`failed_observer_count` on `RepresentationCompletedEvent` (schema unchanged).

Not a retry fix: the embedding client already retries transient errors; the bug is  <br>the swallow after they're exhausted.

**Quantified** (`tests/bench/bench_deriver_silent_loss.py` — real deriver path with  <br>a faked failing save, trials=20):

<!-- linear:table-colwidths:266,266,266 -->
| Metric | Before (`main`) | After |
| -- | -- | -- |
| `silent_loss_rate` | 100% | 0% |
| `failure_visibility_rate` | 0% | 100% |

plastic-labs/honcho#728 reported docs dropping < />300 → < />121 (< />60%) in a 429 burst. Supersedes [#660](<https://github.com/plastic-labs/honcho/issues/660>)  <br>(raised on any failure, no tests); coordinates with plastic-labs/honcho#839 (@akattelu).

## Linked issues

Fixes plastic-labs/honcho#728

## Type of change

- [X] `fix` — bug fix
- [X] `test` — adding or correcting tests

## Test plan

New / updated tests (RED→GREEN):

* `tests/deriver/test_deriver_processing.py`
  * `test_all_observer_saves_failing_surfaces_failure` — every observer save  <br>raises ⇒ `process_representation_tasks_batch` raises (queue marks errored)  <br>instead of returning silently.
  * `test_partial_observer_failure_is_processed_and_surfaced` — one observer  <br>succeeds, one fails ⇒ no raise (unit stays processed), and the emitted  <br>`RepresentationCompletedEvent` reports `observer_count == 1` and  <br>`failed_observer_count == 1`.
* `tests/telemetry/test_representation_v2_fields.py` — asserts the new  <br>`failed_observer_count` defaults to 0 (additive; schema stays at v2).

Quantitative before/after (a standalone harness, not a CI test):

```bash
# AFTER (this branch)
PYTHONPATH=. uv run python tests/bench/bench_deriver_silent_loss.py
# BEFORE (main source)
git checkout main -- src/deriver/deriver.py src/telemetry/events/representation.py
PYTHONPATH=. uv run python tests/bench/bench_deriver_silent_loss.py
git checkout HEAD -- src/deriver/deriver.py src/telemetry/events/representation.py
```

## Checklist

- [X] Tests added/updated for the change
- [X] Existing tests pass (`tests/deriver/` + `tests/telemetry/` green; 4 unrelated  <br>failures in `test_auth_route_policy.py` / `test_document.py` dedup require a  <br>local embedding API key and fail identically on `main`)
- [X] `ruff` and `basedpyright` clean on every changed file
- [X] Commit messages follow Conventional Commits

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented representation processing from completing silently when all observer saves fail.
  * When every observer save fails, the batch now surfaces an explicit error; partial failures continue to emit accurate outcomes.
* **New Features**
  * Added a new completion telemetry field, `failed_observer_count`, to report observer save failures.
* **Tests**
  * Added coverage for all-failure vs partial-failure behavior and telemetry expectations.
  * Added a benchmark to measure “silent loss” and failure visibility rate.