### PR TITLE
chore: clear the two remaining basedpyright warnings

### DIFF
--- a/src/vector_store/__init__.py
+++ b/src/vector_store/__init__.py
@@ -207,10 +207,10 @@ def _create_store_by_type(store_type: str) -> VectorStore:
         except ImportError as exc:
             raise RuntimeError(
                 "VECTOR_STORE.TYPE is set to 'lancedb', but the 'lancedb' package "
-                "is not installed (for example on macOS Intel, where it is omitted "
-                "from dependencies because PyPI has no wheel). "
-                "Use TYPE 'pgvector' or 'turbopuffer', or install lancedb manually. "
-                f"Original import error: {exc}"
+                + "is not installed (for example on macOS Intel, where it is omitted "
+                + "from dependencies because PyPI has no wheel). "
+                + "Use TYPE 'pgvector' or 'turbopuffer', or install lancedb manually. "
+                + f"Original import error: {exc}"
             ) from exc
 
         return LanceDBVectorStore()

--- a/tests/test_cache_redaction.py
+++ b/tests/test_cache_redaction.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.cache.client import _redact_cache_url
+from src.cache.client import _redact_cache_url  # pyright: ignore[reportPrivateUsage]
 
 
 class TestRedactCacheUrl:


### PR DESCRIPTION
`uv run basedpyright tests/ src/` reported two warnings in files that predate this change. The pre-commit hook is file-scoped, so neither surfaced unless the owning file happened to be touched.

- **`src/vector_store/__init__.py`** — the lancedb `RuntimeError` message was built from adjacent string literals (`reportImplicitStringConcatenation`). Joined with explicit `+`, preserving the existing line breaks. `ISC` isn't in ruff's selected rules, so there's no conflicting lint.
- **`tests/test_cache_redaction.py`** — the test deliberately covers a private helper (`reportPrivateUsage`). Annotated the import rather than renaming the helper or widening its visibility for a test's benefit.

No behavior change. `uv run basedpyright tests/ src/` now reports `0 errors, 0 warnings`; `tests/test_cache_redaction.py` passes (20 tests).

Separate from #947 deliberately — unrelated files, no shared review context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error message shown when the selected vector store is unavailable, including clearer guidance and the original error details.

* **Tests**
  * Updated test configuration to support validation of cache URL redaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->