### PR TITLE
fix(llm): recover empty tool-loop responses instead of returning null

### DIFF
--- a/src/llm/tool_loop.py
+++ b/src/llm/tool_loop.py
@@ -404,6 +404,10 @@ async def execute_tool_loop(
     # DialecticCompletedEvent.hit_input_token_cap reflect the cap hit
     # (the toolless path tracks this in src/llm/api.py:325-340).
     hit_input_token_cap = False
+    # Set when an empty tool-less response can't be retried in-loop (no
+    # iterations left) and we break out to the forced synthesis call to
+    # recover a final answer instead of returning empty.
+    empty_recovery_synthesis = False
     # Track effective tool_choice — switches from "required"/"any" to "auto" after iter 1.
     effective_tool_choice = tool_choice
 
@@ -492,24 +496,39 @@ async def execute_tool_loop(
             if not response.tool_calls_made:
                 logger.debug("No tool calls in response, finishing")
 
-                if (
-                    isinstance(response.content, str)
-                    and not response.content.strip()
-                    and empty_response_retries < 1
-                    and iteration < max_tool_iterations - 1
-                ):
-                    empty_response_retries += 1
-                    conversation_messages.append(
-                        {
-                            "role": "user",
-                            "content": (
-                                "Your last response was empty. Provide a concise answer "
-                                "to the original query using the available context."
-                            ),
-                        }
-                    )
-                    iteration += 1
-                    continue
+                is_empty_response = response.content is None or (
+                    isinstance(response.content, str) and not response.content.strip()
+                )
+                if is_empty_response:
+                    # An empty final answer is never useful. Try one in-loop
+                    # nudge while both the retry budget and an iteration remain;
+                    # otherwise recover via the forced synthesis call rather than
+                    # returning null. This covers the minimal tier
+                    # (max_tool_iterations=1, where no in-loop retry is possible)
+                    # and a repeat empty response after the nudge was spent.
+                    if (
+                        empty_response_retries < 1
+                        and iteration < max_tool_iterations - 1
+                    ):
+                        empty_response_retries += 1
+                        conversation_messages.append(
+                            {
+                                "role": "user",
+                                "content": (
+                                    "Your last response was empty. Provide a concise answer "
+                                    "to the original query using the available context."
+                                ),
+                            }
+                        )
+                        iteration += 1
+                        continue
+                    if not stream_final:
+                        # Advance iteration so the synthesis call is counted,
+                        # then break to it. Streaming leaves the empty tail to
+                        # the stream itself.
+                        empty_recovery_synthesis = True
+                        iteration += 1
+                        break
 
                 if stream_final:
                     # Snapshot the plan that just succeeded — streaming retries
@@ -657,19 +676,27 @@ async def execute_tool_loop(
 
         iteration += 1
 
-    logger.warning(
-        f"Tool execution loop reached max iterations ({max_tool_iterations})"
-    )
+    if empty_recovery_synthesis:
+        logger.debug("Empty tool-less response, no retries left; forcing synthesis")
+        synthesis_prompt = (
+            "Your previous response was empty. Using the context already available, "
+            "provide your final answer to the original query now. "
+            "Do not attempt to call any tools."
+        )
+    else:
+        logger.warning(
+            f"Tool execution loop reached max iterations ({max_tool_iterations})"
+        )
+        synthesis_prompt = (
+            "You have reached the maximum number of tool calls. "
+            "Based on all the information you have gathered, provide your final response now. "
+            "Do not attempt to call any more tools."
+        )
 
-    # The max-iteration synthesis call gets iteration N+1 in telemetry so 's
+    # The synthesis call gets iteration N+1 in telemetry so 's
     # AgentIterationEvent and this LLMCallCompletedEvent line up sequentially.
     synthesis_iteration = iteration + 1
 
-    synthesis_prompt = (
-        "You have reached the maximum number of tool calls. "
-        "Based on all the information you have gathered, provide your final response now. "
-        "Do not attempt to call any more tools."
-    )
     conversation_messages.append({"role": "user", "content": synthesis_prompt})
 
     # Truncate again — the per-iteration truncate ran before the last tool

--- a/tests/llm/test_dialectic_minimal_empty_recovery.py
+++ b/tests/llm/test_dialectic_minimal_empty_recovery.py
@@ -1,0 +1,176 @@
+# pyright: reportPrivateUsage=false, reportUnknownLambdaType=false, reportUnknownArgumentType=false, reportArgumentType=false
+"""Isolation tests for empty-final-response recovery in `execute_tool_loop`.
+
+These prove — independent of any deployment, stored data, or LLM
+nondeterminism — that an empty final answer (whether `""`, blank, or `None`)
+with no tool calls is recovered rather than surfaced as `null`.
+
+The recovery is decoupled from the iteration budget: while a retry and an
+iteration remain, one in-loop nudge is tried; otherwise the loop breaks to the
+forced synthesis call. The dialectic `minimal` tier (`MAX_TOOL_ITERATIONS=1`)
+always takes the synthesis path because it has no iteration to loop on, and a
+repeat empty response after the single nudge is routed to synthesis too. The
+synthesis call is counted in `iterations`.
+
+Covered here: empty-string and `None` at a single iteration; a repeat empty
+after the nudge at two iterations; and the in-budget nudge control.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.llm import tool_loop
+from src.llm.runtime import AttemptPlan
+from src.llm.tool_loop import execute_tool_loop
+from src.llm.types import HonchoLLMCallResponse
+
+
+def _make_plan() -> AttemptPlan:
+    """Return a minimal AttemptPlan the mocked inner call passes straight through."""
+    return AttemptPlan(
+        provider="anthropic",
+        model="claude-sonnet-4-5",
+        client=object(),
+        thinking_budget_tokens=None,
+        reasoning_effort=None,
+        selected_config=None,
+        attempt=1,
+        retry_attempts=1,
+        is_fallback=False,
+    )
+
+
+def _resp(content: str | None) -> HonchoLLMCallResponse[Any]:
+    """Build a no-tool-call LLM response carrying the given content (may be None)."""
+    return HonchoLLMCallResponse(
+        content=content,
+        input_tokens=10,
+        output_tokens=5,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        finish_reasons=["stop"],
+        tool_calls_made=[],
+    )
+
+
+class _ScriptedLLM:
+    """Mock inner-LLM driven by a script of per-tool-call contents.
+
+    Each tool-enabled call (``tools`` passed) returns the next scripted content;
+    empty/`None` entries drive the empty-response paths. The forced synthesis
+    call (``tools=None``) always returns a fixed sentinel, so a test can tell
+    recovery happened via synthesis rather than an in-loop nudge.
+    """
+
+    def __init__(
+        self,
+        tool_call_contents: list[str | None],
+        synthesis: str = "recovered via synthesis",
+    ) -> None:
+        """Store the scripted tool-call contents and the synthesis sentinel."""
+        self._contents = list(tool_call_contents)
+        self._synthesis = synthesis
+        self.tool_calls = 0
+        self.synthesis_calls = 0
+
+    async def __call__(self, *_args: Any, **kwargs: Any) -> HonchoLLMCallResponse[Any]:
+        """Return the next scripted content, or the sentinel when ``tools`` is None."""
+        if kwargs.get("tools") is None:  # forced final synthesis call
+            self.synthesis_calls += 1
+            return _resp(self._synthesis)
+        idx = self.tool_calls
+        self.tool_calls += 1
+        content = self._contents[idx] if idx < len(self._contents) else ""
+        return _resp(content)
+
+
+_TOOLS = [{"name": "noop", "description": "no-op", "input_schema": {"type": "object"}}]
+
+
+async def _run(max_tool_iterations: int, mock: _ScriptedLLM) -> Any:
+    """Drive execute_tool_loop with the mock at the given iteration budget."""
+    return await execute_tool_loop(
+        prompt="hi",
+        max_tokens=250,
+        messages=[{"role": "user", "content": "What do you know about me?"}],
+        tools=_TOOLS,
+        tool_choice="auto",
+        tool_executor=lambda _name, _input: "",
+        max_tool_iterations=max_tool_iterations,
+        response_model=None,
+        json_mode=False,
+        temperature=None,
+        stop_seqs=None,
+        verbosity=None,
+        enable_retry=False,
+        retry_attempts=1,
+        max_input_tokens=None,
+        get_attempt_plan=_make_plan,
+        before_retry_callback=lambda _r: None,
+        stream_final=False,
+        telemetry=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_string_recovered_at_single_iteration():
+    """minimal tier: an empty ("") tool-less answer is recovered via synthesis,
+    and `iterations` counts both the empty call and the synthesis call."""
+    mock = _ScriptedLLM([""])
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(tool_loop, "honcho_llm_call_inner", mock)
+        result = await _run(1, mock)
+
+    assert isinstance(result, HonchoLLMCallResponse)
+    assert result.content == "recovered via synthesis"
+    assert mock.synthesis_calls == 1
+    assert result.iterations == 2
+
+
+@pytest.mark.asyncio
+async def test_none_content_recovered_at_single_iteration():
+    """A `None` completion (not just "") is treated as empty and recovered via
+    synthesis — without this the string-only predicate would let it through."""
+    mock = _ScriptedLLM([None])
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(tool_loop, "honcho_llm_call_inner", mock)
+        result = await _run(1, mock)
+
+    assert isinstance(result, HonchoLLMCallResponse)
+    assert result.content == "recovered via synthesis"
+    assert mock.synthesis_calls == 1
+    assert result.iterations == 2
+
+
+@pytest.mark.asyncio
+async def test_repeat_empty_after_nudge_recovered_via_synthesis():
+    """A second empty response after the single in-loop nudge is still recovered
+    via synthesis rather than returned as null (initial + nudged retry +
+    synthesis == 3 LLM calls)."""
+    mock = _ScriptedLLM(["", ""])
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(tool_loop, "honcho_llm_call_inner", mock)
+        result = await _run(2, mock)
+
+    assert isinstance(result, HonchoLLMCallResponse)
+    assert result.content == "recovered via synthesis"
+    assert mock.synthesis_calls == 1
+    assert result.iterations == 3
+
+
+@pytest.mark.asyncio
+async def test_nudge_recovers_within_budget_without_synthesis():
+    """Control: with an iteration to spare, a single empty response is recovered
+    by the in-loop nudge, no synthesis call needed."""
+    mock = _ScriptedLLM(["", "recovered via retry"])
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(tool_loop, "honcho_llm_call_inner", mock)
+        result = await _run(2, mock)
+
+    assert isinstance(result, HonchoLLMCallResponse)
+    assert result.content == "recovered via retry"
+    assert mock.synthesis_calls == 0
+    assert result.iterations == 2


### PR DESCRIPTION
## Description

Ref: #928
`peer.chat(..., reasoning_level="minimal")` returned `null` on broad queries the model answered without a tool call. The tool loop's empty-response retry is gated on `iteration < max_tool_iterations - 1`, which is `0 < 0 == False` for the `minimal` tier (`MAX_TOOL_ITERATIONS=1`), so the retry never fired and the tool-less branch returned empty content without reaching the post-loop synthesis call. The empty string then surfaced as `null` (the chat endpoint maps a falsy answer to `None`). `low` and `medium` were unaffected because they allow `>= 2` iterations.

## Motivation

Broad `minimal` queries silently returned `null` even though the same query answered correctly at `low`/`medium`, so callers relying on `minimal` received no memory and no error signal.

## Changes

- `src/llm/tool_loop.py`: decouple empty-response recovery from the iteration budget. Keep the nudge-and-loop when iterations remain, otherwise break to the forced synthesis call so a final answer is always produced. This is a general tool-loop correctness fix; `minimal` is simply where it is guaranteed to surface. The synthesis prompt and log now distinguish empty-recovery from genuine max-iteration exhaustion, and the streaming path is left unchanged (`not stream_final`).
- `tests/llm/test_dialectic_minimal_empty_recovery.py`: deterministic regression test (mocked inner LLM) covering the single-iteration recovery path and the multi-iteration control.

## Testing

- `tests/llm/` full suite: 242 passed (new regression test RED to GREEN).
- `ruff check` / `ruff format` / `basedpyright` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty model responses at the end of the tool loop, ensuring the system recovers reliably even when no in-loop retry is possible.
  * Adds clearer recovery behavior to choose between synthesis-based recovery and retry-based recovery depending on remaining tool iterations.

* **Tests**
  * Added new isolation tests covering empty-string and `None` final responses, including single-iteration forced synthesis and multi-iteration nudge/retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->