### PR TITLE
fix(deriver): promote cross-speaker target facts

### DIFF
--- a/docs/v3/documentation/core-concepts/representation.mdx
+++ b/docs/v3/documentation/core-concepts/representation.mdx
@@ -27,9 +27,9 @@ Honcho can build different representations based on what each peer observes. Thi
 
 There are two observation modes controlled by [configuration](/v3/documentation/features/advanced/configuration):
 
-**Honcho observing peers** (`observe_me`): When enabled (default), Honcho forms a representation of the peer based on all messages they've sent across all sessions. This is Honcho's understanding of that peer, built from everything they've said and done in your system. Set `observe_me: false` if you don't want Honcho to reason about that peer at all.
+**Honcho observing peers** (`observe_me`): When enabled (default), Honcho forms a representation of the peer from facts about that peer across their sessions. Those facts can be stated by the peer or by the other participant in a two-peer session. Set `observe_me: false` if you don't want Honcho to reason about that peer at all.
 
-**Peers observing others** (`observe_others`): When enabled at the session level, a peer will form representations of other peers in that session based only on messages they've observed. If Alice and Bob are in a session together and Alice has `observe_others: true`, Alice will form a representation of Bob based solely on what Bob said in sessions Alice participated in. Alice's representation of Bob will be completely different from Charlie's representation of Bob if they've observed different interactions.
+**Peers observing others** (`observe_others`): When enabled at the session level, a peer will form representations of other peers in that session based only on messages they've observed. In a two-peer session, the peer's own statements about the other participant can also supply facts about that participant. Alice's representation of Bob may differ substantially from Charlie's representation of Bob if they've observed different interactions.
 
 In the diagram below, assume `observe_me` isn't turned off (again, default behavior) and `observe_others` is turned on for both peers in a session that contains the peers Alice and Bob.
 

--- a/docs/v3/documentation/features/advanced/queue-status.mdx
+++ b/docs/v3/documentation/features/advanced/queue-status.mdx
@@ -71,8 +71,9 @@ This has a few different implications.
 
 - tasks within the same work_unit are processed sequentially, but multiple
 work_units will be processed in parallel
-- If local representations are turned in a Session then a message will
-  generate an additional work unit for every peer that has `observe_others=True`
+- In a two-peer session, a message can generate a second representation work
+  unit when its author has `observe_others=True` and supplies facts about the
+  other participant
 
 ### Tracked task types
 
@@ -96,6 +97,9 @@ not the total number of items ever processed.
 
 The `queue_status` method can take additional
 parameters to scope the status to a specific work unit:
+
+`sender_id` matches the author of the source message, including work that targets
+the other participant's representation.
 
 <CodeGroup>
 ```python Python

--- a/docs/v3/documentation/features/advanced/representation-scopes.mdx
+++ b/docs/v3/documentation/features/advanced/representation-scopes.mdx
@@ -6,14 +6,14 @@ icon: 'circle'
 
 Assuming reasoning is enabled, you can control the perspectives representations are built from. This page covers:
 
-1. **Default Behavior** — Honcho reasons over every message written to a peer
+1. **Default Behavior** — Honcho reasons over facts about each peer
 2. **Observer-Observed Model** — How peers build representations of other peers
 3. **Querying with Target** — Accessing perspective-specific representations
 4. **Use Cases** — When to use directional representations
 
 ## Default: Reasoning On
 
-When `observe_me=true` (the default), Honcho forms one representation per peer, reasoning over every message written to that peer across all sessions.
+When `observe_me=true` (the default), Honcho forms one representation per peer, reasoning over facts about that peer across their sessions.
 
 You can retrieve a subset of conclusions from a peer's representation using `representation()`:
 
@@ -25,7 +25,7 @@ alice_rep = session.representation("alice")
 response = alice.chat("What are Alice's main interests?", session=session.id)
 ```
 
-This is sufficient for most applications—Honcho reasons over every message written to the peer, storing conclusions that any part of your system can retrieve.
+This is sufficient for most applications—Honcho stores conclusions about the peer that any part of your system can retrieve.
 
 ## Observer-Observed Representations
 
@@ -49,19 +49,19 @@ These are stored as separate (observer, observed) pairs in Honcho's internal col
 
 This enables sophisticated scenarios where different agents have different knowledge based on what they've actually witnessed.
 
-**Example**: Bob and Charlie tell different things to Alice in separate sessions.
+**Example**: Alice records different facts about Bob and Charlie in separate sessions.
 
 ```
 Session 1 (Alice + Bob):
-Bob → "I had pancakes for breakfast."
+Alice → "Bob prefers tea."
 
 Session 2 (Alice + Charlie):
-Charlie → "I had pancakes for breakfast. Bob is lying about his breakfast."
+Alice → "Charlie prefers coffee."
 ```
 
 With `observe_others=true` enabled on Alice:
-- **Alice's representation of Bob** only includes Session 1 (she heard Bob say he had pancakes)
-- **Alice's representation of Charlie** only includes Session 2 (she heard Charlie's claim about Bob lying)
+- **Alice's representation of Bob** only includes Session 1 (where Alice stated Bob's preference)
+- **Alice's representation of Charlie** only includes Session 2 (where Alice stated Charlie's preference)
 - **Honcho's representation of Alice** reasons over both sessions
 
 ![](/images/observe_config.png)
@@ -259,11 +259,17 @@ const aliceViewBilling = await session.representation("alice", {
 
 ## When Representations Update
 
-Directional representations update automatically through the reasoning pipeline when:
+Ordinary self-representations update when the message sender has
+`observe_me=true`. Cross-speaker promotion to the other participant additionally
+requires a two-peer session, `observe_others=true` on the sender, and
+`observe_me=true` on the other participant.
 
-1. A message is created in a session
-2. The message sender has `observe_me=true` (or session-level equivalent)
-3. Other peers in the session have `observe_others=true`
+In a two-peer session, a message can update both participants' representations:
+first-person facts apply to the sender, while statements about the other participant
+can apply to that participant. This can create two representation work units for one
+message. Sessions with more than two active peers do not schedule this additional
+target work unit because messages do not identify an addressee. Explicitly named
+facts can still be extracted as context when work for that target already exists.
 
 The pipeline respects scoping—Honcho's representations reason over messages across all sessions, while directional representations only reason over messages from sessions where the observer was an active participant.
 

--- a/docs/v3/documentation/features/advanced/representation-scopes.mdx
+++ b/docs/v3/documentation/features/advanced/representation-scopes.mdx
@@ -6,14 +6,14 @@ icon: 'circle'
 
 Assuming reasoning is enabled, you can control the perspectives representations are built from. This page covers:
 
-1. **Default Behavior** — Honcho reasons over every message written to a peer
+1. **Default Behavior** — Honcho reasons over facts about each peer
 2. **Observer-Observed Model** — How peers build representations of other peers
 3. **Querying with Target** — Accessing perspective-specific representations
 4. **Use Cases** — When to use directional representations
 
 ## Default: Reasoning On
 
-When `observe_me=true` (the default), Honcho forms one representation per peer, reasoning over every message written to that peer across all sessions.
+When `observe_me=true` (the default), Honcho forms one representation per peer, reasoning over facts about that peer across their sessions.
 
 You can retrieve a subset of conclusions from a peer's representation using `representation()`:
 
@@ -25,7 +25,7 @@ alice_rep = session.representation("alice")
 response = alice.chat("What are Alice's main interests?", session_id=session.id)
 ```
 
-This is sufficient for most applications—Honcho reasons over every message written to the peer, storing conclusions that any part of your system can retrieve.
+This is sufficient for most applications—Honcho stores conclusions about the peer that any part of your system can retrieve.
 
 ## Observer-Observed Representations
 
@@ -49,19 +49,19 @@ These are stored as separate (observer, observed) pairs in Honcho's internal col
 
 This enables sophisticated scenarios where different agents have different knowledge based on what they've actually witnessed.
 
-**Example**: Bob and Charlie tell different things to Alice in separate sessions.
+**Example**: Alice records different facts about Bob and Charlie in separate sessions.
 
 ```
 Session 1 (Alice + Bob):
-Bob → "I had pancakes for breakfast."
+Alice → "Bob prefers tea."
 
 Session 2 (Alice + Charlie):
-Charlie → "I had pancakes for breakfast. Bob is lying about his breakfast."
+Alice → "Charlie prefers coffee."
 ```
 
 With `observe_others=true` enabled on Alice:
-- **Alice's representation of Bob** only includes Session 1 (she heard Bob say he had pancakes)
-- **Alice's representation of Charlie** only includes Session 2 (she heard Charlie's claim about Bob lying)
+- **Alice's representation of Bob** only includes Session 1 (where Alice stated Bob's preference)
+- **Alice's representation of Charlie** only includes Session 2 (where Alice stated Charlie's preference)
 - **Honcho's representation of Alice** reasons over both sessions
 
 ![](/images/observe_config.png)
@@ -259,11 +259,17 @@ const aliceViewBilling = await session.representation("alice", {
 
 ## When Representations Update
 
-Directional representations update automatically through the reasoning pipeline when:
+Ordinary self-representations update when the message sender has
+`observe_me=true`. Cross-speaker promotion to the other participant additionally
+requires a two-peer session, `observe_others=true` on the sender, and
+`observe_me=true` on the other participant.
 
-1. A message is created in a session
-2. The message sender has `observe_me=true` (or session-level equivalent)
-3. Other peers in the session have `observe_others=true`
+In a two-peer session, a message can update both participants' representations:
+first-person facts apply to the sender, while statements about the other participant
+can apply to that participant. This can create two representation work units for one
+message. Sessions with more than two active peers do not schedule this additional
+target work unit because messages do not identify an addressee. Explicitly named
+facts can still be extracted as context when work for that target already exists.
 
 The pipeline respects scoping—Honcho's representations reason over messages across all sessions, while directional representations only reason over messages from sessions where the observer was an active participant.
 

--- a/src/crud/deriver.py
+++ b/src/crud/deriver.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from logging import getLogger
 from typing import Any
 
-from sqlalchemy import Select, case, func, or_, select
+from sqlalchemy import Select, and_, case, func, or_, select
 from sqlalchemy.engine import Row
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,7 +17,7 @@ async def get_queue_status(
     session_name: str | None = None,
     *,
     observer: str | None = None,
-    observed: str | None = None,
+    sender: str | None = None,
 ) -> schemas.QueueStatus:
     """
     Get the processing queue status, optionally filtered by observer, sender, and/or session.
@@ -33,18 +33,18 @@ async def get_queue_status(
         workspace_name: Name of the workspace
         session_name: Optional session name to filter by
         observer: Optional name of the observer to filter by
-        observed: Optional name of the observed (message sender) to filter by
+        sender: Optional name of the message sender to filter by
     """
     # Normalize empty strings to None for consistent handling
     normalized_observer = observer if observer else None
-    normalized_observed = observed if observed else None
+    normalized_sender = sender if sender else None
     normalized_session_name = session_name if session_name else None
 
     stmt = _build_queue_status_query(
         workspace_name,
         normalized_session_name,
         observer=normalized_observer,
-        observed=normalized_observed,
+        sender=normalized_sender,
     )
     result = await db.execute(stmt)
     rows = result.fetchall()
@@ -71,7 +71,7 @@ async def get_deriver_status(
         workspace_name=workspace_name,
         session_name=session_name,
         observer=observer,
-        observed=observed,
+        sender=observed,
     )
 
 
@@ -84,11 +84,10 @@ def _build_queue_status_query(
     session_name: str | None,
     *,
     observer: str | None = None,
-    observed: str | None = None,
+    sender: str | None = None,
 ) -> Select[Any]:
     """Build SQL query for queue status with validation and aggregation."""
     observer_name_expr = models.QueueItem.payload["observer"].astext
-    observed_name_expr = models.QueueItem.payload["observed"].astext
 
     # Define conditions for cleaner window functions
     is_completed = models.QueueItem.processed
@@ -138,13 +137,22 @@ def _build_queue_status_query(
         )
         stmt = stmt.where(models.Session.name == session_name)
 
-    peer_conditions = []
+    peer_conditions: list[Any] = []
     if observer is not None:
-        peer_conditions.append(observer_name_expr == observer)  # pyright: ignore
-    if observed is not None:
-        peer_conditions.append(observed_name_expr == observed)  # pyright: ignore
+        peer_conditions.append(
+            or_(
+                observer_name_expr == observer,
+                models.QueueItem.payload["observers"].contains([observer]),
+            )
+        )
+    if sender is not None:
+        stmt = stmt.outerjoin(
+            models.Message,
+            models.QueueItem.message_id == models.Message.id,
+        )
+        peer_conditions.append(models.Message.peer_name == sender)
     if peer_conditions:
-        stmt = stmt.where(or_(*peer_conditions))  # pyright: ignore
+        stmt = stmt.where(and_(*peer_conditions))
 
     return stmt
 

--- a/src/deriver/consumer.py
+++ b/src/deriver/consumer.py
@@ -196,6 +196,7 @@ async def process_representation_batch(
     *,
     observers: list[str] | None,
     observed: str | None,
+    participants: list[str] | None = None,
     queue_item_message_ids: list[int],
     hit_batch_token_cap: bool = False,
     was_flush_enabled: bool = False,
@@ -209,6 +210,7 @@ async def process_representation_batch(
         message_level_configuration: Resolved configuration for this batch
         observers: List of observers for the messages
         observed: The observed of the messages
+        participants: Active session peers captured when the messages were enqueued
         queue_item_message_ids: Message IDs from queue items
         hit_batch_token_cap: whether the queue batcher clamped this batch to fit
         was_flush_enabled: snapshot of DERIVER.FLUSH_ENABLED at fetch time
@@ -226,6 +228,7 @@ async def process_representation_batch(
         message_level_configuration,
         observers=observers,
         observed=observed,
+        participants=participants,
         queue_item_message_ids=queue_item_message_ids,
         hit_batch_token_cap=hit_batch_token_cap,
         was_flush_enabled=was_flush_enabled,

--- a/src/deriver/consumer.py
+++ b/src/deriver/consumer.py
@@ -160,6 +160,7 @@ async def process_representation_batch(
     *,
     observers: list[str] | None,
     observed: str | None,
+    participants: list[str] | None = None,
     queue_item_message_ids: list[int],
     hit_batch_token_cap: bool = False,
     was_flush_enabled: bool = False,
@@ -173,6 +174,7 @@ async def process_representation_batch(
         message_level_configuration: Resolved configuration for this batch
         observers: List of observers for the messages
         observed: The observed of the messages
+        participants: Active session peers captured when the messages were enqueued
         queue_item_message_ids: Message IDs from queue items
         hit_batch_token_cap: whether the queue batcher clamped this batch to fit
         was_flush_enabled: snapshot of DERIVER.FLUSH_ENABLED at fetch time
@@ -190,6 +192,7 @@ async def process_representation_batch(
         message_level_configuration,
         observers=observers,
         observed=observed,
+        participants=participants,
         queue_item_message_ids=queue_item_message_ids,
         hit_batch_token_cap=hit_batch_token_cap,
         was_flush_enabled=was_flush_enabled,

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 
@@ -35,6 +36,30 @@ def _get_deriver_model_config() -> ConfiguredModelSettings:
     return settings.DERIVER.MODEL_CONFIG
 
 
+def _format_deriver_message(message: Message, participants: list[str]) -> str:
+    """Format a message with explicit speaker/addressee roles when unambiguous."""
+    unique_participants = set(participants)
+    other_peers = unique_participants - {message.peer_name}
+    addressee = (
+        next(iter(other_peers))
+        if len(unique_participants) == 2 and message.peer_name in unique_participants
+        else None
+    )
+
+    if addressee is None:
+        return format_new_turn_with_timestamp(
+            message.content, message.created_at, message.peer_name
+        )
+
+    timestamp = message.created_at.strftime("%Y-%m-%d %H:%M:%S")
+    roles = json.dumps(
+        {"speaker": message.peer_name, "addressee": addressee},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return f"{timestamp} {roles}: {message.content}"
+
+
 @with_sentry_transaction("minimal_deriver_batch", op="deriver")
 async def process_representation_tasks_batch(
     messages: list[Message],
@@ -42,6 +67,7 @@ async def process_representation_tasks_batch(
     *,
     observers: list[str],
     observed: str,
+    participants: list[str] | None = None,
     queue_item_message_ids: list[int],
     hit_batch_token_cap: bool = False,
     was_flush_enabled: bool = False,
@@ -55,6 +81,7 @@ async def process_representation_tasks_batch(
         message_level_configuration: Optional configuration override.
         observers: List of observer peer IDs (collections to save to).
         observed: The observed peer ID.
+        participants: Active session peers captured when the work was enqueued.
         queue_item_message_ids: Message IDs from queue items being processed
         hit_batch_token_cap: queue batcher clamped this batch to fit
         was_flush_enabled: DERIVER.FLUSH_ENABLED snapshot at batch time
@@ -103,15 +130,20 @@ async def process_representation_tasks_batch(
         "id",
     )
 
-    # Format messages with timestamps
+    # Format only queued evidence with the participant snapshot captured for that
+    # work item. Interleaved context may predate that snapshot, so assigning it an
+    # addressee could turn an originally ambiguous message into false evidence.
+    queue_item_message_ids_set = set(queue_item_message_ids)
     formatted_messages = "\n".join(
-        format_new_turn_with_timestamp(msg.content, msg.created_at, msg.peer_name)
+        _format_deriver_message(
+            msg,
+            (participants or []) if msg.id in queue_item_message_ids_set else [],
+        )
         for msg in messages
     )
 
     # Track token usage - count only tokens from messages being processed
     prompt_tokens = estimate_deriver_prompt_tokens(custom_instructions)
-    queue_item_message_ids_set = set(queue_item_message_ids)
     messages_tokens = sum(
         msg.token_count for msg in messages if msg.id in queue_item_message_ids_set
     )
@@ -184,9 +216,8 @@ async def process_representation_tasks_batch(
             component=DeriverComponents.OUTPUT_TOTAL.value,
         )
 
-    # Facts can be supported by any speaker in the prompt. Preserve the ordered,
-    # de-duplicated provenance for every message supplied as evidence instead of
-    # discarding cross-speaker sources.
+    # The prompt includes queued messages plus interleaved context, and facts may be
+    # supported by any speaker after cross-speaker target attribution.
     message_ids = list(dict.fromkeys(message.id for message in messages))
 
     # Convert to Representation and save

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -184,7 +184,10 @@ async def process_representation_tasks_batch(
             component=DeriverComponents.OUTPUT_TOTAL.value,
         )
 
-    message_ids = [m.id for m in messages if m.peer_name == observed]
+    # Facts can be supported by any speaker in the prompt. Preserve the ordered,
+    # de-duplicated provenance for every message supplied as evidence instead of
+    # discarding cross-speaker sources.
+    message_ids = list(dict.fromkeys(message.id for message in messages))
 
     # Convert to Representation and save
     observations = Representation.from_prompt_representation(

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 
@@ -35,6 +36,30 @@ def _get_deriver_model_config() -> ConfiguredModelSettings:
     return settings.DERIVER.MODEL_CONFIG
 
 
+def _format_deriver_message(message: Message, participants: list[str]) -> str:
+    """Format a message with explicit speaker/addressee roles when unambiguous."""
+    unique_participants = set(participants)
+    other_peers = unique_participants - {message.peer_name}
+    addressee = (
+        next(iter(other_peers))
+        if len(unique_participants) == 2 and message.peer_name in unique_participants
+        else None
+    )
+
+    if addressee is None:
+        return format_new_turn_with_timestamp(
+            message.content, message.created_at, message.peer_name
+        )
+
+    timestamp = message.created_at.strftime("%Y-%m-%d %H:%M:%S")
+    roles = json.dumps(
+        {"speaker": message.peer_name, "addressee": addressee},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return f"{timestamp} {roles}: {message.content}"
+
+
 @with_sentry_transaction("minimal_deriver_batch", op="deriver")
 async def process_representation_tasks_batch(
     messages: list[Message],
@@ -42,6 +67,7 @@ async def process_representation_tasks_batch(
     *,
     observers: list[str],
     observed: str,
+    participants: list[str] | None = None,
     queue_item_message_ids: list[int],
     hit_batch_token_cap: bool = False,
     was_flush_enabled: bool = False,
@@ -55,6 +81,7 @@ async def process_representation_tasks_batch(
         message_level_configuration: Optional configuration override.
         observers: List of observer peer IDs (collections to save to).
         observed: The observed peer ID.
+        participants: Active session peers captured when the work was enqueued.
         queue_item_message_ids: Message IDs from queue items being processed
         hit_batch_token_cap: queue batcher clamped this batch to fit
         was_flush_enabled: DERIVER.FLUSH_ENABLED snapshot at batch time
@@ -105,8 +132,7 @@ async def process_representation_tasks_batch(
 
     # Format messages with timestamps
     formatted_messages = "\n".join(
-        format_new_turn_with_timestamp(msg.content, msg.created_at, msg.peer_name)
-        for msg in messages
+        _format_deriver_message(msg, participants or []) for msg in messages
     )
 
     # Track token usage - count only tokens from messages being processed
@@ -184,7 +210,9 @@ async def process_representation_tasks_batch(
             component=DeriverComponents.OUTPUT_TOTAL.value,
         )
 
-    message_ids = [m.id for m in messages if m.peer_name == observed]
+    # The prompt includes queued messages plus interleaved context, and facts may be
+    # supported by any speaker after cross-speaker target attribution.
+    message_ids = list(dict.fromkeys(message.id for message in messages))
 
     # Convert to Representation and save
     observations = Representation.from_prompt_representation(

--- a/src/deriver/enqueue.py
+++ b/src/deriver/enqueue.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Literal
+from collections.abc import Mapping
+from typing import Any, Literal, NamedTuple
 
 from sqlalchemy import exists, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,6 +24,14 @@ from src.utils.work_unit import construct_work_unit_key
 logger = logging.getLogger(__name__)
 
 
+class PeerObservationConfiguration(NamedTuple):
+    """Resolved peer settings used by representation queue routing."""
+
+    peer_configuration: dict[str, Any]
+    session_configuration: dict[str, Any]
+    is_active: bool
+
+
 async def enqueue(payload: list[dict[str, Any]]) -> None:
     """
     Add message(s) to the deriver queue for processing.
@@ -31,31 +40,13 @@ async def enqueue(payload: list[dict[str, Any]]) -> None:
         payload: List of message payload dictionaries
     """
 
-    # Cancel any pending dreams for affected collections since user is active again.
-    # This cancels dreams for all collections where observed=peer_name, which covers
-    # both self-observation and peer-to-peer observation cases.
-    dream_scheduler = get_dream_scheduler()
-    if dream_scheduler and payload:
-        cancelled_dreams: set[str] = set()
-        for message in payload:
-            workspace_name = message.get("workspace_name")
-            peer_name = message.get("peer_name")
-            if workspace_name and peer_name:
-                cancelled = await dream_scheduler.cancel_dreams_for_observed(
-                    workspace_name, peer_name
-                )
-                cancelled_dreams.update(cancelled)
+    if not payload:
+        return
 
-        if cancelled_dreams:
-            logger.info(
-                f"Cancelled {len(cancelled_dreams)} pending dreams due to new activity"
-            )
-
+    queue_records: list[dict[str, Any]] = []
+    enqueue_succeeded = False
     async with tracked_db("message_enqueue") as db_session:
         try:
-            # Determine if batch or single processing
-            if not payload:  # Empty list check
-                return
             workspace_name = payload[0]["workspace_name"]
             session_name = payload[0]["session_name"]
 
@@ -70,6 +61,7 @@ async def enqueue(payload: list[dict[str, Any]]) -> None:
                 stmt = insert(QueueItem).returning(QueueItem)
                 await db_session.execute(stmt, queue_records)
                 await db_session.commit()
+            enqueue_succeeded = True
 
         except Exception as e:
             logger.exception("Failed to enqueue message(s)!")
@@ -77,6 +69,38 @@ async def enqueue(payload: list[dict[str, Any]]) -> None:
                 import sentry_sdk
 
                 sentry_sdk.capture_exception(e)
+
+    # New evidence resets inactivity for every representation target it affects,
+    # including a target promoted from a message authored by another peer.
+    dream_scheduler = get_dream_scheduler()
+    if dream_scheduler and enqueue_succeeded:
+        affected_targets = {
+            (message["workspace_name"], message["peer_name"]) for message in payload
+        }
+        affected_targets.update(
+            (record["workspace_name"], record["payload"]["observed"])
+            for record in queue_records
+            if record["task_type"] == "representation"
+        )
+        cancelled_dreams: set[str] = set()
+        for workspace_name, target in affected_targets:
+            try:
+                cancelled = await dream_scheduler.cancel_dreams_for_observed(
+                    workspace_name, target
+                )
+                cancelled_dreams.update(cancelled)
+            except Exception:
+                logger.exception(
+                    "Failed to cancel pending dreams for %s/%s after enqueue",
+                    workspace_name,
+                    target,
+                )
+
+        if cancelled_dreams:
+            logger.info(
+                "Cancelled %s pending dreams due to new evidence",
+                len(cancelled_dreams),
+            )
 
 
 async def handle_session(
@@ -139,7 +163,7 @@ async def handle_session(
 
 async def get_peers_with_configuration(
     db_session: AsyncSession, workspace_name: str, session_name: str
-) -> dict[str, list[dict[str, Any]]]:
+) -> dict[str, PeerObservationConfiguration]:
     """
     Retrieve peers with their configurations for a given session.
 
@@ -157,11 +181,11 @@ async def get_peers_with_configuration(
     peers_with_configuration_result = await db_session.execute(configuration_query)
     peers_with_configuration_list = peers_with_configuration_result.all()
     return {
-        row.peer_name: [
+        row.peer_name: PeerObservationConfiguration(
             row.peer_configuration,
             row.session_peer_configuration,
             row.is_active,
-        ]
+        )
         for row in peers_with_configuration_list
     }
 
@@ -173,6 +197,7 @@ def create_representation_record(
     *,
     observers: list[str],
     observed: str,
+    participants: list[str],
 ) -> dict[str, Any]:
     """
     Create a queue record for representation task.
@@ -182,7 +207,8 @@ def create_representation_record(
         conf: Resolved configuration for this particular message
         session_id: Optional session ID
         observers: List of observer peer names
-        observed: Name of the sender
+        observed: Peer that the representation task should model
+        participants: Active session peers when the message was enqueued
 
     Returns:
         Queue record dictionary with workspace_name and message_id as separate fields
@@ -201,6 +227,7 @@ def create_representation_record(
         task_type="representation",
         observers=observers,
         observed=observed,
+        participants=participants,
     )
     return {
         "work_unit_key": construct_work_unit_key(workspace_name, processed_payload),
@@ -254,47 +281,105 @@ def create_summary_record(
 
 
 def get_effective_observe_me(
-    observed: str, peers_with_configuration: dict[str, list[dict[str, Any]]]
+    target: str,
+    peers_with_configuration: Mapping[str, PeerObservationConfiguration],
 ) -> bool:
     """
-    Determine the effective observe_me setting for a sender, considering session and peer configurations.
+    Determine whether Honcho should form a representation of a target peer.
 
     Args:
-        observed: Name of the sender
+        target: Name of the peer to model
         peers_with_configuration: Dictionary of peer configurations
 
     Returns:
         True if observe_me is enabled, False otherwise
     """
-    # If the sender is not in peers_with_configuration, they left after sending a message.
-    # We'll use the default behavior of observing the sender by instantiating the default
+    # If the target is not in peers_with_configuration, they left after sending a message.
+    # Use the default behavior of observing the target by instantiating the default
     # peer-level and session-level configs.
-    configuration: list[Any] = peers_with_configuration.get(observed, [{}, {}])
-    sender_session_peer_config = (
-        schemas.SessionPeerConfig(**configuration[1]) if configuration[1] else None
+    configuration = peers_with_configuration.get(
+        target, PeerObservationConfiguration({}, {}, False)
     )
-    sender_peer_config = (
-        schemas.PeerConfig(**configuration[0])
-        if configuration[0]
+    target_session_peer_config = (
+        schemas.SessionPeerConfig(**configuration.session_configuration)
+        if configuration.session_configuration
+        else None
+    )
+    target_peer_config = (
+        schemas.PeerConfig(**configuration.peer_configuration)
+        if configuration.peer_configuration
         else schemas.PeerConfig()
     )
 
     # Session peer config takes precedence if it exists and has observe_me set
-    if sender_session_peer_config and sender_session_peer_config.observe_me is not None:
-        return sender_session_peer_config.observe_me
+    if target_session_peer_config and target_session_peer_config.observe_me is not None:
+        return target_session_peer_config.observe_me
 
     # Otherwise use peer config
     return (
-        sender_peer_config.observe_me
-        if sender_peer_config.observe_me is not None
+        target_peer_config.observe_me
+        if target_peer_config.observe_me is not None
         else True
     )
+
+
+def get_effective_observe_others(
+    peer: str,
+    peers_with_configuration: Mapping[str, PeerObservationConfiguration],
+) -> bool:
+    """Return whether an active session peer observes other peers.
+
+    Args:
+        peer: Name of the peer to check.
+        peers_with_configuration: Resolved configuration for the session peers.
+
+    Returns:
+        Whether the peer is active and has session-level observation enabled.
+    """
+    configuration = peers_with_configuration.get(
+        peer, PeerObservationConfiguration({}, {}, False)
+    )
+    if not configuration.is_active:
+        return False
+
+    session_peer_config = (
+        schemas.SessionPeerConfig(**configuration.session_configuration)
+        if configuration.session_configuration
+        else None
+    )
+    return bool(session_peer_config and session_peer_config.observe_others)
+
+
+def get_observers_for_target(
+    target: str,
+    peers_with_configuration: Mapping[str, PeerObservationConfiguration],
+) -> list[str]:
+    """Resolve the collections that should receive facts about a target peer.
+
+    Args:
+        target: Name of the peer being modeled.
+        peers_with_configuration: Resolved configuration for the session peers.
+
+    Returns:
+        Peer names that should receive the target's facts, or an empty list when
+        the target does not permit observation.
+    """
+    if not get_effective_observe_me(target, peers_with_configuration):
+        return []
+
+    observers = [target]
+    for peer_name in peers_with_configuration:
+        if peer_name == target:
+            continue
+        if get_effective_observe_others(peer_name, peers_with_configuration):
+            observers.append(peer_name)
+    return observers
 
 
 async def generate_queue_records(
     db_session: AsyncSession,
     message: dict[str, Any],
-    peers_with_configuration: dict[str, list[dict[str, Any]]],
+    peers_with_configuration: Mapping[str, PeerObservationConfiguration],
     session_id: str,
     conf: ResolvedConfiguration,
 ) -> list[dict[str, Any]]:
@@ -311,7 +396,7 @@ async def generate_queue_records(
     Returns:
         List of queue records for this message
     """
-    observed = message["peer_name"]
+    sender = message["peer_name"]
     message_id: int = message["message_id"]
 
     # Prefer the sequence captured during message creation; fallback only if missing
@@ -339,55 +424,47 @@ async def generate_queue_records(
             )
         )
 
-    # Check if the sender should be observed based on peer configuration
-    should_observe = get_effective_observe_me(observed, peers_with_configuration)
-
     if not conf.reasoning.enabled:
         return records
 
-    # Collect all observers into a single list
-    observers: list[str] = []
+    active_peers = [
+        peer_name
+        for peer_name, peer_conf in peers_with_configuration.items()
+        if peer_conf.is_active
+    ]
+    targets = [sender]
+    active_other_peers = [
+        peer_name for peer_name in active_peers if peer_name != sender
+    ]
+    # Messages have no addressee field. In a two-peer session, a peer that
+    # observes others can unambiguously supply evidence about the other peer.
+    if len(active_other_peers) == 1 and get_effective_observe_others(
+        sender, peers_with_configuration
+    ):
+        targets.append(active_other_peers[0])
 
-    if should_observe:
-        # Self-observation: the sender observes themselves
-        observers.append(observed)
-
-        # Other peers who want to observe
-        for peer_name, peer_conf in peers_with_configuration.items():
-            if peer_name == observed:
-                continue
-
-            # If the observer peer has left the session, skip them
-            if not peer_conf[2]:
-                continue
-
-            session_peer_config = (
-                schemas.SessionPeerConfig(**peer_conf[1]) if peer_conf[1] else None
+    observer_count = 0
+    for target in targets:
+        observers = get_observers_for_target(target, peers_with_configuration)
+        if observers:
+            observer_count += len(observers)
+            records.append(
+                create_representation_record(
+                    message,
+                    conf,
+                    observed=target,
+                    observers=observers,
+                    participants=active_peers,
+                    session_id=session_id,
+                )
             )
-
-            if session_peer_config is None or not session_peer_config.observe_others:
-                continue
-
-            observers.append(peer_name)
-
-    # Create a single record with all observers (if any)
-    if observers:
-        records.append(
-            create_representation_record(
-                message,
-                conf,
-                observed=observed,
-                observers=observers,
-                session_id=session_id,
-            )
-        )
 
     logger.debug(
-        "message %s from %s created %s queue items with %s observers",
+        "message %s from %s created %s queue items across %s observer collections",
         message_id,
-        observed,
+        sender,
         len(records),
-        len(observers),
+        observer_count,
     )
 
     return records

--- a/src/deriver/enqueue.py
+++ b/src/deriver/enqueue.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Literal
+from collections.abc import Mapping
+from typing import Any, Literal, NamedTuple
 
 from sqlalchemy import exists, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,6 +23,14 @@ from src.utils.work_unit import construct_work_unit_key
 logger = logging.getLogger(__name__)
 
 
+class PeerObservationConfiguration(NamedTuple):
+    """Resolved peer settings used by representation queue routing."""
+
+    peer_configuration: dict[str, Any]
+    session_configuration: dict[str, Any]
+    is_active: bool
+
+
 async def enqueue(payload: list[dict[str, Any]]) -> None:
     """
     Add message(s) to the deriver queue for processing.
@@ -30,31 +39,13 @@ async def enqueue(payload: list[dict[str, Any]]) -> None:
         payload: List of message payload dictionaries
     """
 
-    # Cancel any pending dreams for affected collections since user is active again.
-    # This cancels dreams for all collections where observed=peer_name, which covers
-    # both self-observation and peer-to-peer observation cases.
-    dream_scheduler = get_dream_scheduler()
-    if dream_scheduler and payload:
-        cancelled_dreams: set[str] = set()
-        for message in payload:
-            workspace_name = message.get("workspace_name")
-            peer_name = message.get("peer_name")
-            if workspace_name and peer_name:
-                cancelled = await dream_scheduler.cancel_dreams_for_observed(
-                    workspace_name, peer_name
-                )
-                cancelled_dreams.update(cancelled)
+    if not payload:
+        return
 
-        if cancelled_dreams:
-            logger.info(
-                f"Cancelled {len(cancelled_dreams)} pending dreams due to new activity"
-            )
-
+    queue_records: list[dict[str, Any]] = []
+    enqueue_succeeded = False
     async with tracked_db("message_enqueue") as db_session:
         try:
-            # Determine if batch or single processing
-            if not payload:  # Empty list check
-                return
             workspace_name = payload[0]["workspace_name"]
             session_name = payload[0]["session_name"]
 
@@ -69,6 +60,7 @@ async def enqueue(payload: list[dict[str, Any]]) -> None:
                 stmt = insert(QueueItem).returning(QueueItem)
                 await db_session.execute(stmt, queue_records)
                 await db_session.commit()
+            enqueue_succeeded = True
 
         except Exception as e:
             logger.exception("Failed to enqueue message(s)!")
@@ -76,6 +68,38 @@ async def enqueue(payload: list[dict[str, Any]]) -> None:
                 import sentry_sdk
 
                 sentry_sdk.capture_exception(e)
+
+    # New evidence resets inactivity for every representation target it affects,
+    # including a target promoted from a message authored by another peer.
+    dream_scheduler = get_dream_scheduler()
+    if dream_scheduler and enqueue_succeeded:
+        affected_targets = {
+            (message["workspace_name"], message["peer_name"]) for message in payload
+        }
+        affected_targets.update(
+            (record["workspace_name"], record["payload"]["observed"])
+            for record in queue_records
+            if record["task_type"] == "representation"
+        )
+        cancelled_dreams: set[str] = set()
+        for workspace_name, target in affected_targets:
+            try:
+                cancelled = await dream_scheduler.cancel_dreams_for_observed(
+                    workspace_name, target
+                )
+                cancelled_dreams.update(cancelled)
+            except Exception:
+                logger.exception(
+                    "Failed to cancel pending dreams for %s/%s after enqueue",
+                    workspace_name,
+                    target,
+                )
+
+        if cancelled_dreams:
+            logger.info(
+                "Cancelled %s pending dreams due to new evidence",
+                len(cancelled_dreams),
+            )
 
 
 async def handle_session(
@@ -138,7 +162,7 @@ async def handle_session(
 
 async def get_peers_with_configuration(
     db_session: AsyncSession, workspace_name: str, session_name: str
-) -> dict[str, list[dict[str, Any]]]:
+) -> dict[str, PeerObservationConfiguration]:
     """
     Retrieve peers with their configurations for a given session.
 
@@ -156,11 +180,11 @@ async def get_peers_with_configuration(
     peers_with_configuration_result = await db_session.execute(configuration_query)
     peers_with_configuration_list = peers_with_configuration_result.all()
     return {
-        row.peer_name: [
+        row.peer_name: PeerObservationConfiguration(
             row.peer_configuration,
             row.session_peer_configuration,
             row.is_active,
-        ]
+        )
         for row in peers_with_configuration_list
     }
 
@@ -172,6 +196,7 @@ def create_representation_record(
     *,
     observers: list[str],
     observed: str,
+    participants: list[str],
 ) -> dict[str, Any]:
     """
     Create a queue record for representation task.
@@ -181,7 +206,8 @@ def create_representation_record(
         conf: Resolved configuration for this particular message
         session_id: Optional session ID
         observers: List of observer peer names
-        observed: Name of the sender
+        observed: Peer that the representation task should model
+        participants: Active session peers when the message was enqueued
 
     Returns:
         Queue record dictionary with workspace_name and message_id as separate fields
@@ -200,6 +226,7 @@ def create_representation_record(
         task_type="representation",
         observers=observers,
         observed=observed,
+        participants=participants,
     )
     return {
         "work_unit_key": construct_work_unit_key(workspace_name, processed_payload),
@@ -253,47 +280,88 @@ def create_summary_record(
 
 
 def get_effective_observe_me(
-    observed: str, peers_with_configuration: dict[str, list[dict[str, Any]]]
+    target: str,
+    peers_with_configuration: Mapping[str, PeerObservationConfiguration],
 ) -> bool:
     """
-    Determine the effective observe_me setting for a sender, considering session and peer configurations.
+    Determine whether Honcho should form a representation of a target peer.
 
     Args:
-        observed: Name of the sender
+        target: Name of the peer to model
         peers_with_configuration: Dictionary of peer configurations
 
     Returns:
         True if observe_me is enabled, False otherwise
     """
-    # If the sender is not in peers_with_configuration, they left after sending a message.
-    # We'll use the default behavior of observing the sender by instantiating the default
+    # If the target is not in peers_with_configuration, they left after sending a message.
+    # Use the default behavior of observing the target by instantiating the default
     # peer-level and session-level configs.
-    configuration: list[Any] = peers_with_configuration.get(observed, [{}, {}])
-    sender_session_peer_config = (
-        schemas.SessionPeerConfig(**configuration[1]) if configuration[1] else None
+    configuration = peers_with_configuration.get(
+        target, PeerObservationConfiguration({}, {}, False)
     )
-    sender_peer_config = (
-        schemas.PeerConfig(**configuration[0])
-        if configuration[0]
+    target_session_peer_config = (
+        schemas.SessionPeerConfig(**configuration.session_configuration)
+        if configuration.session_configuration
+        else None
+    )
+    target_peer_config = (
+        schemas.PeerConfig(**configuration.peer_configuration)
+        if configuration.peer_configuration
         else schemas.PeerConfig()
     )
 
     # Session peer config takes precedence if it exists and has observe_me set
-    if sender_session_peer_config and sender_session_peer_config.observe_me is not None:
-        return sender_session_peer_config.observe_me
+    if target_session_peer_config and target_session_peer_config.observe_me is not None:
+        return target_session_peer_config.observe_me
 
     # Otherwise use peer config
     return (
-        sender_peer_config.observe_me
-        if sender_peer_config.observe_me is not None
+        target_peer_config.observe_me
+        if target_peer_config.observe_me is not None
         else True
     )
+
+
+def get_effective_observe_others(
+    peer: str,
+    peers_with_configuration: Mapping[str, PeerObservationConfiguration],
+) -> bool:
+    """Return whether an active session peer observes other peers."""
+    configuration = peers_with_configuration.get(
+        peer, PeerObservationConfiguration({}, {}, False)
+    )
+    if not configuration.is_active:
+        return False
+
+    session_peer_config = (
+        schemas.SessionPeerConfig(**configuration.session_configuration)
+        if configuration.session_configuration
+        else None
+    )
+    return bool(session_peer_config and session_peer_config.observe_others)
+
+
+def get_observers_for_target(
+    target: str,
+    peers_with_configuration: Mapping[str, PeerObservationConfiguration],
+) -> list[str]:
+    """Resolve the collections that should receive facts about a target peer."""
+    if not get_effective_observe_me(target, peers_with_configuration):
+        return []
+
+    observers = [target]
+    for peer_name in peers_with_configuration:
+        if peer_name == target:
+            continue
+        if get_effective_observe_others(peer_name, peers_with_configuration):
+            observers.append(peer_name)
+    return observers
 
 
 async def generate_queue_records(
     db_session: AsyncSession,
     message: dict[str, Any],
-    peers_with_configuration: dict[str, list[dict[str, Any]]],
+    peers_with_configuration: Mapping[str, PeerObservationConfiguration],
     session_id: str,
     conf: ResolvedConfiguration,
 ) -> list[dict[str, Any]]:
@@ -310,7 +378,7 @@ async def generate_queue_records(
     Returns:
         List of queue records for this message
     """
-    observed = message["peer_name"]
+    sender = message["peer_name"]
     message_id: int = message["message_id"]
 
     # Prefer the sequence captured during message creation; fallback only if missing
@@ -338,55 +406,47 @@ async def generate_queue_records(
             )
         )
 
-    # Check if the sender should be observed based on peer configuration
-    should_observe = get_effective_observe_me(observed, peers_with_configuration)
-
     if not conf.reasoning.enabled:
         return records
 
-    # Collect all observers into a single list
-    observers: list[str] = []
+    active_peers = [
+        peer_name
+        for peer_name, peer_conf in peers_with_configuration.items()
+        if peer_conf.is_active
+    ]
+    targets = [sender]
+    active_other_peers = [
+        peer_name for peer_name in active_peers if peer_name != sender
+    ]
+    # Messages have no addressee field. In a two-peer session, a peer that
+    # observes others can unambiguously supply evidence about the other peer.
+    if len(active_other_peers) == 1 and get_effective_observe_others(
+        sender, peers_with_configuration
+    ):
+        targets.append(active_other_peers[0])
 
-    if should_observe:
-        # Self-observation: the sender observes themselves
-        observers.append(observed)
-
-        # Other peers who want to observe
-        for peer_name, peer_conf in peers_with_configuration.items():
-            if peer_name == observed:
-                continue
-
-            # If the observer peer has left the session, skip them
-            if not peer_conf[2]:
-                continue
-
-            session_peer_config = (
-                schemas.SessionPeerConfig(**peer_conf[1]) if peer_conf[1] else None
+    observer_count = 0
+    for target in targets:
+        observers = get_observers_for_target(target, peers_with_configuration)
+        if observers:
+            observer_count += len(observers)
+            records.append(
+                create_representation_record(
+                    message,
+                    conf,
+                    observed=target,
+                    observers=observers,
+                    participants=active_peers,
+                    session_id=session_id,
+                )
             )
-
-            if session_peer_config is None or not session_peer_config.observe_others:
-                continue
-
-            observers.append(peer_name)
-
-    # Create a single record with all observers (if any)
-    if observers:
-        records.append(
-            create_representation_record(
-                message,
-                conf,
-                observed=observed,
-                observers=observers,
-                session_id=session_id,
-            )
-        )
 
     logger.debug(
-        "message %s from %s created %s queue items with %s observers",
+        "message %s from %s created %s queue items across %s observer collections",
         message_id,
-        observed,
+        sender,
         len(records),
-        len(observers),
+        observer_count,
     )
 
     return records

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -57,7 +57,7 @@ def minimal_deriver_prompt(
         f"""
 Analyze messages to extract **explicit atomic facts** about the target peer.
 
-[EXPLICIT] DEFINITION: Facts about the target peer that can be derived directly from their messages.
+[EXPLICIT] DEFINITION: Facts about the target peer that are directly supported by any speaker's message.
    - Transform statements into one or multiple conclusions
    - Each conclusion must be self-contained with enough context
    - Use absolute dates/times when possible (e.g. "June 26, 2025" not "yesterday")
@@ -66,15 +66,25 @@ RULES:
 - The target peer is the peer identified below under `Target peer:`.
 - A peer can be a human user, AI agent, bot, service, or other actor.
 - Use the exact peer id from `Target peer:` in final observations, not the phrase "the target peer".
-- Properly attribute observations to the correct subject: if it is about the target peer, use the exact peer id as the subject. If the target peer is referencing someone or something else, make that clear.
+- Extract only facts whose subject is the target peer, regardless of which speaker provides the evidence.
+- The label before `:` identifies the speaker, not necessarily the subject. Resolve pronouns from that speaker's perspective: `I`/`me`/`my` refer to the speaker; `you`/`your` refer to the addressee.
+- A target peer's statement about someone else is not a fact about the target peer. Another speaker's statement about the target peer is valid evidence.
+- Speaking, hearing, receiving, acknowledging, repeating, or knowing another subject's fact is transient conversation state, not a durable fact about the target peer. Never create an observation merely to record that state.
+- If the messages contain no durable identity, capability, preference, relationship, or action attributable to the target peer, return no observations.
+- Omit any observation whose subject is ambiguous.
 - Observations should make sense on their own. Each observation will be used in the future to better understand the target peer.
-- Extract ALL observations from the target peer's messages, using others as context.
+- Extract all supported observations about the target peer, regardless of speaker. Use statements about other subjects only as context.
 - Contextualize each observation sufficiently (e.g. "Ann is nervous about the job interview at the pharmacy" not just "Ann is nervous")
 
 EXAMPLES (using `alice` as the target peer id):
-- EXPLICIT: "I just had my 25th birthday last Saturday" → "alice is 25 years old", "alice's birthday is June 21st"
-- EXPLICIT: "I took my dog for a walk in NYC" → "alice has a dog", "alice lives in NYC"
-- EXPLICIT: "alice attended college" + general knowledge → "alice completed high school or equivalent"
+- TARGET `alice`, MESSAGE `alice: I am 25 years old` → "alice is 25 years old"
+- TARGET `alice`, MESSAGE `alice: I have a dog named Rover` → "alice has a dog named Rover"
+- TARGET `alice`, MESSAGE `bob: alice works remotely on Fridays` → "alice works remotely on Fridays"
+- TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` → no observation about `assistant`
+- TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` → "assistant prefers concise responses"
+- TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` → "user plays tennis on Tuesdays"
+- TARGET `assistant`, MESSAGE `user: assistant is careful about attribution` → "assistant is careful about attribution"
+- Set `is_durable_target_fact=true` only for durable facts about the target peer itself. Set it to `false` for transient conversation state or facts about another subject.
 
 {custom_instructions_section}
 

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -67,7 +67,8 @@ RULES:
 - A peer can be a human user, AI agent, bot, service, or other actor.
 - Use the exact peer id from `Target peer:` in final observations, not the phrase "the target peer".
 - Extract only facts whose subject is the target peer, regardless of which speaker provides the evidence.
-- The label before `:` identifies the speaker, not necessarily the subject. Resolve pronouns from that speaker's perspective: `I`/`me`/`my` refer to the speaker; `you`/`your` refer to the addressee.
+- Each message prefix identifies the speaker and may explicitly identify the addressee as JSON, for example `{{"speaker":"assistant","addressee":"user"}}:`. These roles are authoritative.
+- Resolve pronouns from the labeled speaker's perspective: `I`/`me`/`my` refer to the speaker; `you`/`your` refer only to the labeled addressee, never to the target unless the target is that addressee.
 - A target peer's statement about someone else is not a fact about the target peer. Another speaker's statement about the target peer is valid evidence.
 - Speaking, hearing, receiving, acknowledging, repeating, or knowing another subject's fact is transient conversation state, not a durable fact about the target peer. Never create an observation merely to record that state.
 - If the messages contain no durable identity, capability, preference, relationship, or action attributable to the target peer, return no observations.
@@ -80,9 +81,9 @@ EXAMPLES (using `alice` as the target peer id):
 - TARGET `alice`, MESSAGE `alice: I am 25 years old` → "alice is 25 years old"
 - TARGET `alice`, MESSAGE `alice: I have a dog named Rover` → "alice has a dog named Rover"
 - TARGET `alice`, MESSAGE `bob: alice works remotely on Fridays` → "alice works remotely on Fridays"
-- TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` → no observation about `assistant`
-- TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` → "assistant prefers concise responses"
-- TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` → "user plays tennis on Tuesdays"
+- TARGET `assistant`, MESSAGE `{{"speaker":"assistant","addressee":"user"}}: You play tennis on Tuesdays` → no observation about `assistant`
+- TARGET `assistant`, MESSAGE `{{"speaker":"assistant","addressee":"user"}}: I prefer concise responses` → "assistant prefers concise responses"
+- TARGET `user`, MESSAGE `{{"speaker":"assistant","addressee":"user"}}: You play tennis on Tuesdays` → "user plays tennis on Tuesdays"
 - TARGET `assistant`, MESSAGE `user: assistant is careful about attribution` → "assistant is careful about attribution"
 - Set `is_durable_target_fact=true` only for durable facts about the target peer itself. Set it to `false` for transient conversation state or facts about another subject.
 

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -67,7 +67,8 @@ RULES:
 - A peer can be a human user, AI agent, bot, service, or other actor.
 - Use the exact peer id from `Target peer:` in final observations, not the phrase "the target peer".
 - Extract only facts whose subject is the target peer, regardless of which speaker provides the evidence.
-- Each message is formatted as `<timestamp> <speaker>: <content>`. The speaker label is the text after the timestamp and before the final `:` that introduces the content; it identifies the speaker, not necessarily the subject. Resolve pronouns from that speaker's perspective: `I`/`me`/`my` refer to the speaker; `you`/`your` refer to the addressee.
+- Each message prefix identifies the speaker and may explicitly identify the addressee as JSON, for example `{{"speaker":"assistant","addressee":"user"}}:`. These roles are authoritative.
+- Resolve pronouns from the labeled speaker's perspective: `I`/`me`/`my` refer to the speaker; `you`/`your` refer only to the labeled addressee, never to the target unless the target is that addressee.
 - A target peer's statement about someone else is not a fact about the target peer. Another speaker's statement about the target peer is valid evidence.
 - Speaking, hearing, receiving, acknowledging, repeating, or knowing another subject's fact is transient conversation state, not a durable fact about the target peer. Never create an observation merely to record that state.
 - If the messages contain no durable identity, capability, preference, relationship, or action attributable to the target peer, return no observations.
@@ -83,9 +84,9 @@ EXAMPLES (using `alice` as the target peer id):
 - TARGET `alice`, MESSAGE `alice: I am 25 years old` → "alice is 25 years old"
 - TARGET `alice`, MESSAGE `alice: I have a dog named Rover` → "alice has a dog named Rover"
 - TARGET `alice`, MESSAGE `bob: alice works remotely on Fridays` → "alice works remotely on Fridays"
-- TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` → no observation about `assistant`
-- TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` → "assistant prefers concise responses"
-- TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` → "user plays tennis on Tuesdays"
+- TARGET `assistant`, MESSAGE `{{"speaker":"assistant","addressee":"user"}}: You play tennis on Tuesdays` → no observation about `assistant`
+- TARGET `assistant`, MESSAGE `{{"speaker":"assistant","addressee":"user"}}: I prefer concise responses` → "assistant prefers concise responses"
+- TARGET `user`, MESSAGE `{{"speaker":"assistant","addressee":"user"}}: You play tennis on Tuesdays` → "user plays tennis on Tuesdays"
 - TARGET `assistant`, MESSAGE `user: assistant is careful about attribution` → "assistant is careful about attribution"
 - Set `is_durable_target_fact=true` only for durable facts about the target peer itself. Set it to `false` for transient conversation state or facts about another subject.
 </examples>

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -57,7 +57,7 @@ def minimal_deriver_prompt(
         f"""
 Analyze messages to extract **explicit atomic facts** about the target peer.
 
-[EXPLICIT] DEFINITION: Facts about the target peer that can be derived directly from their messages.
+[EXPLICIT] DEFINITION: Facts about the target peer that are directly supported by any speaker's message.
    - Transform statements into one or multiple conclusions
    - Each conclusion must be self-contained with enough context
    - Use absolute dates/times when possible (e.g. "June 26, 2025" not "yesterday")
@@ -66,18 +66,28 @@ RULES:
 - The target peer is the peer identified below under `Target peer:`.
 - A peer can be a human user, AI agent, bot, service, or other actor.
 - Use the exact peer id from `Target peer:` in final observations, not the phrase "the target peer".
-- Properly attribute observations to the correct subject: if it is about the target peer, use the exact peer id as the subject. If the target peer is referencing someone or something else, make that clear.
+- Extract only facts whose subject is the target peer, regardless of which speaker provides the evidence.
+- Each message is formatted as `<timestamp> <speaker>: <content>`. The speaker label is the text after the timestamp and before the final `:` that introduces the content; it identifies the speaker, not necessarily the subject. Resolve pronouns from that speaker's perspective: `I`/`me`/`my` refer to the speaker; `you`/`your` refer to the addressee.
+- A target peer's statement about someone else is not a fact about the target peer. Another speaker's statement about the target peer is valid evidence.
+- Speaking, hearing, receiving, acknowledging, repeating, or knowing another subject's fact is transient conversation state, not a durable fact about the target peer. Never create an observation merely to record that state.
+- If the messages contain no durable identity, capability, preference, relationship, or action attributable to the target peer, return no observations.
+- Omit any observation whose subject is ambiguous.
 - Observations should make sense on their own. Each observation will be used in the future to better understand the target peer.
-- Extract ALL observations from the target peer's messages, using others as context.
+- Extract all supported observations about the target peer, regardless of speaker. Use statements about other subjects only as context.
 - Contextualize each observation sufficiently (e.g. "Ann is nervous about the job interview at the pharmacy" not just "Ann is nervous")
 
 <examples>
 These examples are fabricated illustrations of the output format. Never emit a conclusion for which content comes from these examples. Every conclusion must be supported by the <messages> block only.
 
 EXAMPLES (using `alice` as the target peer id):
-- EXPLICIT: "I just turned 25" → "alice is 25 years old"
-- EXPLICIT: "I took my dog for a walk in NYC" → "alice has a dog", "alice walked her dog in NYC"
-- EXPLICIT: "I've lived in NYC for six years" → "alice lives in NYC", "alice has lived in NYC for six years"
+- TARGET `alice`, MESSAGE `alice: I am 25 years old` → "alice is 25 years old"
+- TARGET `alice`, MESSAGE `alice: I have a dog named Rover` → "alice has a dog named Rover"
+- TARGET `alice`, MESSAGE `bob: alice works remotely on Fridays` → "alice works remotely on Fridays"
+- TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` → no observation about `assistant`
+- TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` → "assistant prefers concise responses"
+- TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` → "user plays tennis on Tuesdays"
+- TARGET `assistant`, MESSAGE `user: assistant is careful about attribution` → "assistant is careful about attribution"
+- Set `is_durable_target_fact=true` only for durable facts about the target peer itself. Set it to `false` for transient conversation state or facts about another subject.
 </examples>
 
 {custom_instructions_section}

--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -98,7 +98,7 @@ def _detach_queue_batch_objects(
 def _resolve_batch_configuration(
     items_to_process: list[QueueItem],
 ) -> tuple[list[QueueItem], ResolvedConfiguration | None]:
-    """Keep only the initial homogeneous configuration prefix for a batch."""
+    """Keep only the initial homogeneous config and observer prefix for a batch."""
     if not items_to_process:
         return [], None
 
@@ -106,6 +106,8 @@ def _resolve_batch_configuration(
     resolved_config = (
         None if raw_config is None else ResolvedConfiguration.model_validate(raw_config)
     )
+    first_observers = _normalized_observers(items_to_process[0].payload)
+    first_participants = _normalized_participants(items_to_process[0].payload)
 
     valid_items: list[QueueItem] = []
     for item in items_to_process:
@@ -115,11 +117,51 @@ def _resolve_batch_configuration(
             if item_raw_config is None
             else ResolvedConfiguration.model_validate(item_raw_config)
         )
-        if item_config != resolved_config:
+        if (
+            item_config != resolved_config
+            or _normalized_observers(item.payload) != first_observers
+            or _normalized_participants(item.payload) != first_participants
+        ):
             break
         valid_items.append(item)
 
     return valid_items, resolved_config
+
+
+def _queue_item_observers(payload: dict[str, Any]) -> list[str]:
+    """Read observer collections from current or legacy queue payloads."""
+    observers = payload.get("observers")
+    if isinstance(observers, list):
+        return [
+            observer
+            for observer in cast(list[object], observers)
+            if isinstance(observer, str)
+        ]
+
+    legacy_observer = payload.get("observer")
+    return [legacy_observer] if isinstance(legacy_observer, str) else []
+
+
+def _normalized_observers(payload: dict[str, Any]) -> tuple[str, ...]:
+    """Return a stable observer-set key for representation batching."""
+    return tuple(sorted(set(_queue_item_observers(payload))))
+
+
+def _queue_item_participants(payload: dict[str, Any]) -> list[str]:
+    """Read the active-peer snapshot from a representation payload."""
+    participants = payload.get("participants")
+    if not isinstance(participants, list):
+        return []
+    return [
+        participant
+        for participant in cast(list[object], participants)
+        if isinstance(participant, str)
+    ]
+
+
+def _normalized_participants(payload: dict[str, Any]) -> tuple[str, ...]:
+    """Return a stable participant-set key for representation batching."""
+    return tuple(sorted(set(_queue_item_participants(payload))))
 
 
 class QueueManager:
@@ -656,16 +698,9 @@ class QueueManager:
                                 break
 
                             try:
-                                # Extract observers from the payload (handle both old and new format)
                                 payload = items_to_process[0].payload
-                                observers = payload.get("observers")
-                                if observers is None:
-                                    # Legacy format: single observer string
-                                    legacy_observer = payload.get("observer")
-                                    if legacy_observer:
-                                        observers = [legacy_observer]
-                                    else:
-                                        observers = []
+                                observers = _queue_item_observers(payload)
+                                participants = _queue_item_participants(payload)
 
                                 queue_item_message_ids = [
                                     item.message_id
@@ -677,6 +712,7 @@ class QueueManager:
                                     message_level_configuration,
                                     observers=observers,
                                     observed=work_unit.observed,
+                                    participants=participants,
                                     queue_item_message_ids=queue_item_message_ids,
                                     hit_batch_token_cap=batch_result.hit_batch_token_cap,
                                     was_flush_enabled=batch_result.was_flush_enabled,
@@ -883,12 +919,17 @@ class QueueManager:
                 .scalar_subquery()
             )
 
-            # Only include the preceding message if it's from a different peer than observed
-            # This provides conversational context (e.g., the question that prompted the response)
+            # Compare with the queued message author, which can differ from the
+            # representation target for cross-speaker evidence.
+            focused_sender_subq = (
+                select(models.Message.peer_name)
+                .where(models.Message.id == min_unprocessed_message_id_subq)
+                .scalar_subquery()
+            )
             preceding_message_id_subq = (
                 select(models.Message.id)
                 .where(models.Message.id == immediately_preceding_id_subq)
-                .where(models.Message.peer_name != parsed_key.observed)
+                .where(models.Message.peer_name != focused_sender_subq)
                 .scalar_subquery()
             )
 

--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -98,7 +98,7 @@ def _detach_queue_batch_objects(
 def _resolve_batch_configuration(
     items_to_process: list[QueueItem],
 ) -> tuple[list[QueueItem], ResolvedConfiguration | None]:
-    """Keep only the initial homogeneous configuration prefix for a batch."""
+    """Keep only the initial homogeneous config and observer prefix for a batch."""
     if not items_to_process:
         return [], None
 
@@ -106,6 +106,8 @@ def _resolve_batch_configuration(
     resolved_config = (
         None if raw_config is None else ResolvedConfiguration.model_validate(raw_config)
     )
+    first_observers = _normalized_observers(items_to_process[0].payload)
+    first_participants = _normalized_participants(items_to_process[0].payload)
 
     valid_items: list[QueueItem] = []
     for item in items_to_process:
@@ -115,11 +117,51 @@ def _resolve_batch_configuration(
             if item_raw_config is None
             else ResolvedConfiguration.model_validate(item_raw_config)
         )
-        if item_config != resolved_config:
+        if (
+            item_config != resolved_config
+            or _normalized_observers(item.payload) != first_observers
+            or _normalized_participants(item.payload) != first_participants
+        ):
             break
         valid_items.append(item)
 
     return valid_items, resolved_config
+
+
+def _queue_item_observers(payload: dict[str, Any]) -> list[str]:
+    """Read observer collections from current or legacy queue payloads."""
+    observers = payload.get("observers")
+    if isinstance(observers, list):
+        return [
+            observer
+            for observer in cast(list[object], observers)
+            if isinstance(observer, str)
+        ]
+
+    legacy_observer = payload.get("observer")
+    return [legacy_observer] if isinstance(legacy_observer, str) else []
+
+
+def _normalized_observers(payload: dict[str, Any]) -> tuple[str, ...]:
+    """Return a stable observer-set key for representation batching."""
+    return tuple(sorted(set(_queue_item_observers(payload))))
+
+
+def _queue_item_participants(payload: dict[str, Any]) -> list[str]:
+    """Read the active-peer snapshot from a representation payload."""
+    participants = payload.get("participants")
+    if not isinstance(participants, list):
+        return []
+    return [
+        participant
+        for participant in cast(list[object], participants)
+        if isinstance(participant, str)
+    ]
+
+
+def _normalized_participants(payload: dict[str, Any]) -> tuple[str, ...]:
+    """Return a stable participant-set key for representation batching."""
+    return tuple(sorted(set(_queue_item_participants(payload))))
 
 
 class QueueManager:
@@ -643,16 +685,9 @@ class QueueManager:
                                 break
 
                             try:
-                                # Extract observers from the payload (handle both old and new format)
                                 payload = items_to_process[0].payload
-                                observers = payload.get("observers")
-                                if observers is None:
-                                    # Legacy format: single observer string
-                                    legacy_observer = payload.get("observer")
-                                    if legacy_observer:
-                                        observers = [legacy_observer]
-                                    else:
-                                        observers = []
+                                observers = _queue_item_observers(payload)
+                                participants = _queue_item_participants(payload)
 
                                 queue_item_message_ids = [
                                     item.message_id
@@ -664,6 +699,7 @@ class QueueManager:
                                     message_level_configuration,
                                     observers=observers,
                                     observed=work_unit.observed,
+                                    participants=participants,
                                     queue_item_message_ids=queue_item_message_ids,
                                     hit_batch_token_cap=batch_result.hit_batch_token_cap,
                                     was_flush_enabled=batch_result.was_flush_enabled,
@@ -870,12 +906,17 @@ class QueueManager:
                 .scalar_subquery()
             )
 
-            # Only include the preceding message if it's from a different peer than observed
-            # This provides conversational context (e.g., the question that prompted the response)
+            # Compare with the queued message author, which can differ from the
+            # representation target for cross-speaker evidence.
+            focused_sender_subq = (
+                select(models.Message.peer_name)
+                .where(models.Message.id == min_unprocessed_message_id_subq)
+                .scalar_subquery()
+            )
             preceding_message_id_subq = (
                 select(models.Message.id)
                 .where(models.Message.id == immediately_preceding_id_subq)
-                .where(models.Message.peer_name != parsed_key.observed)
+                .where(models.Message.peer_name != focused_sender_subq)
                 .scalar_subquery()
             )
 

--- a/src/routers/workspaces.py
+++ b/src/routers/workspaces.py
@@ -145,13 +145,18 @@ async def search_workspace(
     body: schemas.WorkspaceMessageSearchOptions = Body(
         ..., description="Message search parameters"
     ),
-):
-    """
-    Search messages in a Workspace using optional filters. Use `limit` to control the number of
-    results returned.
+) -> list[models.Message]:
+    """Search messages in a workspace with optional scope filtering.
 
-    Pass `scope` to restrict the search to a scope's member sessions. A scope
-    with no member sessions returns no results (fail-closed).
+    Args:
+        workspace_id: Workspace whose messages are searched.
+        body: Query, filters, result limit, and optional peer scope.
+
+    Returns:
+        Matching messages, or an empty list when a scope has no member sessions.
+
+    Raises:
+        ValidationException: If ``scope`` and a ``session_id`` filter conflict.
     """
     # take user-provided filter and add workspace_id to it
     filters = body.filters or {}
@@ -209,7 +214,7 @@ async def get_queue_status(
             workspace_name=workspace_id,
             session_name=session_id,
             observer=observer_id,
-            observed=sender_id,
+            sender=sender_id,
         )
     except ValueError as e:
         logger.warning(f"Invalid request parameters: {str(e)}")

--- a/src/routers/workspaces.py
+++ b/src/routers/workspaces.py
@@ -186,7 +186,7 @@ async def get_queue_status(
             workspace_name=workspace_id,
             session_name=session_id,
             observer=observer_id,
-            observed=sender_id,
+            sender=sender_id,
         )
     except ValueError as e:
         logger.warning(f"Invalid request parameters: {str(e)}")

--- a/src/utils/queue_payload.py
+++ b/src/utils/queue_payload.py
@@ -20,6 +20,7 @@ class RepresentationPayload(BasePayload):
     content: str
     observers: list[str]
     observed: str
+    participants: list[str] | None = None
     created_at: datetime
     configuration: ResolvedConfiguration
 
@@ -179,6 +180,7 @@ def create_payload(
     *,
     observers: list[str] | None = None,
     observed: str | None = None,
+    participants: list[str] | None = None,
 ) -> dict[str, Any]:
     """
     Create a processed payload from a message for queue processing.
@@ -192,7 +194,8 @@ def create_payload(
         task_type: Type of task ('representation' or 'summary')
         message_seq_in_session: Required for summary tasks, must be None for representation
         observers: List of observer peer names (required for representation tasks)
-        observed: Name of the observed peer (*always* the peer who sent the message) (required for representation tasks)
+        observed: Name of the peer that the representation task should model (required for representation tasks)
+        participants: Active session peers used to resolve the message addressee
 
 
     Returns:
@@ -238,6 +241,7 @@ def create_payload(
                 created_at=created_at,
                 observers=observers,
                 observed=observed,
+                participants=participants,
                 configuration=configuration,
             )
         elif task_type == "summary":

--- a/src/utils/queue_payload.py
+++ b/src/utils/queue_payload.py
@@ -20,6 +20,7 @@ class RepresentationPayload(BasePayload):
     content: str
     observers: list[str]
     observed: str
+    participants: list[str] | None = None
     created_at: datetime
     configuration: ResolvedConfiguration
 
@@ -143,6 +144,7 @@ def create_payload(
     *,
     observers: list[str] | None = None,
     observed: str | None = None,
+    participants: list[str] | None = None,
 ) -> dict[str, Any]:
     """
     Create a processed payload from a message for queue processing.
@@ -156,7 +158,8 @@ def create_payload(
         task_type: Type of task ('representation' or 'summary')
         message_seq_in_session: Required for summary tasks, must be None for representation
         observers: List of observer peer names (required for representation tasks)
-        observed: Name of the observed peer (*always* the peer who sent the message) (required for representation tasks)
+        observed: Name of the peer that the representation task should model (required for representation tasks)
+        participants: Active session peers used to resolve the message addressee
 
 
     Returns:
@@ -202,6 +205,7 @@ def create_payload(
                 created_at=created_at,
                 observers=observers,
                 observed=observed,
+                participants=participants,
                 configuration=configuration,
             )
         elif task_type == "summary":

--- a/src/utils/representation.py
+++ b/src/utils/representation.py
@@ -27,10 +27,13 @@ ALLOWLIST_SAFE_LEVELS = ("explicit",)
 def allowlist_safe_levels(levels: list[str] | None) -> list[str]:
     """Narrow a level filter to those safe to serve under a session allowlist.
 
-    Returns the intersection with :data:`ALLOWLIST_SAFE_LEVELS`; ``None`` means
-    "no level filter requested" and yields the full safe set. An empty result
-    means the caller asked only for levels we can't scope, and should receive
-    nothing rather than unscoped conclusions.
+    Args:
+        levels: Requested conclusion levels, or ``None`` for no requested filter.
+
+    Returns:
+        The requested safe levels, or all safe levels when ``levels`` is ``None``.
+        An empty result means the request contained only levels that cannot be
+        scoped safely and should receive no conclusions.
     """
     if levels is None:
         return list(ALLOWLIST_SAFE_LEVELS)
@@ -89,6 +92,20 @@ class ExplicitObservationBase(BaseModel):
     content: str = Field(description="The explicit observation")
 
 
+class PromptExplicitObservation(ExplicitObservationBase):
+    """Deriver output with an explicit target-attribution decision."""
+
+    is_durable_target_fact: bool = Field(
+        description=(
+            "True only for a durable identity, capability, preference, relationship, "
+            "or action of the target peer itself. False when the observation merely "
+            "records that the target heard, knew, acknowledged, repeated, reported, "
+            "or stated a fact about another peer. For example, 'assistant prefers "
+            "concise plans' is true; 'assistant knows the user plays tennis' is false."
+        )
+    )
+
+
 class DeductiveObservationBase(BaseModel):
     source_ids: list[str] = Field(
         description="Document IDs of premise observations for tree traversal",
@@ -142,8 +159,12 @@ class PromptRepresentation(BaseModel):
     The representation format that is used when getting structured output from an LLM.
     """
 
-    explicit: list[ExplicitObservationBase] = Field(
-        description="Facts LITERALLY stated by the user - direct quotes or clear paraphrases only, no interpretation or inference. Example: ['The user is 25 years old', 'The user has a dog named Rover']",
+    explicit: list[PromptExplicitObservation] = Field(
+        description=(
+            "Durable facts about the target peer directly supported by any speaker's "
+            "message. Use direct quotes or clear paraphrases only, without unsupported "
+            "interpretation or inference."
+        ),
         default_factory=list,
     )
 
@@ -701,6 +722,7 @@ class Representation(BaseModel):
                     session_name=session_name,
                 )
                 for e in prompt_representation.explicit
+                if e.is_durable_target_fact
             ],
             deductive=[],
             inductive=[],

--- a/src/utils/representation.py
+++ b/src/utils/representation.py
@@ -60,6 +60,20 @@ class ExplicitObservationBase(BaseModel):
     content: str = Field(description="The explicit observation")
 
 
+class PromptExplicitObservation(ExplicitObservationBase):
+    """Deriver output with an explicit target-attribution decision."""
+
+    is_durable_target_fact: bool = Field(
+        description=(
+            "True only for a durable identity, capability, preference, relationship, "
+            "or action of the target peer itself. False when the observation merely "
+            "records that the target heard, knew, acknowledged, repeated, reported, "
+            "or stated a fact about another peer. For example, 'assistant prefers "
+            "concise plans' is true; 'assistant knows the user plays tennis' is false."
+        )
+    )
+
+
 class DeductiveObservationBase(BaseModel):
     source_ids: list[str] = Field(
         description="Document IDs of premise observations for tree traversal",
@@ -113,8 +127,12 @@ class PromptRepresentation(BaseModel):
     The representation format that is used when getting structured output from an LLM.
     """
 
-    explicit: list[ExplicitObservationBase] = Field(
-        description="Facts LITERALLY stated by the user - direct quotes or clear paraphrases only, no interpretation or inference. Example: ['The user is 25 years old', 'The user has a dog named Rover']",
+    explicit: list[PromptExplicitObservation] = Field(
+        description=(
+            "Durable facts about the target peer directly supported by any speaker's "
+            "message. Use direct quotes or clear paraphrases only, without unsupported "
+            "interpretation or inference."
+        ),
         default_factory=list,
     )
 
@@ -672,6 +690,7 @@ class Representation(BaseModel):
                     session_name=session_name,
                 )
                 for e in prompt_representation.explicit
+                if e.is_durable_target_fact
             ],
             deductive=[],
             inductive=[],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,7 @@ def _get_test_db_url(worker_id: str) -> URL:
     return CONNECTION_URI.set(database=f"test_db_{run_id}{suffix}")
 
 
-def _drop_database(db_url: URL) -> None:
+def _drop_database(db_url: URL, *, force: bool = True) -> None:
     """Drop a test database, evicting any connections still holding it open.
 
     WITH (FORCE) (pg13+) is what makes this reliable: a pooled connection that
@@ -194,7 +194,8 @@ def _drop_database(db_url: URL) -> None:
     )
     try:
         with engine.connect() as conn:
-            conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+            force_clause = " WITH (FORCE)" if force else ""
+            conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{name}"{force_clause}')
     finally:
         engine.dispose()
 
@@ -272,7 +273,7 @@ def _sweep_stale_test_databases() -> None:
             if not _is_test_database_idle(db_url):
                 continue
             logger.info(f"Dropping stale test database: {name}")
-            _drop_database(db_url)
+            _drop_database(db_url, force=False)
     except Exception as e:
         logger.warning(f"Could not sweep stale test databases: {e}")
 
@@ -387,14 +388,15 @@ async def db_engine(worker_id: str):
 
         yield engine
     finally:
-        if engine is not None:
-            await engine.dispose()
+        try:
+            if engine is not None:
+                await engine.dispose()
+        finally:
+            Base.metadata.schema = original_schema
+            for table in Base.metadata.tables.values():
+                table.schema = original_schema
 
-        Base.metadata.schema = original_schema
-        for table in Base.metadata.tables.values():
-            table.schema = original_schema
-
-        _drop_database(test_db_url)
+            _drop_database(test_db_url)
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,9 +137,12 @@ _RUN_ID_TIME_FORMAT = "%Y%m%d%H%M%S"
 # morning is gone by the afternoon.
 _STALE_DB_AGE_SECONDS = 2 * 60 * 60
 
-# test_db_<14-digit timestamp>_<4 hex>[_gwN] -- only names this function minted.
-# A pinned HONCHO_TEST_RUN_ID deliberately won't match, so it's never swept.
-_SWEEPABLE_DB_NAME = re.compile(r"^test_db_(\d{14})_[0-9a-f]{4}(?:_gw\d+)?$")
+# test_db_<14-digit timestamp>_<4-or-16 hex>[_gwN] -- only names this
+# function minted. The 4-hex form remains sweepable for leaked databases from
+# older test runs. A pinned HONCHO_TEST_RUN_ID deliberately won't match.
+_SWEEPABLE_DB_NAME = re.compile(
+    r"^test_db_(\d{14})_(?:[0-9a-f]{4}|[0-9a-f]{16})(?:_gw\d+)?$"
+)
 
 
 def pytest_configure(config: pytest.Config) -> None:  # pyright: ignore[reportUnusedParameter]
@@ -157,7 +160,7 @@ def pytest_configure(config: pytest.Config) -> None:  # pyright: ignore[reportUn
 
     os.environ.setdefault(
         _RUN_ID_ENV_VAR,
-        f"{time.strftime(_RUN_ID_TIME_FORMAT)}_{uuid.uuid4().hex[:4]}",
+        f"{time.strftime(_RUN_ID_TIME_FORMAT)}_{uuid.uuid4().hex[:16]}",
     )
 
     # Workers inherit the controller's env and would each redo this.
@@ -192,6 +195,30 @@ def _drop_database(db_url: URL) -> None:
     try:
         with engine.connect() as conn:
             conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+    finally:
+        engine.dispose()
+
+
+def _is_test_database_idle(db_url: URL) -> bool:
+    """Return whether a database currently has no active backends."""
+
+    name = db_url.database
+    if not name:
+        return False
+
+    engine = create_engine(
+        db_url.set(database="postgres"), isolation_level="AUTOCOMMIT"
+    )
+    try:
+        with engine.connect() as conn:
+            return not bool(
+                conn.exec_driver_sql(
+                    "SELECT EXISTS ("
+                    "SELECT 1 FROM pg_stat_activity WHERE datname = %s"
+                    ")",
+                    (name,),
+                ).scalar()
+            )
     finally:
         engine.dispose()
 
@@ -241,8 +268,11 @@ def _sweep_stale_test_databases() -> None:
             match = _SWEEPABLE_DB_NAME.match(name)
             if match is None or match.group(1) >= cutoff:
                 continue
+            db_url = CONNECTION_URI.set(database=name)
+            if not _is_test_database_idle(db_url):
+                continue
             logger.info(f"Dropping stale test database: {name}")
-            _drop_database(CONNECTION_URI.set(database=name))
+            _drop_database(db_url)
     except Exception as e:
         logger.warning(f"Could not sweep stale test databases: {e}")
 
@@ -336,30 +366,30 @@ async def _clear_all_tables(engine: AsyncEngine) -> None:
 @pytest_asyncio.fixture(scope="session")
 async def db_engine(worker_id: str):
     test_db_url = _get_test_db_url(worker_id)
-    create_test_database(test_db_url)
-    engine = await setup_test_database(test_db_url)
-
-    # Force the schema to 'public' for tests
-    # Save the original schema to restore later
+    engine: AsyncEngine | None = None
     original_schema = Base.metadata.schema
-    Base.metadata.schema = "public"
-
-    # Update all table schemas to public
-    for table in Base.metadata.tables.values():
-        table.schema = "public"
-
-    # Drop all tables first to ensure clean state
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
-        # Then create all tables with current models
-        await conn.run_sync(Base.metadata.create_all)
-
     try:
+        create_test_database(test_db_url)
+        engine = await setup_test_database(test_db_url)
+
+        # Force the schema to 'public' for tests
+        Base.metadata.schema = "public"
+
+        # Update all table schemas to public
+        for table in Base.metadata.tables.values():
+            table.schema = "public"
+
+        # Recreate all tables from the current models.
+        assert engine is not None
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+
         yield engine
     finally:
-        await engine.dispose()
+        if engine is not None:
+            await engine.dispose()
 
-        # Restore original schema
         Base.metadata.schema = original_schema
         for table in Base.metadata.tables.values():
             table.schema = original_schema
@@ -801,7 +831,7 @@ def mock_honcho_llm_call(request: pytest.FixtureRequest):
 
     from src.utils.representation import (
         # DeductiveObservationBase,
-        ExplicitObservationBase,
+        PromptExplicitObservation,
         PromptRepresentation,
     )
 
@@ -821,7 +851,10 @@ def mock_honcho_llm_call(request: pytest.FixtureRequest):
             if getattr(response_model, "__name__", "") == "ReasoningResponse":
                 _rep = PromptRepresentation(
                     explicit=[
-                        ExplicitObservationBase(content="Test explicit observation")
+                        PromptExplicitObservation(
+                            content="Test explicit observation",
+                            is_durable_target_fact=True,
+                        )
                     ],
                     # deductive=[
                     #     DeductiveObservationBase(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -856,7 +856,11 @@ def mock_honcho_llm_call(request: pytest.FixtureRequest):
                         PromptExplicitObservation(
                             content="Test explicit observation",
                             is_durable_target_fact=True,
-                        )
+                        ),
+                        PromptExplicitObservation(
+                            content="Test non-durable observation",
+                            is_durable_target_fact=False,
+                        ),
                     ],
                     # deductive=[
                     #     DeductiveObservationBase(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -701,7 +701,7 @@ def mock_honcho_llm_call(request: pytest.FixtureRequest):
 
     from src.utils.representation import (
         # DeductiveObservationBase,
-        ExplicitObservationBase,
+        PromptExplicitObservation,
         PromptRepresentation,
     )
 
@@ -721,7 +721,10 @@ def mock_honcho_llm_call(request: pytest.FixtureRequest):
             if getattr(response_model, "__name__", "") == "ReasoningResponse":
                 _rep = PromptRepresentation(
                     explicit=[
-                        ExplicitObservationBase(content="Test explicit observation")
+                        PromptExplicitObservation(
+                            content="Test explicit observation",
+                            is_durable_target_fact=True,
+                        )
                     ],
                     # deductive=[
                     #     DeductiveObservationBase(

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -397,10 +397,8 @@ class TestDeriverProcessing:
         assert event.semantic_dup_rejected_count == 33
         assert event.semantic_dup_replaced_count == 44
 
-    async def test_cross_speaker_evidence_preserves_all_message_provenance(
-        self,
-    ) -> None:
-        user_context = Mock(
+    async def test_cross_speaker_evidence_is_saved_for_target(self) -> None:
+        user_context_message = Mock(
             id=6,
             public_id="msg_user_context",
             session_name="session-1",
@@ -410,20 +408,21 @@ class TestDeriverProcessing:
             token_count=6,
             created_at=datetime.now(timezone.utc),
         )
-        assistant_evidence = Mock(
+        assistant_message = Mock(
             id=7,
             public_id="msg_assistant_user_fact",
             session_name="session-1",
             workspace_name="workspace-1",
             peer_name="assistant",
-            content="The user plays tennis on Tuesdays",
+            content="You play tennis on Tuesdays",
             token_count=7,
             created_at=datetime.now(timezone.utc),
         )
         configuration = Mock()
         configuration.reasoning.enabled = True
         configuration.reasoning.custom_instructions = None
-        response = HonchoLLMCallResponse(
+
+        mock_response = HonchoLLMCallResponse(
             content=PromptRepresentation(
                 explicit=[
                     PromptExplicitObservation(
@@ -445,21 +444,39 @@ class TestDeriverProcessing:
             patch(
                 "src.deriver.deriver.honcho_llm_call",
                 new_callable=AsyncMock,
-                return_value=response,
-            ),
+                return_value=mock_response,
+            ) as mock_llm_call,
             patch(
                 "src.deriver.deriver.RepresentationManager",
                 return_value=manager,
-            ),
+            ) as manager_class,
         ):
             await process_representation_tasks_batch(
-                messages=[user_context, assistant_evidence],
+                messages=[user_context_message, assistant_message],
                 message_level_configuration=configuration,
-                observers=["user"],
+                observers=["user", "assistant"],
                 observed="user",
+                participants=["user", "assistant"],
                 queue_item_message_ids=[7],
             )
 
+        await_args = mock_llm_call.await_args
+        if await_args is None:
+            raise AssertionError("Expected deriver LLM call")
+        rendered_prompt = await_args.kwargs["prompt"]
+        assert (
+            '{"speaker":"assistant","addressee":"user"}: ' "You play tennis on Tuesdays"
+        ) in rendered_prompt
+
+        assert [kwargs for _, kwargs in manager_class.call_args_list] == [
+            {"workspace_name": "workspace-1", "observer": "user", "observed": "user"},
+            {
+                "workspace_name": "workspace-1",
+                "observer": "assistant",
+                "observed": "user",
+            },
+        ]
+        assert manager.save_representation.await_count == 2
         saved_representation, saved_message_ids, *_ = (
             manager.save_representation.await_args.args
         )
@@ -467,6 +484,65 @@ class TestDeriverProcessing:
         assert saved_representation.explicit[0].content == (
             "user plays tennis on Tuesdays"
         )
+
+    async def test_context_does_not_inherit_queued_participant_snapshot(self) -> None:
+        old_context_message = Mock(
+            id=6,
+            public_id="msg_old_context",
+            session_name="session-1",
+            workspace_name="workspace-1",
+            peer_name="assistant",
+            content="You should choose the venue",
+            token_count=6,
+            created_at=datetime.now(timezone.utc),
+        )
+        queued_message = Mock(
+            id=7,
+            public_id="msg_queued",
+            session_name="session-1",
+            workspace_name="workspace-1",
+            peer_name="assistant",
+            content="You play tennis on Tuesdays",
+            token_count=7,
+            created_at=datetime.now(timezone.utc),
+        )
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+        configuration.reasoning.custom_instructions = None
+        response = HonchoLLMCallResponse(
+            content=PromptRepresentation(explicit=[]),
+            input_tokens=20,
+            output_tokens=8,
+            finish_reasons=["STOP"],
+        )
+
+        with patch(
+            "src.deriver.deriver.honcho_llm_call",
+            new_callable=AsyncMock,
+            return_value=response,
+        ) as mock_llm_call:
+            await process_representation_tasks_batch(
+                messages=[old_context_message, queued_message],
+                message_level_configuration=configuration,
+                observers=["user"],
+                observed="user",
+                participants=["user", "assistant"],
+                queue_item_message_ids=[7],
+            )
+
+        await_args = mock_llm_call.await_args
+        if await_args is None:
+            raise AssertionError("Expected deriver LLM call")
+        rendered_prompt = await_args.kwargs["prompt"]
+        assert "assistant: You should choose the venue" in rendered_prompt
+        assert (
+            '{"speaker":"assistant","addressee":"user"}: '
+            "You should choose the venue"
+        ) not in rendered_prompt
+        assert (
+            '{"speaker":"assistant","addressee":"user"}: '
+            "You play tennis on Tuesdays"
+        ) in rendered_prompt
 
 
 class TestBackwardsCompatibility:

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -10,7 +10,7 @@ from src.config import settings
 from src.deriver.deriver import process_representation_tasks_batch
 from src.llm import HonchoLLMCallResponse
 from src.utils.representation import (
-    ExplicitObservationBase,
+    PromptExplicitObservation,
     PromptRepresentation,
     Representation,
 )
@@ -338,7 +338,12 @@ class TestDeriverProcessing:
 
         mock_response = HonchoLLMCallResponse(
             content=PromptRepresentation(
-                explicit=[ExplicitObservationBase(content="alice says hello")]
+                explicit=[
+                    PromptExplicitObservation(
+                        content="alice says hello",
+                        is_durable_target_fact=True,
+                    )
+                ]
             ),
             input_tokens=10,
             output_tokens=5,
@@ -391,6 +396,77 @@ class TestDeriverProcessing:
         assert event.exact_dup_existing_count == 22
         assert event.semantic_dup_rejected_count == 33
         assert event.semantic_dup_replaced_count == 44
+
+    async def test_cross_speaker_evidence_preserves_all_message_provenance(
+        self,
+    ) -> None:
+        user_context = Mock(
+            id=6,
+            public_id="msg_user_context",
+            session_name="session-1",
+            workspace_name="workspace-1",
+            peer_name="user",
+            content="We were discussing weekly activities",
+            token_count=6,
+            created_at=datetime.now(timezone.utc),
+        )
+        assistant_evidence = Mock(
+            id=7,
+            public_id="msg_assistant_user_fact",
+            session_name="session-1",
+            workspace_name="workspace-1",
+            peer_name="assistant",
+            content="The user plays tennis on Tuesdays",
+            token_count=7,
+            created_at=datetime.now(timezone.utc),
+        )
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+        configuration.reasoning.custom_instructions = None
+        response = HonchoLLMCallResponse(
+            content=PromptRepresentation(
+                explicit=[
+                    PromptExplicitObservation(
+                        content="user plays tennis on Tuesdays",
+                        is_durable_target_fact=True,
+                    )
+                ]
+            ),
+            input_tokens=20,
+            output_tokens=8,
+            finish_reasons=["STOP"],
+        )
+        manager = Mock()
+        manager.save_representation = AsyncMock(
+            return_value=crud.CreateDocumentsResult()
+        )
+
+        with (
+            patch(
+                "src.deriver.deriver.honcho_llm_call",
+                new_callable=AsyncMock,
+                return_value=response,
+            ),
+            patch(
+                "src.deriver.deriver.RepresentationManager",
+                return_value=manager,
+            ),
+        ):
+            await process_representation_tasks_batch(
+                messages=[user_context, assistant_evidence],
+                message_level_configuration=configuration,
+                observers=["user"],
+                observed="user",
+                queue_item_message_ids=[7],
+            )
+
+        saved_representation, saved_message_ids, *_ = (
+            manager.save_representation.await_args.args
+        )
+        assert saved_message_ids == [6, 7]
+        assert saved_representation.explicit[0].content == (
+            "user plays tennis on Tuesdays"
+        )
 
 
 class TestBackwardsCompatibility:

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -10,7 +10,7 @@ from src.config import settings
 from src.deriver.deriver import process_representation_tasks_batch
 from src.llm import HonchoLLMCallResponse
 from src.utils.representation import (
-    ExplicitObservationBase,
+    PromptExplicitObservation,
     PromptRepresentation,
     Representation,
 )
@@ -338,7 +338,12 @@ class TestDeriverProcessing:
 
         mock_response = HonchoLLMCallResponse(
             content=PromptRepresentation(
-                explicit=[ExplicitObservationBase(content="alice says hello")]
+                explicit=[
+                    PromptExplicitObservation(
+                        content="alice says hello",
+                        is_durable_target_fact=True,
+                    )
+                ]
             ),
             input_tokens=10,
             output_tokens=5,

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -397,6 +397,94 @@ class TestDeriverProcessing:
         assert event.semantic_dup_rejected_count == 33
         assert event.semantic_dup_replaced_count == 44
 
+    async def test_cross_speaker_evidence_is_saved_for_target(self) -> None:
+        user_context_message = Mock(
+            id=6,
+            public_id="msg_user_context",
+            session_name="session-1",
+            workspace_name="workspace-1",
+            peer_name="user",
+            content="We were discussing weekly activities",
+            token_count=6,
+            created_at=datetime.now(timezone.utc),
+        )
+        assistant_message = Mock(
+            id=7,
+            public_id="msg_assistant_user_fact",
+            session_name="session-1",
+            workspace_name="workspace-1",
+            peer_name="assistant",
+            content="You play tennis on Tuesdays",
+            token_count=7,
+            created_at=datetime.now(timezone.utc),
+        )
+        configuration = Mock()
+        configuration.reasoning.enabled = True
+        configuration.reasoning.custom_instructions = None
+
+        mock_response = HonchoLLMCallResponse(
+            content=PromptRepresentation(
+                explicit=[
+                    PromptExplicitObservation(
+                        content="user plays tennis on Tuesdays",
+                        is_durable_target_fact=True,
+                    )
+                ]
+            ),
+            input_tokens=20,
+            output_tokens=8,
+            finish_reasons=["STOP"],
+        )
+        manager = Mock()
+        manager.save_representation = AsyncMock(
+            return_value=crud.CreateDocumentsResult()
+        )
+
+        with (
+            patch(
+                "src.deriver.deriver.honcho_llm_call",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ) as mock_llm_call,
+            patch(
+                "src.deriver.deriver.RepresentationManager",
+                return_value=manager,
+            ) as manager_class,
+        ):
+            await process_representation_tasks_batch(
+                messages=[user_context_message, assistant_message],
+                message_level_configuration=configuration,
+                observers=["user", "assistant"],
+                observed="user",
+                participants=["user", "assistant"],
+                queue_item_message_ids=[7],
+            )
+
+        await_args = mock_llm_call.await_args
+        if await_args is None:
+            raise AssertionError("Expected deriver LLM call")
+        rendered_prompt = await_args.kwargs["prompt"]
+        assert (
+            '{"speaker":"assistant","addressee":"user"}: ' "You play tennis on Tuesdays"
+        ) in rendered_prompt
+
+        assert [kwargs for _, kwargs in manager_class.call_args_list] == [
+            {"workspace_name": "workspace-1", "observer": "user", "observed": "user"},
+            {
+                "workspace_name": "workspace-1",
+                "observer": "assistant",
+                "observed": "user",
+            },
+        ]
+        assert manager.save_representation.await_count == 2
+        saved_representation, saved_message_ids, *_ = (
+            manager.save_representation.await_args.args
+        )
+        assert saved_message_ids == [6, 7]
+        assert saved_representation.explicit[0].content == (
+            "user plays tennis on Tuesdays"
+        )
+
 
 class TestBackwardsCompatibility:
     """Test backwards compatibility for queue items created before the deduplication change."""

--- a/tests/deriver/test_prompts.py
+++ b/tests/deriver/test_prompts.py
@@ -30,6 +30,71 @@ def test_minimal_deriver_prompt_omits_custom_instructions_when_absent() -> None:
     assert "CUSTOM INSTRUCTIONS:" not in prompt
 
 
+def test_minimal_deriver_prompt_separates_speaker_from_subject() -> None:
+    prompt = minimal_deriver_prompt(
+        peer_id="assistant",
+        messages="assistant: You play tennis on Tuesdays",
+    )
+
+    assert (
+        "it identifies the speaker, not necessarily the subject" in prompt
+    )
+    assert "`I`/`me`/`my` refer to the speaker" in prompt
+    assert "`you`/`your` refer to the addressee" in prompt
+    assert (
+        "Another speaker's statement about the target peer is valid evidence" in prompt
+    )
+    assert (
+        "Facts about the target peer that are directly supported by any speaker's "
+        "message"
+    ) in prompt
+    assert (
+        "Speaking, hearing, receiving, acknowledging, repeating, or knowing another "
+        "subject's fact is transient conversation state"
+    ) in prompt
+    assert "return no observations" in prompt
+    assert "Omit any observation whose subject is ambiguous" in prompt
+    assert (
+        "TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        "→ no observation about `assistant`"
+    ) in prompt
+    assert (
+        "TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` "
+        '→ "assistant prefers concise responses"'
+    ) in prompt
+    assert (
+        "TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        '→ "user plays tennis on Tuesdays"'
+    ) in prompt
+    assert "alice works remotely on Fridays" in prompt
+    assert "general knowledge" not in prompt
+
+
+def test_subject_attribution_rule_matches_timestamped_message_format() -> None:
+    prompt = minimal_deriver_prompt(
+        peer_id="user",
+        messages="2026-08-13 03:20:00 assistant: The user likes tennis",
+    )
+
+    assert "<timestamp> <speaker>: <content>" in prompt
+    assert "text after the timestamp" in prompt
+
+
+def test_subject_attribution_rules_preserve_static_cache_prefix() -> None:
+    alice_prompt = minimal_deriver_prompt(
+        peer_id="alice",
+        messages="alice: I like tea",
+    )
+    bob_prompt = minimal_deriver_prompt(
+        peer_id="bob",
+        messages="bob: I like coffee",
+    )
+
+    alice_prefix = alice_prompt.split("Target peer:", maxsplit=1)[0]
+    bob_prefix = bob_prompt.split("Target peer:", maxsplit=1)[0]
+    assert alice_prefix == bob_prefix
+
+
 def test_estimate_deriver_prompt_tokens_increases_with_custom_instructions() -> None:
     base_tokens = estimate_minimal_deriver_prompt_tokens()
     custom_tokens = estimate_deriver_prompt_tokens(

--- a/tests/deriver/test_prompts.py
+++ b/tests/deriver/test_prompts.py
@@ -30,6 +30,62 @@ def test_minimal_deriver_prompt_omits_custom_instructions_when_absent() -> None:
     assert "CUSTOM INSTRUCTIONS:" not in prompt
 
 
+def test_minimal_deriver_prompt_separates_speaker_from_subject() -> None:
+    prompt = minimal_deriver_prompt(
+        peer_id="assistant",
+        messages="assistant: You play tennis on Tuesdays",
+    )
+
+    assert (
+        "The label before `:` identifies the speaker, not necessarily the subject"
+        in prompt
+    )
+    assert "`I`/`me`/`my` refer to the speaker" in prompt
+    assert "`you`/`your` refer to the addressee" in prompt
+    assert (
+        "Another speaker's statement about the target peer is valid evidence" in prompt
+    )
+    assert (
+        "Facts about the target peer that are directly supported by any speaker's "
+        "message"
+    ) in prompt
+    assert (
+        "Speaking, hearing, receiving, acknowledging, repeating, or knowing another "
+        "subject's fact is transient conversation state"
+    ) in prompt
+    assert "return no observations" in prompt
+    assert "Omit any observation whose subject is ambiguous" in prompt
+    assert (
+        "TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        "→ no observation about `assistant`"
+    ) in prompt
+    assert (
+        "TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` "
+        '→ "assistant prefers concise responses"'
+    ) in prompt
+    assert (
+        "TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        '→ "user plays tennis on Tuesdays"'
+    ) in prompt
+    assert "alice works remotely on Fridays" in prompt
+    assert "general knowledge" not in prompt
+
+
+def test_subject_attribution_rules_preserve_static_cache_prefix() -> None:
+    alice_prompt = minimal_deriver_prompt(
+        peer_id="alice",
+        messages="alice: I like tea",
+    )
+    bob_prompt = minimal_deriver_prompt(
+        peer_id="bob",
+        messages="bob: I like coffee",
+    )
+
+    alice_prefix = alice_prompt.split("Target peer:", maxsplit=1)[0]
+    bob_prefix = bob_prompt.split("Target peer:", maxsplit=1)[0]
+    assert alice_prefix == bob_prefix
+
+
 def test_estimate_deriver_prompt_tokens_increases_with_custom_instructions() -> None:
     base_tokens = estimate_minimal_deriver_prompt_tokens()
     custom_tokens = estimate_deriver_prompt_tokens(

--- a/tests/deriver/test_prompts.py
+++ b/tests/deriver/test_prompts.py
@@ -36,11 +36,10 @@ def test_minimal_deriver_prompt_separates_speaker_from_subject() -> None:
         messages="assistant: You play tennis on Tuesdays",
     )
 
-    assert (
-        "it identifies the speaker, not necessarily the subject" in prompt
-    )
+    assert "Each message prefix identifies the speaker" in prompt
+    assert '"speaker":"assistant","addressee":"user"' in prompt
     assert "`I`/`me`/`my` refer to the speaker" in prompt
-    assert "`you`/`your` refer to the addressee" in prompt
+    assert "`you`/`your` refer only to the labeled addressee" in prompt
     assert (
         "Another speaker's statement about the target peer is valid evidence" in prompt
     )
@@ -55,29 +54,22 @@ def test_minimal_deriver_prompt_separates_speaker_from_subject() -> None:
     assert "return no observations" in prompt
     assert "Omit any observation whose subject is ambiguous" in prompt
     assert (
-        "TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        'TARGET `assistant`, MESSAGE `{"speaker":"assistant",'
+        '"addressee":"user"}: You play tennis on Tuesdays` '
         "→ no observation about `assistant`"
     ) in prompt
     assert (
-        "TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` "
+        'TARGET `assistant`, MESSAGE `{"speaker":"assistant",'
+        '"addressee":"user"}: I prefer concise responses` '
         '→ "assistant prefers concise responses"'
     ) in prompt
     assert (
-        "TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        'TARGET `user`, MESSAGE `{"speaker":"assistant",'
+        '"addressee":"user"}: You play tennis on Tuesdays` '
         '→ "user plays tennis on Tuesdays"'
     ) in prompt
     assert "alice works remotely on Fridays" in prompt
     assert "general knowledge" not in prompt
-
-
-def test_subject_attribution_rule_matches_timestamped_message_format() -> None:
-    prompt = minimal_deriver_prompt(
-        peer_id="user",
-        messages="2026-08-13 03:20:00 assistant: The user likes tennis",
-    )
-
-    assert "<timestamp> <speaker>: <content>" in prompt
-    assert "text after the timestamp" in prompt
 
 
 def test_subject_attribution_rules_preserve_static_cache_prefix() -> None:

--- a/tests/deriver/test_prompts.py
+++ b/tests/deriver/test_prompts.py
@@ -36,12 +36,10 @@ def test_minimal_deriver_prompt_separates_speaker_from_subject() -> None:
         messages="assistant: You play tennis on Tuesdays",
     )
 
-    assert (
-        "The label before `:` identifies the speaker, not necessarily the subject"
-        in prompt
-    )
+    assert "Each message prefix identifies the speaker" in prompt
+    assert '"speaker":"assistant","addressee":"user"' in prompt
     assert "`I`/`me`/`my` refer to the speaker" in prompt
-    assert "`you`/`your` refer to the addressee" in prompt
+    assert "`you`/`your` refer only to the labeled addressee" in prompt
     assert (
         "Another speaker's statement about the target peer is valid evidence" in prompt
     )
@@ -56,15 +54,18 @@ def test_minimal_deriver_prompt_separates_speaker_from_subject() -> None:
     assert "return no observations" in prompt
     assert "Omit any observation whose subject is ambiguous" in prompt
     assert (
-        "TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        'TARGET `assistant`, MESSAGE `{"speaker":"assistant",'
+        '"addressee":"user"}: You play tennis on Tuesdays` '
         "→ no observation about `assistant`"
     ) in prompt
     assert (
-        "TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` "
+        'TARGET `assistant`, MESSAGE `{"speaker":"assistant",'
+        '"addressee":"user"}: I prefer concise responses` '
         '→ "assistant prefers concise responses"'
     ) in prompt
     assert (
-        "TARGET `user`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        'TARGET `user`, MESSAGE `{"speaker":"assistant",'
+        '"addressee":"user"}: You play tennis on Tuesdays` '
         '→ "user plays tennis on Tuesdays"'
     ) in prompt
     assert "alice works remotely on Fridays" in prompt

--- a/tests/deriver/test_queue_processing.py
+++ b/tests/deriver/test_queue_processing.py
@@ -84,6 +84,122 @@ class TestQueueProcessing:
 
         return work_unit_key, queue_items
 
+    async def test_representation_batch_stops_at_observer_set_change(
+        self,
+        db_session: AsyncSession,
+        sample_session_with_peers: tuple[models.Session, list[models.Peer]],
+    ) -> None:
+        session, peers = sample_session_with_peers
+        user, assistant = peers[:2]
+        messages = [
+            models.Message(
+                session_name=session.name,
+                workspace_name=session.workspace_name,
+                peer_name=assistant.name,
+                content=f"Message {index}",
+                token_count=10,
+                seq_in_session=index,
+            )
+            for index in (1, 2)
+        ]
+        db_session.add_all(messages)
+        await db_session.commit()
+
+        work_unit_key = (
+            f"representation:{session.workspace_name}:{session.name}:{user.name}"
+        )
+        queue_items = [
+            models.QueueItem(
+                session_id=session.id,
+                task_type="representation",
+                work_unit_key=work_unit_key,
+                payload={
+                    "task_type": "representation",
+                    "session_name": session.name,
+                    "observed": user.name,
+                    "observers": observers,
+                },
+                processed=False,
+                workspace_name=session.workspace_name,
+                message_id=message.id,
+            )
+            for message, observers in zip(
+                messages,
+                ([user.name], [user.name, assistant.name]),
+                strict=True,
+            )
+        ]
+        db_session.add_all(queue_items)
+        await db_session.commit()
+
+        manager = QueueManager()
+        claimed = await manager.claim_work_units(db_session, [work_unit_key])
+        await db_session.commit()
+
+        batch = await manager.get_queue_item_batch(
+            "representation", work_unit_key, claimed[work_unit_key]
+        )
+
+        assert [item.message_id for item in batch.items_to_process] == [messages[0].id]
+
+    async def test_promoted_target_batch_includes_sender_predecessor(
+        self,
+        db_session: AsyncSession,
+        sample_session_with_peers: tuple[models.Session, list[models.Peer]],
+    ) -> None:
+        session, peers = sample_session_with_peers
+        user, assistant = peers[:2]
+        user_message = models.Message(
+            session_name=session.name,
+            workspace_name=session.workspace_name,
+            peer_name=user.name,
+            content="I have been thinking about a new hobby",
+            token_count=10,
+            seq_in_session=1,
+        )
+        assistant_message = models.Message(
+            session_name=session.name,
+            workspace_name=session.workspace_name,
+            peer_name=assistant.name,
+            content="Yes, you play tennis on Tuesdays",
+            token_count=10,
+            seq_in_session=2,
+        )
+        db_session.add_all([user_message, assistant_message])
+        await db_session.commit()
+
+        payload = {
+            "task_type": "representation",
+            "session_name": session.name,
+            "observed": user.name,
+            "observers": [user.name, assistant.name],
+        }
+        work_unit_key = construct_work_unit_key(session.workspace_name, payload)
+        queue_item = models.QueueItem(
+            session_id=session.id,
+            task_type="representation",
+            work_unit_key=work_unit_key,
+            payload=payload,
+            processed=False,
+            workspace_name=session.workspace_name,
+            message_id=assistant_message.id,
+        )
+        db_session.add(queue_item)
+        await db_session.commit()
+
+        manager = QueueManager()
+        claimed = await manager.claim_work_units(db_session, [work_unit_key])
+        await db_session.commit()
+
+        batch = await manager.get_queue_item_batch(
+            "representation", work_unit_key, claimed[work_unit_key]
+        )
+
+        assert [message.id for message in batch.messages_context] == [
+            user_message.id,
+            assistant_message.id,
+        ]
+
     async def test_get_and_claim_work_units(
         self,
         db_session: AsyncSession,

--- a/tests/deriver/test_representation_crud.py
+++ b/tests/deriver/test_representation_crud.py
@@ -3,7 +3,7 @@ import datetime
 from src.utils.representation import (
     DeductiveObservation,
     ExplicitObservation,
-    ExplicitObservationBase,
+    PromptExplicitObservation,
     PromptRepresentation,
     Representation,
 )
@@ -84,7 +84,7 @@ def test_prompt_representation_conversion():
     Therefore, from_prompt_representation only converts explicit observations.
     """
     pr = PromptRepresentation(
-        explicit=[ExplicitObservationBase(content="A")],
+        explicit=[PromptExplicitObservation(content="A", is_durable_target_fact=True)],
         # Deductive observations in PromptRepresentation are ignored by from_prompt_representation
         # because the Deriver only produces explicit observations
         # deductive=[
@@ -106,3 +106,29 @@ def test_prompt_representation_conversion():
     # (they would be created directly by the Dreamer via the create_observations tool)
     assert len(rep.deductive) == 0
     assert rep.explicit[0].created_at == timestamp
+
+
+def test_prompt_representation_drops_non_durable_target_facts():
+    pr = PromptRepresentation(
+        explicit=[
+            PromptExplicitObservation(
+                content="assistant knows the user plays tennis",
+                is_durable_target_fact=False,
+            ),
+            PromptExplicitObservation(
+                content="assistant prefers concise plans",
+                is_durable_target_fact=True,
+            ),
+        ]
+    )
+
+    rep = Representation.from_prompt_representation(
+        pr,
+        message_ids=[1],
+        session_name="s",
+        created_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+
+    assert [observation.content for observation in rep.explicit] == [
+        "assistant prefers concise plans"
+    ]

--- a/tests/integration/test_enqueue.py
+++ b/tests/integration/test_enqueue.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 from nanoid import generate as generate_nanoid
@@ -9,7 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, models, schemas
 from src.deriver import enqueue
-from src.deriver.enqueue import generate_queue_records
+from src.deriver.enqueue import (
+    PeerObservationConfiguration,
+    generate_queue_records,
+)
 from src.models import Peer, QueueItem, Workspace
 
 
@@ -286,6 +289,146 @@ class TestEnqueueFunction:
             assert observers is not None
             assert test_peer1.name in observers  # self-observation
             assert test_peer2.name in observers  # peer2 observes others
+
+    @pytest.mark.parametrize(
+        (
+            "assistant_observe_me",
+            "assistant_observe_others",
+            "user_observe_me",
+            "third_active_peer",
+            "expected_targets",
+        ),
+        [
+            (False, True, True, False, ["user"]),
+            (True, True, True, False, ["assistant", "user"]),
+            (False, False, True, False, []),
+            (False, True, False, False, []),
+            (False, True, True, True, []),
+        ],
+    )
+    async def test_assistant_message_enqueues_user_target_derivation(
+        self,
+        assistant_observe_me: bool,
+        assistant_observe_others: bool,
+        user_observe_me: bool,
+        third_active_peer: bool,
+        expected_targets: list[str],
+    ) -> None:
+        message = {
+            "message_id": 42,
+            "peer_name": "assistant",
+            "workspace_name": "workspace",
+            "session_name": "session",
+            "content": "You play tennis on Tuesdays",
+            "seq_in_session": 1,
+            "created_at": datetime.now(timezone.utc),
+        }
+        peers_config = {
+            "assistant": PeerObservationConfiguration(
+                {},
+                {
+                    "observe_me": assistant_observe_me,
+                    "observe_others": assistant_observe_others,
+                },
+                True,
+            ),
+            "user": PeerObservationConfiguration(
+                {},
+                {"observe_me": user_observe_me, "observe_others": False},
+                True,
+            ),
+        }
+        if third_active_peer:
+            peers_config["third-peer"] = PeerObservationConfiguration({}, {}, True)
+        resolved_configuration = schemas.ResolvedConfiguration(
+            reasoning=schemas.ResolvedReasoningConfiguration(enabled=True),
+            summary=schemas.ResolvedSummaryConfiguration(
+                enabled=False,
+                messages_per_short_summary=20,
+                messages_per_long_summary=60,
+            ),
+            peer_card=schemas.ResolvedPeerCardConfiguration(use=True, create=True),
+            dream=schemas.ResolvedDreamConfiguration(enabled=True),
+        )
+
+        records = await generate_queue_records(
+            db_session=AsyncMock(),
+            message=message,
+            peers_with_configuration=peers_config,
+            session_id="session-id",
+            conf=resolved_configuration,
+        )
+
+        representation_records = [
+            record for record in records if record["task_type"] == "representation"
+        ]
+        assert [
+            record["payload"]["observed"] for record in representation_records
+        ] == expected_targets
+
+        if "user" in expected_targets:
+            user_record = next(
+                record
+                for record in representation_records
+                if record["payload"]["observed"] == "user"
+            )
+            assert user_record["message_id"] == 42
+            assert user_record["payload"]["observers"] == ["user", "assistant"]
+            assert user_record["payload"]["participants"] == ["assistant", "user"]
+
+    async def test_promoted_target_dream_is_cancelled_after_enqueue(self) -> None:
+        queue_records = [
+            {
+                "workspace_name": "workspace",
+                "task_type": "representation",
+                "payload": {"observed": "assistant"},
+            },
+            {
+                "workspace_name": "workspace",
+                "task_type": "representation",
+                "payload": {"observed": "user"},
+            },
+        ]
+        scheduler = AsyncMock()
+
+        async def cancel_dreams(_workspace: str, target: str) -> set[str]:
+            if target == "assistant":
+                raise RuntimeError("scheduler unavailable")
+            return {"user-dream"}
+
+        scheduler.cancel_dreams_for_observed.side_effect = cancel_dreams
+        db_session = AsyncMock()
+
+        with (
+            patch("src.deriver.enqueue.tracked_db") as tracked_db_mock,
+            patch(
+                "src.deriver.enqueue.handle_session",
+                new_callable=AsyncMock,
+                return_value=queue_records,
+            ),
+            patch(
+                "src.deriver.enqueue.get_dream_scheduler",
+                return_value=scheduler,
+            ),
+        ):
+            tracked_db_mock.return_value.__aenter__.return_value = db_session
+            await enqueue(
+                [
+                    {
+                        "workspace_name": "workspace",
+                        "session_name": "session",
+                        "peer_name": "assistant",
+                    }
+                ]
+            )
+
+        scheduler.cancel_dreams_for_observed.assert_has_awaits(
+            [
+                call("workspace", "assistant"),
+                call("workspace", "user"),
+            ],
+            any_order=True,
+        )
 
     @pytest.mark.asyncio
     async def test_session_with_multiple_peers_some_observe_others(
@@ -757,7 +900,7 @@ class TestGetEffectiveObserveMeFunction:
         from src.deriver.enqueue import get_effective_observe_me
 
         # Empty peer configuration dict simulates sender who left after sending message
-        peers_with_configuration: dict[str, list[dict[str, Any]]] = {}
+        peers_with_configuration: dict[str, PeerObservationConfiguration] = {}
 
         result = get_effective_observe_me("missing_sender", peers_with_configuration)
 
@@ -769,8 +912,8 @@ class TestGetEffectiveObserveMeFunction:
         from src.deriver.enqueue import get_effective_observe_me
 
         # Sender present but with empty configurations
-        peers_with_configuration: dict[str, list[dict[str, Any]]] = {
-            "sender": [{}, {}]  # Empty peer config, empty session config
+        peers_with_configuration = {
+            "sender": PeerObservationConfiguration({}, {}, True)
         }
 
         result = get_effective_observe_me("sender", peers_with_configuration)
@@ -783,7 +926,7 @@ class TestGetEffectiveObserveMeFunction:
         from src.deriver.enqueue import get_effective_observe_me
 
         peers_with_configuration = {
-            "sender": [{"observe_me": False}, {}]  # Peer config with observe_me=False
+            "sender": PeerObservationConfiguration({"observe_me": False}, {}, True)
         }
 
         result = get_effective_observe_me("sender", peers_with_configuration)
@@ -795,10 +938,11 @@ class TestGetEffectiveObserveMeFunction:
         from src.deriver.enqueue import get_effective_observe_me
 
         peers_with_configuration = {
-            "sender": [
+            "sender": PeerObservationConfiguration(
                 {"observe_me": True},  # Peer config says True
                 {"observe_me": False},  # Session config says False - should win
-            ]
+                True,
+            )
         }
 
         result = get_effective_observe_me("sender", peers_with_configuration)
@@ -810,10 +954,11 @@ class TestGetEffectiveObserveMeFunction:
         from src.deriver.enqueue import get_effective_observe_me
 
         peers_with_configuration = {
-            "sender": [
+            "sender": PeerObservationConfiguration(
                 {"observe_me": False},  # Peer config says False
                 {"observe_me": None},  # Session config is None - should fall back
-            ]
+                True,
+            )
         }
 
         result = get_effective_observe_me("sender", peers_with_configuration)
@@ -848,7 +993,9 @@ class TestGetEffectiveObserveMeFunction:
                 observed = "missing_sender"
             else:
                 peers_with_configuration = {
-                    f"sender_{i}": [peer_config or {}, session_config or {}]
+                    f"sender_{i}": PeerObservationConfiguration(
+                        peer_config or {}, session_config or {}, True
+                    )
                 }
                 observed = f"sender_{i}"
 
@@ -1181,11 +1328,12 @@ class TestGenerateQueueRecordsSeqInSession:
             mock_crud.return_value = 200
             mock_db_session = AsyncMock()
 
-            peers_config: dict[str, list[Any]] = {
-                test_peer.name: [
+            peers_config = {
+                test_peer.name: PeerObservationConfiguration(
                     {"observe_me": True},
                     {"observe_others": True},
-                ]
+                    True,
+                )
             }
             resolved_configuration = schemas.ResolvedConfiguration(
                 reasoning=schemas.ResolvedReasoningConfiguration(enabled=True),
@@ -1261,11 +1409,12 @@ class TestGenerateQueueRecordsSeqInSession:
 
             mock_db_session = AsyncMock()
 
-            peers_config: dict[str, list[Any]] = {
-                test_peer.name: [
+            peers_config = {
+                test_peer.name: PeerObservationConfiguration(
                     {"observe_me": True},
                     {"observe_others": True},
-                ]
+                    True,
+                )
             }
             resolved_configuration = schemas.ResolvedConfiguration(
                 reasoning=schemas.ResolvedReasoningConfiguration(enabled=True),

--- a/tests/integration/test_representation.py
+++ b/tests/integration/test_representation.py
@@ -21,7 +21,7 @@ from src.utils.representation import (
     DeductiveObservation,
     # DeductiveObservationBase,
     ExplicitObservation,
-    ExplicitObservationBase,
+    PromptExplicitObservation,
     PromptRepresentation,
     Representation,
 )
@@ -412,8 +412,12 @@ class TestPromptRepresentationConversion:
         """
         prompt_rep = PromptRepresentation(
             explicit=[
-                ExplicitObservationBase(content="User likes coffee"),
-                ExplicitObservationBase(content="User works remotely"),
+                PromptExplicitObservation(
+                    content="User likes coffee", is_durable_target_fact=True
+                ),
+                PromptExplicitObservation(
+                    content="User works remotely", is_durable_target_fact=True
+                ),
             ],
         )
 

--- a/tests/integration/test_token_metrics.py
+++ b/tests/integration/test_token_metrics.py
@@ -32,7 +32,7 @@ from src.telemetry.prometheus.metrics import (
     deriver_tokens_processed_counter,
     dialectic_tokens_processed_counter,
 )
-from src.utils.representation import ExplicitObservationBase, PromptRepresentation
+from src.utils.representation import PromptExplicitObservation, PromptRepresentation
 from src.utils.summarizer import (
     SummaryType,
     _create_and_save_summary,
@@ -183,7 +183,12 @@ def create_mock_deriver_response(
     """Create a mock LLM response for the deriver."""
     return HonchoLLMCallResponse(
         content=PromptRepresentation(
-            explicit=[ExplicitObservationBase(content="Test observation from deriver")],
+            explicit=[
+                PromptExplicitObservation(
+                    content="Test observation from deriver",
+                    is_durable_target_fact=True,
+                )
+            ],
         ),
         input_tokens=100,
         output_tokens=output_tokens,

--- a/tests/routes/test_queue_status.py
+++ b/tests/routes/test_queue_status.py
@@ -170,22 +170,83 @@ class TestDeriverStatusEndpoint:
             params={"sender_id": peer.name},
         )
         assert response.status_code == 200
-        assert response.json()["total_work_units"] == 5
-        assert response.json()["pending_work_units"] == 5
-        # Test with both (OR filter)
+        assert response.json()["total_work_units"] == 0
+        assert response.json()["pending_work_units"] == 0
+        # Test with both filters
         response = client.get(
             f"/v3/workspaces/{workspace.name}/queue/status",
             params={"observer_id": peer.name, "sender_id": peer.name},
         )
         assert response.status_code == 200
-        assert response.json()["total_work_units"] == 5
-        assert response.json()["pending_work_units"] == 5
-        # Test with different observer and sender (should be ok)
+        assert response.json()["total_work_units"] == 0
+        assert response.json()["pending_work_units"] == 0
+        # Test with different observer and sender
         response = client.get(
             f"/v3/workspaces/{workspace.name}/queue/status",
             params={"observer_id": peer.name, "sender_id": "different"},
         )
         assert response.status_code == 200
+        assert response.json()["total_work_units"] == 0
+
+    async def test_sender_filter_uses_message_author_for_promoted_target(
+        self,
+        client: TestClient,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ) -> None:
+        workspace, user = sample_data
+        assistant = models.Peer(workspace_name=workspace.name, name="assistant")
+        session = models.Session(workspace_name=workspace.name, name="session")
+        db_session.add_all([assistant, session])
+        await db_session.commit()
+
+        message = models.Message(
+            workspace_name=workspace.name,
+            session_name=session.name,
+            peer_name=assistant.name,
+            content="You play tennis on Tuesdays",
+            token_count=10,
+            seq_in_session=1,
+        )
+        db_session.add(message)
+        await db_session.commit()
+
+        payload = {
+            "observed": user.name,
+            "observers": [user.name, assistant.name],
+            "task_type": "representation",
+            "workspace_name": workspace.name,
+            "session_name": session.name,
+        }
+        db_session.add(
+            models.QueueItem(
+                session_id=session.id,
+                task_type="representation",
+                work_unit_key=construct_work_unit_key(workspace.name, payload),
+                payload=payload,
+                processed=False,
+                workspace_name=workspace.name,
+                message_id=message.id,
+            )
+        )
+        await db_session.commit()
+
+        assistant_response = client.get(
+            f"/v3/workspaces/{workspace.name}/queue/status",
+            params={"sender_id": assistant.name},
+        )
+        user_response = client.get(
+            f"/v3/workspaces/{workspace.name}/queue/status",
+            params={"sender_id": user.name},
+        )
+        observer_response = client.get(
+            f"/v3/workspaces/{workspace.name}/queue/status",
+            params={"observer_id": assistant.name},
+        )
+
+        assert assistant_response.json()["total_work_units"] == 1
+        assert user_response.json()["total_work_units"] == 0
+        assert observer_response.json()["total_work_units"] == 1
 
     async def test_get_deriver_status_with_sessions_breakdown(
         self,

--- a/tests/utils/test_length_finish_reason.py
+++ b/tests/utils/test_length_finish_reason.py
@@ -36,8 +36,8 @@ class SimpleModel(BaseModel):
 
 VALID_REPR_JSON = {
     "explicit": [
-        {"content": "hermes is 25 years old"},
-        {"content": "hermes has a dog"},
+        {"content": "hermes is 25 years old", "is_durable_target_fact": True},
+        {"content": "hermes has a dog", "is_durable_target_fact": True},
     ]
 }
 
@@ -235,7 +235,9 @@ class TestOpenAILengthFinishReasonRepair:
 
     async def test_token_counts_preserved(self) -> None:
         """Token counts from the truncated completion should be preserved."""
-        truncated_json = '{"explicit": [{"content": "fact one"}'
+        truncated_json = (
+            '{"explicit": [{"content": "fact one", "is_durable_target_fact": true}'
+        )
 
         mock_client = AsyncMock(spec=AsyncOpenAI)
         mock_client.chat.completions.parse = _raise_length_error(truncated_json)


### PR DESCRIPTION
## Summary

- enqueue assistant-authored evidence for the other peer in a two-peer session when sender `observeOthers` and target `observeMe` allow it;
- preserve ordered, deduplicated batch-level message IDs and conversational context when evidence author differs from derivation target;
- label only queued two-peer evidence with its explicit speaker and addressee snapshot, leaving older interleaved context unlabeled when its addressee is unknown;
- keep batches homogeneous when observer collections or participant snapshots change;
- isolate post-commit dream-cancellation failures per promoted target;
- make queue-status sender filtering follow the source-message author and combine filters restrictively;
- document the two-peer promotion behavior.

## Why

The subject-attribution contract in #943 can extract an assistant-authored fact about the user, but the enqueue path only created a derivation task for the sender. The user-target prompt therefore never ran.

This PR is stacked on #943 and should be reviewed after it. Once #943 merges, this PR's remaining diff is the enqueue and promoted-target lifecycle fix.

## Semantics

- sender `observeOthers` authorizes cross-speaker evidence;
- target `observeMe` authorizes modeling that target;
- promotion is limited to two-active-peer sessions;
- the participant snapshot labels only queued messages captured under that snapshot, never older context;
- raw message storage and search are unchanged.

## Relationship to adjacent work

This is the single-commit follow-up to #943. The #944-only delta schedules eligible two-peer evidence for the other target, captures participant/addressee context, keeps batches homogeneous, isolates promoted-target lifecycle failures, and fixes sender-status semantics.

Draft #935 adds exact per-conclusion citation/provenance after a target task exists, while #961 adds prompt-level self-narration filtering. Neither schedules the promoted target task or replaces this PR. Both should preserve #943/#944's accepted any-speaker evidence contract.

## Validation

- 135 focused PostgreSQL-backed deriver, enqueue, queue-manager, queue-status, and fixture tests pass;
- focused Ruff and `git diff --check` pass;
- independent review found no remaining correctness or security issues.

Stacked on #943.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Representation processing now supports participant context and clearer speaker/addressee attribution.
  * Observations distinguish durable facts about the selected peer from unrelated statements.
  * Multi-participant sessions can create separate representation updates for applicable targets.
* **Bug Fixes**
  * Queue status sender filtering now correctly reflects message authors.
  * Empty submissions are safely ignored, and pending work is cancelled only after successful enqueueing.
  * Representation batches now avoid mixing incompatible session context.
* **Documentation**
  * Clarified representation scopes, observation behavior, and queue-status filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1087.