### PR TITLE
fix(dialectic): pass custom_instructions to the dialectic prompt

### DIFF
--- a/src/dialectic/chat.py
+++ b/src/dialectic/chat.py
@@ -77,6 +77,7 @@ async def agentic_chat(
         observer_peer_card=observer_peer_card,
         observed_peer_card=observed_peer_card,
         reasoning_level=reasoning_level,
+        custom_instructions=configuration.reasoning.custom_instructions,
     )
 
     return await agent.answer(query)
@@ -142,6 +143,7 @@ async def agentic_chat_stream(
         observer_peer_card=observer_peer_card,
         observed_peer_card=observed_peer_card,
         reasoning_level=reasoning_level,
+        custom_instructions=configuration.reasoning.custom_instructions,
     )
 
     async for chunk in agent.answer_stream(query):

--- a/src/dialectic/core.py
+++ b/src/dialectic/core.py
@@ -69,6 +69,7 @@ class DialecticAgent:
         metric_key: str | None = None,
         reasoning_level: ReasoningLevel = "low",
         session_id: str | None = None,
+        custom_instructions: str | None = None,
     ):
         """
         Initialize the dialectic agent.
@@ -83,6 +84,7 @@ class DialecticAgent:
             metric_key: Optional key for logging metrics (if provided, agent won't log separately)
             reasoning_level: Level of reasoning to apply
             session_id: ID used for grouping traces (not session_name)
+            custom_instructions: Optional workspace/session instructions for the answer
         """
         self.workspace_name: str = workspace_name
         self.session_name: str | None = session_name
@@ -93,13 +95,18 @@ class DialecticAgent:
         self.observed_peer_card: list[str] | None = observed_peer_card
         self.metric_key: str | None = metric_key
         self.reasoning_level: ReasoningLevel = reasoning_level
+        self.custom_instructions: str | None = custom_instructions
 
         # Initialize conversation history with system prompt
         self.messages: list[dict[str, str]] = [
             {
                 "role": "system",
                 "content": prompts.agent_system_prompt(
-                    observer, observed, observer_peer_card, observed_peer_card
+                    observer,
+                    observed,
+                    observer_peer_card,
+                    observed_peer_card,
+                    custom_instructions,
                 ),
             }
         ]

--- a/src/dialectic/prompts.py
+++ b/src/dialectic/prompts.py
@@ -3,11 +3,27 @@ System prompts for the Dialectic Agent.
 """
 
 
+def _custom_instructions_section(custom_instructions: str | None) -> str:
+    """Render optional custom instructions for the dialectic prompt."""
+    normalized_custom_instructions = (
+        custom_instructions.strip() if custom_instructions else ""
+    )
+    if not normalized_custom_instructions:
+        return ""
+
+    return f"""
+CUSTOM INSTRUCTIONS:
+These instructions come from the workspace or session configuration and apply to how you answer.
+{normalized_custom_instructions}
+"""
+
+
 def agent_system_prompt(
     observer: str,
     observed: str,
     observer_peer_card: list[str] | None,
     observed_peer_card: list[str] | None,
+    custom_instructions: str | None = None,
 ) -> str:
     """
     Generate the agent system prompt for the dialectic agent.
@@ -17,10 +33,12 @@ def agent_system_prompt(
         observed: The peer being queried about
         observer_peer_card: Biographical information about the observer
         observed_peer_card: Biographical information about the observed peer
+        custom_instructions: Optional workspace/session instructions for the answer
 
     Returns:
         Formatted system prompt string for the agent
     """
+    custom_instructions_section = _custom_instructions_section(custom_instructions)
     # Determine if we have any peer card data
     peer_cards_enabled = (
         observer_peer_card is not None or observed_peer_card is not None
@@ -232,6 +250,8 @@ If after thorough searching you find NOTHING relevant:
 **Remember:** A clear, direct "I don't know" or "I have no information about X" is always the RIGHT answer when the information truly does not exist in memory. Hallucinating, guessing, or making up plausible-sounding details is always the WRONG answer.
 
 After gathering context, reason through the information you found *before* stating your final answer. For comparison questions, explicitly compare the values. Only after you've verified your reasoning should you state your conclusion. Do NOT be pedantic, rather, be helpful and try to give the answer that the asker would expect -- they're the one who knows the most about themselves. Try to 'read their mind' -- understand the information they're really after and share it with them! Be **as specific as possible** given the information you have.
+
+{custom_instructions_section}
 
 Do not explain your tool usage - just provide the synthesized answer.
 """

--- a/tests/dialectic/test_custom_instructions.py
+++ b/tests/dialectic/test_custom_instructions.py
@@ -1,0 +1,134 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from nanoid import generate as generate_nanoid
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import models
+from src.dialectic.chat import agentic_chat
+from src.dialectic.core import DialecticAgent
+from src.dialectic.prompts import agent_system_prompt
+
+
+def _system_prompt(agent: DialecticAgent) -> str:
+    return agent.messages[0]["content"]
+
+
+def test_agent_system_prompt_renders_custom_instructions() -> None:
+    prompt = agent_system_prompt(
+        "observer",
+        "observed",
+        None,
+        None,
+        "favor durable patterns, never dwell on sensitive details",
+    )
+
+    assert "CUSTOM INSTRUCTIONS:" in prompt
+    assert "favor durable patterns, never dwell on sensitive details" in prompt
+
+
+@pytest.mark.parametrize("custom_instructions", [None, "", "   "])
+def test_agent_system_prompt_omits_empty_custom_instructions(
+    custom_instructions: str | None,
+) -> None:
+    prompt = agent_system_prompt(
+        "observer", "observed", None, None, custom_instructions
+    )
+
+    assert "CUSTOM INSTRUCTIONS:" not in prompt
+
+
+def test_agent_system_prompt_preserves_multiline_custom_instructions() -> None:
+    prompt = agent_system_prompt(
+        "observer",
+        "observed",
+        None,
+        None,
+        "this is a growth mirror, not a scorecard\nnever dwell on sensitive details",
+    )
+
+    assert "\nCUSTOM INSTRUCTIONS:\n" in prompt
+    assert "\nthis is a growth mirror, not a scorecard\n" in prompt
+    assert "\nnever dwell on sensitive details\n" in prompt
+
+
+def test_dialectic_agent_threads_custom_instructions_into_system_prompt() -> None:
+    agent = DialecticAgent(
+        workspace_name="workspace",
+        session_name="session",
+        observer="observer",
+        observed="observed",
+        custom_instructions="this is a growth mirror, not a performance scorecard",
+    )
+
+    assert "CUSTOM INSTRUCTIONS:" in _system_prompt(agent)
+    assert "this is a growth mirror, not a performance scorecard" in _system_prompt(
+        agent
+    )
+
+
+def test_dialectic_agent_without_custom_instructions_has_no_section() -> None:
+    agent = DialecticAgent(
+        workspace_name="workspace",
+        session_name="session",
+        observer="observer",
+        observed="observed",
+    )
+
+    assert "CUSTOM INSTRUCTIONS:" not in _system_prompt(agent)
+
+
+@pytest.mark.asyncio
+async def test_agentic_chat_forwards_workspace_custom_instructions(
+    db_session: AsyncSession,
+    sample_data: tuple[models.Workspace, models.Peer],
+) -> None:
+    test_workspace, test_peer = sample_data
+    test_workspace.configuration = {
+        "reasoning": {"custom_instructions": "favor durable patterns"}
+    }
+    await db_session.commit()
+
+    with patch("src.dialectic.chat.DialecticAgent") as mock_agent:
+        mock_agent.return_value.answer = AsyncMock(return_value="answer")
+        await agentic_chat(
+            workspace_name=test_workspace.name,
+            session_name=None,
+            query="what do you know about me?",
+            observer=test_peer.name,
+            observed=test_peer.name,
+        )
+
+    assert (
+        mock_agent.call_args.kwargs["custom_instructions"] == "favor durable patterns"
+    )
+
+
+@pytest.mark.asyncio
+async def test_agentic_chat_prefers_session_custom_instructions(
+    db_session: AsyncSession,
+    sample_data: tuple[models.Workspace, models.Peer],
+) -> None:
+    test_workspace, test_peer = sample_data
+    test_workspace.configuration = {
+        "reasoning": {"custom_instructions": "favor durable patterns"}
+    }
+    test_session = models.Session(
+        workspace_name=test_workspace.name,
+        name=str(generate_nanoid()),
+        configuration={"reasoning": {"custom_instructions": "keep answers terse"}},
+    )
+    db_session.add(test_session)
+    await db_session.commit()
+
+    with patch("src.dialectic.chat.DialecticAgent") as mock_agent:
+        mock_agent.return_value.answer = AsyncMock(return_value="answer")
+        await agentic_chat(
+            workspace_name=test_workspace.name,
+            session_name=test_session.name,
+            query="what do you know about me?",
+            observer=test_peer.name,
+            observed=test_peer.name,
+        )
+
+    assert mock_agent.call_args.kwargs["custom_instructions"] == "keep answers terse"


### PR DESCRIPTION
Fixes #874. The dialectic chat path calls `get_configuration()` but only reads `peer_card.use` from it, so workspace and session `custom_instructions` get dropped before the prompt is built. The deriver already honors that field, so instructions shaped how conclusions were written but had no effect on what the chat endpoint actually answered.

This threads `custom_instructions` through `DialecticAgent` into `agent_system_prompt` and renders a CUSTOM INSTRUCTIONS section following the deriver's pattern, on both the streaming and non-streaming paths. I built the section as a plain f-string rather than with `cleandoc`, since multi-line instructions drop the common margin to zero and would leave the surrounding block indented.

Tested with `uv run pytest tests/dialectic` (11 passed) and `tests/routes/test_peers.py` (45 passed), with ruff and basedpyright clean. The two new chat-level tests fail if the kwarg is removed from `chat.py`, and one of them pins session config overriding workspace config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom instructions in dialectic conversations.
  * Custom instructions can now be included in agent prompts and support multiline formatting.
  * Session-level instructions take precedence over workspace-level instructions.

* **Bug Fixes**
  * Ensured configured custom instructions are consistently forwarded to conversations.

* **Tests**
  * Added coverage for instruction rendering, omission, formatting, and configuration precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->