### PR TITLE
fix(deriver): truncate oversize observations so one can't drop the batch (#569)

### DIFF
--- a/src/crud/representation.py
+++ b/src/crud/representation.py
@@ -105,7 +105,7 @@ class RepresentationManager:
                 parent_category="representation",
             ):
                 embeddings = await embedding_client.simple_batch_embed(
-                    observation_texts
+                    observation_texts, on_oversize="truncate"
                 )
         except ValueError as e:
             raise exceptions.ValidationException(

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -663,9 +663,19 @@ class EmbeddingClient:
         """Embed a single query string."""
         return await self._get_client().embed(query)
 
-    async def simple_batch_embed(self, texts: list[str]) -> list[list[float]]:
-        """Batch embed a list of text strings (each must fit token limit)."""
-        return await self._get_client().simple_batch_embed(texts)
+    async def simple_batch_embed(
+        self,
+        texts: list[str],
+        *,
+        on_oversize: Literal["raise", "truncate"] = "raise",
+    ) -> list[list[float]]:
+        """Batch embed a list of text strings, one vector per input.
+
+        See ``_EmbeddingClient.simple_batch_embed`` for ``on_oversize`` semantics.
+        """
+        return await self._get_client().simple_batch_embed(
+            texts, on_oversize=on_oversize
+        )
 
     def prepare_chunks(self, id_resource_dict: dict[str, str]) -> dict[str, list[str]]:
         """Chunk texts using the same rules as `batch_embed` (no network)."""

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -274,39 +274,69 @@ class _EmbeddingClient:
             fn=_call_openai,
         )
 
-    async def simple_batch_embed(self, texts: list[str]) -> list[list[float]]:
+    async def simple_batch_embed(
+        self,
+        texts: list[str],
+        *,
+        on_oversize: Literal["raise", "truncate"] = "raise",
+    ) -> list[list[float]]:
         """
-        Batch-embed a list of text strings. Each input must already fit within
-        `max_embedding_tokens`; this method does not sub-chunk oversized inputs.
+        Batch-embed a list of text strings, one vector per input (1:1).
+
+        Each input must fit within `max_embedding_tokens`. When an input exceeds
+        the cap, behaviour depends on `on_oversize`:
+
+        - ``"raise"`` (default): raise ``ValueError`` — preserves the historical
+          contract for existing callers.
+        - ``"truncate"``: embed a token-capped prefix of the input and log a
+          truncation warning, so one oversize input does not fail the whole batch.
+          The one-input-to-one-vector mapping is preserved.
 
         Internally goes through the same token-aware batching pipeline as
         `batch_embed()` so the per-request token cap is respected.
 
         Args:
             texts: List of text strings to embed
+            on_oversize: How to handle an input over the per-input token cap.
 
         Returns:
             List of embedding vectors, one per input text (in order)
 
         Raises:
-            ValueError: If any text exceeds token limits
+            ValueError: If any text exceeds token limits and ``on_oversize`` is
+                ``"raise"``.
         """
         if not texts:
             return []
 
-        # Validate per-input token limit and collect token counts for batching
+        # Validate per-input token limit and collect the (possibly truncated)
+        # texts plus their token counts for batching.
+        prepared_texts: list[str] = []
         token_counts: list[int] = []
         for idx, text in enumerate(texts):
-            tokens = len(self.encoding.encode(text))
-            if tokens > self.max_embedding_tokens:
+            token_ids = self.encoding.encode(text)
+            if len(token_ids) > self.max_embedding_tokens:
+                if on_oversize == "truncate":
+                    text = self.encoding.decode(token_ids[: self.max_embedding_tokens])
+                    logger.warning(
+                        "truncated oversize embedding input at idx %d: %d->%d tokens",
+                        idx,
+                        len(token_ids),
+                        self.max_embedding_tokens,
+                    )
+                    prepared_texts.append(text)
+                    token_counts.append(self.max_embedding_tokens)
+                    continue
                 raise ValueError(
-                    f"Text at index {idx} exceeds maximum token limit of {self.max_embedding_tokens} tokens (got {tokens} tokens)"
+                    f"Text at index {idx} exceeds maximum token limit of {self.max_embedding_tokens} tokens (got {len(token_ids)} tokens)"
                 )
-            token_counts.append(tokens)
+            prepared_texts.append(text)
+            token_counts.append(len(token_ids))
 
         # Use positional indices as text_ids so we can reassemble in input order.
         text_chunks: dict[str, list[tuple[str, int]]] = {
-            str(i): [(text, token_counts[i])] for i, text in enumerate(texts)
+            str(i): [(prepared_texts[i], token_counts[i])]
+            for i in range(len(prepared_texts))
         }
 
         batches = self._create_batches(text_chunks)

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -317,15 +317,27 @@ class _EmbeddingClient:
             token_ids = self.encoding.encode(text)
             if len(token_ids) > self.max_embedding_tokens:
                 if on_oversize == "truncate":
-                    text = self.encoding.decode(token_ids[: self.max_embedding_tokens])
+                    # decode(ids[:n]) can re-encode to more than n tokens at
+                    # BPE/pre-tokenizer boundaries, so re-encode and trim again
+                    # until it fits: the provider must never receive an over-cap
+                    # input (the bug this guards), and _create_batches budgets on
+                    # the count we return here.
+                    cap = self.max_embedding_tokens
+                    truncated_ids = token_ids[:cap]
+                    while True:
+                        text = self.encoding.decode(truncated_ids)
+                        actual_tokens = len(self.encoding.encode(text))
+                        if actual_tokens <= cap or not truncated_ids:
+                            break
+                        truncated_ids = truncated_ids[: -(actual_tokens - cap)]
                     logger.warning(
                         "truncated oversize embedding input at idx %d: %d->%d tokens",
                         idx,
                         len(token_ids),
-                        self.max_embedding_tokens,
+                        actual_tokens,
                     )
                     prepared_texts.append(text)
-                    token_counts.append(self.max_embedding_tokens)
+                    token_counts.append(actual_tokens)
                     continue
                 raise ValueError(
                     f"Text at index {idx} exceeds maximum token limit of {self.max_embedding_tokens} tokens (got {len(token_ids)} tokens)"

--- a/tests/bench/bench_embedding_oversize_survival.py
+++ b/tests/bench/bench_embedding_oversize_survival.py
@@ -42,6 +42,7 @@ async def measure_batch_survival(batch_n: int = BATCH_N) -> float:
     from src.embedding_client import (
         _EmbeddingClient,  # pyright: ignore[reportPrivateUsage]
     )
+    from src.exceptions import ValidationException
     from src.utils.representation import ExplicitObservation, Representation
 
     class _FakeEmbeddingsAPI:
@@ -127,7 +128,10 @@ async def measure_batch_survival(batch_n: int = BATCH_N) -> float:
                     message_level_configuration=Mock(),
                 )
                 return saved["count"] / batch_n
-            except Exception:
+            # BEFORE mode wraps the oversize failure in ValidationException and
+            # drops the whole batch — that's 0% survival. Any other exception is
+            # a harness bug and must escape, not be scored as a failed batch.
+            except ValidationException:
                 return 0.0
 
 

--- a/tests/bench/bench_embedding_oversize_survival.py
+++ b/tests/bench/bench_embedding_oversize_survival.py
@@ -1,0 +1,158 @@
+"""Embedding oversize-survival benchmark — before/after quantification for #569.
+
+Measures ``batch_survival_rate``: with one over-length observation in a batch of N,
+the fraction of observations that still get embedded + saved through
+``RepresentationManager.save_representation``.
+
+It needs **no database and no real provider**: the embedding provider is faked and
+the DB write is faked (`_save_representation_internal` counts the embeddings it is
+handed). The same script runs unmodified against any checkout, so the before/after
+contrast is produced by running it on ``main`` (before) and on the fix branch
+(after):
+
+    PYTHONPATH=. uv run python tests/bench/bench_embedding_oversize_survival.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+# Make `src` importable when run directly (uv run python tests/bench/<this>.py).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+BATCH_N = 10
+
+
+async def measure_batch_survival(batch_n: int = BATCH_N) -> float:
+    """Save a batch where exactly one observation is over-length.
+
+    Returns the fraction of observations that survive (get embedded + saved).
+    """
+    from src.config import EmbeddingModelConfig
+    from src.crud import representation as representation_module
+    from src.crud.representation import RepresentationManager
+    from src.embedding_client import (
+        _EmbeddingClient,  # pyright: ignore[reportPrivateUsage]
+    )
+    from src.utils.representation import ExplicitObservation, Representation
+
+    class _FakeEmbeddingsAPI:
+        async def create(
+            self, *, input: str | list[str], **_kwargs: Any
+        ) -> SimpleNamespace:
+            items = input if isinstance(input, list) else [input]
+            return SimpleNamespace(
+                data=[SimpleNamespace(embedding=[0.1] * 8) for _ in items]
+            )
+
+    class _FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.api_key: str | None = api_key
+            self.base_url: str | None = base_url
+            self.embeddings: _FakeEmbeddingsAPI = _FakeEmbeddingsAPI()
+
+    @asynccontextmanager
+    async def _fake_tracked_db(_name: str):
+        yield object()
+
+    saved: dict[str, int] = {"count": 0}
+
+    async def _fake_internal(
+        _db: Any,
+        _all_observations: Any,
+        embeddings: list[list[float]],
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> int:
+        saved["count"] = len(embeddings)
+        return len(embeddings)
+
+    with patch("src.embedding_client.AsyncOpenAI", _FakeOpenAIClient):
+        # max_input_tokens=5 makes any real sentence "over-length" without a giant string.
+        client = _EmbeddingClient(
+            EmbeddingModelConfig(
+                transport="openai",
+                model="text-embedding-3-small",
+                api_key="test-key",
+            ),
+            vector_dimensions=8,
+            max_input_tokens=5,
+            max_tokens_per_request=300_000,
+            send_dimensions=False,
+        )
+
+        observations = [
+            ExplicitObservation(
+                content="short",
+                created_at=datetime.now(timezone.utc),
+                message_ids=[1],
+                session_name="session-1",
+            )
+            for _ in range(batch_n - 1)
+        ]
+        observations.append(
+            ExplicitObservation(
+                content="word " * 200,  # far over the 5-token cap
+                created_at=datetime.now(timezone.utc),
+                message_ids=[1],
+                session_name="session-1",
+            )
+        )
+        representation = Representation(explicit=observations)
+        manager = RepresentationManager("workspace-1", observer="bob", observed="alice")
+
+        with (
+            patch.object(representation_module, "embedding_client", client),
+            patch("src.crud.representation.tracked_db", _fake_tracked_db),
+            patch.object(
+                manager,
+                "_save_representation_internal",
+                new=AsyncMock(side_effect=_fake_internal),
+            ),
+        ):
+            try:
+                await manager.save_representation(
+                    representation,
+                    message_ids=[1],
+                    session_name="session-1",
+                    message_created_at=datetime.now(timezone.utc),
+                    message_level_configuration=Mock(),
+                )
+                return saved["count"] / batch_n
+            except Exception:
+                return 0.0
+
+
+def _supports_truncate() -> bool:
+    from src.embedding_client import (
+        _EmbeddingClient,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    params = inspect.signature(_EmbeddingClient.simple_batch_embed).parameters
+    return "on_oversize" in params
+
+
+async def main() -> None:
+    survival = await measure_batch_survival()
+    mode = (
+        "AFTER (truncate supported)" if _supports_truncate() else "BEFORE (no truncate)"
+    )
+
+    print("=" * 60)
+    print(f"Embedding oversize-survival benchmark — {mode}")
+    print(f"  batch_n={BATCH_N}")
+    print("-" * 60)
+    print(f"  batch_survival_rate : {survival:6.1%}   (target: 100%)")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -505,7 +505,7 @@ def mock_openai_embeddings(request: pytest.FixtureRequest):
         mock_embed.side_effect = embed_side_effect
 
         async def mock_simple_batch_embed_func(
-            texts: list[str], *, on_oversize: str = "raise"
+            texts: list[str], **_kwargs: Any
         ) -> list[list[float]]:
             return [_content_to_embedding(text) for text in texts]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -504,7 +504,9 @@ def mock_openai_embeddings(request: pytest.FixtureRequest):
 
         mock_embed.side_effect = embed_side_effect
 
-        async def mock_simple_batch_embed_func(texts: list[str]) -> list[list[float]]:
+        async def mock_simple_batch_embed_func(
+            texts: list[str], *, on_oversize: str = "raise"
+        ) -> list[list[float]]:
             return [_content_to_embedding(text) for text in texts]
 
         mock_simple_batch_embed.side_effect = mock_simple_batch_embed_func

--- a/tests/crud/test_representation_manager.py
+++ b/tests/crud/test_representation_manager.py
@@ -283,10 +283,55 @@ class TestRepresentationManagerSave:
             )
 
         assert len(saved.created_documents) == 1
-        mock_embed.assert_awaited_once_with(["useful observation"])
+        mock_embed.assert_awaited_once_with(
+            ["useful observation"], on_oversize="truncate"
+        )
         saved_observations = _saved_observations(mock_save)
         assert len(saved_observations) == 1
         assert saved_observations[0].content == "useful observation"
+
+    @pytest.mark.asyncio
+    async def test_save_representation_embeds_with_truncate_on_oversize(self):
+        """save_representation embeds observations with on_oversize='truncate' so a
+        single over-length observation does not fail the whole batch (#569)."""
+        manager = RepresentationManager(
+            "workspace",
+            observer="observer",
+            observed="observed",
+        )
+        representation = Representation(
+            explicit=[
+                ExplicitObservation(
+                    content="an observation",
+                    created_at=datetime.now(timezone.utc),
+                    message_ids=[1],
+                    session_name="session",
+                ),
+            ]
+        )
+
+        with (
+            patch("src.crud.representation.tracked_db", _fake_tracked_db),
+            patch(
+                "src.crud.representation.embedding_client.simple_batch_embed",
+                new=AsyncMock(return_value=[[0.1]]),
+            ) as mock_embed,
+            patch.object(
+                manager,
+                "_save_representation_internal",
+                new=AsyncMock(return_value=1),
+            ),
+        ):
+            await manager.save_representation(
+                representation,
+                message_ids=[1],
+                session_name="session",
+                message_created_at=datetime.now(timezone.utc),
+                message_level_configuration=_resolved_config(),
+            )
+
+        assert mock_embed.await_args is not None
+        assert mock_embed.await_args.kwargs.get("on_oversize") == "truncate"
 
     @pytest.mark.asyncio
     async def test_save_representation_filters_blank_deductive_observations(self):
@@ -339,7 +384,9 @@ class TestRepresentationManagerSave:
             )
 
         assert len(saved.created_documents) == 1
-        mock_embed.assert_awaited_once_with(["inferred conclusion"])
+        mock_embed.assert_awaited_once_with(
+            ["inferred conclusion"], on_oversize="truncate"
+        )
         saved_observations = _saved_observations(mock_save)
         assert len(saved_observations) == 1
         assert isinstance(saved_observations[0], DeductiveObservation)

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -93,6 +93,75 @@ async def test_openai_embedding_client_rejects_dimension_mismatch(
 
 
 @pytest.mark.asyncio
+async def test_simple_batch_embed_truncates_oversize_input_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In truncate mode, an input exceeding the token cap is embedded from a
+    token-capped prefix and still yields exactly one vector — one oversize
+    observation must not fail the whole batch (#569)."""
+    fake_embeddings = FakeOpenAIEmbeddingsAPI([0.1] * 8)
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai",
+            model="text-embedding-3-small",
+            api_key="test-key",
+        ),
+        vector_dimensions=8,
+        max_input_tokens=5,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+    oversize = "word " * 100  # far over the 5-token cap
+
+    result = await client.simple_batch_embed([oversize], on_oversize="truncate")
+
+    assert len(result) == 1  # 1:1 preserved
+    assert result[0] == [0.1] * 8
+    # The provider received a truncated input within the cap, not the full text.
+    sent = fake_embeddings.calls[-1]["input"]
+    sent_text = sent[0] if isinstance(sent, list) else sent
+    assert len(client.encoding.encode(sent_text)) <= client.max_embedding_tokens
+
+
+@pytest.mark.asyncio
+async def test_simple_batch_embed_raises_on_oversize_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default mode preserves the historical contract: an oversize input raises,
+    so existing callers are unaffected by the new truncate option (#569 guard)."""
+    fake_embeddings = FakeOpenAIEmbeddingsAPI([0.1] * 8)
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai",
+            model="text-embedding-3-small",
+            api_key="test-key",
+        ),
+        vector_dimensions=8,
+        max_input_tokens=5,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+    with pytest.raises(ValueError, match="exceeds maximum token limit"):
+        await client.simple_batch_embed(["word " * 100])
+
+
+@pytest.mark.asyncio
 async def test_gemini_embedding_client_uses_output_dimensionality(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -126,8 +126,8 @@ async def test_simple_batch_embed_truncates_oversize_input_instead_of_raising(
     assert len(result) == 1  # 1:1 preserved
     assert result[0] == [0.1] * 8
     # The provider received a truncated input within the cap, not the full text.
-    sent = fake_embeddings.calls[-1]["input"]
-    sent_text = sent[0] if isinstance(sent, list) else sent
+    # In batch mode the provider is always called with a list of strings.
+    sent_text = cast("list[str]", fake_embeddings.calls[-1]["input"])[0]
     assert len(client.encoding.encode(sent_text)) <= client.max_embedding_tokens
 
 

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -132,6 +132,56 @@ async def test_simple_batch_embed_truncates_oversize_input_instead_of_raising(
 
 
 @pytest.mark.asyncio
+async def test_simple_batch_embed_truncate_reencodes_when_decode_drifts_over_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """decode(ids[:cap]) can re-encode to more than cap tokens at BPE/pre-token
+    boundaries. A single prefix slice is not enough — the truncate path must
+    re-encode and trim again so the provider never receives an over-cap input
+    (the guarantee #569 relies on)."""
+    fake_embeddings = FakeOpenAIEmbeddingsAPI([0.1] * 8)
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai",
+            model="text-embedding-3-small",
+            api_key="test-key",
+        ),
+        vector_dimensions=8,
+        max_input_tokens=5,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+    class _DriftEncoding:
+        """Every non-empty text encodes to len+1 tokens, so decode(ids[:5])
+        re-encodes to 6 (> cap): a plain slice would slip an over-cap input
+        through, while the re-trim loop converges back within the cap."""
+
+        def encode(self, text: str) -> list[int]:
+            return [0] * (len(text) + 1) if text else []
+
+        def decode(self, ids: list[int]) -> str:
+            return "a" * len(ids)
+
+    monkeypatch.setattr(client, "encoding", _DriftEncoding())
+
+    result = await client.simple_batch_embed(["a" * 10], on_oversize="truncate")
+
+    assert len(result) == 1  # 1:1 preserved
+    # A plain ids[:cap] slice would re-encode to cap+1 and slip through; the
+    # loop must land the sent input within the cap.
+    sent_text = cast("list[str]", fake_embeddings.calls[-1]["input"])[0]
+    assert len(client.encoding.encode(sent_text)) <= client.max_embedding_tokens
+
+
+@pytest.mark.asyncio
 async def test_simple_batch_embed_raises_on_oversize_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Description

`src/crud/representation.py` collects every observation from a deriver pass and  <br>embeds them in one call — `embedding_client.simple_batch_embed(observation_texts)`.  <br>If a **single** observation exceeded the provider's per-input token cap,  <br>`simple_batch_embed` raised `ValueError`, `save_representation` re-raised  <br>`ValidationException`, and the deriver caught it — so **none** of that pass's  <br>observations were saved, not just the long one (plastic-labs/honcho#569). One long pasted artifact  <br>(a PR review, verbose tool output, a stack trace) dropped the whole batch. Rare  <br>under OpenAI's 8192 cap; routine under Gemini's smaller embedding cap.

`simple_batch_embed` has no sub-chunking path (only `batch_embed`, used for  <br>messages, does), and truncation is the right call here: an observation is a short  <br>derived fact, so a token-capped prefix still carries the meaningful content.

This adds an opt-in truncation mode and points the deriver at it:

* `simple_batch_embed` **gains** `on_oversize: "raise" | "truncate"` (keyword-only,  <br>default `"raise"`). `"raise"` preserves the exact historical contract for every  <br>existing caller. `"truncate"` embeds a token-capped prefix of the oversize input  <br>and logs a warning; the one-input→one-vector mapping is preserved.
* `RepresentationManager` **opts into** `on_oversize="truncate"`, so one oversize  <br>observation is truncated instead of failing the whole observer's batch.

Complements plastic-labs/honcho#860 (surface representation save failures instead of silent loss):  <br>plastic-labs/honcho#569 keeps the common oversize case from ever failing; plastic-labs/honcho#860 makes a genuinely  <br>total save failure loud instead of silent. Neither masks the other.

**Quantified** (`tests/bench/bench_embedding_oversize_survival.py` — real  <br>`save_representation` path with a faked provider + faked DB write, `batch_n=10`,  <br>exactly one over-length observation):

<!-- linear:table-colwidths:266,266,266 -->
| Metric | Before (`main`) | After |
| -- | -- | -- |
| `batch_survival_rate` | 0% | 100% |

## Linked issues

Fixes plastic-labs/honcho#569

## Type of change

- [X] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `perf` — performance improvement
- [ ] `docs` — documentation only
- [X] `test` — adding or correcting tests
- [ ] `chore` — build process or tooling

## Test plan

New / updated tests:

* `tests/llm/test_embedding_client.py` — `simple_batch_embed` raises on oversize  <br>when `on_oversize="raise"` (default) and truncates the oversize prefix (keeping  <br>1 vector per input) when `on_oversize="truncate"`. (18 passed)
* `tests/crud/test_representation_manager.py::TestRepresentationManagerSave::test_save_representation_embeds_with_truncate_on_oversize`  <br>— the manager passes `on_oversize="truncate"` through. (7 passed; needs a local  <br>pgvector DB)
* `tests/conftest.py` — the autouse embedding mock accepts the new `on_oversize`  <br>kwarg (via `**_kwargs`) so existing tests keep passing.

Quantitative before/after (standalone harness, not a CI test):

```bash
# AFTER (this branch)
PYTHONPATH=. uv run python tests/bench/bench_embedding_oversize_survival.py
# BEFORE (main source)
git checkout main -- src/embedding_client.py src/crud/representation.py
PYTHONPATH=. uv run python tests/bench/bench_embedding_oversize_survival.py
git checkout HEAD -- src/embedding_client.py src/crud/representation.py
```

## Checklist

- [X] Tests added/updated for the change
- [X] Existing tests pass (`tests/llm/test_embedding_client.py` 18/18;  <br>`tests/crud/test_representation_manager.py` 7/7 against a local pgvector DB)
- [X] `ruff` clean; `basedpyright` 0 errors on every changed file (4 pre-existing  <br>`conftest.py` header warnings, present identically on `main`)
- [X] Commit messages follow Conventional Commits
- [ ] Documentation update — n/a (internal behavior; new param defaults to the  <br>prior raise-on-oversize contract, so no caller changes)

## Summary by CodeRabbit

* **New Features**
  * Added automatic truncation for oversized observation text during embedding, preventing hard failures on long inputs.
* **Bug Fixes**
  * Oversized inputs no longer raise errors when truncation mode is enabled.
  * Ensured returned embeddings stay aligned with the original input order and count.
* **Tests**
  * Added benchmark coverage for “oversize survival.”
  * Expanded unit tests for truncation success, edge-case tokenization drift, and default error behavior.