### PR TITLE
fix: handle Gemini batch embedding count mismatch (avoid zip crash)

### DIFF
--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -460,10 +460,16 @@ class _EmbeddingClient:
                     # input item, in order. This is the documented/expected
                     # behavior and the efficient common case.
                     for item, embedding in zip(batch, embeddings, strict=True):
-                        if embedding.values:
-                            result[item.text_id][item.chunk_index] = (
-                                self._validate_embedding_dimensions(embedding.values)
+                        if not embedding.values:
+                            raise ValueError(
+                                "Gemini API returned an embedding with no "
+                                f"values for text_id={item.text_id!r}, "
+                                f"chunk_index={item.chunk_index!r} (batch "
+                                "path)."
                             )
+                        result[item.text_id][item.chunk_index] = (
+                            self._validate_embedding_dimensions(embedding.values)
+                        )
                 else:
                     # Cardinality mismatch: do NOT assume any particular
                     # alignment between `batch` and `embeddings` (e.g. via
@@ -497,10 +503,16 @@ class _EmbeddingClient:
                                 f"chunk_index={item.chunk_index!r}."
                             )
                         embedding = item_embeddings[0]
-                        if embedding.values:
-                            result[item.text_id][item.chunk_index] = (
-                                self._validate_embedding_dimensions(embedding.values)
+                        if not embedding.values:
+                            raise ValueError(
+                                "Gemini API returned an embedding with no "
+                                f"values for text_id={item.text_id!r}, "
+                                f"chunk_index={item.chunk_index!r} (fallback "
+                                "path)."
                             )
+                        result[item.text_id][item.chunk_index] = (
+                            self._validate_embedding_dimensions(embedding.values)
+                        )
             else:  # openai
                 openai_kwargs: dict[str, Any] = {
                     "model": self.model,

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -448,13 +448,55 @@ class _EmbeddingClient:
             item in analytics."""
             result: dict[str, dict[int, list[float]]] = defaultdict(dict)
             if isinstance(self.client, genai.Client):
-                response = await self.client.aio.models.embed_content(
+                gemini_client = self.client
+                response = await gemini_client.aio.models.embed_content(
                     model=self.model,
                     contents=[item.text for item in batch],
                     config={"output_dimensionality": self.vector_dimensions},
                 )
-                if response.embeddings:
-                    for item, embedding in zip(batch, response.embeddings, strict=True):
+                embeddings = response.embeddings or []
+                if len(embeddings) == len(batch):
+                    # Happy path: Gemini returned exactly one embedding per
+                    # input item, in order. This is the documented/expected
+                    # behavior and the efficient common case.
+                    for item, embedding in zip(batch, embeddings, strict=True):
+                        if embedding.values:
+                            result[item.text_id][item.chunk_index] = (
+                                self._validate_embedding_dimensions(embedding.values)
+                            )
+                else:
+                    # Cardinality mismatch: do NOT assume any particular
+                    # alignment between `batch` and `embeddings` (e.g. via
+                    # zip/truncation) — the SDK docstring claims a strict
+                    # one-to-one, in-order mapping, but this has been
+                    # observed to not always hold (empty/whitespace items
+                    # dropped, batch size >100, other API quirks). Instead,
+                    # fall back to embedding each item individually so we
+                    # can guarantee correct item-to-embedding mapping.
+                    logger.warning(
+                        "Gemini batch embedding call returned %d embeddings "
+                        "for %d input items (mismatch); falling back to "
+                        "per-item embedding calls to preserve correct "
+                        "item-to-embedding alignment.",
+                        len(embeddings),
+                        len(batch),
+                    )
+                    for item in batch:
+                        item_response = await gemini_client.aio.models.embed_content(
+                            model=self.model,
+                            contents=item.text,
+                            config={"output_dimensionality": self.vector_dimensions},
+                        )
+                        item_embeddings = item_response.embeddings or []
+                        if len(item_embeddings) != 1:
+                            raise ValueError(
+                                "Gemini API returned "
+                                f"{len(item_embeddings)} embeddings for a "
+                                "single-item embedding call (expected "
+                                f"exactly 1) for text_id={item.text_id!r}, "
+                                f"chunk_index={item.chunk_index!r}."
+                            )
+                        embedding = item_embeddings[0]
                         if embedding.values:
                             result[item.text_id][item.chunk_index] = (
                                 self._validate_embedding_dimensions(embedding.values)

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -537,9 +537,7 @@ async def test_gemini_batch_embed_multi_item_preserves_order(
     )
     client = _build_gemini_client(monkeypatch, fake_models)
 
-    result = await client.batch_embed(
-        {"first": "aaa", "second": "bbb", "third": "ccc"}
-    )
+    result = await client.batch_embed({"first": "aaa", "second": "bbb", "third": "ccc"})
 
     assert result == {
         "first": [[0.1] * 4],
@@ -577,9 +575,7 @@ async def test_gemini_batch_embed_mismatched_response_falls_back_per_item(
     )
     client = _build_gemini_client(monkeypatch, fake_models)
 
-    result = await client.batch_embed(
-        {"first": "aaa", "second": "bbb", "third": "ccc"}
-    )
+    result = await client.batch_embed({"first": "aaa", "second": "bbb", "third": "ccc"})
 
     assert result == {
         "first": [[0.1] * 4],
@@ -611,4 +607,74 @@ async def test_gemini_batch_embed_fallback_call_wrong_count_raises(
     client = _build_gemini_client(monkeypatch, fake_models)
 
     with pytest.raises(ValueError, match="Gemini API returned"):
+        await client.batch_embed({"first": "aaa", "second": "bbb"})
+
+
+@pytest.mark.asyncio
+async def test_gemini_batch_embed_fallback_call_multiple_embeddings_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(e) During the per-item fallback, if an individual call returns
+    MULTIPLE embeddings for a single item, a controlled ValueError is
+    raised (not a silent pick-one / misalignment)."""
+
+    def single_embeddings_fn(text: str) -> list[Any]:
+        if text == "bbb":
+            return [
+                SimpleNamespace(values=[0.1] * 4),
+                SimpleNamespace(values=[0.2] * 4),
+            ]  # two embeddings for this item -- should raise
+        return [SimpleNamespace(values=[0.1] * 4)]
+
+    fake_models = FakeGeminiModelsBatch(
+        batch_embeddings_fn=lambda contents: [SimpleNamespace(values=[0.9] * 4)],
+        single_embeddings_fn=single_embeddings_fn,
+    )
+    client = _build_gemini_client(monkeypatch, fake_models)
+
+    with pytest.raises(ValueError, match="Gemini API returned"):
+        await client.batch_embed({"first": "aaa", "second": "bbb"})
+
+
+@pytest.mark.asyncio
+async def test_gemini_batch_embed_empty_values_in_matched_batch_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(f) In the cardinality-matched batch (zip) path, if one returned
+    embedding has falsy `values` (empty list), it must raise a
+    ValueError instead of silently omitting that item from the result."""
+    fake_models = FakeGeminiModelsBatch(
+        batch_embeddings_fn=lambda contents: [
+            SimpleNamespace(values=[0.1] * 4),
+            SimpleNamespace(values=[]),  # falsy values -- should raise
+            SimpleNamespace(values=[0.3] * 4),
+        ],
+    )
+    client = _build_gemini_client(monkeypatch, fake_models)
+
+    with pytest.raises(ValueError, match="no values"):
+        await client.batch_embed({"first": "aaa", "second": "bbb", "third": "ccc"})
+
+
+@pytest.mark.asyncio
+async def test_gemini_batch_embed_fallback_empty_values_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(g) In the per-item fallback path, if the single embedding
+    returned has falsy `values`, it must raise a ValueError instead of
+    silently omitting that item from the result."""
+
+    def single_embeddings_fn(text: str) -> list[Any]:
+        if text == "bbb":
+            return [SimpleNamespace(values=[])]  # falsy values -- should raise
+        return [SimpleNamespace(values=[0.1] * 4)]
+
+    fake_models = FakeGeminiModelsBatch(
+        # Force cardinality mismatch to enter the fallback path.
+        batch_embeddings_fn=lambda contents: [SimpleNamespace(values=[0.9] * 4)],
+        single_embeddings_fn=single_embeddings_fn,
+    )
+    client = _build_gemini_client(monkeypatch, fake_models)
+
+    with pytest.raises(ValueError, match="no values"):
         await client.batch_embed({"first": "aaa", "second": "bbb"})

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -444,3 +444,171 @@ def test_prepare_chunks_returns_ordered_chunks(
     assert len(out["long"]) > 1
     # Order preserved
     assert isinstance(out["long"][0], str)
+
+
+class FakeGeminiModelsBatch:
+    """Fake Gemini `models` API allowing distinct behavior for batch vs.
+    single-item calls, so tests can exercise the batch->per-item fallback."""
+
+    def __init__(
+        self,
+        *,
+        batch_embeddings_fn: Any = None,
+        single_embeddings_fn: Any = None,
+    ) -> None:
+        # Deterministic function of the batch contents -> embeddings list,
+        # so retries (which re-invoke the whole batch call) are idempotent.
+        self.batch_embeddings_fn = batch_embeddings_fn
+        self.single_embeddings_fn = single_embeddings_fn
+        self.batch_calls: list[list[str]] = []
+        self.single_calls: list[str] = []
+
+    async def embed_content(
+        self,
+        *,
+        model: str,
+        contents: str | list[str],
+        config: dict[str, Any],
+    ) -> SimpleNamespace:
+        if isinstance(contents, list):
+            self.batch_calls.append(contents)
+            embeddings = self.batch_embeddings_fn(contents)
+            return SimpleNamespace(embeddings=embeddings)
+        else:
+            self.single_calls.append(contents)
+            embeddings = self.single_embeddings_fn(contents)
+            return SimpleNamespace(embeddings=embeddings)
+
+
+def _build_gemini_client(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_models: FakeGeminiModelsBatch,
+    *,
+    vector_dimensions: int = 4,
+) -> _EmbeddingClient:
+    class FakeGeminiClient:
+        def __init__(self, *, api_key: str | None, http_options: Any) -> None:
+            self.aio: Any = SimpleNamespace(models=fake_models)
+
+    monkeypatch.setattr("src.embedding_client.genai.Client", FakeGeminiClient)
+
+    return _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="gemini",
+            model="gemini-embedding-001",
+            api_key="gemini-key",
+        ),
+        vector_dimensions=vector_dimensions,
+        max_input_tokens=8192,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_gemini_batch_embed_single_item_normal_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(a) A single-item batch where Gemini returns exactly one embedding."""
+    fake_models = FakeGeminiModelsBatch(
+        batch_embeddings_fn=lambda contents: [SimpleNamespace(values=[0.1] * 4)],
+    )
+    client = _build_gemini_client(monkeypatch, fake_models)
+
+    result = await client.batch_embed({"only": "hello world"})
+
+    assert result == {"only": [[0.1] * 4]}
+    assert fake_models.batch_calls == [["hello world"]]
+    assert fake_models.single_calls == []
+
+
+@pytest.mark.asyncio
+async def test_gemini_batch_embed_multi_item_preserves_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(b) A multi-item batch where Gemini returns one embedding per item,
+    in order -- verify each text_id maps to the correct embedding."""
+    fake_models = FakeGeminiModelsBatch(
+        batch_embeddings_fn=lambda contents: [
+            SimpleNamespace(values=[0.1] * 4),
+            SimpleNamespace(values=[0.2] * 4),
+            SimpleNamespace(values=[0.3] * 4),
+        ],
+    )
+    client = _build_gemini_client(monkeypatch, fake_models)
+
+    result = await client.batch_embed(
+        {"first": "aaa", "second": "bbb", "third": "ccc"}
+    )
+
+    assert result == {
+        "first": [[0.1] * 4],
+        "second": [[0.2] * 4],
+        "third": [[0.3] * 4],
+    }
+    assert fake_models.batch_calls == [["aaa", "bbb", "ccc"]]
+    assert fake_models.single_calls == []
+
+
+@pytest.mark.asyncio
+async def test_gemini_batch_embed_mismatched_response_falls_back_per_item(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(c) Gemini returns fewer embeddings than input items for a batch
+    call. Must NOT crash (previously: zip(strict=True) ValueError) and
+    must NOT silently misalign -- instead falls back to per-item calls
+    and correctly maps every item to its own embedding."""
+
+    def single_embeddings_fn(text: str) -> list[Any]:
+        mapping = {
+            "aaa": [0.1] * 4,
+            "bbb": [0.2] * 4,
+            "ccc": [0.3] * 4,
+        }
+        return [SimpleNamespace(values=mapping[text])]
+
+    fake_models = FakeGeminiModelsBatch(
+        # Batch call returns only 2 embeddings for 3 input items.
+        batch_embeddings_fn=lambda contents: [
+            SimpleNamespace(values=[0.9] * 4),
+            SimpleNamespace(values=[0.9] * 4),
+        ],
+        single_embeddings_fn=single_embeddings_fn,
+    )
+    client = _build_gemini_client(monkeypatch, fake_models)
+
+    result = await client.batch_embed(
+        {"first": "aaa", "second": "bbb", "third": "ccc"}
+    )
+
+    assert result == {
+        "first": [[0.1] * 4],
+        "second": [[0.2] * 4],
+        "third": [[0.3] * 4],
+    }
+    # One initial batch call, then one fallback call per item.
+    assert fake_models.batch_calls == [["aaa", "bbb", "ccc"]]
+    assert fake_models.single_calls == ["aaa", "bbb", "ccc"]
+
+
+@pytest.mark.asyncio
+async def test_gemini_batch_embed_fallback_call_wrong_count_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(d) During the per-item fallback, if an individual call itself
+    returns zero or multiple embeddings, a controlled ValueError is
+    raised (not a crash / silent misalignment)."""
+
+    def single_embeddings_fn(text: str) -> list[Any]:
+        if text == "bbb":
+            return []  # zero embeddings for this item -- should raise
+        return [SimpleNamespace(values=[0.1] * 4)]
+
+    fake_models = FakeGeminiModelsBatch(
+        batch_embeddings_fn=lambda contents: [SimpleNamespace(values=[0.9] * 4)],
+        single_embeddings_fn=single_embeddings_fn,
+    )
+    client = _build_gemini_client(monkeypatch, fake_models)
+
+    with pytest.raises(ValueError, match="Gemini API returned"):
+        await client.batch_embed({"first": "aaa", "second": "bbb"})


### PR DESCRIPTION
## Problem

Batch Gemini embedding calls in `src/embedding_client.py` did:

```python
contents=[item.text for item in batch]
...
for item, embedding in zip(batch, response.embeddings, strict=True):
```

This assumed Gemini always returns exactly one embedding per input item, in order. While the SDK docstring claims this, it does not always hold in practice (possible causes: empty/whitespace items dropped, batch size >100, other API quirks). When the counts didn't match, `zip(..., strict=True)` raised `ValueError: zip() argument 2 is shorter than argument 1`, crashing the whole batch.

## Fix

- Keep the efficient multi-item batch call as the normal path.
- Explicitly check `len(response.embeddings) != len(batch)` before zipping.
- On a mismatch, fall back to embedding each item in that batch **individually** (one call per item, preserving original order) instead of guessing at alignment.
- Each individual fallback call must return exactly one embedding; if it returns zero or multiple, raise `ValueError` with a clear diagnostic (text_id/chunk_index) instead of silently dropping or misaligning data.

## Tests

Added to `tests/llm/test_embedding_client.py`:
- Normal single-item batch response
- Normal multi-item batch response, verifying item-to-embedding order
- Mismatched (short) multi-item batch response triggering per-item fallback, verifying correct mapping
- Fallback individual call returning zero embeddings raises a controlled `ValueError`

```
20 passed, 17 warnings in 10.93s
```

---

This is a separate, independent fix from BUG1 (PR #925) — no overlap with that branch/commit.

Created with AI assistance — Hermes Agent v0.17.0, model Claude Sonnet 4.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Gemini batch embeddings by validating response cardinality against the requested batch size.
  * Ensures embeddings are correctly mapped back to items; falls back to per-item embedding when batch alignment isn’t safe.
  * Added strict error handling for embeddings missing required values and for invalid per-item response sizes.
* **Tests**
  * Extended Gemini embedding tests to cover matched batch success, order preservation, fallback behavior, and multiple error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->