### PR TITLE
fix(deriver): prevent cross-subject self-observations

### DIFF
--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -184,7 +184,10 @@ async def process_representation_tasks_batch(
             component=DeriverComponents.OUTPUT_TOTAL.value,
         )
 
-    message_ids = [m.id for m in messages if m.peer_name == observed]
+    # Facts can be supported by any speaker in the prompt. Preserve the ordered,
+    # de-duplicated provenance for every message supplied as evidence instead of
+    # discarding cross-speaker sources.
+    message_ids = list(dict.fromkeys(message.id for message in messages))
 
     # Convert to Representation and save
     observations = Representation.from_prompt_representation(

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -57,7 +57,7 @@ def minimal_deriver_prompt(
         f"""
 Analyze messages to extract **explicit atomic facts** about the target peer.
 
-[EXPLICIT] DEFINITION: Facts about the target peer that can be derived directly from their messages.
+[EXPLICIT] DEFINITION: Facts about the target peer that are directly supported by any speaker's message.
    - Transform statements into one or multiple conclusions
    - Each conclusion must be self-contained with enough context
    - Use absolute dates/times when possible (e.g. "June 26, 2025" not "yesterday")
@@ -66,15 +66,25 @@ RULES:
 - The target peer is the peer identified below under `Target peer:`.
 - A peer can be a human user, AI agent, bot, service, or other actor.
 - Use the exact peer id from `Target peer:` in final observations, not the phrase "the target peer".
-- Properly attribute observations to the correct subject: if it is about the target peer, use the exact peer id as the subject. If the target peer is referencing someone or something else, make that clear.
+- Extract only facts whose subject is the target peer, regardless of which speaker provides the evidence.
+- The label before `:` identifies the speaker, not necessarily the subject. Resolve pronouns from that speaker's perspective: `I`/`me`/`my` refer to the speaker; `you`/`your` refer to the addressee.
+- A target peer's statement about someone else is not a fact about the target peer. Another speaker's statement about the target peer is valid evidence.
+- Speaking, hearing, receiving, acknowledging, repeating, or knowing another subject's fact is transient conversation state, not a durable fact about the target peer. Never create an observation merely to record that state.
+- If the messages contain no durable identity, capability, preference, relationship, or action attributable to the target peer, return no observations.
+- Omit any observation whose subject is ambiguous.
 - Observations should make sense on their own. Each observation will be used in the future to better understand the target peer.
-- Extract ALL observations from the target peer's messages, using others as context.
+- Extract all supported observations about the target peer, regardless of speaker. Use statements about other subjects only as context.
 - Contextualize each observation sufficiently (e.g. "Ann is nervous about the job interview at the pharmacy" not just "Ann is nervous")
 
 EXAMPLES (using `alice` as the target peer id):
-- EXPLICIT: "I just had my 25th birthday last Saturday" → "alice is 25 years old", "alice's birthday is June 21st"
-- EXPLICIT: "I took my dog for a walk in NYC" → "alice has a dog", "alice lives in NYC"
-- EXPLICIT: "alice attended college" + general knowledge → "alice completed high school or equivalent"
+- TARGET `alice`, MESSAGE `alice: I am 25 years old` → "alice is 25 years old"
+- TARGET `alice`, MESSAGE `alice: I have a dog named Rover` → "alice has a dog named Rover"
+- TARGET `alice`, MESSAGE `bob: alice works remotely on Fridays` → "alice works remotely on Fridays"
+- TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` → no observation about `assistant`
+- TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` → "assistant prefers concise responses"
+- TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` → "user plays tennis on Tuesdays"
+- TARGET `assistant`, MESSAGE `user: assistant is careful about attribution` → "assistant is careful about attribution"
+- Set `is_durable_target_fact=true` only for durable facts about the target peer itself. Set it to `false` for transient conversation state or facts about another subject.
 
 {custom_instructions_section}
 

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -57,7 +57,7 @@ def minimal_deriver_prompt(
         f"""
 Analyze messages to extract **explicit atomic facts** about the target peer.
 
-[EXPLICIT] DEFINITION: Facts about the target peer that can be derived directly from their messages.
+[EXPLICIT] DEFINITION: Facts about the target peer that are directly supported by any speaker's message.
    - Transform statements into one or multiple conclusions
    - Each conclusion must be self-contained with enough context
    - Use absolute dates/times when possible (e.g. "June 26, 2025" not "yesterday")
@@ -66,18 +66,28 @@ RULES:
 - The target peer is the peer identified below under `Target peer:`.
 - A peer can be a human user, AI agent, bot, service, or other actor.
 - Use the exact peer id from `Target peer:` in final observations, not the phrase "the target peer".
-- Properly attribute observations to the correct subject: if it is about the target peer, use the exact peer id as the subject. If the target peer is referencing someone or something else, make that clear.
+- Extract only facts whose subject is the target peer, regardless of which speaker provides the evidence.
+- Each message is formatted as `<timestamp> <speaker>: <content>`. The speaker label is the text after the timestamp and before the final `:` that introduces the content; it identifies the speaker, not necessarily the subject. Resolve pronouns from that speaker's perspective: `I`/`me`/`my` refer to the speaker; `you`/`your` refer to the addressee.
+- A target peer's statement about someone else is not a fact about the target peer. Another speaker's statement about the target peer is valid evidence.
+- Speaking, hearing, receiving, acknowledging, repeating, or knowing another subject's fact is transient conversation state, not a durable fact about the target peer. Never create an observation merely to record that state.
+- If the messages contain no durable identity, capability, preference, relationship, or action attributable to the target peer, return no observations.
+- Omit any observation whose subject is ambiguous.
 - Observations should make sense on their own. Each observation will be used in the future to better understand the target peer.
-- Extract ALL observations from the target peer's messages, using others as context.
+- Extract all supported observations about the target peer, regardless of speaker. Use statements about other subjects only as context.
 - Contextualize each observation sufficiently (e.g. "Ann is nervous about the job interview at the pharmacy" not just "Ann is nervous")
 
 <examples>
 These examples are fabricated illustrations of the output format. Never emit a conclusion for which content comes from these examples. Every conclusion must be supported by the <messages> block only.
 
 EXAMPLES (using `alice` as the target peer id):
-- EXPLICIT: "I just turned 25" → "alice is 25 years old"
-- EXPLICIT: "I took my dog for a walk in NYC" → "alice has a dog", "alice walked her dog in NYC"
-- EXPLICIT: "I've lived in NYC for six years" → "alice lives in NYC", "alice has lived in NYC for six years"
+- TARGET `alice`, MESSAGE `alice: I am 25 years old` → "alice is 25 years old"
+- TARGET `alice`, MESSAGE `alice: I have a dog named Rover` → "alice has a dog named Rover"
+- TARGET `alice`, MESSAGE `bob: alice works remotely on Fridays` → "alice works remotely on Fridays"
+- TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` → no observation about `assistant`
+- TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` → "assistant prefers concise responses"
+- TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` → "user plays tennis on Tuesdays"
+- TARGET `assistant`, MESSAGE `user: assistant is careful about attribution` → "assistant is careful about attribution"
+- Set `is_durable_target_fact=true` only for durable facts about the target peer itself. Set it to `false` for transient conversation state or facts about another subject.
 </examples>
 
 {custom_instructions_section}

--- a/src/utils/representation.py
+++ b/src/utils/representation.py
@@ -27,10 +27,13 @@ ALLOWLIST_SAFE_LEVELS = ("explicit",)
 def allowlist_safe_levels(levels: list[str] | None) -> list[str]:
     """Narrow a level filter to those safe to serve under a session allowlist.
 
-    Returns the intersection with :data:`ALLOWLIST_SAFE_LEVELS`; ``None`` means
-    "no level filter requested" and yields the full safe set. An empty result
-    means the caller asked only for levels we can't scope, and should receive
-    nothing rather than unscoped conclusions.
+    Args:
+        levels: Requested conclusion levels, or ``None`` for no requested filter.
+
+    Returns:
+        The requested safe levels, or all safe levels when ``levels`` is ``None``.
+        An empty result means the request contained only levels that cannot be
+        scoped safely and should receive no conclusions.
     """
     if levels is None:
         return list(ALLOWLIST_SAFE_LEVELS)
@@ -89,6 +92,20 @@ class ExplicitObservationBase(BaseModel):
     content: str = Field(description="The explicit observation")
 
 
+class PromptExplicitObservation(ExplicitObservationBase):
+    """Deriver output with an explicit target-attribution decision."""
+
+    is_durable_target_fact: bool = Field(
+        description=(
+            "True only for a durable identity, capability, preference, relationship, "
+            "or action of the target peer itself. False when the observation merely "
+            "records that the target heard, knew, acknowledged, repeated, reported, "
+            "or stated a fact about another peer. For example, 'assistant prefers "
+            "concise plans' is true; 'assistant knows the user plays tennis' is false."
+        )
+    )
+
+
 class DeductiveObservationBase(BaseModel):
     source_ids: list[str] = Field(
         description="Document IDs of premise observations for tree traversal",
@@ -142,8 +159,12 @@ class PromptRepresentation(BaseModel):
     The representation format that is used when getting structured output from an LLM.
     """
 
-    explicit: list[ExplicitObservationBase] = Field(
-        description="Facts LITERALLY stated by the user - direct quotes or clear paraphrases only, no interpretation or inference. Example: ['The user is 25 years old', 'The user has a dog named Rover']",
+    explicit: list[PromptExplicitObservation] = Field(
+        description=(
+            "Durable facts about the target peer directly supported by any speaker's "
+            "message. Use direct quotes or clear paraphrases only, without unsupported "
+            "interpretation or inference."
+        ),
         default_factory=list,
     )
 
@@ -701,6 +722,7 @@ class Representation(BaseModel):
                     session_name=session_name,
                 )
                 for e in prompt_representation.explicit
+                if e.is_durable_target_fact
             ],
             deductive=[],
             inductive=[],

--- a/src/utils/representation.py
+++ b/src/utils/representation.py
@@ -60,6 +60,20 @@ class ExplicitObservationBase(BaseModel):
     content: str = Field(description="The explicit observation")
 
 
+class PromptExplicitObservation(ExplicitObservationBase):
+    """Deriver output with an explicit target-attribution decision."""
+
+    is_durable_target_fact: bool = Field(
+        description=(
+            "True only for a durable identity, capability, preference, relationship, "
+            "or action of the target peer itself. False when the observation merely "
+            "records that the target heard, knew, acknowledged, repeated, reported, "
+            "or stated a fact about another peer. For example, 'assistant prefers "
+            "concise plans' is true; 'assistant knows the user plays tennis' is false."
+        )
+    )
+
+
 class DeductiveObservationBase(BaseModel):
     source_ids: list[str] = Field(
         description="Document IDs of premise observations for tree traversal",
@@ -113,8 +127,12 @@ class PromptRepresentation(BaseModel):
     The representation format that is used when getting structured output from an LLM.
     """
 
-    explicit: list[ExplicitObservationBase] = Field(
-        description="Facts LITERALLY stated by the user - direct quotes or clear paraphrases only, no interpretation or inference. Example: ['The user is 25 years old', 'The user has a dog named Rover']",
+    explicit: list[PromptExplicitObservation] = Field(
+        description=(
+            "Durable facts about the target peer directly supported by any speaker's "
+            "message. Use direct quotes or clear paraphrases only, without unsupported "
+            "interpretation or inference."
+        ),
         default_factory=list,
     )
 
@@ -672,6 +690,7 @@ class Representation(BaseModel):
                     session_name=session_name,
                 )
                 for e in prompt_representation.explicit
+                if e.is_durable_target_fact
             ],
             deductive=[],
             inductive=[],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,7 @@ def _get_test_db_url(worker_id: str) -> URL:
     return CONNECTION_URI.set(database=f"test_db_{run_id}{suffix}")
 
 
-def _drop_database(db_url: URL) -> None:
+def _drop_database(db_url: URL, *, force: bool = True) -> None:
     """Drop a test database, evicting any connections still holding it open.
 
     WITH (FORCE) (pg13+) is what makes this reliable: a pooled connection that
@@ -194,7 +194,8 @@ def _drop_database(db_url: URL) -> None:
     )
     try:
         with engine.connect() as conn:
-            conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+            force_clause = " WITH (FORCE)" if force else ""
+            conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{name}"{force_clause}')
     finally:
         engine.dispose()
 
@@ -272,7 +273,7 @@ def _sweep_stale_test_databases() -> None:
             if not _is_test_database_idle(db_url):
                 continue
             logger.info(f"Dropping stale test database: {name}")
-            _drop_database(db_url)
+            _drop_database(db_url, force=False)
     except Exception as e:
         logger.warning(f"Could not sweep stale test databases: {e}")
 
@@ -387,14 +388,15 @@ async def db_engine(worker_id: str):
 
         yield engine
     finally:
-        if engine is not None:
-            await engine.dispose()
+        try:
+            if engine is not None:
+                await engine.dispose()
+        finally:
+            Base.metadata.schema = original_schema
+            for table in Base.metadata.tables.values():
+                table.schema = original_schema
 
-        Base.metadata.schema = original_schema
-        for table in Base.metadata.tables.values():
-            table.schema = original_schema
-
-        _drop_database(test_db_url)
+            _drop_database(test_db_url)
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,9 +137,12 @@ _RUN_ID_TIME_FORMAT = "%Y%m%d%H%M%S"
 # morning is gone by the afternoon.
 _STALE_DB_AGE_SECONDS = 2 * 60 * 60
 
-# test_db_<14-digit timestamp>_<4 hex>[_gwN] -- only names this function minted.
-# A pinned HONCHO_TEST_RUN_ID deliberately won't match, so it's never swept.
-_SWEEPABLE_DB_NAME = re.compile(r"^test_db_(\d{14})_[0-9a-f]{4}(?:_gw\d+)?$")
+# test_db_<14-digit timestamp>_<4-or-16 hex>[_gwN] -- only names this
+# function minted. The 4-hex form remains sweepable for leaked databases from
+# older test runs. A pinned HONCHO_TEST_RUN_ID deliberately won't match.
+_SWEEPABLE_DB_NAME = re.compile(
+    r"^test_db_(\d{14})_(?:[0-9a-f]{4}|[0-9a-f]{16})(?:_gw\d+)?$"
+)
 
 
 def pytest_configure(config: pytest.Config) -> None:  # pyright: ignore[reportUnusedParameter]
@@ -157,7 +160,7 @@ def pytest_configure(config: pytest.Config) -> None:  # pyright: ignore[reportUn
 
     os.environ.setdefault(
         _RUN_ID_ENV_VAR,
-        f"{time.strftime(_RUN_ID_TIME_FORMAT)}_{uuid.uuid4().hex[:4]}",
+        f"{time.strftime(_RUN_ID_TIME_FORMAT)}_{uuid.uuid4().hex[:16]}",
     )
 
     # Workers inherit the controller's env and would each redo this.
@@ -192,6 +195,30 @@ def _drop_database(db_url: URL) -> None:
     try:
         with engine.connect() as conn:
             conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+    finally:
+        engine.dispose()
+
+
+def _is_test_database_idle(db_url: URL) -> bool:
+    """Return whether a database currently has no active backends."""
+
+    name = db_url.database
+    if not name:
+        return False
+
+    engine = create_engine(
+        db_url.set(database="postgres"), isolation_level="AUTOCOMMIT"
+    )
+    try:
+        with engine.connect() as conn:
+            return not bool(
+                conn.exec_driver_sql(
+                    "SELECT EXISTS ("
+                    "SELECT 1 FROM pg_stat_activity WHERE datname = %s"
+                    ")",
+                    (name,),
+                ).scalar()
+            )
     finally:
         engine.dispose()
 
@@ -241,8 +268,11 @@ def _sweep_stale_test_databases() -> None:
             match = _SWEEPABLE_DB_NAME.match(name)
             if match is None or match.group(1) >= cutoff:
                 continue
+            db_url = CONNECTION_URI.set(database=name)
+            if not _is_test_database_idle(db_url):
+                continue
             logger.info(f"Dropping stale test database: {name}")
-            _drop_database(CONNECTION_URI.set(database=name))
+            _drop_database(db_url)
     except Exception as e:
         logger.warning(f"Could not sweep stale test databases: {e}")
 
@@ -336,30 +366,30 @@ async def _clear_all_tables(engine: AsyncEngine) -> None:
 @pytest_asyncio.fixture(scope="session")
 async def db_engine(worker_id: str):
     test_db_url = _get_test_db_url(worker_id)
-    create_test_database(test_db_url)
-    engine = await setup_test_database(test_db_url)
-
-    # Force the schema to 'public' for tests
-    # Save the original schema to restore later
+    engine: AsyncEngine | None = None
     original_schema = Base.metadata.schema
-    Base.metadata.schema = "public"
-
-    # Update all table schemas to public
-    for table in Base.metadata.tables.values():
-        table.schema = "public"
-
-    # Drop all tables first to ensure clean state
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
-        # Then create all tables with current models
-        await conn.run_sync(Base.metadata.create_all)
-
     try:
+        create_test_database(test_db_url)
+        engine = await setup_test_database(test_db_url)
+
+        # Force the schema to 'public' for tests
+        Base.metadata.schema = "public"
+
+        # Update all table schemas to public
+        for table in Base.metadata.tables.values():
+            table.schema = "public"
+
+        # Recreate all tables from the current models.
+        assert engine is not None
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+
         yield engine
     finally:
-        await engine.dispose()
+        if engine is not None:
+            await engine.dispose()
 
-        # Restore original schema
         Base.metadata.schema = original_schema
         for table in Base.metadata.tables.values():
             table.schema = original_schema
@@ -801,7 +831,7 @@ def mock_honcho_llm_call(request: pytest.FixtureRequest):
 
     from src.utils.representation import (
         # DeductiveObservationBase,
-        ExplicitObservationBase,
+        PromptExplicitObservation,
         PromptRepresentation,
     )
 
@@ -821,7 +851,10 @@ def mock_honcho_llm_call(request: pytest.FixtureRequest):
             if getattr(response_model, "__name__", "") == "ReasoningResponse":
                 _rep = PromptRepresentation(
                     explicit=[
-                        ExplicitObservationBase(content="Test explicit observation")
+                        PromptExplicitObservation(
+                            content="Test explicit observation",
+                            is_durable_target_fact=True,
+                        )
                     ],
                     # deductive=[
                     #     DeductiveObservationBase(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -701,7 +701,7 @@ def mock_honcho_llm_call(request: pytest.FixtureRequest):
 
     from src.utils.representation import (
         # DeductiveObservationBase,
-        ExplicitObservationBase,
+        PromptExplicitObservation,
         PromptRepresentation,
     )
 
@@ -721,7 +721,10 @@ def mock_honcho_llm_call(request: pytest.FixtureRequest):
             if getattr(response_model, "__name__", "") == "ReasoningResponse":
                 _rep = PromptRepresentation(
                     explicit=[
-                        ExplicitObservationBase(content="Test explicit observation")
+                        PromptExplicitObservation(
+                            content="Test explicit observation",
+                            is_durable_target_fact=True,
+                        )
                     ],
                     # deductive=[
                     #     DeductiveObservationBase(

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -10,7 +10,7 @@ from src.config import settings
 from src.deriver.deriver import process_representation_tasks_batch
 from src.llm import HonchoLLMCallResponse
 from src.utils.representation import (
-    ExplicitObservationBase,
+    PromptExplicitObservation,
     PromptRepresentation,
     Representation,
 )
@@ -338,7 +338,12 @@ class TestDeriverProcessing:
 
         mock_response = HonchoLLMCallResponse(
             content=PromptRepresentation(
-                explicit=[ExplicitObservationBase(content="alice says hello")]
+                explicit=[
+                    PromptExplicitObservation(
+                        content="alice says hello",
+                        is_durable_target_fact=True,
+                    )
+                ]
             ),
             input_tokens=10,
             output_tokens=5,
@@ -391,6 +396,77 @@ class TestDeriverProcessing:
         assert event.exact_dup_existing_count == 22
         assert event.semantic_dup_rejected_count == 33
         assert event.semantic_dup_replaced_count == 44
+
+    async def test_cross_speaker_evidence_preserves_all_message_provenance(
+        self,
+    ) -> None:
+        user_context = Mock(
+            id=6,
+            public_id="msg_user_context",
+            session_name="session-1",
+            workspace_name="workspace-1",
+            peer_name="user",
+            content="We were discussing weekly activities",
+            token_count=6,
+            created_at=datetime.now(timezone.utc),
+        )
+        assistant_evidence = Mock(
+            id=7,
+            public_id="msg_assistant_user_fact",
+            session_name="session-1",
+            workspace_name="workspace-1",
+            peer_name="assistant",
+            content="The user plays tennis on Tuesdays",
+            token_count=7,
+            created_at=datetime.now(timezone.utc),
+        )
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+        configuration.reasoning.custom_instructions = None
+        response = HonchoLLMCallResponse(
+            content=PromptRepresentation(
+                explicit=[
+                    PromptExplicitObservation(
+                        content="user plays tennis on Tuesdays",
+                        is_durable_target_fact=True,
+                    )
+                ]
+            ),
+            input_tokens=20,
+            output_tokens=8,
+            finish_reasons=["STOP"],
+        )
+        manager = Mock()
+        manager.save_representation = AsyncMock(
+            return_value=crud.CreateDocumentsResult()
+        )
+
+        with (
+            patch(
+                "src.deriver.deriver.honcho_llm_call",
+                new_callable=AsyncMock,
+                return_value=response,
+            ),
+            patch(
+                "src.deriver.deriver.RepresentationManager",
+                return_value=manager,
+            ),
+        ):
+            await process_representation_tasks_batch(
+                messages=[user_context, assistant_evidence],
+                message_level_configuration=configuration,
+                observers=["user"],
+                observed="user",
+                queue_item_message_ids=[7],
+            )
+
+        saved_representation, saved_message_ids, *_ = (
+            manager.save_representation.await_args.args
+        )
+        assert saved_message_ids == [6, 7]
+        assert saved_representation.explicit[0].content == (
+            "user plays tennis on Tuesdays"
+        )
 
 
 class TestBackwardsCompatibility:

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -10,7 +10,7 @@ from src.config import settings
 from src.deriver.deriver import process_representation_tasks_batch
 from src.llm import HonchoLLMCallResponse
 from src.utils.representation import (
-    ExplicitObservationBase,
+    PromptExplicitObservation,
     PromptRepresentation,
     Representation,
 )
@@ -338,7 +338,12 @@ class TestDeriverProcessing:
 
         mock_response = HonchoLLMCallResponse(
             content=PromptRepresentation(
-                explicit=[ExplicitObservationBase(content="alice says hello")]
+                explicit=[
+                    PromptExplicitObservation(
+                        content="alice says hello",
+                        is_durable_target_fact=True,
+                    )
+                ]
             ),
             input_tokens=10,
             output_tokens=5,

--- a/tests/deriver/test_prompts.py
+++ b/tests/deriver/test_prompts.py
@@ -30,6 +30,71 @@ def test_minimal_deriver_prompt_omits_custom_instructions_when_absent() -> None:
     assert "CUSTOM INSTRUCTIONS:" not in prompt
 
 
+def test_minimal_deriver_prompt_separates_speaker_from_subject() -> None:
+    prompt = minimal_deriver_prompt(
+        peer_id="assistant",
+        messages="assistant: You play tennis on Tuesdays",
+    )
+
+    assert (
+        "it identifies the speaker, not necessarily the subject" in prompt
+    )
+    assert "`I`/`me`/`my` refer to the speaker" in prompt
+    assert "`you`/`your` refer to the addressee" in prompt
+    assert (
+        "Another speaker's statement about the target peer is valid evidence" in prompt
+    )
+    assert (
+        "Facts about the target peer that are directly supported by any speaker's "
+        "message"
+    ) in prompt
+    assert (
+        "Speaking, hearing, receiving, acknowledging, repeating, or knowing another "
+        "subject's fact is transient conversation state"
+    ) in prompt
+    assert "return no observations" in prompt
+    assert "Omit any observation whose subject is ambiguous" in prompt
+    assert (
+        "TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        "→ no observation about `assistant`"
+    ) in prompt
+    assert (
+        "TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` "
+        '→ "assistant prefers concise responses"'
+    ) in prompt
+    assert (
+        "TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        '→ "user plays tennis on Tuesdays"'
+    ) in prompt
+    assert "alice works remotely on Fridays" in prompt
+    assert "general knowledge" not in prompt
+
+
+def test_subject_attribution_rule_matches_timestamped_message_format() -> None:
+    prompt = minimal_deriver_prompt(
+        peer_id="user",
+        messages="2026-08-13 03:20:00 assistant: The user likes tennis",
+    )
+
+    assert "<timestamp> <speaker>: <content>" in prompt
+    assert "text after the timestamp" in prompt
+
+
+def test_subject_attribution_rules_preserve_static_cache_prefix() -> None:
+    alice_prompt = minimal_deriver_prompt(
+        peer_id="alice",
+        messages="alice: I like tea",
+    )
+    bob_prompt = minimal_deriver_prompt(
+        peer_id="bob",
+        messages="bob: I like coffee",
+    )
+
+    alice_prefix = alice_prompt.split("Target peer:", maxsplit=1)[0]
+    bob_prefix = bob_prompt.split("Target peer:", maxsplit=1)[0]
+    assert alice_prefix == bob_prefix
+
+
 def test_estimate_deriver_prompt_tokens_increases_with_custom_instructions() -> None:
     base_tokens = estimate_minimal_deriver_prompt_tokens()
     custom_tokens = estimate_deriver_prompt_tokens(

--- a/tests/deriver/test_prompts.py
+++ b/tests/deriver/test_prompts.py
@@ -30,6 +30,62 @@ def test_minimal_deriver_prompt_omits_custom_instructions_when_absent() -> None:
     assert "CUSTOM INSTRUCTIONS:" not in prompt
 
 
+def test_minimal_deriver_prompt_separates_speaker_from_subject() -> None:
+    prompt = minimal_deriver_prompt(
+        peer_id="assistant",
+        messages="assistant: You play tennis on Tuesdays",
+    )
+
+    assert (
+        "The label before `:` identifies the speaker, not necessarily the subject"
+        in prompt
+    )
+    assert "`I`/`me`/`my` refer to the speaker" in prompt
+    assert "`you`/`your` refer to the addressee" in prompt
+    assert (
+        "Another speaker's statement about the target peer is valid evidence" in prompt
+    )
+    assert (
+        "Facts about the target peer that are directly supported by any speaker's "
+        "message"
+    ) in prompt
+    assert (
+        "Speaking, hearing, receiving, acknowledging, repeating, or knowing another "
+        "subject's fact is transient conversation state"
+    ) in prompt
+    assert "return no observations" in prompt
+    assert "Omit any observation whose subject is ambiguous" in prompt
+    assert (
+        "TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        "→ no observation about `assistant`"
+    ) in prompt
+    assert (
+        "TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` "
+        '→ "assistant prefers concise responses"'
+    ) in prompt
+    assert (
+        "TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        '→ "user plays tennis on Tuesdays"'
+    ) in prompt
+    assert "alice works remotely on Fridays" in prompt
+    assert "general knowledge" not in prompt
+
+
+def test_subject_attribution_rules_preserve_static_cache_prefix() -> None:
+    alice_prompt = minimal_deriver_prompt(
+        peer_id="alice",
+        messages="alice: I like tea",
+    )
+    bob_prompt = minimal_deriver_prompt(
+        peer_id="bob",
+        messages="bob: I like coffee",
+    )
+
+    alice_prefix = alice_prompt.split("Target peer:", maxsplit=1)[0]
+    bob_prefix = bob_prompt.split("Target peer:", maxsplit=1)[0]
+    assert alice_prefix == bob_prefix
+
+
 def test_estimate_deriver_prompt_tokens_increases_with_custom_instructions() -> None:
     base_tokens = estimate_minimal_deriver_prompt_tokens()
     custom_tokens = estimate_deriver_prompt_tokens(

--- a/tests/deriver/test_representation_crud.py
+++ b/tests/deriver/test_representation_crud.py
@@ -3,7 +3,7 @@ import datetime
 from src.utils.representation import (
     DeductiveObservation,
     ExplicitObservation,
-    ExplicitObservationBase,
+    PromptExplicitObservation,
     PromptRepresentation,
     Representation,
 )
@@ -84,7 +84,7 @@ def test_prompt_representation_conversion():
     Therefore, from_prompt_representation only converts explicit observations.
     """
     pr = PromptRepresentation(
-        explicit=[ExplicitObservationBase(content="A")],
+        explicit=[PromptExplicitObservation(content="A", is_durable_target_fact=True)],
         # Deductive observations in PromptRepresentation are ignored by from_prompt_representation
         # because the Deriver only produces explicit observations
         # deductive=[
@@ -106,3 +106,29 @@ def test_prompt_representation_conversion():
     # (they would be created directly by the Dreamer via the create_observations tool)
     assert len(rep.deductive) == 0
     assert rep.explicit[0].created_at == timestamp
+
+
+def test_prompt_representation_drops_non_durable_target_facts():
+    pr = PromptRepresentation(
+        explicit=[
+            PromptExplicitObservation(
+                content="assistant knows the user plays tennis",
+                is_durable_target_fact=False,
+            ),
+            PromptExplicitObservation(
+                content="assistant prefers concise plans",
+                is_durable_target_fact=True,
+            ),
+        ]
+    )
+
+    rep = Representation.from_prompt_representation(
+        pr,
+        message_ids=[1],
+        session_name="s",
+        created_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+
+    assert [observation.content for observation in rep.explicit] == [
+        "assistant prefers concise plans"
+    ]

--- a/tests/integration/test_representation.py
+++ b/tests/integration/test_representation.py
@@ -21,7 +21,7 @@ from src.utils.representation import (
     DeductiveObservation,
     # DeductiveObservationBase,
     ExplicitObservation,
-    ExplicitObservationBase,
+    PromptExplicitObservation,
     PromptRepresentation,
     Representation,
 )
@@ -412,8 +412,12 @@ class TestPromptRepresentationConversion:
         """
         prompt_rep = PromptRepresentation(
             explicit=[
-                ExplicitObservationBase(content="User likes coffee"),
-                ExplicitObservationBase(content="User works remotely"),
+                PromptExplicitObservation(
+                    content="User likes coffee", is_durable_target_fact=True
+                ),
+                PromptExplicitObservation(
+                    content="User works remotely", is_durable_target_fact=True
+                ),
             ],
         )
 

--- a/tests/integration/test_token_metrics.py
+++ b/tests/integration/test_token_metrics.py
@@ -32,7 +32,7 @@ from src.telemetry.prometheus.metrics import (
     deriver_tokens_processed_counter,
     dialectic_tokens_processed_counter,
 )
-from src.utils.representation import ExplicitObservationBase, PromptRepresentation
+from src.utils.representation import PromptExplicitObservation, PromptRepresentation
 from src.utils.summarizer import (
     SummaryType,
     _create_and_save_summary,
@@ -183,7 +183,12 @@ def create_mock_deriver_response(
     """Create a mock LLM response for the deriver."""
     return HonchoLLMCallResponse(
         content=PromptRepresentation(
-            explicit=[ExplicitObservationBase(content="Test observation from deriver")],
+            explicit=[
+                PromptExplicitObservation(
+                    content="Test observation from deriver",
+                    is_durable_target_fact=True,
+                )
+            ],
         ),
         input_tokens=100,
         output_tokens=output_tokens,

--- a/tests/utils/test_length_finish_reason.py
+++ b/tests/utils/test_length_finish_reason.py
@@ -36,8 +36,8 @@ class SimpleModel(BaseModel):
 
 VALID_REPR_JSON = {
     "explicit": [
-        {"content": "hermes is 25 years old"},
-        {"content": "hermes has a dog"},
+        {"content": "hermes is 25 years old", "is_durable_target_fact": True},
+        {"content": "hermes has a dog", "is_durable_target_fact": True},
     ]
 }
 
@@ -235,7 +235,9 @@ class TestOpenAILengthFinishReasonRepair:
 
     async def test_token_counts_preserved(self) -> None:
         """Token counts from the truncated completion should be preserved."""
-        truncated_json = '{"explicit": [{"content": "fact one"}'
+        truncated_json = (
+            '{"explicit": [{"content": "fact one", "is_durable_target_fact": true}'
+        )
 
         mock_client = AsyncMock(spec=AsyncOpenAI)
         mock_client.chat.completions.parse = _raise_length_error(truncated_json)


### PR DESCRIPTION
## Summary

Fix deriver subject attribution without disabling peer self-observation or filtering stored messages.

- distinguish the message speaker from the fact subject;
- retain target facts supplied by any speaker with ordered, deduplicated whole-batch message IDs;
- require structured output to classify whether each conclusion is a durable target fact;
- discard transient cross-subject speech or knowledge conclusions before persistence.

## Motivation

With self-observation enabled, an assistant reply such as `You play tennis on Tuesdays` can produce an AI self-conclusion such as `assistant knows the user plays tennis on Tuesdays`, or misattribute the tennis schedule directly to the assistant. Disabling self-observation prevents the corruption but also removes useful AI identity, capability, and preference learning.

This fixes the attribution boundary while preserving assistant messages, cross-peer observation, and genuine AI self-representation.

## Implementation

The existing single deriver call returns `is_durable_target_fact` for each explicit conclusion. Only conclusions classified as durable facts about the target peer are converted into persistent observations. Timestamped-message speaker rules and paired positive and negative examples disambiguate speaker from subject.

Each persisted conclusion currently receives the ordered, deduplicated IDs for every message in the deriver batch, including cross-speaker context. This is coarse whole-batch provenance, not exact per-conclusion evidence attribution.

This deliberately does not apply the SQL speaker filter proposed in #823. Interleaved messages remain available so another speaker can provide valid evidence about the target peer, matching the maintainer guidance on that PR.

End-to-end enqueue promotion for assistant-authored facts about the other participant is provided by the stacked follow-up #944.

## Relationship to adjacent work

- Supersedes closed #823's SQL-filter approach while preserving intentional interleaved cross-peer evidence.
- Builds on merged #985 and #1028; neither implements subject attribution.
- #961 is complementary agent self-narration/debug-status filtering, not a replacement for structured target-fact classification.
- Draft #935 is complementary exact per-conclusion citation work through source indices/message IDs. This PR retains ordered IDs for the whole deriver batch and does not claim exact evidence attribution; #935 should build on this attribution contract without requiring a target-authored source.
- The PostgreSQL fixture hardening corrects race and partial-cleanup gaps in merged #949 and supports this PR's regressions and stacked #944.

## Validation

- 59 focused tests pass.
- Focused Ruff and `git diff --check` pass.
- Independent review found no remaining correctness or security issues.

Fixes #817.
Supersedes the attribution approach in #823 while preserving its reported reproduction and maintainer feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved fact extraction to identify durable facts specifically about the target peer.
  * Added clearer handling for speaker attribution, pronouns, ambiguous subjects, and statements about others.
  * Excludes transient communication states and non-durable observations from results.
  * Returns no observations when no valid durable target-peer facts are found.

* **Bug Fixes**
  * Preserved ordered, deduplicated batch-level message references when facts are supported by multiple speakers.
  * Removed duplicate message references while maintaining their original order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->