### PR TITLE
fix(docker): copy uv build inputs for podman compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,12 @@ ENV UV_LINK_MODE=copy
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# Install the project's dependencies using the lockfile and settings
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --no-group dev
-
 # Copy only requirements to cache them in docker layer
 COPY uv.lock pyproject.toml /app/
+
+# Install the project's dependencies using the lockfile and settings
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-group dev
 
 # Sync the project
 RUN --mount=type=cache,target=/root/.cache/uv \


### PR DESCRIPTION
# **This pull request fixes #877 issue**

## **Description**

This PR updates the Dockerfile dependency-install layer to copy `uv.lock` and `pyproject.toml` before running `uv sync`, instead of reading them through BuildKit bind mounts.

The previous bind-mount form can fail under Podman on macOS with:

```text
error: failed to open file `/app/pyproject.toml`: Permission denied (os error 13)
```

`pyproject.toml` and `uv.lock` are intrinsic build inputs for the Honcho image. Copying them into the dependency layer keeps dependency caching isolated from application source changes while avoiding Podman/macOS bind-mount permission issues.

No new runtime dependencies are introduced.

---

### **Additional context**

Validated locally with Podman 5.8.3 on macOS:

```text
podman compose up -d --build
curl http://localhost:8000/openapi.json
```

The API started successfully at `http://localhost:8000` after this change.

## **Changelog**

### **Added**

### **Changed**

- Use `COPY uv.lock pyproject.toml /app/` before the dependency install step instead of BuildKit bind mounts.

### **Deprecated**

### **Removed**

- Removed BuildKit bind mounts for `uv.lock` and `pyproject.toml` from the dependency install step.

### **Fixed**

- Fixed Podman/macOS image builds failing to read `pyproject.toml` from a build-time bind mount.

### **Security**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build setup to use a simpler dependency caching approach, which can improve build consistency and efficiency.
  * Kept dependency installation behavior the same while streamlining how build inputs are prepared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->