### PR TITLE
fix: redact Redis password from cache connection logs

### DIFF
--- a/src/cache/client.py
+++ b/src/cache/client.py
@@ -24,46 +24,89 @@ logger = logging.getLogger(__name__)
 _cache_lock = asyncio.Lock()
 
 
+# Query parameters that carry secrets when configured via URL:
+# redis-py accepts ``?password=`` (all querystring options become client
+# kwargs) and cashews accepts ``?secret=`` (HMAC key for value signing).
+_SENSITIVE_QUERY_PARAMS = frozenset({"password", "secret"})
+
+
+def _mask_sensitive_query(query: str) -> str:
+    """Mask values of secret-bearing query parameters.
+
+    Operates on the raw query string (no decode/re-encode round trip)
+    so non-secret parameters are preserved byte-for-byte.
+
+    Args:
+        query: The raw query string from a parsed URL.
+
+    Returns:
+        The query string with sensitive values replaced by ``***``, or
+        the original string if no sensitive parameter is present.
+    """
+    if not query:
+        return query
+    parts: list[str] = []
+    changed = False
+    for part in query.split("&"):
+        name, sep, _value = part.partition("=")
+        if sep and name.lower() in _SENSITIVE_QUERY_PARAMS:
+            parts.append(f"{name}=***")
+            changed = True
+        else:
+            parts.append(part)
+    return "&".join(parts) if changed else query
+
+
 def _redact_cache_url(url: str) -> str:
-    """Mask the password in a Redis connection URL before logging.
+    """Mask credentials in a Redis connection URL before logging.
 
     Given ``redis://:password@host:port/db`` returns
-    ``redis://:***@host:port/db``.  If the URL has no userinfo
-    component it is returned unchanged.  This function never raises
-    and never returns a password: an invalid port is omitted from the
-    output, and a URL that cannot be parsed at all is replaced by a
-    generic placeholder rather than echoed back, so that logging
+    ``redis://:***@host:port/db``; secret-bearing query parameters
+    (``?password=``, ``?secret=``) are masked as well.  A URL carrying
+    no credentials is returned unchanged.  This function never raises
+    and never returns a credential: an invalid port is omitted from
+    the output, and a URL that cannot be parsed at all is replaced by
+    a generic placeholder rather than echoed back, so that logging
     inside ``except`` blocks can neither crash startup nor leak the
-    credential this helper exists to hide.
+    secrets this helper exists to hide.
 
     Args:
         url: The Redis connection URL to redact.
 
     Returns:
-        The URL with its password masked, the original URL if it has
-        no password, or ``"<redacted-unparseable-url>"`` if parsing
+        The URL with its credentials masked, the original URL if it
+        carries none, or ``"<redacted-unparseable-url>"`` if parsing
         fails entirely.
     """
     try:
         parsed = urlparse(url)
+        query = _mask_sensitive_query(parsed.query)
         # .password only splits netloc and never raises, unlike .port
-        if parsed.password is None:
+        if parsed.password is None and query == parsed.query:
+            # A string with an "@" but no parsed authority (e.g. a URL
+            # missing its scheme, ":pass@host:6379/0") may still carry
+            # userinfo that urlparse could not see — never echo it.
+            if "@" in url and not parsed.netloc:
+                return "<redacted-unparseable-url>"
             return url
-        userinfo = parsed.username or ""
-        hostname = parsed.hostname or ""
-        # Preserve IPv6 brackets (urlparse strips them from .hostname)
-        if hostname and ":" in hostname and not hostname.startswith("["):
-            hostname = f"[{hostname}]"
-        netloc = f"{userinfo}:***@{hostname}"
-        try:
-            port = parsed.port
-        except ValueError:
-            # Invalid or out-of-range port: omit it rather than let the
-            # outer fallback echo the raw URL (and its password) back.
-            port = None
-        if port is not None:
-            netloc += f":{port}"
-        parsed = parsed._replace(netloc=netloc)
+        netloc = parsed.netloc
+        if parsed.password is not None:
+            userinfo = parsed.username or ""
+            hostname = parsed.hostname or ""
+            # Preserve IPv6 brackets (urlparse strips them from .hostname)
+            if hostname and ":" in hostname and not hostname.startswith("["):
+                hostname = f"[{hostname}]"
+            netloc = f"{userinfo}:***@{hostname}"
+            try:
+                port = parsed.port
+            except ValueError:
+                # Invalid or out-of-range port: omit it rather than let
+                # the outer fallback echo the raw URL (and its password)
+                # back.
+                port = None
+            if port is not None:
+                netloc += f":{port}"
+        parsed = parsed._replace(netloc=netloc, query=query)
         return urlunparse(parsed)
     except (ValueError, TypeError):
         # Unparseable URL: never return the raw input — it may contain

--- a/src/cache/client.py
+++ b/src/cache/client.py
@@ -29,17 +29,33 @@ def _redact_cache_url(url: str) -> str:
 
     Given ``redis://:password@host:port/db`` returns
     ``redis://:***@host:port/db``.  If the URL has no userinfo
-    component it is returned unchanged.
+    component it is returned unchanged.  This function never raises:
+    if the URL is malformed it returns the original string so that
+    logging inside ``except`` blocks cannot crash startup.
+
+    Args:
+        url: The Redis connection URL to redact.
+
+    Returns:
+        The URL with its password masked, or the original URL if it
+        has no password or cannot be parsed.
     """
-    parsed = urlparse(url)
-    if parsed.password is None:
+    try:
+        parsed = urlparse(url)
+        if parsed.password is None:
+            return url
+        userinfo = parsed.username or ""
+        hostname = parsed.hostname or ""
+        # Preserve IPv6 brackets (urlparse strips them from .hostname)
+        if hostname and ":" in hostname and not hostname.startswith("["):
+            hostname = f"[{hostname}]"
+        netloc = f"{userinfo}:***@{hostname}"
+        if parsed.port is not None:
+            netloc += f":{parsed.port}"
+        parsed = parsed._replace(netloc=netloc)
+        return urlunparse(parsed)
+    except (ValueError, TypeError):
         return url
-    userinfo = parsed.username or ""
-    netloc = f"{userinfo}:***@{parsed.hostname or ''}"
-    if parsed.port is not None:
-        netloc += f":{parsed.port}"
-    parsed = parsed._replace(netloc=netloc)
-    return urlunparse(parsed)
 
 
 def is_cache_enabled() -> bool:

--- a/src/cache/client.py
+++ b/src/cache/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import Any, cast
+from urllib.parse import urlparse, urlunparse
 
 import sentry_sdk
 from cashews import cache
@@ -20,8 +21,25 @@ from src.config import settings
 
 logger = logging.getLogger(__name__)
 
-
 _cache_lock = asyncio.Lock()
+
+
+def _redact_cache_url(url: str) -> str:
+    """Mask the password in a Redis connection URL before logging.
+
+    Given ``redis://:password@host:port/db`` returns
+    ``redis://:***@host:port/db``.  If the URL has no userinfo
+    component it is returned unchanged.
+    """
+    parsed = urlparse(url)
+    if parsed.password is None:
+        return url
+    userinfo = parsed.username or ""
+    netloc = f"{userinfo}:***@{parsed.hostname or ''}"
+    if parsed.port is not None:
+        netloc += f":{parsed.port}"
+    parsed = parsed._replace(netloc=netloc)
+    return urlunparse(parsed)
 
 
 def is_cache_enabled() -> bool:
@@ -55,7 +73,7 @@ async def init_cache() -> None:
         except Exception as setup_err:
             logger.warning(
                 "Cache setup failed for %s: %s. Falling back to in-memory cache",
-                settings.CACHE.URL,
+                _redact_cache_url(settings.CACHE.URL),
                 setup_err,
             )
             if settings.SENTRY.ENABLED:
@@ -83,7 +101,10 @@ async def init_cache() -> None:
                 with attempt:
                     async with asyncio.timeout(2):
                         await cache.ping()
-                        logger.info("Connected to cache at %s", settings.CACHE.URL)
+                        logger.info(
+                            "Connected to cache at %s",
+                            _redact_cache_url(settings.CACHE.URL),
+                        )
         except (
             redis_exc.TimeoutError,
             redis_exc.ConnectionError,
@@ -92,7 +113,7 @@ async def init_cache() -> None:
         ) as e:
             logger.warning(
                 "Failed to connect to cache at %s: %s. Falling back to in-memory cache",
-                settings.CACHE.URL,
+                _redact_cache_url(settings.CACHE.URL),
                 e,
             )
             if settings.SENTRY.ENABLED:
@@ -103,7 +124,7 @@ async def init_cache() -> None:
         except Exception as e:
             logger.warning(
                 "Unexpected cache error at %s: %s. Falling back to in-memory cache",
-                settings.CACHE.URL,
+                _redact_cache_url(settings.CACHE.URL),
                 e,
             )
             if settings.SENTRY.ENABLED:

--- a/src/cache/client.py
+++ b/src/cache/client.py
@@ -29,19 +29,24 @@ def _redact_cache_url(url: str) -> str:
 
     Given ``redis://:password@host:port/db`` returns
     ``redis://:***@host:port/db``.  If the URL has no userinfo
-    component it is returned unchanged.  This function never raises:
-    if the URL is malformed it returns the original string so that
-    logging inside ``except`` blocks cannot crash startup.
+    component it is returned unchanged.  This function never raises
+    and never returns a password: an invalid port is omitted from the
+    output, and a URL that cannot be parsed at all is replaced by a
+    generic placeholder rather than echoed back, so that logging
+    inside ``except`` blocks can neither crash startup nor leak the
+    credential this helper exists to hide.
 
     Args:
         url: The Redis connection URL to redact.
 
     Returns:
-        The URL with its password masked, or the original URL if it
-        has no password or cannot be parsed.
+        The URL with its password masked, the original URL if it has
+        no password, or ``"<redacted-unparseable-url>"`` if parsing
+        fails entirely.
     """
     try:
         parsed = urlparse(url)
+        # .password only splits netloc and never raises, unlike .port
         if parsed.password is None:
             return url
         userinfo = parsed.username or ""
@@ -50,12 +55,20 @@ def _redact_cache_url(url: str) -> str:
         if hostname and ":" in hostname and not hostname.startswith("["):
             hostname = f"[{hostname}]"
         netloc = f"{userinfo}:***@{hostname}"
-        if parsed.port is not None:
-            netloc += f":{parsed.port}"
+        try:
+            port = parsed.port
+        except ValueError:
+            # Invalid or out-of-range port: omit it rather than let the
+            # outer fallback echo the raw URL (and its password) back.
+            port = None
+        if port is not None:
+            netloc += f":{port}"
         parsed = parsed._replace(netloc=netloc)
         return urlunparse(parsed)
     except (ValueError, TypeError):
-        return url
+        # Unparseable URL: never return the raw input — it may contain
+        # the very password this helper exists to hide.
+        return "<redacted-unparseable-url>"
 
 
 def is_cache_enabled() -> bool:

--- a/tests/test_cache_redaction.py
+++ b/tests/test_cache_redaction.py
@@ -16,7 +16,7 @@ class TestRedactCacheUrl:
         )
 
     def test_user_and_password(self):
-        result = _redact_cache_url("redis://user:***@10.0.0.1:6380/2")
+        result = _redact_cache_url("redis://user:s3cret@10.0.0.1:6380/2")
         assert "***" in result
         assert "s3cret" not in result
         assert "user" in result
@@ -28,15 +28,15 @@ class TestRedactCacheUrl:
         assert "secret" not in result
 
     def test_complex_password(self):
-        result = _redact_cache_url("redis://:p@ssw0rd!#$@host:6379/0")
+        result = _redact_cache_url("redis://:p%40ssw0rd!%24@host:6379/0")
         assert "***" in result
-        assert "p@ssw0rd" not in result
+        assert "p%40ssw0rd" not in result
 
     def test_password_never_leaked(self):
         """The original password must never appear in the redacted output."""
         for url in [
             "redis://:hunter2@localhost:6379/0",
-            "redis://admin:***@localhost:6379/0",
+            "redis://admin:hunter2@localhost:6379/0",
             "rediss://:hunter2@[::1]:6380/1",
         ]:
             assert "hunter2" not in _redact_cache_url(url)
@@ -45,8 +45,8 @@ class TestRedactCacheUrl:
 
     def test_user_without_password_unchanged(self):
         assert (
-            _redact_cache_url("redis://user@localhost:***@localhost:6379/0")
-            == "redis://localhost:6379/0"
+            _redact_cache_url("redis://user@localhost:6379/0")
+            == "redis://user@localhost:6379/0"
         )
 
     def test_in_memory_url_unchanged(self):

--- a/tests/test_cache_redaction.py
+++ b/tests/test_cache_redaction.py
@@ -1,0 +1,81 @@
+"""Unit tests for the cache client's _redact_cache_url helper."""
+
+from src.cache.client import _redact_cache_url
+
+
+class TestRedactCacheUrl:
+    """Tests for _redact_cache_url — a security-relevant logging helper
+    that must never raise and must never leak a password."""
+
+    # --- Password masking ---
+
+    def test_password_only_userinfo(self):
+        assert (
+            _redact_cache_url("redis://:secret@localhost:6379/0")
+            == "redis://:***@localhost:6379/0"
+        )
+
+    def test_user_and_password(self):
+        result = _redact_cache_url("redis://user:***@10.0.0.1:6380/2")
+        assert "***" in result
+        assert "s3cret" not in result
+        assert "user" in result
+
+    def test_rediss_protocol(self):
+        result = _redact_cache_url("rediss://:secret@redis.example.com:6380")
+        assert result.startswith("rediss://")
+        assert "***" in result
+        assert "secret" not in result
+
+    def test_complex_password(self):
+        result = _redact_cache_url("redis://:p@ssw0rd!#$@host:6379/0")
+        assert "***" in result
+        assert "p@ssw0rd" not in result
+
+    def test_password_never_leaked(self):
+        """The original password must never appear in the redacted output."""
+        for url in [
+            "redis://:hunter2@localhost:6379/0",
+            "redis://admin:***@localhost:6379/0",
+            "rediss://:hunter2@[::1]:6380/1",
+        ]:
+            assert "hunter2" not in _redact_cache_url(url)
+
+    # --- No-password URLs (returned unchanged) ---
+
+    def test_user_without_password_unchanged(self):
+        assert (
+            _redact_cache_url("redis://user@localhost:***@localhost:6379/0")
+            == "redis://localhost:6379/0"
+        )
+
+    def test_in_memory_url_unchanged(self):
+        assert _redact_cache_url("mem://") == "mem://"
+
+    # --- IPv6 ---
+
+    def test_ipv6_brackets_preserved(self):
+        result = _redact_cache_url("rediss://:secret@[::1]:6380/1")
+        assert "[::1]" in result
+        assert "***" in result
+        assert "secret" not in result
+
+    # --- Malformed URLs (must NOT raise) ---
+
+    def test_invalid_port_does_not_raise(self):
+        """Regression test for the bug found in review: accessing
+        ``parsed.port`` on a URL with a non-numeric port raises
+        ``ValueError``.  The helper must catch this and return the
+        original URL rather than crashing startup inside an except block.
+        """
+        url = "redis://:pass@host:notaport/0"
+        result = _redact_cache_url(url)
+        # Must not raise; password should still be redacted if possible,
+        # but the key requirement is that it returns a string, not raises.
+        assert isinstance(result, str)
+
+    def test_garbage_input_does_not_raise(self):
+        assert isinstance(_redact_cache_url("not a url at all"), str)
+
+    def test_empty_string_does_not_raise(self):
+        assert isinstance(_redact_cache_url(""), str)

--- a/tests/test_cache_redaction.py
+++ b/tests/test_cache_redaction.py
@@ -1,5 +1,7 @@
 """Unit tests for the cache client's _redact_cache_url helper."""
 
+import pytest
+
 from src.cache.client import _redact_cache_url
 
 
@@ -40,6 +42,32 @@ class TestRedactCacheUrl:
             "rediss://:hunter2@[::1]:6380/1",
         ]:
             assert "hunter2" not in _redact_cache_url(url)
+
+    # --- Secrets in query parameters ---
+    # redis-py accepts ?password= (querystring options become client
+    # kwargs) and cashews accepts ?secret= (HMAC signing key), so both
+    # are real configuration paths that must not reach the logs.
+
+    @pytest.mark.parametrize("param", ["password", "secret", "PASSWORD"])
+    def test_query_param_secret_masked(self, param: str):
+        result = _redact_cache_url(f"redis://host:6379/0?{param}=s3cret")
+        assert "s3cret" not in result
+        assert f"{param}=***" in result
+
+    def test_query_param_masking_preserves_other_params(self):
+        result = _redact_cache_url("redis://host:6379/0?db=1&password=s3cret&ssl=true")
+        assert "s3cret" not in result
+        assert "db=1" in result
+        assert "ssl=true" in result
+
+    def test_userinfo_and_query_secret_both_masked(self):
+        result = _redact_cache_url("redis://:hunter2@host:6379/0?secret=s3cret")
+        assert "hunter2" not in result
+        assert "s3cret" not in result
+
+    def test_non_secret_query_params_unchanged(self):
+        url = "redis://localhost:6379/0?suppress=true"
+        assert _redact_cache_url(url) == url
 
     # --- No-password URLs (returned unchanged) ---
 
@@ -83,6 +111,13 @@ class TestRedactCacheUrl:
         # fallback must return a placeholder, not the raw input.
         result = _redact_cache_url("redis://:secret@[::1:6379/0")
         assert "secret" not in result
+
+    def test_missing_scheme_never_echoed(self):
+        # Without "redis://" urlparse sees no netloc, so the userinfo
+        # (and its password) is invisible to .password — the string
+        # must not be echoed back.
+        result = _redact_cache_url(":hunter2@host:6379/0")
+        assert "hunter2" not in result
 
     def test_garbage_input_does_not_raise(self):
         assert isinstance(_redact_cache_url("not a url at all"), str)

--- a/tests/test_cache_redaction.py
+++ b/tests/test_cache_redaction.py
@@ -62,17 +62,27 @@ class TestRedactCacheUrl:
 
     # --- Malformed URLs (must NOT raise) ---
 
-    def test_invalid_port_does_not_raise(self):
-        """Regression test for the bug found in review: accessing
+    def test_invalid_port_redacts_password(self):
+        """Regression test for two review findings: accessing
         ``parsed.port`` on a URL with a non-numeric port raises
-        ``ValueError``.  The helper must catch this and return the
-        original URL rather than crashing startup inside an except block.
+        ``ValueError`` (must not crash startup inside an except block),
+        and the fallback must never echo the raw URL back — the
+        password has to be masked even when the port is unparseable.
         """
-        url = "redis://:pass@host:notaport/0"
-        result = _redact_cache_url(url)
-        # Must not raise; password should still be redacted if possible,
-        # but the key requirement is that it returns a string, not raises.
-        assert isinstance(result, str)
+        result = _redact_cache_url("redis://:pass@host:notaport/0")
+        assert "pass" not in result
+        assert "***" in result
+
+    def test_out_of_range_port_redacts_password(self):
+        result = _redact_cache_url("redis://:supersecret@host:99999/0")
+        assert "supersecret" not in result
+        assert "***" in result
+
+    def test_unparseable_url_never_echoed(self):
+        # Unbalanced IPv6 bracket makes urlparse itself raise; the
+        # fallback must return a placeholder, not the raw input.
+        result = _redact_cache_url("redis://:secret@[::1:6379/0")
+        assert "secret" not in result
 
     def test_garbage_input_does_not_raise(self):
         assert isinstance(_redact_cache_url("not a url at all"), str)


### PR DESCRIPTION
## Summary

`src/cache/client.py` logged the full Redis connection URL — including the password — at four log call sites during cache initialization. This exposed the live Redis credential in stdout/container logs and any downstream log aggregation (Loki, CloudWatch, ELK, etc.) on every container start.

## Changes

Added `_redact_cache_url()` which uses `urllib.parse.urlparse` to mask the password component of the URL before logging:

- `redis://:password@host:port/db` → `redis://:***@host:port/db`
- URLs without a password are returned unchanged

Replaced all 4 occurrences of `settings.CACHE.URL` in log calls with `_redact_cache_url(settings.CACHE.URL)`:
- `cache.setup` failure path (warning)
- `cache.ping` success path (info)
- `cache.ping` retry exhaustion (warning)
- `cache.ping` unexpected error (warning)

## Verification

Tested `_redact_cache_url()` with 5 cases — all pass:
- Password-only userinfo: `redis://:secret@localhost:6379/0` → `redis://:***@localhost:6379/0`
- User + password: `redis://user:secret@host:6380/2` → `redis://user:***@host:6380/2`
- Rediss protocol: `rediss://:secret@host:6380` → `rediss://:***@host:6380`
- No password: `redis://localhost:6379/0` → unchanged
- In-memory: `mem://` → unchanged

No functional/behavioral changes — only log output is affected.

Closes #866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cache connection and error logging to automatically redact Redis credentials (including password and secret values in both embedded userinfo and query parameters), reducing the risk of exposing sensitive details while keeping cache behavior unchanged.
* **Tests**
  * Expanded unit coverage to validate redaction across multiple Redis URL formats (URL-encoded secrets, IPv6, and edge cases), and to ensure malformed inputs are handled safely without leaking raw secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->