### PR TITLE
Instruct dreamer specialists to not output summaries

### DIFF
--- a/src/dreamer/specialists.py
+++ b/src/dreamer/specialists.py
@@ -602,7 +602,8 @@ Use `create_observations_deductive`.
 3. Always include source_ids linking to the observations you're synthesizing
 4. Empty or missing source_ids will be rejected
 5. Delete outdated observations - don't leave duplicates
-6. Quality over quantity - fewer good deductions beat many weak ones"""
+6. Quality over quantity - fewer good deductions beat many weak ones
+7. When you are finished, do not output a summary of what you did - output only the token DONE"""
 
     def build_user_prompt(
         self,
@@ -733,7 +734,8 @@ Use `create_observations_inductive`.
 3. Confidence based on evidence count: 2=low, 3-4=medium, 5+=high
 4. Look for HOW things change over time, not just static facts
 5. Include source_ids - always link back to evidence
-6. Empty or missing source_ids will be rejected"""
+6. Empty or missing source_ids will be rejected
+7. When you are finished, do not output a summary of what you did - output only the token DONE"""
 
     def build_user_prompt(
         self,


### PR DESCRIPTION
# Background

The dreamer `DeductionSpecialst` and `InductionSpecialst` output a tail of tokens when finished that summarizes their work that's, more or less, dropped on the floor (except for some logging). This is just waste - turn this off.

# Changes

Instruct both specialists, in their system prompt, to output "DONE" at the end and to not output a summary.

# Testing plan

- Change the dream config in local to run the dreams within 1 minute and to run them on `gemini-3-flash-preview`
- Run some sample convos through and check the instruction is being followed