### PR TITLE
fix: date dreamer conclusions to latest source observation

### DIFF
--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -24,7 +24,11 @@ from src.telemetry.events import (
     emit,
 )
 from src.utils import summarizer
-from src.utils.formatting import format_new_turn_with_timestamp, utc_now_iso
+from src.utils.formatting import (
+    format_datetime_utc,
+    format_new_turn_with_timestamp,
+    utc_now_iso,
+)
 from src.utils.representation import Representation
 from src.utils.types import ToolResult, embedding_call_purpose, get_current_iteration
 
@@ -1306,6 +1310,49 @@ def _normalize_observation_id(obs_id: str) -> str:
     return obs_id.strip()
 
 
+async def _latest_source_timestamp(
+    ctx: ToolContext,
+    observations: list[schemas.ObservationInput],
+) -> str | None:
+    """Latest ``message_created_at`` across all source observations in the batch.
+
+    Dreamer conclusions (deductive/inductive) are derived from existing
+    observations referenced by ``source_ids`` rather than from live messages. To
+    keep their timeline aligned with their evidence, we date them to the most
+    recent source observation instead of the dream-run time. Returns None if no
+    source_ids resolve to a usable timestamp (caller falls back to now).
+    """
+    source_ids: list[str] = []
+    for obs in observations:
+        if obs.source_ids:
+            source_ids.extend(obs.source_ids)
+    if not source_ids:
+        return None
+
+    async with tracked_db("create_observations.source_ts", read_only=True) as db:
+        docs = await crud.fetch_documents_by_ids(
+            db,
+            workspace_name=ctx.workspace_name,
+            observer=ctx.observer,
+            observed=ctx.observed,
+            document_ids=list(set(source_ids)),
+        )
+
+    latest: datetime | None = None
+    for doc in docs:
+        raw = doc.internal_metadata.get("message_created_at")
+        if not isinstance(raw, str):
+            continue
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if latest is None or parsed > latest:
+            latest = parsed
+
+    return format_datetime_utc(latest) if latest is not None else None
+
+
 async def _handle_create_observations_impl(
     ctx: ToolContext,
     tool_input: dict[str, Any],
@@ -1370,8 +1417,11 @@ async def _handle_create_observations_impl(
         message_ids = [msg.id for msg in ctx.current_messages]
         message_created_at = str(ctx.current_messages[-1].created_at)
     else:
+        # Dreamer path: no current messages. Backdate the conclusion to the latest source observation.
         message_ids = []
-        message_created_at = utc_now_iso()
+        message_created_at = (
+            await _latest_source_timestamp(ctx, observations)
+        ) or utc_now_iso()
 
     # Use lock to serialize database writes (prevents concurrent commit issues)
     async with ctx.db_lock:

--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -1318,10 +1318,13 @@ async def _latest_source_timestamp(
     """Latest ``message_created_at`` across all source observations in the batch.
 
     Dreamer conclusions (deductive/inductive) are derived from existing
-    observations referenced by ``source_ids`` rather than from live messages. To
-    keep their timeline aligned with their evidence, we date them to the most
-    recent source observation instead of the dream-run time. Returns None if no
-    source_ids resolve to a usable timestamp (caller falls back to now).
+    observations referenced by ``source_ids`` rather than from live messages.
+    Their logical timestamp is the point when the conclusion became possible
+    from its evidence, not when the dreamer happened to run, so we date
+    ``internal_metadata["message_created_at"]`` to the most recent source
+    observation. The physical ``Document.created_at`` column remains the insert
+    time. Returns None if no source_ids resolve to a usable timestamp (caller
+    falls back to now).
     """
     source_ids: list[str] = []
     for obs in observations:
@@ -1339,9 +1342,6 @@ async def _latest_source_timestamp(
             observed=ctx.observed,
             document_ids=list(set(source_ids)),
         )
-        # Read ORM attributes inside the session: once it closes the Document
-        # instances are detached, and an expired attribute would trigger a lazy
-        # refresh with no session bound (DetachedInstanceError).
         for doc in docs:
             raw = doc.internal_metadata.get("message_created_at")
             if not isinstance(raw, str):
@@ -1422,7 +1422,9 @@ async def _handle_create_observations_impl(
         # same ISO-8601 Z format as the dreamer path below
         message_created_at = format_datetime_utc(ctx.current_messages[-1].created_at)
     else:
-        # Dreamer path: no current messages. Backdate the conclusion to the latest source observation.
+        # Dreamer path: no current messages. Backdate the conclusion to the
+        # latest source observation, which is when the inference became possible.
+
         message_ids = []
         message_created_at = (
             await _latest_source_timestamp(ctx, observations)

--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -27,6 +27,7 @@ from src.utils import summarizer
 from src.utils.formatting import (
     format_datetime_utc,
     format_new_turn_with_timestamp,
+    parse_datetime_iso,
     utc_now_iso,
 )
 from src.utils.representation import Representation
@@ -1329,6 +1330,7 @@ async def _latest_source_timestamp(
     if not source_ids:
         return None
 
+    latest: datetime | None = None
     async with tracked_db("create_observations.source_ts", read_only=True) as db:
         docs = await crud.fetch_documents_by_ids(
             db,
@@ -1337,18 +1339,20 @@ async def _latest_source_timestamp(
             observed=ctx.observed,
             document_ids=list(set(source_ids)),
         )
-
-    latest: datetime | None = None
-    for doc in docs:
-        raw = doc.internal_metadata.get("message_created_at")
-        if not isinstance(raw, str):
-            continue
-        try:
-            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-        except ValueError:
-            continue
-        if latest is None or parsed > latest:
-            latest = parsed
+        # Read ORM attributes inside the session: once it closes the Document
+        # instances are detached, and an expired attribute would trigger a lazy
+        # refresh with no session bound (DetachedInstanceError).
+        for doc in docs:
+            raw = doc.internal_metadata.get("message_created_at")
+            if not isinstance(raw, str):
+                continue
+            try:
+                # always tz-aware, so the comparison below can't crash on mixed formats
+                parsed = parse_datetime_iso(raw)
+            except ValueError:
+                continue
+            if latest is None or parsed > latest:
+                latest = parsed
 
     return format_datetime_utc(latest) if latest is not None else None
 
@@ -1415,7 +1419,8 @@ async def _handle_create_observations_impl(
     # Determine message context
     if ctx.current_messages:
         message_ids = [msg.id for msg in ctx.current_messages]
-        message_created_at = str(ctx.current_messages[-1].created_at)
+        # same ISO-8601 Z format as the dreamer path below
+        message_created_at = format_datetime_utc(ctx.current_messages[-1].created_at)
     else:
         # Dreamer path: no current messages. Backdate the conclusion to the latest source observation.
         message_ids = []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observation timestamps to align with the underlying source messages.
  * Ensured timestamps are consistently formatted in UTC.
  * Added a fallback to the current time when source timestamps are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->