### PR TITLE
chore: updating cli version 0.1.2

### DIFF
--- a/honcho-cli/CHANGELOG.md
+++ b/honcho-cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.2] - 2026-07-20
+
+### Added
+
+- Device-code OAuth login for managed Honcho servers. `honcho init` now offers browser-based login (RFC 8628 device authorization grant) when the host advertises the device grant in its OAuth authorization-server metadata; tokens are persisted to `~/.honcho/config.json` and auto-refreshed (#891)
+
 ## [0.1.1] - 2026-06-15
 
 ### Fixed

--- a/honcho-cli/pyproject.toml
+++ b/honcho-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "honcho-cli"
-version = "0.1.1"
+version = "0.1.2"
 description = "A terminal for Honcho — memory that reasons."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/honcho-cli/src/honcho_cli/__init__.py
+++ b/honcho-cli/src/honcho_cli/__init__.py
@@ -1,3 +1,3 @@
 """Honcho CLI — a terminal for Honcho."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1302,7 +1302,7 @@ dev = [{ name = "ruff", specifier = ">=0.11.13" }]
 
 [[package]]
 name = "honcho-cli"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "honcho-cli" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-based Device Code OAuth login for managed Honcho servers when supported.
  * Login tokens are saved automatically and refreshed when needed.

* **Chores**
  * Released Honcho CLI version 0.1.2 with updated release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->