### PR TITLE
fix(deriver): coerce bare-string explicit observations from json_object providers

### DIFF
--- a/src/utils/representation.py
+++ b/src/utils/representation.py
@@ -114,16 +114,28 @@ class PromptRepresentation(BaseModel):
     """
 
     explicit: list[ExplicitObservationBase] = Field(
-        description="Facts LITERALLY stated by the user - direct quotes or clear paraphrases only, no interpretation or inference. Example: ['The user is 25 years old', 'The user has a dog named Rover']",
+        description="Facts LITERALLY stated by the user - direct quotes or clear paraphrases only, no interpretation or inference. Example: [{'content': 'The user is 25 years old'}, {'content': 'The user has a dog named Rover'}]",
         default_factory=list,
     )
 
     @field_validator("explicit", mode="before")
     @classmethod
-    def convert_none_to_empty_list(cls, v: Any) -> Any:
-        """Convert None to empty list - handles LLMs returning null instead of []."""
+    def normalize_explicit(cls, v: Any) -> Any:
+        """Normalize the ``explicit`` payload before validation.
+
+        Handles two shapes LLMs emit in ``json_object`` mode, where the model
+        sees only the prompt/schema text and often returns the simpler form:
+
+        - ``None`` instead of ``[]`` (some models return null for empty lists).
+        - bare strings instead of ``{"content": ...}`` objects. Providers
+          without ``json_schema`` support (e.g. DeepSeek, some vLLM configs)
+          frequently emit ``{"explicit": ["fact 1", ...]}``; coerce each string
+          into the expected object so observations aren't silently dropped (#893).
+        """
         if v is None:
             return []
+        if isinstance(v, list):
+            return [{"content": item} if isinstance(item, str) else item for item in v]
         return v
 
 

--- a/src/utils/representation.py
+++ b/src/utils/representation.py
@@ -143,16 +143,28 @@ class PromptRepresentation(BaseModel):
     """
 
     explicit: list[ExplicitObservationBase] = Field(
-        description="Facts LITERALLY stated by the user - direct quotes or clear paraphrases only, no interpretation or inference. Example: ['The user is 25 years old', 'The user has a dog named Rover']",
+        description="Facts LITERALLY stated by the user - direct quotes or clear paraphrases only, no interpretation or inference. Example: [{'content': 'The user is 25 years old'}, {'content': 'The user has a dog named Rover'}]",
         default_factory=list,
     )
 
     @field_validator("explicit", mode="before")
     @classmethod
-    def convert_none_to_empty_list(cls, v: Any) -> Any:
-        """Convert None to empty list - handles LLMs returning null instead of []."""
+    def normalize_explicit(cls, v: Any) -> Any:
+        """Normalize the ``explicit`` payload before validation.
+
+        Handles two shapes LLMs emit in ``json_object`` mode, where the model
+        sees only the prompt/schema text and often returns the simpler form:
+
+        - ``None`` instead of ``[]`` (some models return null for empty lists).
+        - bare strings instead of ``{"content": ...}`` objects. Providers
+          without ``json_schema`` support (e.g. DeepSeek, some vLLM configs)
+          frequently emit ``{"explicit": ["fact 1", ...]}``; coerce each string
+          into the expected object so observations aren't silently dropped (#893).
+        """
         if v is None:
             return []
+        if isinstance(v, list):
+            return [{"content": item} if isinstance(item, str) else item for item in v]
         return v
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,8 @@ _RUNTIME_MOCK_TEST_BLOCKLIST_PREFIXES = (
     # LLM transport tests mock providers directly and don't need database/runtime setup.
     "tests/utils/test_length_finish_reason.py",
     "tests/utils/test_clients.py",
+    # Pure PromptRepresentation model-validation tests — no DB needed.
+    "tests/utils/test_representation.py",
     # Pure JWT scope tests — operate on src.security directly, no DB needed.
     "tests/test_security.py",
     "tests/test_generate_jwt_script.py",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,8 @@ _RUNTIME_MOCK_TEST_BLOCKLIST_PREFIXES = (
     "tests/utils/test_clients.py",
     # Session-scope SQL shape — asserts on compiled statements, never executes one.
     "tests/crud/test_session_scope_clauses.py",
+    # Pure PromptRepresentation model-validation tests — no DB needed.
+    "tests/utils/test_representation.py",
     # Pure JWT scope tests — operate on src.security directly, no DB needed.
     "tests/test_security.py",
     "tests/test_generate_jwt_script.py",

--- a/tests/utils/test_representation.py
+++ b/tests/utils/test_representation.py
@@ -1,0 +1,54 @@
+"""
+Tests for PromptRepresentation input normalization.
+
+Providers without ``json_schema`` structured-output support (e.g. DeepSeek via
+LiteLLM, some vLLM configs) run in ``json_object`` mode and infer the JSON shape
+from the prompt/schema text. They frequently return the ``explicit`` field as a
+list of bare strings instead of ``{"content": ...}`` objects. These tests pin
+that the bare-string shape is coerced rather than silently dropped (#893).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from src.utils.representation import ExplicitObservationBase, PromptRepresentation
+
+
+def test_explicit_bare_strings_are_coerced_to_objects() -> None:
+    rep = PromptRepresentation.model_validate(
+        {"explicit": ["alice is 25 years old", "alice has a dog"]}
+    )
+
+    assert rep.explicit == [
+        ExplicitObservationBase(content="alice is 25 years old"),
+        ExplicitObservationBase(content="alice has a dog"),
+    ]
+
+
+def test_explicit_objects_still_accepted() -> None:
+    rep = PromptRepresentation.model_validate(
+        {"explicit": [{"content": "alice is 25 years old"}]}
+    )
+
+    assert rep.explicit == [ExplicitObservationBase(content="alice is 25 years old")]
+
+
+def test_explicit_mixed_shapes_are_normalized() -> None:
+    rep = PromptRepresentation.model_validate(
+        {"explicit": ["bare fact", {"content": "object fact"}]}
+    )
+
+    assert [o.content for o in rep.explicit] == ["bare fact", "object fact"]
+
+
+def test_explicit_none_becomes_empty_list() -> None:
+    rep = PromptRepresentation.model_validate({"explicit": None})
+
+    assert rep.explicit == []
+
+
+def test_explicit_non_string_scalar_still_rejected() -> None:
+    # Coercion is limited to strings; a stray int is a genuine shape error and
+    # should not be silently turned into content.
+    with pytest.raises(ValidationError):
+        PromptRepresentation.model_validate({"explicit": [123]})


### PR DESCRIPTION
## Linked Issue

Closes #893

## Description

`minimal_deriver_prompt()`'s examples and the `PromptRepresentation.explicit` field description both present explicit facts as **bare strings**, but the field type is `list[ExplicitObservationBase]` (objects with a `content` key). Providers without `json_schema` structured-output support (DeepSeek via LiteLLM, some vLLM configs) run in `json_object` mode and infer the JSON shape from that prompt/schema text, so they emit:

```json
{"explicit": ["alice is 25 years old", "alice has a dog"]}
```

That fails `PromptRepresentation` validation and, via the structured-output fallback in `src/llm/structured_output.py`, is silently turned into `PromptRepresentation(explicit=[])` — **zero observations, no error surfaced**.

### Fix

- Extend the existing `explicit` `mode="before"` validator to coerce bare strings into `{"content": ...}`. Dicts/objects pass through unchanged; non-string scalars (e.g. a stray `int`) still raise, so genuine shape errors aren't masked. This mirrors the precedent already in `structured_output.py`, which repairs `deductive` shape drift.
- Fix the misleading `explicit` field-description example so the schema injected in `json_object` mode no longer advertises the wrong (bare-string) shape.

Load-bearing decision: coercion lives on the model boundary (not only in the repair path) so it applies whether the payload arrives via `json_object` repair or direct validation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — objects and `None` continue to validate exactly as before; only the previously-failing bare-string shape now succeeds.

## Test Coverage

- [x] I added/updated unit tests

Added `tests/utils/test_representation.py` (pure model-validation, no DB — registered in the conftest runtime-mock blocklist alongside the other `tests/utils` unit tests). Covers: bare strings coerced, objects still accepted, mixed input normalized, `None` → `[]`, and non-string scalar still rejected.

Verified locally: with the fix all 5 pass; reverting only the validator makes the two coercion tests fail with the exact `ValidationError` that becomes a silent `explicit=[]` in production. `ruff check` and `ruff format --check` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of explicit observations provided as plain text values.
  * Continued support for object-form observations and mixed input formats.
  * Empty or missing explicit observations now normalize consistently.
  * Invalid non-text values remain rejected with validation errors.

* **Documentation**
  * Updated field examples to reflect the supported object format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->