### PR TITLE
docs: document pgvector's 2000-dim HNSW limit for embedding config

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,8 +472,9 @@ cp config.toml.example config.toml
 
 Then modify the values as needed. The TOML file is organized into sections:
 
-- `[app]` - Application-level settings (log level, session limits, embedding settings, namespace)
+- `[app]` - Application-level settings (log level, session limits, namespace)
 - `[db]` - Database connection and pool settings
+- `[embedding]` - Embedding model and vector dimension settings. `VECTOR_DIMENSIONS` must be at or below 2000 (pgvector's HNSW index hard limit) — some models (e.g. Gemini's `gemini-embedding-001`) default to higher dimensions than that and need this set explicitly
 - `[auth]` - Authentication configuration
 - `[cache]` - Redis cache configuration
 - `[llm]` - LLM provider API keys and general settings

--- a/config.toml.example
+++ b/config.toml.example
@@ -66,6 +66,17 @@ OPENAI_API_KEY = "your-api-key-here"
 # GEMINI_API_KEY = "your-api-key"
 
 # Embedding settings
+#
+# VECTOR_DIMENSIONS must be <= 2000: pgvector's HNSW index has a hard limit
+# of 2000 dimensions, and this is not currently validated at config-load
+# time (only pgvector itself will reject it, at index creation). Some
+# embedding models default to higher output dimensions than that — e.g.
+# Gemini's gemini-embedding-001 defaults to 3072. If you switch to such a
+# model, you must set VECTOR_DIMENSIONS to a value at or below 2000
+# (1536 is a common choice). For models that support Matryoshka
+# Representation Learning (including gemini-embedding-001), setting
+# VECTOR_DIMENSIONS truncates the output to that size instead of failing;
+# it must still match what your chosen model can actually produce.
 [embedding]
 VECTOR_DIMENSIONS = 1536
 MAX_INPUT_TOKENS = 8192

--- a/config.toml.example
+++ b/config.toml.example
@@ -68,9 +68,11 @@ OPENAI_API_KEY = "your-api-key-here"
 # Embedding settings
 #
 # VECTOR_DIMENSIONS must be <= 2000: pgvector's HNSW index has a hard limit
-# of 2000 dimensions, and this is not currently validated at config-load
-# time (only pgvector itself will reject it, at index creation). Some
-# embedding models default to higher output dimensions than that — e.g.
+# of 2000 dimensions. A mismatch may be caught earlier by the startup
+# schema validator (src/startup/embedding_validator.py, which compares
+# VECTOR_DIMENSIONS against the existing pgvector column on boot) or only
+# surface later at index creation, depending on whether a schema already
+# exists. Some embedding models default to higher output dimensions — e.g.
 # Gemini's gemini-embedding-001 defaults to 3072. If you switch to such a
 # model, you must set VECTOR_DIMENSIONS to a value at or below 2000
 # (1536 is a common choice). For models that support Matryoshka


### PR DESCRIPTION
## What

`VECTOR_DIMENSIONS` has no upper-bound validation at config-load time. Some
embedding models default to output dimensions higher than pgvector's HNSW
index hard limit (2000) — e.g. Gemini's `gemini-embedding-001` defaults to
3072. If you switch to such a model without explicitly setting
`VECTOR_DIMENSIONS` to a supported value, the failure only shows up later,
at index creation, with no indication of why.

This documents the limit directly next to `VECTOR_DIMENSIONS` in
`config.toml.example`, and adds a dedicated `[embedding]` entry to the
README's config section list (it was previously folded into `[app]`'s
description, but `[app]` has no embedding-related keys — that line was
stale).

## Why

Ran into this directly running a self-hosted instance with Gemini as the
embedding provider — nothing in the docs or code warns about the 2000-dim
ceiling before you hit it.

## Testing

- Verified `config.toml.example` still loads correctly against the real
  `AppSettings` pydantic schema (`docker run ... python3 -c "from src.config
  import settings; ..."`).
- `README.md` passes `markdownlint-cli2` clean.
- Docs-only change, no code paths touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified embedding configuration requirements, including the 2,000-dimension limit imposed by vector indexing.
  * Added guidance for embedding models with higher default dimensions, including examples of when you must set dimensions explicitly.
  * Explained how Matryoshka-compatible embeddings behave when dimensions are configured (truncation vs. failure).
  * Updated the configuration reference to list embedding settings separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->