### PR TITLE
fix(llm): satisfy lowercase json_object prompt checks

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -30,11 +30,12 @@ def _json_object_instruction(response_format: type[BaseModel]) -> str:
     instruction — the deriver issues one structured call per batch on the worker
     hot path and would otherwise re-walk the schema + re-serialize it every call.
     """
-    # "JSON" must appear in the messages to satisfy the json_object contract.
+    # Some OpenAI-compatible providers enforce this json_object precondition with
+    # a case-sensitive substring check, so include lowercase "json" explicitly.
     return (
-        "You must respond with a single JSON object that conforms exactly to "
-        "the following JSON schema. Do not include any text, markdown, or code "
-        "fences outside the JSON object.\n\nJSON schema:\n"
+        "You must respond with a single json object that conforms exactly to "
+        "the following json schema. Do not include any text, markdown, or code "
+        "fences outside the json object.\n\njson schema:\n"
         f"{json.dumps(response_format.model_json_schema())}"
     )
 

--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -30,12 +30,12 @@ def _json_object_instruction(response_format: type[BaseModel]) -> str:
     instruction — the deriver issues one structured call per batch on the worker
     hot path and would otherwise re-walk the schema + re-serialize it every call.
     """
-    # Some OpenAI-compatible providers enforce this json_object precondition with
+    # Some OpenAI-compatible providers enforce this JSON-object precondition with
     # a case-sensitive substring check, so include lowercase "json" explicitly.
     return (
-        "You must respond with a single json object that conforms exactly to "
-        "the following json schema. Do not include any text, markdown, or code "
-        "fences outside the json object.\n\njson schema:\n"
+        "You must respond with a single JSON object (json) that conforms "
+        "exactly to the following JSON schema. Do not include any text, "
+        "markdown, or code fences outside the JSON object.\n\nJSON schema:\n"
         f"{json.dumps(response_format.model_json_schema())}"
     )
 

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -807,6 +807,7 @@ async def test_structured_output_json_object_mode_request_shape() -> None:
     system_messages = [m for m in call["messages"] if m["role"] == "system"]
     assert system_messages, "expected a system message carrying the schema"
     system_content = system_messages[0]["content"]
+    assert "JSON" in system_content
     assert "json" in system_content
     assert "answer" in system_content  # schema property serialized in
     assert isinstance(result.content, _StructuredResponse)
@@ -943,4 +944,6 @@ async def test_stream_structured_output_json_object_mode() -> None:
     call = _await_kwargs(client.chat.completions.create)
     assert call["response_format"] == {"type": "json_object"}
     system_messages = [m for m in call["messages"] if m["role"] == "system"]
-    assert system_messages and "json" in system_messages[0]["content"]
+    assert system_messages
+    assert "JSON" in system_messages[0]["content"]
+    assert "json" in system_messages[0]["content"]

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -807,7 +807,7 @@ async def test_structured_output_json_object_mode_request_shape() -> None:
     system_messages = [m for m in call["messages"] if m["role"] == "system"]
     assert system_messages, "expected a system message carrying the schema"
     system_content = system_messages[0]["content"]
-    assert "JSON" in system_content
+    assert "json" in system_content
     assert "answer" in system_content  # schema property serialized in
     assert isinstance(result.content, _StructuredResponse)
     assert result.content.answer == "ok"
@@ -943,4 +943,4 @@ async def test_stream_structured_output_json_object_mode() -> None:
     call = _await_kwargs(client.chat.completions.create)
     assert call["response_format"] == {"type": "json_object"}
     system_messages = [m for m in call["messages"] if m["role"] == "system"]
-    assert system_messages and "JSON" in system_messages[0]["content"]
+    assert system_messages and "json" in system_messages[0]["content"]


### PR DESCRIPTION
## Summary

- make the OpenAI `json_object` schema-injection prompt include lowercase `json`
- update OpenAI backend tests to assert the lowercase token is present for non-streaming and streaming structured-output requests

Closes #885.

## Why

Some OpenAI-compatible providers enforce the json-object precondition with a case-sensitive check for lowercase `json`. Honcho previously injected uppercase `JSON`, which could still be rejected even though the instruction was semantically correct.

## Test plan

- `uv run pytest tests/llm/test_backends/test_openai.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the instruction text for `json_object` structured-output requests to use lowercase `"json"` consistently, improving compatibility with providers that enforce case-sensitive checks.
  * Updated and refined the corresponding unit tests to validate the updated system message content for both non-streaming and streaming request modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->