### PR TITLE
fix: preserve active session peer membership timestamps

### DIFF
--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -1020,30 +1020,36 @@ async def _get_or_add_peers_to_session(
         result = await db.execute(select_stmt)
         return list(result.scalars().all())
 
-    # Only validate observer limit if we're adding peers with observe_others=True
-    new_observer_count = count_observers_in_config(peer_names)
+    # Active peers retain their stored configuration. Only new and departed peers
+    # contribute their submitted observer configuration to the effective total.
+    active_peer_names_stmt = select(models.SessionPeer.peer_name).where(
+        models.SessionPeer.session_name == session_name,
+        models.SessionPeer.workspace_name == workspace_name,
+        models.SessionPeer.left_at.is_(None),
+        models.SessionPeer.peer_name.in_(peer_names),
+    )
+    result = await db.execute(active_peer_names_stmt)
+    active_peer_names = set(result.scalars())
 
-    if new_observer_count > 0:
-        # Use a single efficient query to count existing observers not being updated
-        # This uses PostgreSQL's JSONB operators to check the observe_others field directly
-        existing_observers_stmt = select(func.count()).where(
-            models.SessionPeer.session_name == session_name,
-            models.SessionPeer.workspace_name == workspace_name,
-            models.SessionPeer.left_at.is_(None),  # Only active peers
-            models.SessionPeer.peer_name.notin_(
-                peer_names.keys()
-            ),  # Exclude peers being updated
-            models.SessionPeer.configuration["observe_others"].astext.cast(
-                Boolean
-            ),  # Only observers
-        )
-        result = await db.execute(existing_observers_stmt)
-        existing_observer_count = result.scalar() or 0
+    existing_observers_stmt = select(func.count()).where(
+        models.SessionPeer.session_name == session_name,
+        models.SessionPeer.workspace_name == workspace_name,
+        models.SessionPeer.left_at.is_(None),
+        models.SessionPeer.configuration["observe_others"].astext.cast(Boolean),
+    )
+    result = await db.execute(existing_observers_stmt)
+    existing_observer_count = result.scalar() or 0
+    submitted_observer_count = count_observers_in_config(
+        {
+            peer_name: configuration
+            for peer_name, configuration in peer_names.items()
+            if peer_name not in active_peer_names
+        }
+    )
+    total_observers = existing_observer_count + submitted_observer_count
 
-        total_observers = existing_observer_count + new_observer_count
-
-        if total_observers > settings.SESSION_OBSERVERS_LIMIT:
-            raise ObserverException(session_name, total_observers)
+    if total_observers > settings.SESSION_OBSERVERS_LIMIT:
+        raise ObserverException(session_name, total_observers)
 
     # Use upsert to handle both new peers and rejoining peers
     stmt = pg_insert(models.SessionPeer).values(

--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -1060,13 +1060,14 @@ async def _get_or_add_peers_to_session(
         ]
     )
 
-    # On conflict, update joined_at and clear left_at (rejoin scenario)
-    # If left_at is not None (peer has left the session): Use the new configuration (stmt.excluded.configuration)
-    # If left_at is None (peer is still active): Keep the existing configuration (models.SessionPeer.configuration)
+    # On conflict, rejoin departed peers but leave active memberships unchanged.
     stmt = stmt.on_conflict_do_update(
         index_elements=["session_name", "peer_name", "workspace_name"],
         set_={
-            "joined_at": func.now(),
+            "joined_at": case(
+                (models.SessionPeer.left_at.is_not(None), func.now()),
+                else_=models.SessionPeer.joined_at,
+            ),
             "left_at": None,
             "configuration": case(
                 (models.SessionPeer.left_at.is_not(None), stmt.excluded.configuration),

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -6,14 +6,111 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, models, schemas
+from src.config import settings
 from src.crud.session import (
     _get_or_add_peers_to_session,  # pyright: ignore[reportPrivateUsage]
 )
-from src.exceptions import ResourceNotFoundException
+from src.exceptions import ObserverException, ResourceNotFoundException
 
 
 class TestSessionCRUD:
     """Test suite for session CRUD operations"""
+
+    @pytest.mark.asyncio
+    async def test_add_peers_counts_active_observer_stored_configuration(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """An active observer remains counted when its submitted config disables it."""
+        workspace, active_observer = sample_data
+        new_observer = models.Peer(
+            name=str(generate_nanoid()), workspace_name=workspace.name
+        )
+        session = models.Session(name=str(generate_nanoid()), workspace_name=workspace.name)
+        db_session.add_all([new_observer, session])
+        await db_session.flush()
+        monkeypatch.setattr(settings, "SESSION_OBSERVERS_LIMIT", 1)
+
+        await db_session.execute(
+            models.session_peers_table.insert().values(
+                workspace_name=workspace.name,
+                session_name=session.name,
+                peer_name=active_observer.name,
+                joined_at=datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC),
+                configuration={"observe_others": True},
+            )
+        )
+        await db_session.flush()
+
+        with pytest.raises(ObserverException):
+            await _get_or_add_peers_to_session(
+                db_session,
+                workspace.name,
+                session.name,
+                {
+                    active_observer.name: schemas.SessionPeerConfig(
+                        observe_others=False
+                    ),
+                    new_observer.name: schemas.SessionPeerConfig(observe_others=True),
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_add_peers_ignores_active_non_observer_submitted_configuration(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """An active non-observer does not consume capacity from a submitted config."""
+        workspace, active_non_observer = sample_data
+        existing_observer = models.Peer(
+            name=str(generate_nanoid()), workspace_name=workspace.name
+        )
+        session = models.Session(name=str(generate_nanoid()), workspace_name=workspace.name)
+        db_session.add_all([existing_observer, session])
+        await db_session.flush()
+        monkeypatch.setattr(settings, "SESSION_OBSERVERS_LIMIT", 1)
+
+        await db_session.execute(
+            models.session_peers_table.insert(),
+            [
+                {
+                    "workspace_name": workspace.name,
+                    "session_name": session.name,
+                    "peer_name": active_non_observer.name,
+                    "joined_at": datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC),
+                    "configuration": {"observe_others": False},
+                },
+                {
+                    "workspace_name": workspace.name,
+                    "session_name": session.name,
+                    "peer_name": existing_observer.name,
+                    "joined_at": datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC),
+                    "configuration": {"observe_others": True},
+                },
+            ],
+        )
+        await db_session.flush()
+
+        await _get_or_add_peers_to_session(
+            db_session,
+            workspace.name,
+            session.name,
+            {
+                active_non_observer.name: schemas.SessionPeerConfig(observe_others=True),
+            },
+        )
+        active_configuration = await db_session.scalar(
+            select(models.SessionPeer.configuration).where(
+                models.SessionPeer.workspace_name == workspace.name,
+                models.SessionPeer.session_name == session.name,
+                models.SessionPeer.peer_name == active_non_observer.name,
+            )
+        )
+        assert active_configuration == {"observe_others": False}
 
     @pytest.mark.asyncio
     async def test_add_peers_preserves_active_members_and_rejoins_departed_members(

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -1,13 +1,89 @@
+import datetime
+
 import pytest
 from nanoid import generate as generate_nanoid
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, models, schemas
+from src.crud.session import (
+    _get_or_add_peers_to_session,  # pyright: ignore[reportPrivateUsage]
+)
 from src.exceptions import ResourceNotFoundException
 
 
 class TestSessionCRUD:
     """Test suite for session CRUD operations"""
+
+    @pytest.mark.asyncio
+    async def test_add_peers_preserves_active_members_and_rejoins_departed_members(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Active memberships are idempotent while departed memberships are rejoined."""
+        workspace, active_peer = sample_data
+        departed_peer = models.Peer(
+            name=str(generate_nanoid()), workspace_name=workspace.name
+        )
+        session = models.Session(name=str(generate_nanoid()), workspace_name=workspace.name)
+        db_session.add_all([departed_peer, session])
+        await db_session.flush()
+
+        joined_at = datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC)
+        left_at = joined_at + datetime.timedelta(days=1)
+        active_config = schemas.SessionPeerConfig(observe_others=False, observe_me=True)
+        departed_config = schemas.SessionPeerConfig(observe_others=True, observe_me=False)
+        await db_session.execute(
+            models.session_peers_table.insert(),
+            [
+                {
+                    "workspace_name": workspace.name,
+                    "session_name": session.name,
+                    "peer_name": active_peer.name,
+                    "joined_at": joined_at,
+                    "left_at": None,
+                    "configuration": active_config.model_dump(),
+                },
+                {
+                    "workspace_name": workspace.name,
+                    "session_name": session.name,
+                    "peer_name": departed_peer.name,
+                    "joined_at": joined_at,
+                    "left_at": left_at,
+                    "configuration": active_config.model_dump(),
+                },
+            ],
+        )
+        await db_session.flush()
+
+        await _get_or_add_peers_to_session(
+            db_session,
+            workspace.name,
+            session.name,
+            {active_peer.name: departed_config, departed_peer.name: departed_config},
+        )
+        await db_session.flush()
+
+        memberships = (
+            await db_session.execute(
+                select(models.SessionPeer).where(
+                    models.SessionPeer.workspace_name == workspace.name,
+                    models.SessionPeer.session_name == session.name,
+                )
+            )
+        ).scalars()
+        memberships_by_peer = {membership.peer_name: membership for membership in memberships}
+
+        active_membership = memberships_by_peer[active_peer.name]
+        assert active_membership.joined_at == joined_at
+        assert active_membership.left_at is None
+        assert active_membership.configuration == active_config.model_dump()
+
+        departed_membership = memberships_by_peer[departed_peer.name]
+        assert departed_membership.joined_at > left_at
+        assert departed_membership.left_at is None
+        assert departed_membership.configuration == departed_config.model_dump()
 
     @pytest.mark.asyncio
     async def test_get_session_peer_configuration(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -7,6 +7,10 @@ from nanoid import generate as generate_nanoid
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, models
+from src.crud.session import (
+    _get_or_add_peers_to_session,  # pyright: ignore[reportPrivateUsage]
+)
+from src.schemas import SessionPeerConfig
 from src.utils.search import search
 
 
@@ -75,6 +79,58 @@ async def test_peer_perspective_search_single_session(
     assert len(results) == 2
     assert msg1.public_id in [m.public_id for m in results]
     assert msg2.public_id in [m.public_id for m in results]
+
+
+@pytest.mark.asyncio
+async def test_peer_perspective_search_preserves_active_membership_window_on_readd(
+    db_session: AsyncSession,
+):
+    """Re-adding an active peer does not hide messages from its original window."""
+    workspace = models.Workspace(name=generate_nanoid())
+    peer = models.Peer(name="perspective-peer", workspace_name=workspace.name)
+    sender = models.Peer(name="sender-peer", workspace_name=workspace.name)
+    session = models.Session(name="session", workspace_name=workspace.name)
+    db_session.add_all([workspace, peer, sender, session])
+    await db_session.flush()
+
+    joined_at = datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC)
+    original_config = SessionPeerConfig(observe_others=False, observe_me=True)
+    await db_session.execute(
+        models.session_peers_table.insert().values(
+            workspace_name=workspace.name,
+            session_name=session.name,
+            peer_name=peer.name,
+            joined_at=joined_at,
+            left_at=None,
+            configuration=original_config.model_dump(),
+        )
+    )
+    message = models.Message(
+        content="Message from the original membership window",
+        session_name=session.name,
+        peer_name=sender.name,
+        workspace_name=workspace.name,
+        seq_in_session=1,
+        created_at=joined_at + datetime.timedelta(minutes=1),
+    )
+    db_session.add(message)
+    await db_session.commit()
+
+    await _get_or_add_peers_to_session(
+        db_session,
+        workspace.name,
+        session.name,
+        {peer.name: SessionPeerConfig(observe_others=True, observe_me=False)},
+    )
+    await db_session.commit()
+
+    results = await search(
+        "original membership window",
+        filters={"peer_perspective": peer.name, "workspace_id": workspace.name},
+        limit=10,
+    )
+
+    assert [result.public_id for result in results] == [message.public_id]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve `SessionPeer.joined_at` when an already-active peer is added to the same session again
- continue assigning a fresh database timestamp, clearing `left_at`, and applying supplied configuration for genuine rejoins
- validate observer limits against the effective stored configuration: active peers retain their stored configuration, while new and departed peers use the submitted configuration
- add database-backed regression coverage for membership state and `peer_perspective` search visibility

Fixes #940.

## Problem

Workspace message searches using `peer_perspective` constrain messages to the selected peer's temporal session-membership window. The session-peer conflict update previously set `joined_at = now()` on every re-add, including when the peer was already active. That moved the start of an uninterrupted membership past existing messages and could make valid perspective searches empty or incomplete.

## Behavior after this change

- already-active membership (`left_at IS NULL`): preserve the stored `joined_at` and configuration
- genuine rejoin (`left_at IS NOT NULL`): assign a new database timestamp, clear `left_at`, and apply the supplied configuration
- observer-limit checks count all active stored observers and add submitted observers only for new or departed peers
- existing temporal search predicates and boundary behavior remain unchanged

## Verification

At commit `034080d3581115383159c85c027cd1ca787fb7f9`:

- `uv run pytest -q -n 0 tests/crud/test_session.py tests/test_search.py` — 20 passed using an isolated temporary pgvector PostgreSQL container
- `uv run ruff check src/crud/session.py tests/crud/test_session.py tests/test_search.py` — passed
- `uv run basedpyright src/crud/session.py tests/crud/test_session.py tests/test_search.py` — 0 errors, 0 warnings, 0 notes
- independent review — approved the same commit with no findings

No schema, migration, API contract, temporal-search filter, queue/deriver behavior, or unrelated code is changed.