### PR TITLE
fix: add a safe Codex compatibility relay

### DIFF
--- a/docs/codex-relay.md
+++ b/docs/codex-relay.md
@@ -48,17 +48,31 @@ authentication; it is not an upstream Codex OAuth token.
 Supported Chat controls are: messages, model, stream, tools, tool_choice
 (`none`, `auto`, `required`, or a named function), parallel_tool_calls,
 reasoning_effort, response_format (`json_object`/`json_schema`), and
-max_tokens/max_completion_tokens (translated to `max_output_tokens`). Conflicting
-output-limit aliases and invalid values are rejected. Controls that cannot be
-represented safely by Codex Responses (temperature, top_p, stop, penalties,
-seed, stream_options, logprobs, n, and user) are rejected with a clear 400 rather
-than silently dropped.
+max_tokens/max_completion_tokens (translated to `max_output_tokens`). The current
+Honcho OpenAI streaming backend's `stream_options: {"include_usage": true}` is
+accepted; the relay emits an OpenAI-compatible final usage chunk before `[DONE]`.
+Conflicting output-limit aliases and invalid values are rejected. Controls that
+cannot be represented safely by Codex Responses (temperature, top_p, stop,
+penalties, seed, logprobs, n, user, verbosity, reasoning, and SDK passthrough
+fields such as extra_body) are rejected with a clear 400 rather than silently
+dropped. Other unknown top-level fields and malformed supported fields are also
+rejected with a clear 400.
 
 Responses streams must end in `response.completed` or `response.incomplete`.
-Provider errors, malformed data, EOF/truncation, and transport failures are
-returned as sanitized errors; an already-started downstream stream emits one
+The relay stops reading immediately after the first valid terminal event and
+closes the upstream response. Provider HTTP error bodies are sanitized to a
+stable OpenAI-compatible error while preserving the upstream status code;
+credential, malformed data, malformed usage, EOF/truncation, and transport
+failures are sanitized as well. An already-started downstream stream emits one
 error event followed by one `[DONE]`. Incomplete content-filter results map to
 `content_filter`; other incomplete results map to `length`.
+
+The credential document must contain a mapping at
+`providers.openai-codex.tokens.access_token` with a non-empty string token.
+Missing, corrupt, or malformed documents and non-ASCII/empty transport tokens
+return a sanitized 503 credential error. Malformed or opaque JWT claims are
+never decoded into headers or reflected in errors; if the upstream rejects such
+a token, its HTTP error is sanitized.
 
 ## Reproducible checks
 

--- a/docs/codex-relay.md
+++ b/docs/codex-relay.md
@@ -1,0 +1,48 @@
+# Local Codex Responses relay
+
+`src.codex_relay` provides a narrow OpenAI Chat Completions compatibility layer for
+Honcho's local development setup. It reads the `openai-codex` credential from the
+Hermes auth store on each request, refreshes an expiring OAuth token through the
+standard Codex OAuth token endpoint, and atomically writes rotated credentials
+back without logging token values.
+
+The upstream request is always sent as a streaming Responses request to:
+
+`https://chatgpt.com/backend-api/codex/responses`
+
+The relay converts system/developer prompts, user and assistant messages,
+function calls and function results, reasoning effort, tools, and JSON response
+formats. Non-streaming Chat Completions calls aggregate the Codex SSE stream;
+streaming calls receive translated Chat Completions SSE. Upstream HTTP error
+status and bodies are returned unchanged. Provider errors emitted inside SSE are
+returned as structured errors with a classification-friendly status.
+
+## Start
+
+From the repository root, the default listener is loopback-only:
+
+```bash
+uv run python -m src.codex_relay --host 127.0.0.1 --port 8787
+```
+
+For a Honcho container on the same private Docker network, bind explicitly to
+that network interface/address rather than exposing the port publicly:
+
+```bash
+uv run python -m src.codex_relay --host 0.0.0.0 --port 8787
+```
+
+The relay does not modify `.env`, start/reload Honcho containers, or claim to be
+deployed. Point an OpenAI-compatible Honcho model configuration at the relay's
+OpenAI base URL (`http://127.0.0.1:8787/v1` for a host-local process).
+
+## Checks
+
+```bash
+uv run pytest tests/llm/test_codex_relay.py -q
+uv run ruff check src/codex_relay.py tests/llm/test_codex_relay.py
+uv run basedpyright src/codex_relay.py tests/llm/test_codex_relay.py
+```
+
+The test suite uses a mocked SSE transport and never reads or prints live
+credentials.

--- a/docs/codex-relay.md
+++ b/docs/codex-relay.md
@@ -1,48 +1,78 @@
 # Local Codex Responses relay
 
-`src.codex_relay` provides a narrow OpenAI Chat Completions compatibility layer for
-Honcho's local development setup. It reads the `openai-codex` credential from the
-Hermes auth store on each request, refreshes an expiring OAuth token through the
-standard Codex OAuth token endpoint, and atomically writes rotated credentials
-back without logging token values.
+`src.codex_relay` is a narrow, local-only OpenAI Chat Completions compatibility
+process for Honcho development. It translates the supported Chat request subset
+to a streaming Codex Responses request and translates the response back.
 
-The upstream request is always sent as a streaming Responses request to:
+## Security and credential ownership
 
-`https://chatgpt.com/backend-api/codex/responses`
+The relay does not refresh or write Hermes credentials. Hermes remains the sole
+owner of OAuth rotation, locks, profile selection, pool selection, and persistence.
+The optional `--auth-path` is a read-only JSON source for a single canonical
+`providers.openai-codex.tokens.access_token` record; it is not a Hermes credential
+adapter and must not be used as a shared refresh store. For rotation, the embedding
+process must inject a token provider (`TokenProvider(force_refresh)`) that delegates
+to the active Hermes profile. No credential value is logged by the relay.
 
-The relay converts system/developer prompts, user and assistant messages,
-function calls and function results, reasoning effort, tools, and JSON response
-formats. Non-streaming Chat Completions calls aggregate the Codex SSE stream;
-streaming calls receive translated Chat Completions SSE. Upstream HTTP error
-status and bodies are returned unchanged. Provider errors emitted inside SSE are
-returned as structured errors with a classification-friendly status.
-
-## Start
-
-From the repository root, the default listener is loopback-only:
+The default listener is loopback-only and may be used without an inbound key:
 
 ```bash
-uv run python -m src.codex_relay --host 127.0.0.1 --port 8787
+uv run python -m src.codex_relay --host 127.0.0.1 --port 8787 \
+  --auth-path "$HERMES_HOME/profiles/$HERMES_PROFILE/auth.json"
 ```
 
-For a Honcho container on the same private Docker network, bind explicitly to
-that network interface/address rather than exposing the port publicly:
+Every non-loopback bind requires a separately configured relay key. The key is
+accepted as an Authorization Bearer relay key and is compared in constant time.
+Configure it through the environment or a secret manager; do not put it in
+source control or logs:
 
 ```bash
-uv run python -m src.codex_relay --host 0.0.0.0 --port 8787
+CODEX_RELAY_INBOUND_KEY='use-a-secret-manager-value' \
+  uv run python -m src.codex_relay --host 192.0.2.10 --port 8787
 ```
 
-The relay does not modify `.env`, start/reload Honcho containers, or claim to be
-deployed. Point an OpenAI-compatible Honcho model configuration at the relay's
-OpenAI base URL (`http://127.0.0.1:8787/v1` for a host-local process).
+Do not use `0.0.0.0` as a claim of privacy. If wildcard binding is unavoidable,
+require the inbound key, restrict the published port with a firewall/container
+network policy, and treat every reachable peer as untrusted. The upstream Codex
+transport is HTTPS by default at
+`https://chatgpt.com/backend-api/codex/responses`.
 
-## Checks
+## Honcho configuration
+
+Point the current upstream `OpenAIBackend`/`AsyncOpenAI` client at
+`http://127.0.0.1:8787/v1` (or the explicitly trusted relay address), use a model
+name accepted by the upstream configuration, and provide Honcho's required
+OpenAI API-key field with the same relay key. The relay key is inbound relay
+authentication; it is not an upstream Codex OAuth token.
+
+Supported Chat controls are: messages, model, stream, tools, tool_choice
+(`none`, `auto`, `required`, or a named function), parallel_tool_calls,
+reasoning_effort, response_format (`json_object`/`json_schema`), and
+max_tokens/max_completion_tokens (translated to `max_output_tokens`). Conflicting
+output-limit aliases and invalid values are rejected. Controls that cannot be
+represented safely by Codex Responses (temperature, top_p, stop, penalties,
+seed, stream_options, logprobs, n, and user) are rejected with a clear 400 rather
+than silently dropped.
+
+Responses streams must end in `response.completed` or `response.incomplete`.
+Provider errors, malformed data, EOF/truncation, and transport failures are
+returned as sanitized errors; an already-started downstream stream emits one
+error event followed by one `[DONE]`. Incomplete content-filter results map to
+`content_filter`; other incomplete results map to `length`.
+
+## Reproducible checks
+
+From a clean checkout with the locked development dependencies available:
 
 ```bash
-uv run pytest tests/llm/test_codex_relay.py -q
+uv sync --frozen
+uv run pytest tests/llm/test_codex_relay.py -q -n 0
 uv run ruff check src/codex_relay.py tests/llm/test_codex_relay.py
 uv run basedpyright src/codex_relay.py tests/llm/test_codex_relay.py
 ```
 
-The test suite uses a mocked SSE transport and never reads or prints live
-credentials.
+These tests use synthetic tokens and `httpx.MockTransport`/in-process ASGI only;
+they do not read live credentials or call a live provider. Before review, also
+run `git diff --check` and the repository's approved secret scanner. The targeted
+type command may report pre-existing warnings in a dependency-complete checkout;
+record its actual exit code rather than treating warnings as success.

--- a/src/codex_relay.py
+++ b/src/codex_relay.py
@@ -30,8 +30,6 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 logger = logging.getLogger("codex_relay")
 CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
 DEFAULT_AUTH_PATH = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "auth.json"
-CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
-CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 
 
 class RelayError(RuntimeError):
@@ -132,7 +130,7 @@ def _assistant_tool_calls(message: dict[str, Any]) -> list[dict[str, Any]]:
     return converted
 
 
-def _response_tool(tool: dict[str, Any]) -> dict[str, Any] | None:
+def _response_tool(tool: Any) -> dict[str, Any]:
     if not isinstance(tool, dict):
         raise RelayError("tool must be an object", status_code=400)
     if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
@@ -741,9 +739,9 @@ class CodexRelay:
                     tool_calls.append(call)
                     yield _sse_line({"id": response_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {"tool_calls": [call]}, "finish_reason": None}]})
             elif event_type in {"response.completed", "response.incomplete"}:
-                response, usage = _terminal_response(event, require_usage=include_usage)
+                terminal_response, usage = _terminal_response(event, require_usage=include_usage)
                 terminal = True
-                details = response.get("incomplete_details")
+                details = terminal_response.get("incomplete_details")
                 reason = details.get("reason") if isinstance(details, dict) else None
                 if event_type == "response.incomplete" and reason in {"content_filter", "content_filtering"}:
                     finish = "content_filter"
@@ -798,6 +796,7 @@ def _is_loopback(host: str) -> bool:
 
 def create_app(relay: CodexRelay | None = None, *, inbound_key: str | None = None, bind_host: str = "127.0.0.1") -> FastAPI:
     relay = relay or CodexRelay()
+    inbound_key = inbound_key or None
     if not _is_loopback(bind_host) and not inbound_key:
         raise ValueError("inbound_key is required for non-loopback binds")
 
@@ -819,7 +818,9 @@ def create_app(relay: CodexRelay | None = None, *, inbound_key: str | None = Non
         if inbound_key is not None:
             supplied = request.headers.get("authorization", "")
             candidate = supplied[7:] if supplied.lower().startswith("bearer ") else ""
-            if not candidate or not hmac.compare_digest(candidate, inbound_key):
+            candidate_bytes = candidate.encode("utf-8")
+            key_bytes = inbound_key.encode("utf-8")
+            if not candidate_bytes or not hmac.compare_digest(candidate_bytes, key_bytes):
                 return JSONResponse({"error": {"message": "Invalid relay authentication", "code": "relay_unauthorized"}}, status_code=401)
         try:
             body = await request.json()

--- a/src/codex_relay.py
+++ b/src/codex_relay.py
@@ -1,0 +1,654 @@
+"""Local OpenAI Chat Completions to ChatGPT Codex Responses relay.
+
+The relay deliberately speaks only the subset Honcho uses. It always sends a
+streaming Responses request to Codex (the Codex endpoint requires this shape),
+then either forwards translated SSE or aggregates it into a Chat Completions
+response. It is a local compatibility process, not a production proxy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import logging
+import os
+import tempfile
+import time
+import uuid
+from collections.abc import AsyncIterator, Iterable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+logger = logging.getLogger("codex_relay")
+CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+DEFAULT_AUTH_PATH = Path.home() / ".hermes" / "auth.json"
+CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+
+class RelayError(RuntimeError):
+    """An error that can be represented as an OpenAI-compatible error body."""
+
+    def __init__(self, message: str, *, status_code: int = 502, payload: Any = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.payload = payload
+
+
+class ProviderStreamError(RelayError):
+    """The provider sent a terminal error inside an otherwise successful SSE stream."""
+
+
+@dataclass(slots=True)
+class AggregatedResponse:
+    content: str = ""
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    response_id: str | None = None
+    model: str | None = None
+    finish_reason: str = "stop"
+    usage: dict[str, int] = field(default_factory=dict)
+    reasoning: str = ""
+
+
+def _as_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict) and isinstance(part.get("text"), str):
+                parts.append(part["text"])
+        return "".join(parts)
+    return str(content)
+
+
+def _responses_content(content: Any, *, assistant: bool = False) -> Any:
+    if not isinstance(content, list):
+        return _as_text(content)
+    parts: list[dict[str, Any]] = []
+    text_type = "output_text" if assistant else "input_text"
+    for part in content:
+        if isinstance(part, str):
+            parts.append({"type": text_type, "text": part})
+            continue
+        if not isinstance(part, dict):
+            continue
+        part_type = str(part.get("type") or "").lower()
+        if part_type in {"text", "input_text", "output_text"}:
+            parts.append({"type": text_type, "text": _as_text(part.get("text"))})
+        elif part_type in {"image_url", "input_image"}:
+            image = part.get("image_url")
+            detail = part.get("detail")
+            if isinstance(image, dict):
+                detail = image.get("detail", detail)
+                image = image.get("url")
+            if isinstance(image, str) and image:
+                item: dict[str, Any] = {"type": "input_image", "image_url": image}
+                if isinstance(detail, str) and detail:
+                    item["detail"] = detail
+                parts.append(item)
+    return parts
+
+
+def _assistant_tool_calls(message: dict[str, Any]) -> list[dict[str, Any]]:
+    converted: list[dict[str, Any]] = []
+    for call in message.get("tool_calls") or []:
+        if not isinstance(call, dict):
+            continue
+        function = call.get("function") or {}
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        arguments = function.get("arguments", "{}")
+        if not isinstance(arguments, str):
+            arguments = json.dumps(arguments, ensure_ascii=False)
+        converted.append(
+            {
+                "type": "function_call",
+                "call_id": str(call.get("id") or f"call_{uuid.uuid4().hex[:16]}"),
+                "name": name,
+                "arguments": arguments or "{}",
+            }
+        )
+    return converted
+
+
+def _response_tool(tool: dict[str, Any]) -> dict[str, Any] | None:
+    if not isinstance(tool, dict):
+        return None
+    if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+        function = tool["function"]
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            return None
+        return {
+            "type": "function",
+            "name": name,
+            "description": str(function.get("description") or ""),
+            "parameters": function.get("parameters") or {"type": "object"},
+            "strict": bool(function.get("strict", False)),
+        }
+    # Honcho's provider-independent tool shape is also accepted directly.
+    name = tool.get("name")
+    if isinstance(name, str) and name:
+        return {
+            "type": "function",
+            "name": name,
+            "description": str(tool.get("description") or ""),
+            "parameters": tool.get("input_schema") or tool.get("parameters") or {"type": "object"},
+            "strict": bool(tool.get("strict", False)),
+        }
+    return None
+
+
+def _response_format(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    kind = value.get("type")
+    if kind == "json_object":
+        return {"format": {"type": "json_object"}}
+    if kind == "json_schema":
+        schema = value.get("json_schema")
+        if isinstance(schema, dict):
+            fmt: dict[str, Any] = {
+                "type": "json_schema",
+                "name": str(schema.get("name") or "response"),
+                "schema": schema.get("schema") or {},
+                "strict": bool(schema.get("strict", True)),
+            }
+            return {"format": fmt}
+    return None
+
+
+def build_responses_request(chat_request: dict[str, Any]) -> dict[str, Any]:
+    """Convert an OpenAI Chat Completions request to Codex Responses JSON."""
+    messages = chat_request.get("messages")
+    if not isinstance(messages, list):
+        raise RelayError("messages must be a list", status_code=400)
+    instructions: list[str] = []
+    input_items: list[dict[str, Any]] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            raise RelayError("each message must be an object", status_code=400)
+        role = str(message.get("role") or "user")
+        content = message.get("content", "")
+        if role in {"system", "developer"}:
+            text = _as_text(content)
+            if text:
+                instructions.append(text)
+            continue
+        if role == "tool":
+            call_id = message.get("tool_call_id")
+            if isinstance(call_id, str) and call_id:
+                input_items.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": _as_text(content),
+                    }
+                )
+            continue
+        if role not in {"user", "assistant"}:
+            role = "user"
+        if role == "assistant":
+            calls = _assistant_tool_calls(message)
+            if calls:
+                input_items.extend(calls)
+            if content not in (None, "", []):
+                input_items.append(
+                    {"role": "assistant", "content": _responses_content(content, assistant=True)}
+                )
+        else:
+            input_items.append({"role": role, "content": _responses_content(content)})
+
+    request: dict[str, Any] = {
+        "model": str(chat_request.get("model") or "gpt-5.6-luna"),
+        "instructions": "\n\n".join(instructions),
+        "input": input_items,
+        "store": False,
+        "stream": True,
+    }
+    effort = chat_request.get("reasoning_effort")
+    if isinstance(effort, str) and effort:
+        request["reasoning"] = {"effort": effort, "summary": "auto"}
+    tools = [_response_tool(tool) for tool in (chat_request.get("tools") or [])]
+    request_tools = [tool for tool in tools if tool is not None]
+    if request_tools:
+        request["tools"] = request_tools
+        choice = chat_request.get("tool_choice")
+        if choice not in (None, "none"):
+            request["tool_choice"] = choice if choice is not None else "auto"
+        request["parallel_tool_calls"] = True
+    response_format = _response_format(chat_request.get("response_format"))
+    if response_format:
+        request["text"] = response_format
+    return request
+
+
+def _sse_events(lines: Iterable[str]) -> Iterable[dict[str, Any]]:
+    event_name: str | None = None
+    data_lines: list[str] = []
+
+    def flush() -> dict[str, Any] | None:
+        nonlocal event_name, data_lines
+        if not data_lines:
+            event_name = None
+            return None
+        raw = "\n".join(data_lines).strip()
+        name = event_name
+        event_name = None
+        data_lines = []
+        if not raw or raw == "[DONE]":
+            return None
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(payload, dict) and name and "type" not in payload:
+            payload["type"] = name
+        return payload if isinstance(payload, dict) else None
+
+    for raw_line in lines:
+        line = raw_line.decode("utf-8", errors="replace") if isinstance(raw_line, bytes) else str(raw_line)
+        if line == "":
+            payload = flush()
+            if payload is not None:
+                yield payload
+        elif line.startswith(":"):
+            continue
+        elif line.startswith("event:"):
+            event_name = line[6:].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+    payload = flush()
+    if payload is not None:
+        yield payload
+
+
+def _nested(payload: Any, key: str) -> Any:
+    return payload.get(key) if isinstance(payload, dict) else None
+
+
+def _usage(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    prompt = int(value.get("input_tokens") or value.get("prompt_tokens") or 0)
+    completion = int(value.get("output_tokens") or value.get("completion_tokens") or 0)
+    return {"prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": prompt + completion}
+
+
+def _provider_error(payload: dict[str, Any]) -> ProviderStreamError:
+    nested = payload.get("error")
+    error: dict[str, Any] = nested if isinstance(nested, dict) else payload
+    code = str(error.get("code") or error.get("type") or "provider_error")
+    message = str(error.get("message") or "Codex Responses request failed")
+    status = 429 if "rate" in code or "quota" in code else 400 if "invalid" in code else 502
+    return ProviderStreamError(f"{code}: {message}", status_code=status, payload={"error": error})
+
+
+def aggregate_codex_sse(raw: str | Iterable[str]) -> AggregatedResponse:
+    """Aggregate Codex SSE events into the fields used by Chat Completions."""
+    result = AggregatedResponse()
+    arguments: dict[str, list[str]] = {}
+    for event in _sse_events(raw.splitlines() if isinstance(raw, str) else raw):
+        event_type = str(event.get("type") or "")
+        if event_type == "error":
+            raise _provider_error(event)
+        if "output_text.delta" in event_type:
+            result.content += str(event.get("delta") or "")
+        elif "reasoning" in event_type and "delta" in event_type:
+            result.reasoning += str(event.get("delta") or "")
+        elif "function_call_arguments.delta" in event_type:
+            item_id = str(event.get("item_id") or event.get("call_id") or "")
+            arguments.setdefault(item_id, []).append(str(event.get("delta") or ""))
+        elif event_type == "response.output_item.done":
+            item = event.get("item")
+            if isinstance(item, dict) and item.get("type") == "function_call":
+                call_id = str(item.get("call_id") or item.get("id") or f"call_{len(result.tool_calls)}")
+                raw_args = item.get("arguments")
+                if not isinstance(raw_args, str):
+                    raw_args = "".join(arguments.get(str(item.get("id") or call_id), []))
+                result.tool_calls.append(
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": str(item.get("name") or ""),
+                            "arguments": raw_args or "{}",
+                        },
+                    }
+                )
+        elif event_type in {"response.completed", "response.incomplete", "response.failed"}:
+            response = event.get("response")
+            if isinstance(response, dict):
+                result.response_id = response.get("id")
+                result.model = response.get("model")
+                result.usage = _usage(response.get("usage"))
+                if event_type == "response.incomplete":
+                    result.finish_reason = "length"
+                elif event_type == "response.failed":
+                    raise _provider_error(response)
+    if result.tool_calls:
+        result.finish_reason = "tool_calls"
+    return result
+
+
+def _chat_response(result: AggregatedResponse, requested_model: str) -> dict[str, Any]:
+    response_id = result.response_id or f"chatcmpl-relay-{uuid.uuid4().hex}"
+    message: dict[str, Any] = {"role": "assistant", "content": result.content or None}
+    if result.tool_calls:
+        message["tool_calls"] = result.tool_calls
+    return {
+        "id": response_id,
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": result.model or requested_model,
+        "choices": [{"index": 0, "message": message, "finish_reason": result.finish_reason}],
+        "usage": result.usage,
+    }
+
+
+def _error_response(error: RelayError) -> JSONResponse:
+    payload = error.payload if isinstance(error.payload, dict) else {"error": {"message": str(error)}}
+    return JSONResponse(payload, status_code=error.status_code)
+
+
+class AuthStore:
+    """Read Hermes auth state on demand and refresh an expiring Codex token."""
+
+    def __init__(self, path: Path = DEFAULT_AUTH_PATH) -> None:
+        self.path = path
+        self._lock = asyncio.Lock()
+
+    def _read(self) -> dict[str, Any]:
+        with self.path.open(encoding="utf-8") as handle:
+            value = json.load(handle)
+        if not isinstance(value, dict):
+            raise RelayError("Hermes auth store is not an object", status_code=503)
+        return value
+
+    @contextmanager
+    def _file_lock(self) -> Iterator[None]:
+        """Serialize refresh/rotation with other relay processes."""
+        import fcntl
+
+        lock_path = self.path.with_name(f".{self.path.name}.lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+", encoding="utf-8") as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+    @staticmethod
+    def _expiry(token: str) -> float | None:
+        try:
+            encoded = token.split(".")[1]
+            encoded += "=" * (-len(encoded) % 4)
+            claims = json.loads(base64.urlsafe_b64decode(encoded))
+            return float(claims["exp"])
+        except (IndexError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+
+    def _candidate(self, state: dict[str, Any]) -> tuple[str, dict[str, Any] | None]:
+        provider = state.get("providers", {}).get("openai-codex", {})
+        tokens = provider.get("tokens") if isinstance(provider, dict) else None
+        if isinstance(tokens, dict) and tokens.get("access_token"):
+            return str(tokens["access_token"]), tokens
+        pool = state.get("credential_pool", {}).get("openai-codex", [])
+        if isinstance(pool, list):
+            for entry in sorted(pool, key=lambda item: item.get("priority", 0) if isinstance(item, dict) else 0):
+                if isinstance(entry, dict) and entry.get("access_token"):
+                    return str(entry["access_token"]), entry
+        raise RelayError("No openai-codex OAuth access token in Hermes auth.json", status_code=503)
+
+    async def token(self, *, force_refresh: bool = False) -> str:
+        async with self._lock:
+            with self._file_lock():
+                state = self._read()
+                access, token_record = self._candidate(state)
+                refresh = token_record.get("refresh_token") if token_record else None
+                expiry = self._expiry(access)
+                needs_refresh = force_refresh or (expiry is not None and expiry <= time.time() + 120)
+                if not needs_refresh or not isinstance(refresh, str) or not refresh:
+                    return access
+                response = await self._refresh(refresh)
+                new_access = response.get("access_token")
+                if not isinstance(new_access, str) or not new_access:
+                    raise RelayError("Codex token refresh returned no access_token", status_code=503)
+                new_refresh = response.get("refresh_token") or refresh
+                self._update(state, access, new_access, str(new_refresh))
+                self._atomic_write(state)
+                return new_access
+
+    async def _refresh(self, refresh_token: str) -> dict[str, Any]:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.post(
+                CODEX_OAUTH_TOKEN_URL,
+                data={"grant_type": "refresh_token", "refresh_token": refresh_token, "client_id": CODEX_OAUTH_CLIENT_ID},
+                headers={"Accept": "application/json", "User-Agent": "honcho-codex-relay"},
+            )
+        if response.status_code != 200:
+            raise RelayError(
+                f"Codex token refresh failed with status {response.status_code}",
+                status_code=response.status_code,
+                payload={"error": {"message": response.text, "code": "codex_refresh_failed"}},
+            )
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise RelayError("Codex token refresh returned invalid JSON", status_code=503) from exc
+        return payload if isinstance(payload, dict) else {}
+
+    @staticmethod
+    def _update(state: dict[str, Any], old: str, access: str, refresh: str) -> None:
+        provider = state.get("providers", {}).get("openai-codex", {})
+        records: list[dict[str, Any]] = []
+        if isinstance(provider, dict) and isinstance(provider.get("tokens"), dict):
+            records.append(provider["tokens"])
+        pool = state.get("credential_pool", {}).get("openai-codex", [])
+        if isinstance(pool, list):
+            records.extend(record for record in pool if isinstance(record, dict) and record.get("access_token") == old)
+        for record in records:
+            record["access_token"] = access
+            record["refresh_token"] = refresh
+            record["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    def _atomic_write(self, state: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(prefix=f".{self.path.name}.", dir=self.path.parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(state, handle, indent=2)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+
+
+class CodexRelay:
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        access_token: str | None = None,
+        auth_path: Path = DEFAULT_AUTH_PATH,
+        upstream_url: str = CODEX_RESPONSES_URL,
+    ) -> None:
+        self.client = client or httpx.AsyncClient(timeout=httpx.Timeout(1800.0, connect=30.0))
+        self._owns_client = client is None
+        self.access_token = access_token
+        self.auth = AuthStore(auth_path)
+        self.upstream_url = upstream_url
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self.client.aclose()
+
+    async def _send(self, payload: dict[str, Any], *, force_refresh: bool = False) -> httpx.Response:
+        token = self.access_token or await self.auth.token(force_refresh=force_refresh)
+        headers = {
+            "Accept": "text/event-stream",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "codex_cli_rs/0.0.0 (Honcho relay)",
+            "originator": "codex_cli_rs",
+        }
+        request = self.client.build_request("POST", self.upstream_url, json=payload, headers=headers)
+        return await self.client.send(request, stream=True)
+
+    async def open_upstream(self, chat_request: dict[str, Any]) -> httpx.Response:
+        payload = build_responses_request(chat_request)
+        response = await self._send(payload)
+        if response.status_code == 401 and not self.access_token:
+            await response.aclose()
+            response = await self._send(payload, force_refresh=True)
+        return response
+
+    async def complete(self, chat_request: dict[str, Any]) -> Response:
+        response = await self.open_upstream(chat_request)
+        try:
+            raw = await response.aread()
+            if response.status_code >= 400:
+                return Response(content=raw, status_code=response.status_code, media_type=response.headers.get("content-type"))
+            try:
+                result = aggregate_codex_sse(raw.decode("utf-8", errors="replace"))
+            except RelayError as exc:
+                return _error_response(exc)
+            return JSONResponse(_chat_response(result, str(chat_request.get("model") or "")))
+        finally:
+            await response.aclose()
+
+    async def stream_chat(self, response: httpx.Response, model: str) -> AsyncIterator[bytes]:
+        response_id = f"chatcmpl-relay-{uuid.uuid4().hex}"
+        created = int(time.time())
+        first_delta = True
+        tool_calls: list[dict[str, Any]] = []
+
+        def event_payload(event_name: str | None, data_lines: list[str]) -> dict[str, Any] | None:
+            raw = "\n".join(data_lines).strip()
+            if not raw or raw == "[DONE]":
+                return None
+            try:
+                event: Any = json.loads(raw)
+            except json.JSONDecodeError:
+                return None
+            if isinstance(event, dict) and event_name and "type" not in event:
+                event["type"] = event_name
+            return event if isinstance(event, dict) else None
+
+        async def translate(event: dict[str, Any]) -> AsyncIterator[bytes]:
+            nonlocal first_delta
+            event_type = str(event.get("type") or "")
+            if event_type == "error":
+                yield _sse_line({"error": event})
+                yield b"data: [DONE]\n\n"
+                return
+            if "output_text.delta" in event_type:
+                delta = str(event.get("delta") or "")
+                if delta:
+                    yield _sse_line({"id": response_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {"role": "assistant" if first_delta else None, "content": delta}, "finish_reason": None}]})
+                    first_delta = False
+            elif event_type == "response.output_item.done":
+                item = event.get("item")
+                if isinstance(item, dict) and item.get("type") == "function_call":
+                    call = {"index": len(tool_calls), "id": item.get("call_id") or item.get("id"), "type": "function", "function": {"name": item.get("name", ""), "arguments": item.get("arguments", "{}")} }
+                    tool_calls.append(call)
+                    yield _sse_line({"id": response_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {"tool_calls": [call]}, "finish_reason": None}]})
+            elif event_type in {"response.completed", "response.incomplete", "response.failed"}:
+                if event_type == "response.failed":
+                    yield _sse_line({"error": event.get("response") or event})
+                finish = "tool_calls" if tool_calls else "length" if event_type == "response.incomplete" else "stop"
+                yield _sse_line({"id": response_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {}, "finish_reason": finish}]})
+                yield b"data: [DONE]\n\n"
+
+        event_name: str | None = None
+        data_lines: list[str] = []
+        try:
+            async for line in response.aiter_lines():
+                if line == "":
+                    event = event_payload(event_name, data_lines)
+                    event_name = None
+                    data_lines = []
+                    if event is not None:
+                        async for chunk in translate(event):
+                            yield chunk
+                elif line.startswith(":"):
+                    continue
+                elif line.startswith("event:"):
+                    event_name = line[6:].strip()
+                elif line.startswith("data:"):
+                    data_lines.append(line[5:].lstrip())
+            event = event_payload(event_name, data_lines)
+            if event is not None:
+                async for chunk in translate(event):
+                    yield chunk
+        finally:
+            await response.aclose()
+
+
+def _sse_line(payload: dict[str, Any]) -> bytes:
+    return f"data: {json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}\n\n".encode()
+
+
+def create_app(relay: CodexRelay | None = None) -> FastAPI:
+    relay = relay or CodexRelay()
+    app = FastAPI(title="Honcho Codex relay", docs_url=None, redoc_url=None)
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request) -> Response:
+        try:
+            body = await request.json()
+            if not isinstance(body, dict):
+                raise RelayError("request body must be an object", status_code=400)
+            if body.get("stream") is True:
+                upstream = await relay.open_upstream(body)
+                if upstream.status_code >= 400:
+                    raw = await upstream.aread()
+                    await upstream.aclose()
+                    return Response(content=raw, status_code=upstream.status_code, media_type=upstream.headers.get("content-type"))
+                return StreamingResponse(relay.stream_chat(upstream, str(body.get("model") or "")), media_type="text/event-stream")
+            return await relay.complete(body)
+        except RelayError as exc:
+            return _error_response(exc)
+        except (json.JSONDecodeError, ValueError) as exc:
+            return _error_response(RelayError(str(exc), status_code=400))
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1", help="Bind address (default: loopback only)")
+    parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument("--auth-path", type=Path, default=DEFAULT_AUTH_PATH)
+    parser.add_argument("--upstream-url", default=CODEX_RESPONSES_URL)
+    args = parser.parse_args()
+    import uvicorn
+
+    logger.info("Starting local Codex relay on %s:%s", args.host, args.port)
+    uvicorn.run(create_app(CodexRelay(auth_path=args.auth_path, upstream_url=args.upstream_url)), host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/codex_relay.py
+++ b/src/codex_relay.py
@@ -503,17 +503,21 @@ def _chat_response(result: AggregatedResponse, requested_model: str) -> dict[str
 
 
 def _error_response(error: RelayError) -> JSONResponse:
-    if isinstance(error.payload, dict):
-        payload = error.payload
-    elif isinstance(error, CredentialError):
+    if isinstance(error, CredentialError):
         payload = {"error": {"message": "Codex credential source unavailable", "code": "credential_unavailable"}}
+        status_code = 503
+    elif isinstance(error.payload, dict):
+        payload = error.payload
+        status_code = error.status_code
     elif error.status_code == 400:
         # Input-validation details are safe and useful to the caller. Provider,
         # credential, and filesystem failures may contain secrets or local paths.
         payload = {"error": {"message": str(error), "code": "invalid_request"}}
+        status_code = error.status_code
     else:
         payload = {"error": {"message": "Codex provider request failed", "code": "provider_error"}}
-    return JSONResponse(payload, status_code=error.status_code)
+        status_code = error.status_code
+    return JSONResponse(payload, status_code=status_code)
 
 
 class AuthStore:
@@ -598,7 +602,10 @@ class CodexRelay:
             if self.access_token is not None:
                 token = self.access_token
             elif self.token_provider is not None:
-                token = await self.token_provider(force_refresh)
+                try:
+                    token = await self.token_provider(force_refresh)
+                except Exception as exc:
+                    raise CredentialError("Codex credential source is unavailable", status_code=503) from exc
             else:
                 token = await self.auth.token(force_refresh=force_refresh)
         except CredentialError:

--- a/src/codex_relay.py
+++ b/src/codex_relay.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import hmac
 import json
 import logging
@@ -129,49 +130,69 @@ def _assistant_tool_calls(message: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _response_tool(tool: dict[str, Any]) -> dict[str, Any] | None:
     if not isinstance(tool, dict):
-        return None
+        raise RelayError("tool must be an object", status_code=400)
     if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
         function = tool["function"]
         name = function.get("name")
         if not isinstance(name, str) or not name:
-            return None
+            raise RelayError("function tool name must be a non-empty string", status_code=400)
+        parameters = function.get("parameters", {"type": "object"})
+        if not isinstance(parameters, dict):
+            raise RelayError("function tool parameters must be an object", status_code=400)
+        description = function.get("description", "")
+        if description is not None and not isinstance(description, str):
+            raise RelayError("function tool description must be a string", status_code=400)
+        strict = function.get("strict", False)
+        if not isinstance(strict, bool):
+            raise RelayError("function tool strict must be a boolean", status_code=400)
         return {
             "type": "function",
             "name": name,
-            "description": str(function.get("description") or ""),
-            "parameters": function.get("parameters") or {"type": "object"},
-            "strict": bool(function.get("strict", False)),
+            "description": description or "",
+            "parameters": parameters,
+            "strict": strict,
         }
     # Honcho's provider-independent tool shape is also accepted directly.
     name = tool.get("name")
     if isinstance(name, str) and name:
+        parameters = tool.get("input_schema") or tool.get("parameters") or {"type": "object"}
+        if not isinstance(parameters, dict):
+            raise RelayError("tool parameters must be an object", status_code=400)
+        strict = tool.get("strict", False)
+        if not isinstance(strict, bool):
+            raise RelayError("tool strict must be a boolean", status_code=400)
         return {
             "type": "function",
             "name": name,
             "description": str(tool.get("description") or ""),
-            "parameters": tool.get("input_schema") or tool.get("parameters") or {"type": "object"},
-            "strict": bool(tool.get("strict", False)),
+            "parameters": parameters,
+            "strict": strict,
         }
-    return None
+    raise RelayError("tool must contain a named function", status_code=400)
 
 
 def _response_format(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, dict):
-        return None
+        raise RelayError("response_format must be an object", status_code=400)
     kind = value.get("type")
     if kind == "json_object":
         return {"format": {"type": "json_object"}}
     if kind == "json_schema":
         schema = value.get("json_schema")
-        if isinstance(schema, dict):
-            fmt: dict[str, Any] = {
-                "type": "json_schema",
-                "name": str(schema.get("name") or "response"),
-                "schema": schema.get("schema") or {},
-                "strict": bool(schema.get("strict", True)),
-            }
-            return {"format": fmt}
-    return None
+        if not isinstance(schema, dict):
+            raise RelayError("response_format.json_schema must be an object", status_code=400)
+        name = schema.get("name", "response")
+        shape = schema.get("schema", {})
+        strict = schema.get("strict", True)
+        if not isinstance(name, str) or not name:
+            raise RelayError("response_format.json_schema.name must be a non-empty string", status_code=400)
+        if not isinstance(shape, dict):
+            raise RelayError("response_format.json_schema.schema must be an object", status_code=400)
+        if not isinstance(strict, bool):
+            raise RelayError("response_format.json_schema.strict must be a boolean", status_code=400)
+        fmt: dict[str, Any] = {"type": "json_schema", "name": name, "schema": shape, "strict": strict}
+        return {"format": fmt}
+    raise RelayError("response_format has an unsupported type", status_code=400)
 
 
 def _responses_tool_choice(value: Any) -> str | dict[str, str] | None:
@@ -190,9 +211,16 @@ def _responses_tool_choice(value: Any) -> str | dict[str, str] | None:
     raise RelayError("tool_choice has an unsupported shape", status_code=400)
 
 
+_CHAT_REQUEST_FIELDS = {
+    "model", "messages", "stream", "tools", "tool_choice", "parallel_tool_calls",
+    "reasoning_effort", "response_format", "max_tokens", "max_completion_tokens",
+    "stream_options",
+}
+
 _UNSUPPORTED_CHAT_FIELDS = {
     "temperature", "top_p", "stop", "presence_penalty", "frequency_penalty",
-    "seed", "stream_options", "logprobs", "top_logprobs", "n", "user",
+    "seed", "logprobs", "top_logprobs", "n", "user", "verbosity", "reasoning",
+    "extra_body", "extra_headers", "extra_query",
 }
 
 
@@ -201,9 +229,20 @@ def build_responses_request(chat_request: dict[str, Any]) -> dict[str, Any]:
     messages = chat_request.get("messages")
     if not isinstance(messages, list):
         raise RelayError("messages must be a list", status_code=400)
-    unsupported = sorted(key for key in _UNSUPPORTED_CHAT_FIELDS if chat_request.get(key) is not None)
+    unknown = sorted(set(chat_request) - _CHAT_REQUEST_FIELDS - _UNSUPPORTED_CHAT_FIELDS)
+    if unknown:
+        raise RelayError(f"unsupported Chat Completions parameter: {unknown[0]}", status_code=400)
+    unsupported = sorted(key for key in _UNSUPPORTED_CHAT_FIELDS if key in chat_request)
     if unsupported:
         raise RelayError(f"unsupported Chat Completions parameter: {unsupported[0]}", status_code=400)
+    if "stream" in chat_request and not isinstance(chat_request["stream"], bool):
+        raise RelayError("stream must be a boolean", status_code=400)
+    if "stream_options" in chat_request:
+        options = chat_request["stream_options"]
+        if not isinstance(options, dict) or set(options) - {"include_usage"}:
+            raise RelayError("stream_options only supports include_usage", status_code=400)
+        if "include_usage" in options and not isinstance(options["include_usage"], bool):
+            raise RelayError("stream_options.include_usage must be a boolean", status_code=400)
     instructions: list[str] = []
     input_items: list[dict[str, Any]] = []
     for message in messages:
@@ -248,21 +287,25 @@ def build_responses_request(chat_request: dict[str, Any]) -> dict[str, Any]:
         "stream": True,
     }
     effort = chat_request.get("reasoning_effort")
-    if isinstance(effort, str) and effort:
+    if effort is not None and (not isinstance(effort, str) or not effort):
+        raise RelayError("reasoning_effort must be a non-empty string", status_code=400)
+    if effort:
         request["reasoning"] = {"effort": effort, "summary": "auto"}
-    tools = [_response_tool(tool) for tool in (chat_request.get("tools") or [])]
-    request_tools = [tool for tool in tools if tool is not None]
+    raw_tools = chat_request.get("tools")
+    if raw_tools is not None and not isinstance(raw_tools, list):
+        raise RelayError("tools must be a list", status_code=400)
+    request_tools = [_response_tool(tool) for tool in (raw_tools or [])]
+    choice = _responses_tool_choice(chat_request["tool_choice"]) if "tool_choice" in chat_request else None
     if request_tools:
         request["tools"] = request_tools
-        choice = _responses_tool_choice(chat_request.get("tool_choice"))
         if choice is not None:
             request["tool_choice"] = choice
-        if "parallel_tool_calls" in chat_request:
-            if not isinstance(chat_request["parallel_tool_calls"], bool):
-                raise RelayError("parallel_tool_calls must be a boolean", status_code=400)
-            request["parallel_tool_calls"] = chat_request["parallel_tool_calls"]
-    elif chat_request.get("tool_choice") not in (None, "none"):
+    elif choice not in (None, "none"):
         raise RelayError("tool_choice requires tools", status_code=400)
+    if "parallel_tool_calls" in chat_request:
+        if not isinstance(chat_request["parallel_tool_calls"], bool):
+            raise RelayError("parallel_tool_calls must be a boolean", status_code=400)
+        request["parallel_tool_calls"] = chat_request["parallel_tool_calls"]
     limits = [chat_request.get("max_completion_tokens"), chat_request.get("max_tokens")]
     if limits[0] is not None and limits[1] is not None and limits[0] != limits[1]:
         raise RelayError("max_completion_tokens and max_tokens disagree", status_code=400)
@@ -271,7 +314,7 @@ def build_responses_request(chat_request: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
             raise RelayError("output token limit must be a positive integer", status_code=400)
         request["max_output_tokens"] = limit
-    response_format = _response_format(chat_request.get("response_format"))
+    response_format = _response_format(chat_request["response_format"]) if "response_format" in chat_request else None
     if response_format:
         request["text"] = response_format
     return request
@@ -298,7 +341,9 @@ def _sse_events(lines: Iterable[str]) -> Iterable[dict[str, Any]]:
             raise ProviderStreamError("Codex returned malformed stream data", status_code=502) from exc
         if isinstance(payload, dict) and name and "type" not in payload:
             payload["type"] = name
-        return payload if isinstance(payload, dict) else None
+        if not isinstance(payload, dict):
+            raise ProviderStreamError("Codex returned a non-object stream event", status_code=502)
+        return payload
 
     for raw_line in lines:
         line = raw_line.decode("utf-8", errors="replace") if isinstance(raw_line, bytes) else str(raw_line)
@@ -322,11 +367,36 @@ def _nested(payload: Any, key: str) -> Any:
 
 
 def _usage(value: Any) -> dict[str, int]:
-    if not isinstance(value, dict):
+    if value is None:
         return {}
-    prompt = int(value.get("input_tokens") or value.get("prompt_tokens") or 0)
-    completion = int(value.get("output_tokens") or value.get("completion_tokens") or 0)
+    if not isinstance(value, dict):
+        raise ProviderStreamError("Codex returned malformed usage data", status_code=502)
+
+    def count(*keys: str) -> int:
+        raw = next((value[key] for key in keys if key in value), 0)
+        if not isinstance(raw, int) or isinstance(raw, bool) or raw < 0:
+            raise ProviderStreamError("Codex returned malformed usage data", status_code=502)
+        return raw
+
+    prompt = count("input_tokens", "prompt_tokens")
+    completion = count("output_tokens", "completion_tokens")
     return {"prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": prompt + completion}
+
+
+def _terminal_response(event: dict[str, Any]) -> tuple[dict[str, Any], dict[str, int]]:
+    response = event.get("response")
+    if not isinstance(response, dict):
+        raise ProviderStreamError("Codex returned malformed terminal data", status_code=502)
+    for key in ("id", "model"):
+        if key in response and response[key] is not None and not isinstance(response[key], str):
+            raise ProviderStreamError("Codex returned malformed terminal data", status_code=502)
+    if "incomplete_details" in response:
+        details = response["incomplete_details"]
+        if details is not None and not isinstance(details, dict):
+            raise ProviderStreamError("Codex returned malformed terminal data", status_code=502)
+        if isinstance(details, dict) and "reason" in details and not isinstance(details["reason"], str):
+            raise ProviderStreamError("Codex returned malformed terminal data", status_code=502)
+    return response, _usage(response.get("usage"))
 
 
 def _provider_error(payload: dict[str, Any]) -> ProviderStreamError:
@@ -346,7 +416,7 @@ def aggregate_codex_sse(raw: str | Iterable[str]) -> AggregatedResponse:
     terminal_type: str | None = None
     for event in _sse_events(raw.splitlines() if isinstance(raw, str) else raw):
         if terminal:
-            continue
+            break
         event_type = str(event.get("type") or "")
         if event_type in {"error", "response.failed"}:
             raise _provider_error(event)
@@ -375,14 +445,12 @@ def aggregate_codex_sse(raw: str | Iterable[str]) -> AggregatedResponse:
                     }
                 )
         elif event_type in {"response.completed", "response.incomplete"}:
-            response = event.get("response")
-            if not isinstance(response, dict):
-                raise ProviderStreamError("Codex returned malformed terminal data", status_code=502)
+            response, usage = _terminal_response(event)
             terminal = True
             terminal_type = event_type
             result.response_id = response.get("id")
             result.model = response.get("model")
-            result.usage = _usage(response.get("usage"))
+            result.usage = usage
             if event_type == "response.incomplete":
                 details = response.get("incomplete_details")
                 reason = details.get("reason") if isinstance(details, dict) else None
@@ -446,10 +514,12 @@ class AuthStore:
         return value
 
     def _candidate(self, state: dict[str, Any]) -> str:
-        provider = state.get("providers", {}).get("openai-codex", {})
+        providers = state.get("providers")
+        provider = providers.get("openai-codex") if isinstance(providers, dict) else None
         tokens = provider.get("tokens") if isinstance(provider, dict) else None
-        if isinstance(tokens, dict) and isinstance(tokens.get("access_token"), str):
-            return tokens["access_token"]
+        token = tokens.get("access_token") if isinstance(tokens, dict) else None
+        if isinstance(token, str) and token.strip():
+            return token
         raise RelayError("No Codex access token is available", status_code=503)
 
     async def token(self, *, force_refresh: bool = False) -> str:
@@ -461,13 +531,21 @@ class AuthStore:
 def _account_id_from_token(token: str) -> str | None:
     """Return only the canonical account id claim; malformed/opaque tokens are safe."""
     try:
-        encoded = token.split(".")[1]
-        encoded += "=" * (-len(encoded) % 4)
-        claims = json.loads(base64.urlsafe_b64decode(encoded))
+        encoded = token.split(".")[1].encode("ascii")
+        encoded += b"=" * (-len(encoded) % 4)
+        claims = json.loads(base64.b64decode(encoded, altchars=b"-_", validate=True))
         auth = claims.get("https://api.openai.com/auth") if isinstance(claims, dict) else None
         account_id = auth.get("chatgpt_account_id") if isinstance(auth, dict) else None
         return account_id if isinstance(account_id, str) and account_id else None
-    except (IndexError, TypeError, ValueError, json.JSONDecodeError, UnicodeDecodeError):
+    except (
+        IndexError,
+        TypeError,
+        ValueError,
+        binascii.Error,
+        json.JSONDecodeError,
+        UnicodeDecodeError,
+        UnicodeEncodeError,
+    ):
         return None
 
 
@@ -499,6 +577,12 @@ class CodexRelay:
             token = await self.token_provider(force_refresh)
         else:
             token = await self.auth.token(force_refresh=force_refresh)
+        if not isinstance(token, str) or not token.strip():
+            raise RelayError("Codex credential source is unavailable", status_code=503)
+        try:
+            token.encode("ascii")
+        except UnicodeEncodeError as exc:
+            raise RelayError("Codex credential source is unavailable", status_code=503) from exc
         headers = {
             "Accept": "text/event-stream",
             "Authorization": f"Bearer {token}",
@@ -525,7 +609,8 @@ class CodexRelay:
         try:
             raw = await response.aread()
             if response.status_code >= 400:
-                return Response(content=raw, status_code=response.status_code, media_type=response.headers.get("content-type"))
+                status = response.status_code if response.status_code < 600 else 502
+                return _error_response(RelayError("Codex provider request failed", status_code=status))
             try:
                 result = aggregate_codex_sse(raw.decode("utf-8", errors="replace"))
             except RelayError as exc:
@@ -534,7 +619,9 @@ class CodexRelay:
         finally:
             await response.aclose()
 
-    async def stream_chat(self, response: httpx.Response, model: str) -> AsyncIterator[bytes]:
+    async def stream_chat(
+        self, response: httpx.Response, model: str, *, include_usage: bool = False
+    ) -> AsyncIterator[bytes]:
         response_id = f"chatcmpl-relay-{uuid.uuid4().hex}"
         created = int(time.time())
         first_delta = True
@@ -551,7 +638,9 @@ class CodexRelay:
                 raise ProviderStreamError("Codex returned malformed stream data", status_code=502) from exc
             if isinstance(event, dict) and event_name and "type" not in event:
                 event["type"] = event_name
-            return event if isinstance(event, dict) else None
+            if not isinstance(event, dict):
+                raise ProviderStreamError("Codex returned a non-object stream event", status_code=502)
+            return event
 
         async def translate(event: dict[str, Any]) -> AsyncIterator[bytes]:
             nonlocal first_delta, terminal
@@ -572,9 +661,9 @@ class CodexRelay:
                     tool_calls.append(call)
                     yield _sse_line({"id": response_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {"tool_calls": [call]}, "finish_reason": None}]})
             elif event_type in {"response.completed", "response.incomplete"}:
-                response = event.get("response")
-                if not isinstance(response, dict):
-                    raise ProviderStreamError("Codex returned malformed terminal data", status_code=502)
+                response, usage = _terminal_response(event)
+                if include_usage and "usage" not in response:
+                    raise ProviderStreamError("Codex returned malformed usage data", status_code=502)
                 terminal = True
                 details = response.get("incomplete_details")
                 reason = details.get("reason") if isinstance(details, dict) else None
@@ -583,6 +672,8 @@ class CodexRelay:
                 else:
                     finish = "tool_calls" if tool_calls else "length" if event_type == "response.incomplete" else "stop"
                 yield _sse_line({"id": response_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {}, "finish_reason": finish}]})
+                if include_usage:
+                    yield _sse_line({"id": response_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [], "usage": usage})
                 yield b"data: [DONE]\n\n"
 
         event_name: str | None = None
@@ -596,16 +687,19 @@ class CodexRelay:
                     if event is not None:
                         async for chunk in translate(event):
                             yield chunk
+                        if terminal:
+                            break
                 elif line.startswith(":"):
                     continue
                 elif line.startswith("event:"):
                     event_name = line[6:].strip()
                 elif line.startswith("data:"):
                     data_lines.append(line[5:].lstrip())
-            event = event_payload(event_name, data_lines)
-            if event is not None:
-                async for chunk in translate(event):
-                    yield chunk
+            if not terminal:
+                event = event_payload(event_name, data_lines)
+                if event is not None:
+                    async for chunk in translate(event):
+                        yield chunk
             if not terminal:
                 raise ProviderStreamError("Codex stream ended without a terminal response", status_code=502)
         except (RelayError, httpx.HTTPError):
@@ -656,15 +750,24 @@ def create_app(relay: CodexRelay | None = None, *, inbound_key: str | None = Non
             if body.get("stream") is True:
                 upstream = await relay.open_upstream(body)
                 if upstream.status_code >= 400:
-                    raw = await upstream.aread()
-                    await upstream.aclose()
-                    return Response(content=raw, status_code=upstream.status_code, media_type=upstream.headers.get("content-type"))
-                return StreamingResponse(relay.stream_chat(upstream, str(body.get("model") or "")), media_type="text/event-stream")
+                    try:
+                        status = upstream.status_code if upstream.status_code < 600 else 502
+                        return _error_response(RelayError("Codex provider request failed", status_code=status))
+                    finally:
+                        await upstream.aclose()
+                options = body.get("stream_options") or {}
+                include_usage = bool(options.get("include_usage")) if isinstance(options, dict) else False
+                return StreamingResponse(
+                    relay.stream_chat(upstream, str(body.get("model") or ""), include_usage=include_usage),
+                    media_type="text/event-stream",
+                )
             return await relay.complete(body)
         except RelayError as exc:
             return _error_response(exc)
         except (httpx.HTTPError, OSError):
             return _error_response(RelayError("Codex provider request failed", status_code=502))
+        except UnicodeError:
+            return _error_response(RelayError("Codex credential source is unavailable", status_code=503))
         except (json.JSONDecodeError, ValueError):
             return _error_response(RelayError("Invalid JSON request body", status_code=400))
 

--- a/src/codex_relay.py
+++ b/src/codex_relay.py
@@ -43,6 +43,10 @@ class RelayError(RuntimeError):
         self.payload = payload
 
 
+class CredentialError(RelayError):
+    """A failure resolving or validating the local Codex credential source."""
+
+
 class ProviderStreamError(RelayError):
     """The provider sent a terminal error inside an otherwise successful SSE stream."""
 
@@ -366,14 +370,20 @@ def _nested(payload: Any, key: str) -> Any:
     return payload.get(key) if isinstance(payload, dict) else None
 
 
-def _usage(value: Any) -> dict[str, int]:
+def _usage(value: Any, *, required: bool = False) -> dict[str, int]:
     if value is None:
+        if required:
+            raise ProviderStreamError("Codex returned malformed usage data", status_code=502)
         return {}
     if not isinstance(value, dict):
         raise ProviderStreamError("Codex returned malformed usage data", status_code=502)
 
     def count(*keys: str) -> int:
-        raw = next((value[key] for key in keys if key in value), 0)
+        raw = next((value[key] for key in keys if key in value), None)
+        if raw is None and required:
+            raise ProviderStreamError("Codex returned malformed usage data", status_code=502)
+        if raw is None:
+            raw = 0
         if not isinstance(raw, int) or isinstance(raw, bool) or raw < 0:
             raise ProviderStreamError("Codex returned malformed usage data", status_code=502)
         return raw
@@ -383,7 +393,9 @@ def _usage(value: Any) -> dict[str, int]:
     return {"prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": prompt + completion}
 
 
-def _terminal_response(event: dict[str, Any]) -> tuple[dict[str, Any], dict[str, int]]:
+def _terminal_response(
+    event: dict[str, Any], *, require_usage: bool = False
+) -> tuple[dict[str, Any], dict[str, int]]:
     response = event.get("response")
     if not isinstance(response, dict):
         raise ProviderStreamError("Codex returned malformed terminal data", status_code=502)
@@ -396,7 +408,7 @@ def _terminal_response(event: dict[str, Any]) -> tuple[dict[str, Any], dict[str,
             raise ProviderStreamError("Codex returned malformed terminal data", status_code=502)
         if isinstance(details, dict) and "reason" in details and not isinstance(details["reason"], str):
             raise ProviderStreamError("Codex returned malformed terminal data", status_code=502)
-    return response, _usage(response.get("usage"))
+    return response, _usage(response.get("usage"), required=require_usage)
 
 
 def _provider_error(payload: dict[str, Any]) -> ProviderStreamError:
@@ -408,60 +420,71 @@ def _provider_error(payload: dict[str, Any]) -> ProviderStreamError:
     return ProviderStreamError("Codex provider returned an error", status_code=status, payload={"error": {"message": "Codex provider request failed", "code": code}})
 
 
-def aggregate_codex_sse(raw: str | Iterable[str]) -> AggregatedResponse:
+def _aggregate_event(
+    result: AggregatedResponse,
+    arguments: dict[str, list[str]],
+    event: dict[str, Any],
+    *,
+    require_usage: bool = False,
+) -> bool:
+    event_type = str(event.get("type") or "")
+    if event_type in {"error", "response.failed"}:
+        raise _provider_error(event)
+    if "output_text.delta" in event_type:
+        result.content += str(event.get("delta") or "")
+    elif "reasoning" in event_type and "delta" in event_type:
+        result.reasoning += str(event.get("delta") or "")
+    elif "function_call_arguments.delta" in event_type:
+        item_id = str(event.get("item_id") or event.get("call_id") or "")
+        arguments.setdefault(item_id, []).append(str(event.get("delta") or ""))
+    elif event_type == "response.output_item.done":
+        item = event.get("item")
+        if isinstance(item, dict) and item.get("type") == "function_call":
+            call_id = str(item.get("call_id") or item.get("id") or f"call_{len(result.tool_calls)}")
+            raw_args = item.get("arguments")
+            if not isinstance(raw_args, str):
+                raw_args = "".join(arguments.get(str(item.get("id") or call_id), []))
+            result.tool_calls.append(
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": str(item.get("name") or ""),
+                        "arguments": raw_args or "{}",
+                    },
+                }
+            )
+    elif event_type in {"response.completed", "response.incomplete"}:
+        response, usage = _terminal_response(event, require_usage=require_usage)
+        result.response_id = response.get("id")
+        result.model = response.get("model")
+        result.usage = usage
+        if event_type == "response.incomplete":
+            details = response.get("incomplete_details")
+            reason = details.get("reason") if isinstance(details, dict) else None
+            result.finish_reason = "content_filter" if reason in {"content_filter", "content_filtering"} else "length"
+        return True
+    return False
+
+
+def _finish_aggregate(result: AggregatedResponse) -> AggregatedResponse:
+    if result.tool_calls:
+        result.finish_reason = "tool_calls"
+    return result
+
+
+def aggregate_codex_sse(raw: str | Iterable[str], *, require_usage: bool = False) -> AggregatedResponse:
     """Aggregate Codex SSE events into the fields used by Chat Completions."""
     result = AggregatedResponse()
     arguments: dict[str, list[str]] = {}
     terminal = False
-    terminal_type: str | None = None
     for event in _sse_events(raw.splitlines() if isinstance(raw, str) else raw):
-        if terminal:
-            break
-        event_type = str(event.get("type") or "")
-        if event_type in {"error", "response.failed"}:
-            raise _provider_error(event)
-        if "output_text.delta" in event_type:
-            result.content += str(event.get("delta") or "")
-        elif "reasoning" in event_type and "delta" in event_type:
-            result.reasoning += str(event.get("delta") or "")
-        elif "function_call_arguments.delta" in event_type:
-            item_id = str(event.get("item_id") or event.get("call_id") or "")
-            arguments.setdefault(item_id, []).append(str(event.get("delta") or ""))
-        elif event_type == "response.output_item.done":
-            item = event.get("item")
-            if isinstance(item, dict) and item.get("type") == "function_call":
-                call_id = str(item.get("call_id") or item.get("id") or f"call_{len(result.tool_calls)}")
-                raw_args = item.get("arguments")
-                if not isinstance(raw_args, str):
-                    raw_args = "".join(arguments.get(str(item.get("id") or call_id), []))
-                result.tool_calls.append(
-                    {
-                        "id": call_id,
-                        "type": "function",
-                        "function": {
-                            "name": str(item.get("name") or ""),
-                            "arguments": raw_args or "{}",
-                        },
-                    }
-                )
-        elif event_type in {"response.completed", "response.incomplete"}:
-            response, usage = _terminal_response(event)
+        if _aggregate_event(result, arguments, event, require_usage=require_usage):
             terminal = True
-            terminal_type = event_type
-            result.response_id = response.get("id")
-            result.model = response.get("model")
-            result.usage = usage
-            if event_type == "response.incomplete":
-                details = response.get("incomplete_details")
-                reason = details.get("reason") if isinstance(details, dict) else None
-                result.finish_reason = "content_filter" if reason in {"content_filter", "content_filtering"} else "length"
-
-
-    if not terminal or terminal_type not in {"response.completed", "response.incomplete"}:
+            break
+    if not terminal:
         raise ProviderStreamError("Codex stream ended without a terminal response", status_code=502)
-    if result.tool_calls:
-        result.finish_reason = "tool_calls"
-    return result
+    return _finish_aggregate(result)
 
 
 def _chat_response(result: AggregatedResponse, requested_model: str) -> dict[str, Any]:
@@ -482,12 +505,12 @@ def _chat_response(result: AggregatedResponse, requested_model: str) -> dict[str
 def _error_response(error: RelayError) -> JSONResponse:
     if isinstance(error.payload, dict):
         payload = error.payload
+    elif isinstance(error, CredentialError):
+        payload = {"error": {"message": "Codex credential source unavailable", "code": "credential_unavailable"}}
     elif error.status_code == 400:
         # Input-validation details are safe and useful to the caller. Provider,
         # credential, and filesystem failures may contain secrets or local paths.
         payload = {"error": {"message": str(error), "code": "invalid_request"}}
-    elif error.status_code == 503:
-        payload = {"error": {"message": "Codex credential source unavailable", "code": "credential_unavailable"}}
     else:
         payload = {"error": {"message": "Codex provider request failed", "code": "provider_error"}}
     return JSONResponse(payload, status_code=error.status_code)
@@ -508,9 +531,9 @@ class AuthStore:
             with self.path.open(encoding="utf-8") as handle:
                 value = json.load(handle)
         except (OSError, json.JSONDecodeError) as exc:
-            raise RelayError("Hermes credential source is unavailable", status_code=503) from exc
+            raise CredentialError("Hermes credential source is unavailable", status_code=503) from exc
         if not isinstance(value, dict):
-            raise RelayError("Hermes credential source is invalid", status_code=503)
+            raise CredentialError("Hermes credential source is invalid", status_code=503)
         return value
 
     def _candidate(self, state: dict[str, Any]) -> str:
@@ -520,11 +543,11 @@ class AuthStore:
         token = tokens.get("access_token") if isinstance(tokens, dict) else None
         if isinstance(token, str) and token.strip():
             return token
-        raise RelayError("No Codex access token is available", status_code=503)
+        raise CredentialError("No Codex access token is available", status_code=503)
 
     async def token(self, *, force_refresh: bool = False) -> str:
         if force_refresh:
-            raise RelayError("credential refresh is owned by Hermes, not the relay", status_code=503)
+            raise CredentialError("credential refresh is owned by Hermes, not the relay", status_code=503)
         return self._candidate(self._read())
 
 
@@ -571,18 +594,23 @@ class CodexRelay:
             await self.client.aclose()
 
     async def _send(self, payload: dict[str, Any], *, force_refresh: bool = False) -> httpx.Response:
-        if self.access_token is not None:
-            token = self.access_token
-        elif self.token_provider is not None:
-            token = await self.token_provider(force_refresh)
-        else:
-            token = await self.auth.token(force_refresh=force_refresh)
+        try:
+            if self.access_token is not None:
+                token = self.access_token
+            elif self.token_provider is not None:
+                token = await self.token_provider(force_refresh)
+            else:
+                token = await self.auth.token(force_refresh=force_refresh)
+        except CredentialError:
+            raise
+        except RelayError as exc:
+            raise CredentialError("Codex credential source is unavailable", status_code=503) from exc
         if not isinstance(token, str) or not token.strip():
-            raise RelayError("Codex credential source is unavailable", status_code=503)
+            raise CredentialError("Codex credential source is unavailable", status_code=503)
         try:
             token.encode("ascii")
         except UnicodeEncodeError as exc:
-            raise RelayError("Codex credential source is unavailable", status_code=503) from exc
+            raise CredentialError("Codex credential source is unavailable", status_code=503) from exc
         headers = {
             "Accept": "text/event-stream",
             "Authorization": f"Bearer {token}",
@@ -606,16 +634,61 @@ class CodexRelay:
 
     async def complete(self, chat_request: dict[str, Any]) -> Response:
         response = await self.open_upstream(chat_request)
+        include_usage = (
+            isinstance(chat_request.get("stream_options"), dict)
+            and chat_request["stream_options"].get("include_usage") is True
+        )
+        result = AggregatedResponse()
+        arguments: dict[str, list[str]] = {}
+        event_name: str | None = None
+        data_lines: list[str] = []
+        terminal = False
+
+        def event_payload() -> dict[str, Any] | None:
+            raw = "\n".join(data_lines).strip()
+            if not raw or raw == "[DONE]":
+                return None
+            try:
+                event: Any = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ProviderStreamError("Codex returned malformed stream data", status_code=502) from exc
+            if isinstance(event, dict) and event_name and "type" not in event:
+                event["type"] = event_name
+            if not isinstance(event, dict):
+                raise ProviderStreamError("Codex returned a non-object stream event", status_code=502)
+            return event
+
         try:
-            raw = await response.aread()
             if response.status_code >= 400:
                 status = response.status_code if response.status_code < 600 else 502
                 return _error_response(RelayError("Codex provider request failed", status_code=status))
-            try:
-                result = aggregate_codex_sse(raw.decode("utf-8", errors="replace"))
-            except RelayError as exc:
-                return _error_response(exc)
-            return JSONResponse(_chat_response(result, str(chat_request.get("model") or "")))
+            async for line in response.aiter_lines():
+                if line == "":
+                    event = event_payload()
+                    event_name = None
+                    data_lines = []
+                    if event is not None and _aggregate_event(
+                        result, arguments, event, require_usage=include_usage
+                    ):
+                        terminal = True
+                        break
+                elif line.startswith(":"):
+                    continue
+                elif line.startswith("event:"):
+                    event_name = line[6:].strip()
+                elif line.startswith("data:"):
+                    data_lines.append(line[5:].lstrip())
+            if not terminal:
+                event = event_payload()
+                if event is not None:
+                    terminal = _aggregate_event(
+                        result, arguments, event, require_usage=include_usage
+                    )
+            if not terminal:
+                raise ProviderStreamError("Codex stream ended without a terminal response", status_code=502)
+            return JSONResponse(_chat_response(_finish_aggregate(result), str(chat_request.get("model") or "")))
+        except RelayError as exc:
+            return _error_response(exc)
         finally:
             await response.aclose()
 
@@ -661,9 +734,7 @@ class CodexRelay:
                     tool_calls.append(call)
                     yield _sse_line({"id": response_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {"tool_calls": [call]}, "finish_reason": None}]})
             elif event_type in {"response.completed", "response.incomplete"}:
-                response, usage = _terminal_response(event)
-                if include_usage and "usage" not in response:
-                    raise ProviderStreamError("Codex returned malformed usage data", status_code=502)
+                response, usage = _terminal_response(event, require_usage=include_usage)
                 terminal = True
                 details = response.get("incomplete_details")
                 reason = details.get("reason") if isinstance(details, dict) else None

--- a/src/codex_relay.py
+++ b/src/codex_relay.py
@@ -9,16 +9,15 @@ response. It is a local compatibility process, not a production proxy.
 from __future__ import annotations
 
 import argparse
-import asyncio
 import base64
+import hmac
 import json
 import logging
 import os
-import tempfile
 import time
 import uuid
-from collections.abc import AsyncIterator, Iterable, Iterator
-from contextlib import contextmanager
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -29,7 +28,7 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 logger = logging.getLogger("codex_relay")
 CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
-DEFAULT_AUTH_PATH = Path.home() / ".hermes" / "auth.json"
+DEFAULT_AUTH_PATH = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "auth.json"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 
@@ -45,6 +44,9 @@ class RelayError(RuntimeError):
 
 class ProviderStreamError(RelayError):
     """The provider sent a terminal error inside an otherwise successful SSE stream."""
+
+
+TokenProvider = Callable[[bool], Awaitable[str]]
 
 
 @dataclass(slots=True)
@@ -172,11 +174,36 @@ def _response_format(value: Any) -> dict[str, Any] | None:
     return None
 
 
+def _responses_tool_choice(value: Any) -> str | dict[str, str] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        if value in {"none", "auto", "required"}:
+            return value
+        raise RelayError("tool_choice must be none, auto, or required, or a named function", status_code=400)
+    if isinstance(value, dict):
+        function = value.get("function")
+        if value.get("type") == "function" and isinstance(function, dict) and isinstance(function.get("name"), str):
+            return {"type": "function", "name": function["name"]}
+        if value.get("type") == "function" and isinstance(value.get("name"), str):
+            return {"type": "function", "name": value["name"]}
+    raise RelayError("tool_choice has an unsupported shape", status_code=400)
+
+
+_UNSUPPORTED_CHAT_FIELDS = {
+    "temperature", "top_p", "stop", "presence_penalty", "frequency_penalty",
+    "seed", "stream_options", "logprobs", "top_logprobs", "n", "user",
+}
+
+
 def build_responses_request(chat_request: dict[str, Any]) -> dict[str, Any]:
     """Convert an OpenAI Chat Completions request to Codex Responses JSON."""
     messages = chat_request.get("messages")
     if not isinstance(messages, list):
         raise RelayError("messages must be a list", status_code=400)
+    unsupported = sorted(key for key in _UNSUPPORTED_CHAT_FIELDS if chat_request.get(key) is not None)
+    if unsupported:
+        raise RelayError(f"unsupported Chat Completions parameter: {unsupported[0]}", status_code=400)
     instructions: list[str] = []
     input_items: list[dict[str, Any]] = []
     for message in messages:
@@ -227,10 +254,23 @@ def build_responses_request(chat_request: dict[str, Any]) -> dict[str, Any]:
     request_tools = [tool for tool in tools if tool is not None]
     if request_tools:
         request["tools"] = request_tools
-        choice = chat_request.get("tool_choice")
-        if choice not in (None, "none"):
-            request["tool_choice"] = choice if choice is not None else "auto"
-        request["parallel_tool_calls"] = True
+        choice = _responses_tool_choice(chat_request.get("tool_choice"))
+        if choice is not None:
+            request["tool_choice"] = choice
+        if "parallel_tool_calls" in chat_request:
+            if not isinstance(chat_request["parallel_tool_calls"], bool):
+                raise RelayError("parallel_tool_calls must be a boolean", status_code=400)
+            request["parallel_tool_calls"] = chat_request["parallel_tool_calls"]
+    elif chat_request.get("tool_choice") not in (None, "none"):
+        raise RelayError("tool_choice requires tools", status_code=400)
+    limits = [chat_request.get("max_completion_tokens"), chat_request.get("max_tokens")]
+    if limits[0] is not None and limits[1] is not None and limits[0] != limits[1]:
+        raise RelayError("max_completion_tokens and max_tokens disagree", status_code=400)
+    limit = limits[0] if limits[0] is not None else limits[1]
+    if limit is not None:
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+            raise RelayError("output token limit must be a positive integer", status_code=400)
+        request["max_output_tokens"] = limit
     response_format = _response_format(chat_request.get("response_format"))
     if response_format:
         request["text"] = response_format
@@ -254,8 +294,8 @@ def _sse_events(lines: Iterable[str]) -> Iterable[dict[str, Any]]:
             return None
         try:
             payload = json.loads(raw)
-        except json.JSONDecodeError:
-            return None
+        except json.JSONDecodeError as exc:
+            raise ProviderStreamError("Codex returned malformed stream data", status_code=502) from exc
         if isinstance(payload, dict) and name and "type" not in payload:
             payload["type"] = name
         return payload if isinstance(payload, dict) else None
@@ -292,19 +332,23 @@ def _usage(value: Any) -> dict[str, int]:
 def _provider_error(payload: dict[str, Any]) -> ProviderStreamError:
     nested = payload.get("error")
     error: dict[str, Any] = nested if isinstance(nested, dict) else payload
-    code = str(error.get("code") or error.get("type") or "provider_error")
-    message = str(error.get("message") or "Codex Responses request failed")
+    raw_code = str(error.get("code") or error.get("type") or "provider_error")
+    code = raw_code if raw_code.isascii() and raw_code.replace("_", "").replace("-", "").isalnum() else "provider_error"
     status = 429 if "rate" in code or "quota" in code else 400 if "invalid" in code else 502
-    return ProviderStreamError(f"{code}: {message}", status_code=status, payload={"error": error})
+    return ProviderStreamError("Codex provider returned an error", status_code=status, payload={"error": {"message": "Codex provider request failed", "code": code}})
 
 
 def aggregate_codex_sse(raw: str | Iterable[str]) -> AggregatedResponse:
     """Aggregate Codex SSE events into the fields used by Chat Completions."""
     result = AggregatedResponse()
     arguments: dict[str, list[str]] = {}
+    terminal = False
+    terminal_type: str | None = None
     for event in _sse_events(raw.splitlines() if isinstance(raw, str) else raw):
+        if terminal:
+            continue
         event_type = str(event.get("type") or "")
-        if event_type == "error":
+        if event_type in {"error", "response.failed"}:
             raise _provider_error(event)
         if "output_text.delta" in event_type:
             result.content += str(event.get("delta") or "")
@@ -330,16 +374,23 @@ def aggregate_codex_sse(raw: str | Iterable[str]) -> AggregatedResponse:
                         },
                     }
                 )
-        elif event_type in {"response.completed", "response.incomplete", "response.failed"}:
+        elif event_type in {"response.completed", "response.incomplete"}:
             response = event.get("response")
-            if isinstance(response, dict):
-                result.response_id = response.get("id")
-                result.model = response.get("model")
-                result.usage = _usage(response.get("usage"))
-                if event_type == "response.incomplete":
-                    result.finish_reason = "length"
-                elif event_type == "response.failed":
-                    raise _provider_error(response)
+            if not isinstance(response, dict):
+                raise ProviderStreamError("Codex returned malformed terminal data", status_code=502)
+            terminal = True
+            terminal_type = event_type
+            result.response_id = response.get("id")
+            result.model = response.get("model")
+            result.usage = _usage(response.get("usage"))
+            if event_type == "response.incomplete":
+                details = response.get("incomplete_details")
+                reason = details.get("reason") if isinstance(details, dict) else None
+                result.finish_reason = "content_filter" if reason in {"content_filter", "content_filtering"} else "length"
+
+
+    if not terminal or terminal_type not in {"response.completed", "response.incomplete"}:
+        raise ProviderStreamError("Codex stream ended without a terminal response", status_code=502)
     if result.tool_calls:
         result.finish_reason = "tool_calls"
     return result
@@ -361,125 +412,63 @@ def _chat_response(result: AggregatedResponse, requested_model: str) -> dict[str
 
 
 def _error_response(error: RelayError) -> JSONResponse:
-    payload = error.payload if isinstance(error.payload, dict) else {"error": {"message": str(error)}}
+    if isinstance(error.payload, dict):
+        payload = error.payload
+    elif error.status_code == 400:
+        # Input-validation details are safe and useful to the caller. Provider,
+        # credential, and filesystem failures may contain secrets or local paths.
+        payload = {"error": {"message": str(error), "code": "invalid_request"}}
+    elif error.status_code == 503:
+        payload = {"error": {"message": "Codex credential source unavailable", "code": "credential_unavailable"}}
+    else:
+        payload = {"error": {"message": "Codex provider request failed", "code": "provider_error"}}
     return JSONResponse(payload, status_code=error.status_code)
 
 
 class AuthStore:
-    """Read Hermes auth state on demand and refresh an expiring Codex token."""
+    """Read-only adapter for a Hermes auth document.
+
+    Hermes owns refresh rotation, locking, profile selection, and persistence. The
+    relay never writes this file; callers that need rotation inject a token provider.
+    """
 
     def __init__(self, path: Path = DEFAULT_AUTH_PATH) -> None:
         self.path = path
-        self._lock = asyncio.Lock()
 
     def _read(self) -> dict[str, Any]:
-        with self.path.open(encoding="utf-8") as handle:
-            value = json.load(handle)
+        try:
+            with self.path.open(encoding="utf-8") as handle:
+                value = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RelayError("Hermes credential source is unavailable", status_code=503) from exc
         if not isinstance(value, dict):
-            raise RelayError("Hermes auth store is not an object", status_code=503)
+            raise RelayError("Hermes credential source is invalid", status_code=503)
         return value
 
-    @contextmanager
-    def _file_lock(self) -> Iterator[None]:
-        """Serialize refresh/rotation with other relay processes."""
-        import fcntl
-
-        lock_path = self.path.with_name(f".{self.path.name}.lock")
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        with lock_path.open("a+", encoding="utf-8") as lock:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
-
-    @staticmethod
-    def _expiry(token: str) -> float | None:
-        try:
-            encoded = token.split(".")[1]
-            encoded += "=" * (-len(encoded) % 4)
-            claims = json.loads(base64.urlsafe_b64decode(encoded))
-            return float(claims["exp"])
-        except (IndexError, KeyError, TypeError, ValueError, json.JSONDecodeError):
-            return None
-
-    def _candidate(self, state: dict[str, Any]) -> tuple[str, dict[str, Any] | None]:
+    def _candidate(self, state: dict[str, Any]) -> str:
         provider = state.get("providers", {}).get("openai-codex", {})
         tokens = provider.get("tokens") if isinstance(provider, dict) else None
-        if isinstance(tokens, dict) and tokens.get("access_token"):
-            return str(tokens["access_token"]), tokens
-        pool = state.get("credential_pool", {}).get("openai-codex", [])
-        if isinstance(pool, list):
-            for entry in sorted(pool, key=lambda item: item.get("priority", 0) if isinstance(item, dict) else 0):
-                if isinstance(entry, dict) and entry.get("access_token"):
-                    return str(entry["access_token"]), entry
-        raise RelayError("No openai-codex OAuth access token in Hermes auth.json", status_code=503)
+        if isinstance(tokens, dict) and isinstance(tokens.get("access_token"), str):
+            return tokens["access_token"]
+        raise RelayError("No Codex access token is available", status_code=503)
 
     async def token(self, *, force_refresh: bool = False) -> str:
-        async with self._lock:
-            with self._file_lock():
-                state = self._read()
-                access, token_record = self._candidate(state)
-                refresh = token_record.get("refresh_token") if token_record else None
-                expiry = self._expiry(access)
-                needs_refresh = force_refresh or (expiry is not None and expiry <= time.time() + 120)
-                if not needs_refresh or not isinstance(refresh, str) or not refresh:
-                    return access
-                response = await self._refresh(refresh)
-                new_access = response.get("access_token")
-                if not isinstance(new_access, str) or not new_access:
-                    raise RelayError("Codex token refresh returned no access_token", status_code=503)
-                new_refresh = response.get("refresh_token") or refresh
-                self._update(state, access, new_access, str(new_refresh))
-                self._atomic_write(state)
-                return new_access
+        if force_refresh:
+            raise RelayError("credential refresh is owned by Hermes, not the relay", status_code=503)
+        return self._candidate(self._read())
 
-    async def _refresh(self, refresh_token: str) -> dict[str, Any]:
-        async with httpx.AsyncClient(timeout=20.0) as client:
-            response = await client.post(
-                CODEX_OAUTH_TOKEN_URL,
-                data={"grant_type": "refresh_token", "refresh_token": refresh_token, "client_id": CODEX_OAUTH_CLIENT_ID},
-                headers={"Accept": "application/json", "User-Agent": "honcho-codex-relay"},
-            )
-        if response.status_code != 200:
-            raise RelayError(
-                f"Codex token refresh failed with status {response.status_code}",
-                status_code=response.status_code,
-                payload={"error": {"message": response.text, "code": "codex_refresh_failed"}},
-            )
-        try:
-            payload = response.json()
-        except ValueError as exc:
-            raise RelayError("Codex token refresh returned invalid JSON", status_code=503) from exc
-        return payload if isinstance(payload, dict) else {}
 
-    @staticmethod
-    def _update(state: dict[str, Any], old: str, access: str, refresh: str) -> None:
-        provider = state.get("providers", {}).get("openai-codex", {})
-        records: list[dict[str, Any]] = []
-        if isinstance(provider, dict) and isinstance(provider.get("tokens"), dict):
-            records.append(provider["tokens"])
-        pool = state.get("credential_pool", {}).get("openai-codex", [])
-        if isinstance(pool, list):
-            records.extend(record for record in pool if isinstance(record, dict) and record.get("access_token") == old)
-        for record in records:
-            record["access_token"] = access
-            record["refresh_token"] = refresh
-            record["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-
-    def _atomic_write(self, state: dict[str, Any]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        fd, temporary = tempfile.mkstemp(prefix=f".{self.path.name}.", dir=self.path.parent)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                json.dump(state, handle, indent=2)
-                handle.write("\n")
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.replace(temporary, self.path)
-        finally:
-            if os.path.exists(temporary):
-                os.unlink(temporary)
+def _account_id_from_token(token: str) -> str | None:
+    """Return only the canonical account id claim; malformed/opaque tokens are safe."""
+    try:
+        encoded = token.split(".")[1]
+        encoded += "=" * (-len(encoded) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(encoded))
+        auth = claims.get("https://api.openai.com/auth") if isinstance(claims, dict) else None
+        account_id = auth.get("chatgpt_account_id") if isinstance(auth, dict) else None
+        return account_id if isinstance(account_id, str) and account_id else None
+    except (IndexError, TypeError, ValueError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
 
 
 class CodexRelay:
@@ -488,12 +477,14 @@ class CodexRelay:
         *,
         client: httpx.AsyncClient | None = None,
         access_token: str | None = None,
+        token_provider: TokenProvider | None = None,
         auth_path: Path = DEFAULT_AUTH_PATH,
         upstream_url: str = CODEX_RESPONSES_URL,
     ) -> None:
         self.client = client or httpx.AsyncClient(timeout=httpx.Timeout(1800.0, connect=30.0))
         self._owns_client = client is None
         self.access_token = access_token
+        self.token_provider = token_provider
         self.auth = AuthStore(auth_path)
         self.upstream_url = upstream_url
 
@@ -502,7 +493,12 @@ class CodexRelay:
             await self.client.aclose()
 
     async def _send(self, payload: dict[str, Any], *, force_refresh: bool = False) -> httpx.Response:
-        token = self.access_token or await self.auth.token(force_refresh=force_refresh)
+        if self.access_token is not None:
+            token = self.access_token
+        elif self.token_provider is not None:
+            token = await self.token_provider(force_refresh)
+        else:
+            token = await self.auth.token(force_refresh=force_refresh)
         headers = {
             "Accept": "text/event-stream",
             "Authorization": f"Bearer {token}",
@@ -510,13 +506,16 @@ class CodexRelay:
             "User-Agent": "codex_cli_rs/0.0.0 (Honcho relay)",
             "originator": "codex_cli_rs",
         }
+        account_id = _account_id_from_token(token)
+        if account_id:
+            headers["ChatGPT-Account-ID"] = account_id
         request = self.client.build_request("POST", self.upstream_url, json=payload, headers=headers)
         return await self.client.send(request, stream=True)
 
     async def open_upstream(self, chat_request: dict[str, Any]) -> httpx.Response:
         payload = build_responses_request(chat_request)
         response = await self._send(payload)
-        if response.status_code == 401 and not self.access_token:
+        if response.status_code == 401 and self.token_provider is not None:
             await response.aclose()
             response = await self._send(payload, force_refresh=True)
         return response
@@ -540,6 +539,7 @@ class CodexRelay:
         created = int(time.time())
         first_delta = True
         tool_calls: list[dict[str, Any]] = []
+        terminal = False
 
         def event_payload(event_name: str | None, data_lines: list[str]) -> dict[str, Any] | None:
             raw = "\n".join(data_lines).strip()
@@ -547,19 +547,19 @@ class CodexRelay:
                 return None
             try:
                 event: Any = json.loads(raw)
-            except json.JSONDecodeError:
-                return None
+            except json.JSONDecodeError as exc:
+                raise ProviderStreamError("Codex returned malformed stream data", status_code=502) from exc
             if isinstance(event, dict) and event_name and "type" not in event:
                 event["type"] = event_name
             return event if isinstance(event, dict) else None
 
         async def translate(event: dict[str, Any]) -> AsyncIterator[bytes]:
-            nonlocal first_delta
-            event_type = str(event.get("type") or "")
-            if event_type == "error":
-                yield _sse_line({"error": event})
-                yield b"data: [DONE]\n\n"
+            nonlocal first_delta, terminal
+            if terminal:
                 return
+            event_type = str(event.get("type") or "")
+            if event_type in {"error", "response.failed"}:
+                raise _provider_error(event)
             if "output_text.delta" in event_type:
                 delta = str(event.get("delta") or "")
                 if delta:
@@ -571,10 +571,17 @@ class CodexRelay:
                     call = {"index": len(tool_calls), "id": item.get("call_id") or item.get("id"), "type": "function", "function": {"name": item.get("name", ""), "arguments": item.get("arguments", "{}")} }
                     tool_calls.append(call)
                     yield _sse_line({"id": response_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {"tool_calls": [call]}, "finish_reason": None}]})
-            elif event_type in {"response.completed", "response.incomplete", "response.failed"}:
-                if event_type == "response.failed":
-                    yield _sse_line({"error": event.get("response") or event})
-                finish = "tool_calls" if tool_calls else "length" if event_type == "response.incomplete" else "stop"
+            elif event_type in {"response.completed", "response.incomplete"}:
+                response = event.get("response")
+                if not isinstance(response, dict):
+                    raise ProviderStreamError("Codex returned malformed terminal data", status_code=502)
+                terminal = True
+                details = response.get("incomplete_details")
+                reason = details.get("reason") if isinstance(details, dict) else None
+                if event_type == "response.incomplete" and reason in {"content_filter", "content_filtering"}:
+                    finish = "content_filter"
+                else:
+                    finish = "tool_calls" if tool_calls else "length" if event_type == "response.incomplete" else "stop"
                 yield _sse_line({"id": response_id, "object": "chat.completion.chunk", "created": created, "model": model, "choices": [{"index": 0, "delta": {}, "finish_reason": finish}]})
                 yield b"data: [DONE]\n\n"
 
@@ -599,6 +606,12 @@ class CodexRelay:
             if event is not None:
                 async for chunk in translate(event):
                     yield chunk
+            if not terminal:
+                raise ProviderStreamError("Codex stream ended without a terminal response", status_code=502)
+        except (RelayError, httpx.HTTPError):
+            if not terminal:
+                yield _sse_line({"error": {"message": "Codex provider stream failed", "code": "provider_stream_error"}})
+                yield b"data: [DONE]\n\n"
         finally:
             await response.aclose()
 
@@ -607,9 +620,23 @@ def _sse_line(payload: dict[str, Any]) -> bytes:
     return f"data: {json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}\n\n".encode()
 
 
-def create_app(relay: CodexRelay | None = None) -> FastAPI:
+def _is_loopback(host: str) -> bool:
+    return host in {"127.0.0.1", "::1", "localhost"}
+
+
+def create_app(relay: CodexRelay | None = None, *, inbound_key: str | None = None, bind_host: str = "127.0.0.1") -> FastAPI:
     relay = relay or CodexRelay()
-    app = FastAPI(title="Honcho Codex relay", docs_url=None, redoc_url=None)
+    if not _is_loopback(bind_host) and not inbound_key:
+        raise ValueError("inbound_key is required for non-loopback binds")
+
+    @asynccontextmanager
+    async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+        try:
+            yield
+        finally:
+            await relay.close()
+
+    app = FastAPI(title="Honcho Codex relay", docs_url=None, redoc_url=None, lifespan=lifespan)
 
     @app.get("/healthz")
     async def healthz() -> dict[str, str]:
@@ -617,6 +644,11 @@ def create_app(relay: CodexRelay | None = None) -> FastAPI:
 
     @app.post("/v1/chat/completions")
     async def chat_completions(request: Request) -> Response:
+        if inbound_key is not None:
+            supplied = request.headers.get("authorization", "")
+            candidate = supplied[7:] if supplied.lower().startswith("bearer ") else ""
+            if not candidate or not hmac.compare_digest(candidate, inbound_key):
+                return JSONResponse({"error": {"message": "Invalid relay authentication", "code": "relay_unauthorized"}}, status_code=401)
         try:
             body = await request.json()
             if not isinstance(body, dict):
@@ -631,8 +663,10 @@ def create_app(relay: CodexRelay | None = None) -> FastAPI:
             return await relay.complete(body)
         except RelayError as exc:
             return _error_response(exc)
-        except (json.JSONDecodeError, ValueError) as exc:
-            return _error_response(RelayError(str(exc), status_code=400))
+        except (httpx.HTTPError, OSError):
+            return _error_response(RelayError("Codex provider request failed", status_code=502))
+        except (json.JSONDecodeError, ValueError):
+            return _error_response(RelayError("Invalid JSON request body", status_code=400))
 
     return app
 
@@ -643,11 +677,14 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=8787)
     parser.add_argument("--auth-path", type=Path, default=DEFAULT_AUTH_PATH)
     parser.add_argument("--upstream-url", default=CODEX_RESPONSES_URL)
+    parser.add_argument("--inbound-key", default=os.environ.get("CODEX_RELAY_INBOUND_KEY"), help="shared inbound API key (also CODEX_RELAY_INBOUND_KEY)")
     args = parser.parse_args()
     import uvicorn
 
+    if not _is_loopback(args.host) and not args.inbound_key:
+        parser.error("--inbound-key or CODEX_RELAY_INBOUND_KEY is required for non-loopback binds")
     logger.info("Starting local Codex relay on %s:%s", args.host, args.port)
-    uvicorn.run(create_app(CodexRelay(auth_path=args.auth_path, upstream_url=args.upstream_url)), host=args.host, port=args.port)
+    uvicorn.run(create_app(CodexRelay(auth_path=args.auth_path, upstream_url=args.upstream_url), inbound_key=args.inbound_key, bind_host=args.host), host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/tests/llm/test_codex_relay.py
+++ b/tests/llm/test_codex_relay.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -128,7 +129,7 @@ async def test_stream_completion_translates_codex_sse() -> None:
 
 
 @pytest.mark.asyncio
-async def test_upstream_http_error_status_and_body_are_preserved() -> None:
+async def test_upstream_http_error_is_sanitized() -> None:
     error_body = '{"error":{"type":"invalid_request_error","message":"bad model"}}'
 
     async def handler(_: httpx.Request) -> httpx.Response:
@@ -140,7 +141,23 @@ async def test_upstream_http_error_status_and_body_are_preserved() -> None:
     await client.aclose()
 
     assert response.status_code == 401
-    assert bytes(response.body).decode() == error_body
+    assert json.loads(bytes(response.body).decode()) == {"error": {"message": "Codex provider request failed", "code": "provider_error"}}
+
+
+def test_stream_upstream_http_error_is_sanitized() -> None:
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="PROVIDER_PRIVATE_DETAIL", headers={"content-type": "text/plain"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(CodexRelay(client=client, access_token="test-token"))
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/v1/chat/completions",
+            json={"model": "gpt-5.6-luna", "messages": [], "stream": True},
+        )
+    assert response.status_code == 500
+    assert response.json() == {"error": {"message": "Codex provider request failed", "code": "provider_error"}}
+    assert "PROVIDER_PRIVATE_DETAIL" not in response.text
 
 
 def test_health_smoke() -> None:
@@ -167,6 +184,53 @@ def test_auth_store_reads_only_canonical_provider_token(tmp_path: Any) -> None:
     assert list(tmp_path.iterdir()) == [path]
 
 
+@pytest.mark.parametrize(
+    "document",
+    [
+        {"providers": []},
+        {"providers": {"openai-codex": []}},
+        {"providers": {"openai-codex": {"tokens": {"access_token": ""}}}},
+        {"providers": {"openai-codex": {"tokens": {"access_token": 123}}}},
+    ],
+)
+def test_malformed_auth_documents_are_sanitized_at_route(tmp_path: Any, document: dict[str, Any]) -> None:
+    path = tmp_path / "auth.json"
+    path.write_text(json.dumps(document))
+    app = create_app(CodexRelay(auth_path=path))
+    with TestClient(app) as client:
+        response = client.post("/v1/chat/completions", json={"messages": []})
+    assert response.status_code == 503
+    assert response.json() == {"error": {"message": "Codex credential source unavailable", "code": "credential_unavailable"}}
+
+
+def test_corrupt_auth_document_and_non_ascii_token_are_sanitized(tmp_path: Any) -> None:
+    path = tmp_path / "auth.json"
+    path.write_text("{not-json")
+    app = create_app(CodexRelay(auth_path=path))
+    with TestClient(app) as client:
+        response = client.post("/v1/chat/completions", json={"messages": []})
+    assert response.status_code == 503
+    assert "not-json" not in response.text
+
+    non_ascii = create_app(CodexRelay(access_token="x.☃.y"))
+    with TestClient(non_ascii) as client:
+        response = client.post("/v1/chat/completions", json={"messages": []})
+    assert response.status_code == 503
+    assert "☃" not in response.text
+
+    async def unauthorized(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text='{"error":{"message":"private auth detail"}}')
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(unauthorized))
+    malformed = create_app(CodexRelay(client=client, access_token="x.%%%.y"))
+    with TestClient(malformed) as test_client:
+        response = test_client.post("/v1/chat/completions", json={"messages": []})
+    assert response.status_code == 401
+    assert "private auth detail" not in response.text
+    assert "%%" not in response.text
+    asyncio.run(client.aclose())
+
+
 def test_tool_controls_are_translated_or_rejected() -> None:
     request = build_responses_request({
         "messages": [{"role": "user", "content": "x"}],
@@ -180,6 +244,35 @@ def test_tool_controls_are_translated_or_rejected() -> None:
     assert request["max_output_tokens"] == 20
     with pytest.raises(RelayError, match="unsupported"):
         build_responses_request({"messages": [], "temperature": 0.2})
+
+
+@pytest.mark.parametrize("field", ["verbosity", "reasoning", "extra_body", "unknown_control"])
+def test_request_allowlist_rejects_untranslated_top_level_controls(field: str) -> None:
+    with pytest.raises(RelayError, match="unsupported Chat Completions parameter"):
+        build_responses_request({"messages": [], field: {"value": 1}})
+
+
+def test_stream_options_include_usage_is_supported_and_validated() -> None:
+    request = build_responses_request({"messages": [], "stream_options": {"include_usage": True}})
+    assert "stream_options" not in request
+    with pytest.raises(RelayError, match="stream_options"):
+        build_responses_request({"messages": [], "stream_options": {"include_usage": "yes"}})
+    with pytest.raises(RelayError, match="stream_options"):
+        build_responses_request({"messages": [], "stream_options": {"other": True}})
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("tools", ["not-an-object"], "tool"),
+        ("tool_choice", {"type": "function"}, "tool_choice"),
+        ("parallel_tool_calls", "yes", "parallel_tool_calls"),
+        ("response_format", {"type": "xml"}, "response_format"),
+    ],
+)
+def test_malformed_supported_fields_are_rejected(field: str, value: Any, message: str) -> None:
+    with pytest.raises(RelayError, match=message):
+        build_responses_request({"messages": [], field: value})
 
 
 def test_aggregate_requires_terminal_and_ignores_post_terminal_data() -> None:
@@ -205,6 +298,61 @@ def test_aggregate_provider_and_malformed_events_are_sanitized() -> None:
     assert "SECRET_TOKEN" not in str(provider.value)
     with pytest.raises(RelayError, match="malformed"):
         aggregate_codex_sse("event: response.completed\ndata: {not-json}\n\n")
+    with pytest.raises(RelayError, match="object"):
+        aggregate_codex_sse("event: response.completed\ndata: [1,2,3]\n\n")
+
+
+def test_aggregate_rejects_malformed_usage_and_terminal_shapes() -> None:
+    with pytest.raises(RelayError, match="usage"):
+        aggregate_codex_sse(
+            'event: response.completed\ndata: {"response":{"usage":{"input_tokens":"bad"}}}\n\n'
+        )
+    with pytest.raises(RelayError, match="terminal"):
+        aggregate_codex_sse('event: response.completed\ndata: {"response":[]}\n\n')
+
+
+@pytest.mark.asyncio
+async def test_stream_stops_without_reading_after_terminal_and_rejects_non_object() -> None:
+    class BlockingAfterTerminal(httpx.AsyncByteStream):
+        def __init__(self) -> None:
+            self.read_after_terminal = False
+            self.closed = False
+            self._release = asyncio.Event()
+
+        async def __aiter__(self):
+            yield b"event: response.completed\n"
+            yield b'data: {"response":{"id":"r","usage":{"input_tokens":1,"output_tokens":1}}}\n'
+            yield b"\n"
+            self.read_after_terminal = True
+            await self._release.wait()
+
+        async def aclose(self) -> None:
+            self.closed = True
+            self._release.set()
+
+    stream = BlockingAfterTerminal()
+    response = httpx.Response(200, stream=stream, headers={"content-type": "text/event-stream"})
+    relay = CodexRelay(access_token="synthetic")
+    chunks = await asyncio.wait_for(
+        _collect(relay.stream_chat(response, "gpt-5.6-luna")), timeout=1
+    )
+    assert chunks[-1] == b"data: [DONE]\n\n"
+    assert stream.read_after_terminal is False
+    assert stream.closed is True
+
+    async def non_object(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="data: [1,2,3]\n\n", headers={"content-type": "text/event-stream"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(non_object))
+    relay = CodexRelay(client=client, access_token="synthetic")
+    upstream = await relay.open_upstream({"messages": []})
+    streamed = b"".join([chunk async for chunk in relay.stream_chat(upstream, "gpt-5.6-luna")])
+    assert b"provider_stream_error" in streamed
+    await client.aclose()
+
+
+async def _collect(iterator: Any) -> list[bytes]:
+    return [chunk async for chunk in iterator]
 
 
 def test_non_loopback_requires_key_and_rejects_before_upstream() -> None:
@@ -324,10 +472,13 @@ async def test_current_openai_sdk_and_backend_in_process_paths() -> None:
         pytest.skip(f"upstream backend dependencies unavailable: {exc}")
 
     seen: list[dict[str, Any]] = []
+    responses: list[httpx.Response] = []
 
     async def upstream(request: httpx.Request) -> httpx.Response:
         seen.append(json.loads(request.content))
-        return httpx.Response(200, text=TEXT_SSE, headers={"content-type": "text/event-stream"})
+        response = httpx.Response(200, text=TEXT_SSE, headers={"content-type": "text/event-stream"})
+        responses.append(response)
+        return response
 
     relay_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
     relay = CodexRelay(client=relay_client, access_token="synthetic")
@@ -341,14 +492,41 @@ async def test_current_openai_sdk_and_backend_in_process_paths() -> None:
     stream = await sdk.chat.completions.create(model="gpt-5.6-luna", messages=[{"role": "user", "content": "stream"}], stream=True)
     streamed = [chunk async for chunk in stream]
     backend = OpenAIBackend(sdk)
+    backend_stream = backend.stream(model="gpt-5.6-luna", messages=[{"role": "user", "content": "backend stream"}], max_tokens=20)
+    backend_chunks = [chunk async for chunk in backend_stream]
+    from openai import BadRequestError
+    with pytest.raises(BadRequestError, match="verbosity"):
+        unsupported_stream = backend.stream(
+            model="gpt-5.6-luna",
+            messages=[{"role": "user", "content": "verbosity"}],
+            max_tokens=20,
+            extra_params={"verbosity": "high"},
+        )
+        [chunk async for chunk in unsupported_stream]
+    with pytest.raises(BadRequestError, match="reasoning"):
+        unsupported_reasoning = backend.stream(
+            model="gpt-5.6-luna",
+            messages=[{"role": "user", "content": "reasoning"}],
+            max_tokens=20,
+            extra_params={"extra_body": {"reasoning": {"max_tokens": 256}}},
+        )
+        [chunk async for chunk in unsupported_reasoning]
     backend_result = await backend.complete(model="gpt-5.6-luna", messages=[{"role": "user", "content": "backend"}], max_tokens=20)
 
     assert normal.choices[0].message.content == "Hello world"
     assert structured.choices[0].message.content == "Hello world"
     assert tool.choices[0].finish_reason == "stop"
     assert streamed[-1].choices[0].finish_reason == "stop"
+    assert "".join(chunk.content for chunk in backend_chunks if chunk.content) == "Hello world"
+    assert backend_chunks[-1].is_done is True
+    assert backend_chunks[-1].finish_reason == "stop"
+    assert backend_chunks[-1].output_tokens == 4
     assert backend_result.content == "Hello world"
     assert seen[2]["parallel_tool_calls"] is False
     assert seen[1]["text"] == {"format": {"type": "json_object"}}
+    backend_stream_request = next(body for body in seen if "backend stream" in json.dumps(body))
+    assert backend_stream_request["stream"] is True
+    assert "stream_options" not in backend_stream_request
+    assert all(response.is_closed for response in responses)
     await sdk_http.aclose()
     await relay_client.aclose()

--- a/tests/llm/test_codex_relay.py
+++ b/tests/llm/test_codex_relay.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from src.codex_relay import (
+    AuthStore,
+    CodexRelay,
+    aggregate_codex_sse,
+    build_responses_request,
+    create_app,
+)
+
+TEXT_SSE = """event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"Hello "}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"world"}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","usage":{"input_tokens":12,"output_tokens":4}}}
+
+"""
+
+TOOL_SSE = """event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_1","name":"lookup","arguments":""}}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\\"city\\":\\"Paris\\"}"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{\\"city\\":\\"Paris\\"}","status":"completed"}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_2","status":"completed","usage":{"input_tokens":20,"output_tokens":7}}}
+
+"""
+
+
+def test_build_responses_request_translates_chat_contract() -> None:
+    request = build_responses_request(
+        {
+            "model": "gpt-5.6-luna",
+            "messages": [
+                {"role": "system", "content": "Be concise."},
+                {"role": "user", "content": "Weather?"},
+                {"role": "assistant", "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}]},
+                {"role": "tool", "tool_call_id": "call_1", "content": "sunny"},
+            ],
+            "tools": [{"type": "function", "function": {"name": "lookup", "description": "Lookup weather", "parameters": {"type": "object"}}}],
+            "reasoning_effort": "high",
+            "response_format": {"type": "json_object"},
+            "max_tokens": 200,
+        }
+    )
+
+    assert request["model"] == "gpt-5.6-luna"
+    assert request["instructions"] == "Be concise."
+    assert request["store"] is False
+    assert request["stream"] is True
+    assert request["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert request["text"] == {"format": {"type": "json_object"}}
+    assert "max_output_tokens" not in request
+    assert request["input"][-2:] == [
+        {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "call_1", "output": "sunny"},
+    ]
+    assert request["tools"] == [{"type": "function", "name": "lookup", "description": "Lookup weather", "parameters": {"type": "object"}, "strict": False}]
+
+
+def test_aggregate_codex_sse_text_response() -> None:
+    result = aggregate_codex_sse(TEXT_SSE)
+    assert result.content == "Hello world"
+    assert result.tool_calls == []
+    assert result.response_id == "resp_1"
+    assert result.usage == {"prompt_tokens": 12, "completion_tokens": 4, "total_tokens": 16}
+    assert result.finish_reason == "stop"
+
+
+def test_aggregate_codex_sse_tool_call_response() -> None:
+    result = aggregate_codex_sse(TOOL_SSE)
+    assert result.content == ""
+    assert result.finish_reason == "tool_calls"
+    assert result.tool_calls == [{"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": '{"city":"Paris"}'}}]
+
+
+@pytest.mark.asyncio
+async def test_non_stream_completion_aggregates_upstream_sse() -> None:
+    seen: dict[str, Any] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        assert request.url.path == "/backend-api/codex/responses"
+        return httpx.Response(200, text=TEXT_SSE, headers={"content-type": "text/event-stream"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    relay = CodexRelay(client=client, access_token="test-token")
+    response = await relay.complete({"model": "gpt-5.6-luna", "messages": [{"role": "user", "content": "Hi"}]})
+    await client.aclose()
+
+    assert response.status_code == 200
+    body = json.loads(bytes(response.body).decode())
+    assert body["choices"][0]["message"]["content"] == "Hello world"
+    assert body["usage"]["total_tokens"] == 16
+    assert seen["body"]["stream"] is True  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_stream_completion_translates_codex_sse() -> None:
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=TEXT_SSE, headers={"content-type": "text/event-stream"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    relay = CodexRelay(client=client, access_token="test-token")
+    upstream = await relay.open_upstream({"model": "gpt-5.6-luna", "messages": [{"role": "user", "content": "Hi"}], "stream": True})
+    chunks = [chunk async for chunk in relay.stream_chat(upstream, "gpt-5.6-luna")]
+    await client.aclose()
+
+    streamed = b"".join(chunks)
+    assert b'"content":"Hello "' in streamed
+    assert b'"finish_reason":"stop"' in streamed
+    assert streamed.endswith(b"data: [DONE]\n\n")
+
+
+@pytest.mark.asyncio
+async def test_upstream_http_error_status_and_body_are_preserved() -> None:
+    error_body = '{"error":{"type":"invalid_request_error","message":"bad model"}}'
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text=error_body, headers={"content-type": "application/json"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    relay = CodexRelay(client=client, access_token="test-token")
+    response = await relay.complete({"model": "gpt-5.6-luna", "messages": [{"role": "user", "content": "Hi"}]})
+    await client.aclose()
+
+    assert response.status_code == 401
+    assert bytes(response.body).decode() == error_body
+
+
+def test_health_smoke() -> None:
+    client = TestClient(create_app(CodexRelay(access_token="test-token")))
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_auth_store_refreshes_and_persists_rotated_pool_token(tmp_path: Any) -> None:
+    def encoded(value: dict[str, Any]) -> str:
+        raw = json.dumps(value).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    old = f"header.{encoded({'exp': time.time() - 1})}.signature"
+    path = tmp_path / "auth.json"
+    path.write_text(
+        json.dumps({"credential_pool": {"openai-codex": [{"access_token": old, "refresh_token": "refresh-1"}]}})
+    )
+    store = AuthStore(path)
+
+    async def fake_refresh(refresh_token: str) -> dict[str, Any]:
+        assert refresh_token == "refresh-1"
+        return {"access_token": "new-access", "refresh_token": "refresh-2"}
+
+    store._refresh = fake_refresh  # type: ignore[method-assign]
+    assert await store.token() == "new-access"
+    persisted = json.loads(path.read_text())
+    assert persisted["credential_pool"]["openai-codex"][0]["access_token"] == "new-access"
+    assert persisted["credential_pool"]["openai-codex"][0]["refresh_token"] == "refresh-2"

--- a/tests/llm/test_codex_relay.py
+++ b/tests/llm/test_codex_relay.py
@@ -144,6 +144,38 @@ async def test_upstream_http_error_is_sanitized() -> None:
     assert json.loads(bytes(response.body).decode()) == {"error": {"message": "Codex provider request failed", "code": "provider_error"}}
 
 
+@pytest.mark.asyncio
+async def test_provider_http_503_keeps_provider_classification_for_non_stream() -> None:
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="PROVIDER_OUTAGE_DETAIL")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    relay = CodexRelay(client=client, access_token="test-token")
+    response = await relay.complete({"messages": []})
+    await client.aclose()
+
+    assert response.status_code == 503
+    assert json.loads(bytes(response.body).decode()) == {
+        "error": {"message": "Codex provider request failed", "code": "provider_error"}
+    }
+    assert "PROVIDER_OUTAGE_DETAIL" not in bytes(response.body).decode()
+
+
+def test_provider_http_503_keeps_provider_classification_for_stream() -> None:
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="PROVIDER_OUTAGE_DETAIL")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(CodexRelay(client=client, access_token="test-token"))
+    with TestClient(app) as test_client:
+        response = test_client.post("/v1/chat/completions", json={"messages": [], "stream": True})
+    assert response.status_code == 503
+    assert response.json() == {
+        "error": {"message": "Codex provider request failed", "code": "provider_error"}
+    }
+    assert "PROVIDER_OUTAGE_DETAIL" not in response.text
+
+
 def test_stream_upstream_http_error_is_sanitized() -> None:
     async def handler(_: httpx.Request) -> httpx.Response:
         return httpx.Response(500, text="PROVIDER_PRIVATE_DETAIL", headers={"content-type": "text/plain"})
@@ -292,6 +324,18 @@ data: {\"type\":\"response.output_text.delta\",\"delta\":\"bad\"}
         aggregate_codex_sse('event: response.output_text.delta\ndata: {"delta":"partial"}\n\n')
 
 
+def test_aggregate_does_not_request_another_input_after_terminal() -> None:
+    def fail_if_read() -> Any:
+        yield "event: response.completed"
+        yield 'data: {"response":{"id":"r","usage":{"input_tokens":1,"output_tokens":2}}}'
+        yield ""
+        raise AssertionError("aggregate requested input after terminal event")
+
+    result = aggregate_codex_sse(fail_if_read())
+    assert result.content == ""
+    assert result.usage == {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+
+
 def test_aggregate_provider_and_malformed_events_are_sanitized() -> None:
     with pytest.raises(RelayError, match="provider") as provider:
         aggregate_codex_sse('event: error\ndata: {"message":"SECRET_TOKEN"}\n\n')
@@ -348,6 +392,66 @@ async def test_stream_stops_without_reading_after_terminal_and_rejects_non_objec
     upstream = await relay.open_upstream({"messages": []})
     streamed = b"".join([chunk async for chunk in relay.stream_chat(upstream, "gpt-5.6-luna")])
     assert b"provider_stream_error" in streamed
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_non_stream_completion_stops_without_reading_after_terminal() -> None:
+    class BlockingAfterTerminal(httpx.AsyncByteStream):
+        def __init__(self) -> None:
+            self.read_after_terminal = False
+            self.closed = False
+            self._release = asyncio.Event()
+
+        async def __aiter__(self):
+            yield b"event: response.output_text.delta\n"
+            yield b'data: {"delta":"ok"}\n'
+            yield b"\n"
+            yield b"event: response.completed\n"
+            yield b'data: {"response":{"id":"r","usage":{"input_tokens":1,"output_tokens":2}}}\n'
+            yield b"\n"
+            self.read_after_terminal = True
+            await self._release.wait()
+
+        async def aclose(self) -> None:
+            self.closed = True
+            self._release.set()
+
+    stream = BlockingAfterTerminal()
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream, headers={"content-type": "text/event-stream"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    relay = CodexRelay(client=client, access_token="synthetic")
+    response = await asyncio.wait_for(
+        relay.complete({"messages": [{"role": "user", "content": "hi"}]}), timeout=1
+    )
+    assert response.status_code == 200
+    body = json.loads(bytes(response.body).decode())
+    assert body["choices"][0]["message"]["content"] == "ok"
+    assert body["usage"]["total_tokens"] == 3
+    assert stream.read_after_terminal is False
+    assert stream.closed is True
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_include_usage_rejects_null_terminal_usage() -> None:
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text='event: response.completed\ndata: {"response":{"id":"r","usage":null}}\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    relay = CodexRelay(client=client, access_token="synthetic")
+    upstream = await relay.open_upstream({"messages": []})
+    streamed = b"".join([chunk async for chunk in relay.stream_chat(upstream, "gpt-5.6-luna", include_usage=True)])
+    assert streamed.count(b"provider_stream_error") == 1
+    assert b'"finish_reason"' not in streamed
+    assert streamed.endswith(b"data: [DONE]\n\n")
     await client.aclose()
 
 
@@ -433,6 +537,9 @@ async def test_injected_token_provider_retries_once_and_sanitizes_failure() -> N
     with TestClient(broken_app) as test_client:
         result = test_client.post("/v1/chat/completions", json={"messages": []})
     assert result.status_code == 503
+    assert result.json() == {
+        "error": {"message": "Codex credential source unavailable", "code": "credential_unavailable"}
+    }
     assert "provider secret" not in result.text
     await client.aclose()
 
@@ -475,8 +582,14 @@ async def test_current_openai_sdk_and_backend_in_process_paths() -> None:
     responses: list[httpx.Response] = []
 
     async def upstream(request: httpx.Request) -> httpx.Response:
-        seen.append(json.loads(request.content))
-        response = httpx.Response(200, text=TEXT_SSE, headers={"content-type": "text/event-stream"})
+        body = json.loads(request.content)
+        seen.append(body)
+        stream_text = (
+            'event: response.completed\ndata: {"response":{"id":"r","usage":null}}\n\n'
+            if "null usage" in json.dumps(body)
+            else TEXT_SSE
+        )
+        response = httpx.Response(200, text=stream_text, headers={"content-type": "text/event-stream"})
         responses.append(response)
         return response
 
@@ -494,6 +607,38 @@ async def test_current_openai_sdk_and_backend_in_process_paths() -> None:
     backend = OpenAIBackend(sdk)
     backend_stream = backend.stream(model="gpt-5.6-luna", messages=[{"role": "user", "content": "backend stream"}], max_tokens=20)
     backend_chunks = [chunk async for chunk in backend_stream]
+
+    null_stream = await sdk.chat.completions.create(
+        model="gpt-5.6-luna",
+        messages=[{"role": "user", "content": "null usage"}],
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+    sdk_null_error: Exception | None = None
+    try:
+        sdk_null_chunks = [chunk async for chunk in null_stream]
+    except Exception as exc:
+        sdk_null_chunks = []
+        sdk_null_error = exc
+    assert sdk_null_error is not None
+    assert "Codex provider stream failed" in str(sdk_null_error)
+    assert not any(
+        chunk.choices and chunk.choices[0].finish_reason for chunk in sdk_null_chunks
+    )
+
+    backend_null_stream = backend.stream(
+        model="gpt-5.6-luna", messages=[{"role": "user", "content": "null usage"}], max_tokens=20
+    )
+    backend_null_error: Exception | None = None
+    try:
+        backend_null_chunks = [chunk async for chunk in backend_null_stream]
+    except Exception as exc:
+        backend_null_chunks = []
+        backend_null_error = exc
+    assert backend_null_error is not None
+    assert "Codex provider stream failed" in str(backend_null_error)
+    assert not any(chunk.is_done and chunk.output_tokens is None for chunk in backend_null_chunks)
+
     from openai import BadRequestError
     with pytest.raises(BadRequestError, match="verbosity"):
         unsupported_stream = backend.stream(

--- a/tests/llm/test_codex_relay.py
+++ b/tests/llm/test_codex_relay.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 from src.codex_relay import (
     AuthStore,
     CodexRelay,
+    CredentialError,
     RelayError,
     aggregate_codex_sse,
     build_responses_request,
@@ -507,6 +508,106 @@ async def test_account_claim_header_and_opaque_token_are_safe() -> None:
     await response.aclose()
     assert seen["account"] is None
     await client.aclose()
+
+
+@pytest.mark.parametrize(
+    "provider_error",
+    [
+        OSError("OS_PRIVATE_DETAIL"),
+        ValueError("VALUE_PRIVATE_DETAIL"),
+        RuntimeError("RUNTIME_PRIVATE_DETAIL"),
+        httpx.ConnectError("HTTP_PRIVATE_DETAIL"),
+        UnicodeError("UNICODE_PRIVATE_DETAIL"),
+        Exception("GENERIC_PRIVATE_DETAIL"),
+    ],
+    ids=["oserror", "value", "runtime", "http", "unicode", "generic"],
+)
+def test_injected_token_provider_exception_types_are_sanitized_at_route(provider_error: Exception) -> None:
+    calls: list[bool] = []
+
+    async def provider(force_refresh: bool) -> str:
+        calls.append(force_refresh)
+        raise provider_error
+
+    app = create_app(CodexRelay(token_provider=provider))
+    with TestClient(app) as client:
+        response = client.post("/v1/chat/completions", json={"messages": []})
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "error": {"message": "Codex credential source unavailable", "code": "credential_unavailable"}
+    }
+    assert str(provider_error) not in response.text
+    assert calls == [False]
+
+
+def test_credential_error_payload_is_never_reflected_at_route() -> None:
+    private_payload = {"error": {"message": "PRIVATE_CREDENTIAL_PAYLOAD", "code": "private_code"}}
+
+    async def provider(_: bool) -> str:
+        raise CredentialError("PRIVATE_CREDENTIAL_EXCEPTION", status_code=418, payload=private_payload)
+
+    app = create_app(CodexRelay(token_provider=provider))
+    with TestClient(app) as client:
+        response = client.post("/v1/chat/completions", json={"messages": []})
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "error": {"message": "Codex credential source unavailable", "code": "credential_unavailable"}
+    }
+    assert "PRIVATE_CREDENTIAL" not in response.text
+    assert "private_code" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_initial_401_is_closed_when_forced_refresh_provider_fails() -> None:
+    class ClosingStream(httpx.AsyncByteStream):
+        def __init__(self) -> None:
+            self.closed: bool = False
+
+        async def __aiter__(self):
+            yield b""
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    initial_stream = ClosingStream()
+    refreshes: list[bool] = []
+
+    async def provider(force_refresh: bool) -> str:
+        refreshes.append(force_refresh)
+        if force_refresh:
+            raise RuntimeError("REFRESH_PRIVATE_DETAIL")
+        return "synthetic-stale"
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, stream=initial_stream)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(CodexRelay(client=client, token_provider=provider))
+
+    route_client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://relay")
+    response = await route_client.post("/v1/chat/completions", json={"messages": []})
+    await route_client.aclose()
+    await client.aclose()
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "error": {"message": "Codex credential source unavailable", "code": "credential_unavailable"}
+    }
+    assert "REFRESH_PRIVATE_DETAIL" not in response.text
+    assert refreshes == [False, True]
+    assert initial_stream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_injected_token_provider_does_not_catch_cancellation() -> None:
+    async def provider(_: bool) -> str:
+        raise asyncio.CancelledError
+
+    relay = CodexRelay(token_provider=provider)
+    with pytest.raises(asyncio.CancelledError):
+        await relay.open_upstream({"messages": []})
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_codex_relay.py
+++ b/tests/llm/test_codex_relay.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 from typing import Any
 
@@ -204,7 +205,6 @@ def test_auth_store_is_read_only_and_reports_missing_source(tmp_path: Any) -> No
     path = tmp_path / "auth.json"
     store = AuthStore(path)
     with pytest.raises(RelayError, match="credential source"):
-        import asyncio
         asyncio.run(store.token())
 
 
@@ -212,7 +212,6 @@ def test_auth_store_reads_only_canonical_provider_token(tmp_path: Any) -> None:
     path = tmp_path / "auth.json"
     path.write_text(json.dumps({"providers": {"openai-codex": {"tokens": {"access_token": "synthetic"}}}}))
     store = AuthStore(path)
-    import asyncio
     assert asyncio.run(store.token()) == "synthetic"
     assert list(tmp_path.iterdir()) == [path]
 
@@ -465,6 +464,21 @@ def test_non_loopback_requires_key_and_rejects_before_upstream() -> None:
         create_app(CodexRelay(access_token="synthetic"), bind_host="0.0.0.0")
 
 
+def test_empty_inbound_key_is_unconfigured_on_loopback_but_required_off_host() -> None:
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=TEXT_SSE)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(CodexRelay(client=client, access_token="synthetic"), inbound_key="")
+    with TestClient(app) as test_client:
+        response = test_client.post("/v1/chat/completions", json={"messages": []})
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "Hello world"
+
+    with pytest.raises(ValueError, match="inbound_key"):
+        create_app(CodexRelay(access_token="synthetic"), inbound_key="", bind_host="0.0.0.0")
+
+
 def test_relay_auth_rejects_missing_wrong_and_malformed_before_upstream() -> None:
     calls = 0
 
@@ -484,10 +498,35 @@ def test_relay_auth_rejects_missing_wrong_and_malformed_before_upstream() -> Non
     assert calls == 1
 
 
+def test_non_ascii_bearer_candidate_returns_normal_unauthorized_response() -> None:
+    calls = 0
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, text=TEXT_SSE)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(
+        CodexRelay(client=client, access_token="synthetic"),
+        inbound_key="relay-secret",
+        bind_host="192.0.2.10",
+    )
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/v1/chat/completions",
+            headers={b"Authorization": b"Bearer \xc3\xa9"},
+            json={"messages": []},
+        )
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": {"message": "Invalid relay authentication", "code": "relay_unauthorized"}
+    }
+    assert calls == 0
+
+
 @pytest.mark.asyncio
 async def test_account_claim_header_and_opaque_token_are_safe() -> None:
-    import base64
-
     def enc(value: Any) -> str:
         return base64.urlsafe_b64encode(json.dumps(value).encode()).decode().rstrip("=")
 

--- a/tests/llm/test_codex_relay.py
+++ b/tests/llm/test_codex_relay.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import base64
 import json
-import time
 from typing import Any
 
 import httpx
@@ -12,6 +10,7 @@ from fastapi.testclient import TestClient
 from src.codex_relay import (
     AuthStore,
     CodexRelay,
+    RelayError,
     aggregate_codex_sse,
     build_responses_request,
     create_app,
@@ -66,7 +65,7 @@ def test_build_responses_request_translates_chat_contract() -> None:
     assert request["stream"] is True
     assert request["reasoning"] == {"effort": "high", "summary": "auto"}
     assert request["text"] == {"format": {"type": "json_object"}}
-    assert "max_output_tokens" not in request
+    assert request["max_output_tokens"] == 200
     assert request["input"][-2:] == [
         {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": "{}"},
         {"type": "function_call_output", "call_id": "call_1", "output": "sunny"},
@@ -151,25 +150,205 @@ def test_health_smoke() -> None:
     assert response.json() == {"status": "ok"}
 
 
-@pytest.mark.asyncio
-async def test_auth_store_refreshes_and_persists_rotated_pool_token(tmp_path: Any) -> None:
-    def encoded(value: dict[str, Any]) -> str:
-        raw = json.dumps(value).encode()
-        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
-
-    old = f"header.{encoded({'exp': time.time() - 1})}.signature"
+def test_auth_store_is_read_only_and_reports_missing_source(tmp_path: Any) -> None:
     path = tmp_path / "auth.json"
-    path.write_text(
-        json.dumps({"credential_pool": {"openai-codex": [{"access_token": old, "refresh_token": "refresh-1"}]}})
-    )
     store = AuthStore(path)
+    with pytest.raises(RelayError, match="credential source"):
+        import asyncio
+        asyncio.run(store.token())
 
-    async def fake_refresh(refresh_token: str) -> dict[str, Any]:
-        assert refresh_token == "refresh-1"
-        return {"access_token": "new-access", "refresh_token": "refresh-2"}
 
-    store._refresh = fake_refresh  # type: ignore[method-assign]
-    assert await store.token() == "new-access"
-    persisted = json.loads(path.read_text())
-    assert persisted["credential_pool"]["openai-codex"][0]["access_token"] == "new-access"
-    assert persisted["credential_pool"]["openai-codex"][0]["refresh_token"] == "refresh-2"
+def test_auth_store_reads_only_canonical_provider_token(tmp_path: Any) -> None:
+    path = tmp_path / "auth.json"
+    path.write_text(json.dumps({"providers": {"openai-codex": {"tokens": {"access_token": "synthetic"}}}}))
+    store = AuthStore(path)
+    import asyncio
+    assert asyncio.run(store.token()) == "synthetic"
+    assert list(tmp_path.iterdir()) == [path]
+
+
+def test_tool_controls_are_translated_or_rejected() -> None:
+    request = build_responses_request({
+        "messages": [{"role": "user", "content": "x"}],
+        "tools": [{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}],
+        "tool_choice": {"type": "function", "function": {"name": "lookup"}},
+        "parallel_tool_calls": False,
+        "max_completion_tokens": 20,
+    })
+    assert request["tool_choice"] == {"type": "function", "name": "lookup"}
+    assert request["parallel_tool_calls"] is False
+    assert request["max_output_tokens"] == 20
+    with pytest.raises(RelayError, match="unsupported"):
+        build_responses_request({"messages": [], "temperature": 0.2})
+
+
+def test_aggregate_requires_terminal_and_ignores_post_terminal_data() -> None:
+    raw = """event: response.output_text.delta
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}
+
+event: response.completed
+data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\"}}
+
+event: response.output_text.delta
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"bad\"}
+
+"""
+    result = aggregate_codex_sse(raw)
+    assert result.content == "ok"
+    with pytest.raises(RelayError, match="without a terminal"):
+        aggregate_codex_sse('event: response.output_text.delta\ndata: {"delta":"partial"}\n\n')
+
+
+def test_aggregate_provider_and_malformed_events_are_sanitized() -> None:
+    with pytest.raises(RelayError, match="provider") as provider:
+        aggregate_codex_sse('event: error\ndata: {"message":"SECRET_TOKEN"}\n\n')
+    assert "SECRET_TOKEN" not in str(provider.value)
+    with pytest.raises(RelayError, match="malformed"):
+        aggregate_codex_sse("event: response.completed\ndata: {not-json}\n\n")
+
+
+def test_non_loopback_requires_key_and_rejects_before_upstream() -> None:
+    with pytest.raises(ValueError, match="inbound_key"):
+        create_app(CodexRelay(access_token="synthetic"), bind_host="0.0.0.0")
+
+
+def test_relay_auth_rejects_missing_wrong_and_malformed_before_upstream() -> None:
+    calls = 0
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, text=TEXT_SSE)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(CodexRelay(client=client, access_token="synthetic"), inbound_key="relay-secret", bind_host="192.0.2.10")
+    with TestClient(app) as test_client:
+        for headers in ({}, {"Authorization": "Bearer wrong"}, {"Authorization": "Basic relay-secret"}):
+            response = test_client.post("/v1/chat/completions", headers=headers, json={"messages": []})
+            assert response.status_code == 401
+        response = test_client.post("/v1/chat/completions", headers={"Authorization": "Bearer relay-secret"}, json={"messages": []})
+        assert response.status_code == 200
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_account_claim_header_and_opaque_token_are_safe() -> None:
+    import base64
+
+    def enc(value: Any) -> str:
+        return base64.urlsafe_b64encode(json.dumps(value).encode()).decode().rstrip("=")
+
+    token = f"h.{enc({'https://api.openai.com/auth': {'chatgpt_account_id': 'acct-synthetic'}})}.s"
+    seen: dict[str, str | None] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["account"] = request.headers.get("ChatGPT-Account-ID")
+        return httpx.Response(200, text=TEXT_SSE)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    relay = CodexRelay(client=client, access_token=token)
+    response = await relay.open_upstream({"messages": [{"role": "user", "content": "x"}]})
+    await response.aclose()
+    assert seen["account"] == "acct-synthetic"
+    relay.access_token = "opaque-token"
+    response = await relay.open_upstream({"messages": [{"role": "user", "content": "x"}]})
+    await response.aclose()
+    assert seen["account"] is None
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_injected_token_provider_retries_once_and_sanitizes_failure() -> None:
+    calls = 0
+    refreshes: list[bool] = []
+
+    async def provider(force_refresh: bool) -> str:
+        refreshes.append(force_refresh)
+        return "synthetic-refreshed" if force_refresh else "synthetic-stale"
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(401 if calls == 1 else 200, text=TEXT_SSE)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    relay = CodexRelay(client=client, token_provider=provider)
+    response = await relay.open_upstream({"messages": [{"role": "user", "content": "x"}]})
+    await response.aclose()
+    assert calls == 2
+    assert refreshes == [False, True]
+
+    async def broken(_: bool) -> str:
+        raise RelayError("provider secret", status_code=503)
+
+    broken_app = create_app(CodexRelay(client=client, token_provider=broken), bind_host="127.0.0.1")
+    with TestClient(broken_app) as test_client:
+        result = test_client.post("/v1/chat/completions", json={"messages": []})
+    assert result.status_code == 503
+    assert "provider secret" not in result.text
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_failed_and_eof_emit_only_sanitized_error_done() -> None:
+    failed = "event: response.output_text.delta\ndata: {\"delta\":\"partial\"}\n\nevent: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"SECRET\"}}}\n\n"
+    eof = "event: response.output_text.delta\ndata: {\"delta\":\"partial\"}\n\n"
+
+    calls = 0
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, text=failed if calls == 1 else eof)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    relay = CodexRelay(client=client, access_token="synthetic")
+    for request_body in ({"messages": [{"role": "user", "content": "failed"}]}, {"messages": [{"role": "user", "content": "eof"}]}):
+        response = await relay.open_upstream(request_body)
+        chunks = b"".join([chunk async for chunk in relay.stream_chat(response, "gpt-5.6-luna")])
+        assert chunks.endswith(b"data: [DONE]\n\n")
+        assert chunks.count(b"provider_stream_error") == 1
+        assert b'"finish_reason":"stop"' not in chunks
+        assert b"SECRET" not in chunks
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_current_openai_sdk_and_backend_in_process_paths() -> None:
+    pytest.importorskip("openai")
+    from openai import AsyncOpenAI
+
+    try:
+        from src.llm.backends.openai import OpenAIBackend
+    except ImportError as exc:
+        pytest.skip(f"upstream backend dependencies unavailable: {exc}")
+
+    seen: list[dict[str, Any]] = []
+
+    async def upstream(request: httpx.Request) -> httpx.Response:
+        seen.append(json.loads(request.content))
+        return httpx.Response(200, text=TEXT_SSE, headers={"content-type": "text/event-stream"})
+
+    relay_client = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+    relay = CodexRelay(client=relay_client, access_token="synthetic")
+    sdk_transport = httpx.ASGITransport(app=create_app(relay))
+    sdk_http = httpx.AsyncClient(transport=sdk_transport, base_url="http://relay")
+    sdk = AsyncOpenAI(api_key="synthetic-relay-key", base_url="http://relay/v1", http_client=sdk_http)
+
+    normal = await sdk.chat.completions.create(model="gpt-5.6-luna", messages=[{"role": "user", "content": "hi"}])
+    structured = await sdk.chat.completions.create(model="gpt-5.6-luna", messages=[{"role": "user", "content": "json"}], response_format={"type": "json_object"})
+    tool = await sdk.chat.completions.create(model="gpt-5.6-luna", messages=[{"role": "user", "content": "lookup"}], tools=[{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}], tool_choice="auto", parallel_tool_calls=False)
+    stream = await sdk.chat.completions.create(model="gpt-5.6-luna", messages=[{"role": "user", "content": "stream"}], stream=True)
+    streamed = [chunk async for chunk in stream]
+    backend = OpenAIBackend(sdk)
+    backend_result = await backend.complete(model="gpt-5.6-luna", messages=[{"role": "user", "content": "backend"}], max_tokens=20)
+
+    assert normal.choices[0].message.content == "Hello world"
+    assert structured.choices[0].message.content == "Hello world"
+    assert tool.choices[0].finish_reason == "stop"
+    assert streamed[-1].choices[0].finish_reason == "stop"
+    assert backend_result.content == "Hello world"
+    assert seen[2]["parallel_tool_calls"] is False
+    assert seen[1]["text"] == {"format": {"type": "json_object"}}
+    await sdk_http.aclose()
+    await relay_client.aclose()


### PR DESCRIPTION
Honcho normally talks to language models using the OpenAI chat format, while Codex uses a slightly different format. This pull request adds a small bridge between those two formats, so Honcho can use Codex without changing the way the rest of Honcho talks to models.

It also makes that bridge safer: it does not write or refresh credentials itself, requires a key when exposed beyond the local machine, handles streaming correctly, and avoids passing private error details back to callers.

## What this changes

- Adds a narrow Chat Completions → Codex Responses compatibility relay.
- Supports both ordinary and streaming responses, including usage information used by Honcho's current OpenAI backend.
- Stops cleanly when Codex has finished, rather than waiting indefinitely for a connection to close.
- Rejects unsupported or unknown request controls instead of silently ignoring them.
- Keeps the built-in credential source read-only; credential refresh remains the responsibility of the embedding application.
- Requires inbound authentication for non-loopback listeners.
- Sanitizes provider, credential, and malformed-stream errors.
- Adds focused documentation and regression coverage.

Existing Honcho deployments are unchanged unless this optional relay is started and configured.

## Why

Honcho's current OpenAI backend speaks the Chat Completions protocol. Codex exposes a Responses endpoint. Without a compatibility layer, the two sides cannot be used together reliably, especially for streaming and usage reporting.

This PR keeps the integration deliberately small and explicit rather than changing Honcho's general LLM abstraction.

## Related Honcho work

These existing PRs are relevant context and should be considered alongside this one:

- [#898](https://github.com/plastic-labs/honcho/pull/898) adds opt-in Responses API support directly to Honcho's OpenAI backend. That is an alternative/complement to this local compatibility boundary; maintainers may decide whether the approaches should converge.
- [#825](https://github.com/plastic-labs/honcho/pull/825) adds OpenAI/Codex OAuth and a direct Codex Responses backend. This PR intentionally does not duplicate OAuth or take ownership of credential refresh.
- [#879](https://github.com/plastic-labs/honcho/pull/879) is the merged Codex integration guide and provides useful user-facing background.

## Verification

All checks were run from the locked project environment:

- `uv run --frozen pytest tests/llm/test_codex_relay.py -q -n 0` — **49 passed**
- `uv run --frozen pytest tests/llm -q` — **289 passed**
- Current OpenAI SDK/backend integration — **1 passed**, not skipped
- Ruff — passed
- Python syntax compilation — passed
- Git diff checks — passed
- Bounded added-line secret scan — zero findings
- BasedPyright — 0 errors, 128 warnings; the nonzero exit is recorded as a warning-only repository result

I also ran two real smoke checks against the branch in a temporary local process:

- non-stream request — HTTP 200, valid completion, usage returned
- streaming request — HTTP 200, correct finish signal, usage received, `[DONE]` received

No production service was restarted or changed.

## Known limitation

The full repository test command remains limited by the local PostgreSQL fixture: the environment cannot authenticate/connect to `postgres@localhost:5432`. The relay-focused and complete LLM suites are green.

## Scope

The change is limited to:

- `docs/codex-relay.md`
- `src/codex_relay.py`
- `tests/llm/test_codex_relay.py`

I would appreciate feedback on whether the supported request boundary and the credential-ownership model are the right fit for Honcho upstream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local compatibility relay for OpenAI-style chat completion requests.
  * Supports streaming and non-streaming responses, tool calls, structured outputs, images, usage reporting, and health checks.
  * Added configurable authentication, credential handling, upstream connection settings, and server startup options.
  * Provides sanitized, OpenAI-compatible validation and error responses.

* **Documentation**
  * Added setup, configuration, security, supported controls, and testing guidance.

* **Tests**
  * Added comprehensive coverage for request translation, streaming, authentication, errors, credentials, and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->