### PR TITLE
fix(openai): fallback to json_object when json_schema structured output fails

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -240,10 +240,41 @@ class OpenAIBackend:
                     ),
                 )
             # parse() returned no model: repair raw content, surface a refusal,
-            # or raise so the retry/fallback chain engages on a junk response.
-            content = self._parse_or_repair_structured_content(
-                response, response_format, model, empty_on_missing=False
-            )
+            # or fall back to json_object mode for OpenAI-compatible providers
+            # that accept the request but fail to populate structured output.
+            try:
+                content = self._parse_or_repair_structured_content(
+                    response, response_format, model, empty_on_missing=False
+                )
+            except (ValidationException, StructuredOutputError, ValidationError) as structured_exc:
+                # Fallback to json_object mode. Some providers (e.g. Kimi, MiMo)
+                # accept parse() / json_schema but return empty or malformed
+                # content. json_object injects the schema into the prompt and
+                # lets the provider return loose JSON that we can repair.
+                logger.warning(
+                    "Structured output via json_schema produced no parseable content "
+                    "for model %s; retrying with json_object mode.",
+                    model,
+                )
+                json_object_params = dict(params)
+                self._apply_json_object_mode(json_object_params, response_format)
+                json_object_response = await self._client.chat.completions.create(
+                    **json_object_params
+                )
+                try:
+                    content = self._parse_or_repair_structured_content(
+                        json_object_response,
+                        response_format,
+                        model,
+                        empty_on_missing=False,
+                    )
+                except (ValidationException, StructuredOutputError, ValidationError):
+                    # json_object mode also failed; raise the original exception
+                    # so the retry/fallback chain can engage as before.
+                    raise structured_exc
+                return self._normalize_response(
+                    json_object_response, content_override=content
+                )
             return self._normalize_response(response, content_override=content)
         if response_format is not None:
             params["response_format"] = response_format

--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -256,10 +256,41 @@ class OpenAIBackend:
                     ),
                 )
             # parse() returned no model: repair raw content, surface a refusal,
-            # or raise so the retry/fallback chain engages on a junk response.
-            content = self._parse_or_repair_structured_content(
-                response, response_format, model, empty_on_missing=False
-            )
+            # or fall back to json_object mode for OpenAI-compatible providers
+            # that accept the request but fail to populate structured output.
+            try:
+                content = self._parse_or_repair_structured_content(
+                    response, response_format, model, empty_on_missing=False
+                )
+            except (ValidationException, StructuredOutputError, ValidationError) as structured_exc:
+                # Fallback to json_object mode. Some providers (e.g. Kimi, MiMo)
+                # accept parse() / json_schema but return empty or malformed
+                # content. json_object injects the schema into the prompt and
+                # lets the provider return loose JSON that we can repair.
+                logger.warning(
+                    "Structured output via json_schema produced no parseable content "
+                    "for model %s; retrying with json_object mode.",
+                    model,
+                )
+                json_object_params = dict(params)
+                self._apply_json_object_mode(json_object_params, response_format)
+                json_object_response = await self._client.chat.completions.create(
+                    **json_object_params
+                )
+                try:
+                    content = self._parse_or_repair_structured_content(
+                        json_object_response,
+                        response_format,
+                        model,
+                        empty_on_missing=False,
+                    )
+                except (ValidationException, StructuredOutputError, ValidationError):
+                    # json_object mode also failed; raise the original exception
+                    # so the retry/fallback chain can engage as before.
+                    raise structured_exc from None
+                return self._normalize_response(
+                    json_object_response, content_override=content
+                )
             return self._normalize_response(response, content_override=content)
         if response_format is not None:
             params["response_format"] = response_format

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -652,12 +652,16 @@ async def test_structured_output_parsed_none_returns_refusal() -> None:
 
 @pytest.mark.asyncio
 async def test_structured_output_parsed_none_no_content_raises() -> None:
-    """json_schema with no parsed model, content, or refusal raises so the
-    retry/fallback chain engages — it must NOT silently empty like json_object."""
+    """json_schema with no parsed model, content, or refusal falls back to
+    json_object mode; if json_object also fails, the original exception is
+    re-raised so the retry/fallback chain can engage."""
     from src.exceptions import ValidationException
 
     client = Mock()
     client.chat.completions.parse = AsyncMock(
+        return_value=_structured_create_return("", parsed=None)
+    )
+    client.chat.completions.create = AsyncMock(
         return_value=_structured_create_return("", parsed=None)
     )
 
@@ -669,6 +673,93 @@ async def test_structured_output_parsed_none_no_content_raises() -> None:
             max_tokens=100,
             response_format=_StructuredResponse,
         )
+
+    assert client.chat.completions.parse.await_count == 1
+    assert client.chat.completions.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_structured_output_parsed_none_empty_content_fallback_to_json_object() -> None:
+    """OpenAI-compatible providers that accept parse() but return empty content
+    are retried with json_object mode."""
+    client = Mock()
+    client.chat.completions.parse = AsyncMock(
+        return_value=_structured_create_return("", parsed=None)
+    )
+    client.chat.completions.create = AsyncMock(
+        return_value=_structured_create_return('{"answer": "ok"}', parsed=None)
+    )
+
+    backend = OpenAIBackend(client)
+    result = await backend.complete(
+        model="kimi-k3",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        response_format=_StructuredResponse,
+    )
+
+    assert client.chat.completions.parse.await_count == 1
+    assert client.chat.completions.create.await_count == 1
+    call = _await_kwargs(client.chat.completions.create)
+    assert call["response_format"] == {"type": "json_object"}
+    assert isinstance(result.content, _StructuredResponse)
+    assert result.content.answer == "ok"
+
+
+@pytest.mark.asyncio
+async def test_structured_output_parsed_malformed_json_fallback_to_json_object() -> None:
+    """OpenAI-compatible providers that return malformed but repairable JSON via
+    json_schema still succeed without a second request. json_repair handles
+    common provider quirks like unquoted keys."""
+    client = Mock()
+    client.chat.completions.parse = AsyncMock(
+        return_value=_structured_create_return(
+            '{answer: "ok"}', parsed=None
+        )
+    )
+    client.chat.completions.create = AsyncMock()
+
+    backend = OpenAIBackend(client)
+    result = await backend.complete(
+        model="mimo-v2.5-pro",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        response_format=_StructuredResponse,
+    )
+
+    assert client.chat.completions.parse.await_count == 1
+    # No second request needed when json_repair can fix the json_schema response.
+    assert client.chat.completions.create.await_count == 0
+    assert isinstance(result.content, _StructuredResponse)
+    assert result.content.answer == "ok"
+
+
+@pytest.mark.asyncio
+async def test_structured_output_parsed_unrepairable_content_fallback_to_json_object() -> None:
+    """OpenAI-compatible providers that return unrepairable JSON from parse()
+    are retried with json_object mode."""
+    client = Mock()
+    client.chat.completions.parse = AsyncMock(
+        return_value=_structured_create_return(
+            "not valid json at all", parsed=None
+        )
+    )
+    client.chat.completions.create = AsyncMock(
+        return_value=_structured_create_return('{"answer": "ok"}', parsed=None)
+    )
+
+    backend = OpenAIBackend(client)
+    result = await backend.complete(
+        model="mimo-v2.5-pro",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        response_format=_StructuredResponse,
+    )
+
+    assert client.chat.completions.parse.await_count == 1
+    assert client.chat.completions.create.await_count == 1
+    assert isinstance(result.content, _StructuredResponse)
+    assert result.content.answer == "ok"
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -731,12 +731,16 @@ async def test_structured_output_parsed_none_returns_refusal() -> None:
 
 @pytest.mark.asyncio
 async def test_structured_output_parsed_none_no_content_raises() -> None:
-    """json_schema with no parsed model, content, or refusal raises so the
-    retry/fallback chain engages — it must NOT silently empty like json_object."""
+    """json_schema with no parsed model, content, or refusal falls back to
+    json_object mode; if json_object also fails, the original exception is
+    re-raised so the retry/fallback chain can engage."""
     from src.exceptions import ValidationException
 
     client = Mock()
     client.chat.completions.parse = AsyncMock(
+        return_value=_structured_create_return("", parsed=None)
+    )
+    client.chat.completions.create = AsyncMock(
         return_value=_structured_create_return("", parsed=None)
     )
 
@@ -748,6 +752,93 @@ async def test_structured_output_parsed_none_no_content_raises() -> None:
             max_tokens=100,
             response_format=_StructuredResponse,
         )
+
+    assert client.chat.completions.parse.await_count == 1
+    assert client.chat.completions.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_structured_output_parsed_none_empty_content_fallback_to_json_object() -> None:
+    """OpenAI-compatible providers that accept parse() but return empty content
+    are retried with json_object mode."""
+    client = Mock()
+    client.chat.completions.parse = AsyncMock(
+        return_value=_structured_create_return("", parsed=None)
+    )
+    client.chat.completions.create = AsyncMock(
+        return_value=_structured_create_return('{"answer": "ok"}', parsed=None)
+    )
+
+    backend = OpenAIBackend(client)
+    result = await backend.complete(
+        model="kimi-k3",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        response_format=_StructuredResponse,
+    )
+
+    assert client.chat.completions.parse.await_count == 1
+    assert client.chat.completions.create.await_count == 1
+    call = _await_kwargs(client.chat.completions.create)
+    assert call["response_format"] == {"type": "json_object"}
+    assert isinstance(result.content, _StructuredResponse)
+    assert result.content.answer == "ok"
+
+
+@pytest.mark.asyncio
+async def test_structured_output_parsed_malformed_json_fallback_to_json_object() -> None:
+    """OpenAI-compatible providers that return malformed but repairable JSON via
+    json_schema still succeed without a second request. json_repair handles
+    common provider quirks like unquoted keys."""
+    client = Mock()
+    client.chat.completions.parse = AsyncMock(
+        return_value=_structured_create_return(
+            '{answer: "ok"}', parsed=None
+        )
+    )
+    client.chat.completions.create = AsyncMock()
+
+    backend = OpenAIBackend(client)
+    result = await backend.complete(
+        model="mimo-v2.5-pro",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        response_format=_StructuredResponse,
+    )
+
+    assert client.chat.completions.parse.await_count == 1
+    # No second request needed when json_repair can fix the json_schema response.
+    assert client.chat.completions.create.await_count == 0
+    assert isinstance(result.content, _StructuredResponse)
+    assert result.content.answer == "ok"
+
+
+@pytest.mark.asyncio
+async def test_structured_output_parsed_unrepairable_content_fallback_to_json_object() -> None:
+    """OpenAI-compatible providers that return unrepairable JSON from parse()
+    are retried with json_object mode."""
+    client = Mock()
+    client.chat.completions.parse = AsyncMock(
+        return_value=_structured_create_return(
+            "not valid json at all", parsed=None
+        )
+    )
+    client.chat.completions.create = AsyncMock(
+        return_value=_structured_create_return('{"answer": "ok"}', parsed=None)
+    )
+
+    backend = OpenAIBackend(client)
+    result = await backend.complete(
+        model="mimo-v2.5-pro",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        response_format=_StructuredResponse,
+    )
+
+    assert client.chat.completions.parse.await_count == 1
+    assert client.chat.completions.create.await_count == 1
+    assert isinstance(result.content, _StructuredResponse)
+    assert result.content.answer == "ok"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
OpenAI-compatible providers (e.g. Kimi, MiMo) often accept chat.completions.parse() / json_schema but return empty or unparseable content.\n\nThis change retries the request with structured_output_mode=json_object when parse() produces no parseable content. json_object injects the schema into the prompt and lets json_repair recover loose provider JSON.\n\nIf json_object mode also fails, the original exception is re-raised so the retry/fallback chain can still engage.\n\n- Added fallback logic in OpenAIBackend.complete()\n- Added tests for empty content, repairable malformed JSON, and unrepairable content\n\nRelates to: issues where providers return key-must-be-a-string or empty JSON from structured outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete or invalid structured responses from OpenAI.
  * Automatically retries using JSON mode when structured output cannot be parsed.
  * Recovers malformed but repairable JSON without making an additional request.
  * Preserves the original error when fallback attempts also fail.
  * Provides more reliable structured-response handling while maintaining existing error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->