### PR TITLE
fix: make OpenAPI servers list configurable via API_BASE_URL env var [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1446,6 +1446,11 @@ class AppSettings(HonchoSettings):
         "https://api.honcho.dev",
     ]
 
+    # Override the OpenAPI "Servers" dropdown in Swagger UI.
+    # When set, the self-hosted URL is used as the only server entry.
+    # Falls back to the default production + localhost entries when unset.
+    API_BASE_URL: str | None = None
+
     COLLECT_METRICS_LOCAL: bool = False
     LOCAL_METRICS_FILE: str = "metrics.jsonl"
     REASONING_TRACES_FILE: str | None = None  # Path to JSONL file for reasoning traces

--- a/src/main.py
+++ b/src/main.py
@@ -135,12 +135,21 @@ async def lifespan(_: FastAPI):
         await shutdown_telemetry()
 
 
-app = FastAPI(
-    lifespan=lifespan,
-    servers=[
+def _build_servers() -> list[dict[str, str]]:
+    """Build the OpenAPI servers list from settings, falling back to defaults."""
+    if settings.API_BASE_URL:
+        return [
+            {"url": settings.API_BASE_URL, "description": "Self-hosted deployment"},
+        ]
+    return [
         {"url": "https://api.honcho.dev", "description": "Production SaaS Platform"},
         {"url": "http://localhost:8000", "description": "Local Development Server"},
-    ],
+    ]
+
+
+app = FastAPI(
+    lifespan=lifespan,
+    servers=_build_servers(),
     title="Honcho API",
     summary="The Identity Layer for the Agentic World",
     description="""Honcho is a platform for giving agents user-centric memory and social cognition.""",


### PR DESCRIPTION
## Description

When self-hosting Honcho, the FastAPI app hardcodes a fixed servers list in the OpenAPI schema. This causes the Swagger UI 'Servers' dropdown to show only 'https://api.honcho.dev' and 'http://localhost:8000', neither of which matches a self-hosted deployment on a different host/port.

## Changes

1. **src/config.py**: Added `API_BASE_URL: str | None = None` to `AppSettings`. When set via the `API_BASE_URL` env var, it overrides the servers list in the OpenAPI schema.
2. **src/main.py**: Added `_build_servers()` helper that reads `settings.API_BASE_URL`. When set, returns a single-entry servers list with the self-hosted URL. Falls back to the current hardcoded values (production + localhost) when unset.

## Testing

- **Without API_BASE_URL**: Swagger UI shows the same servers as before (backward compatible).
- **With API_BASE_URL=http://192.168.1.50:8070**: Swagger UI shows only that server URL.

Closes https://github.com/plastic-labs/honcho/issues/875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration setting to customize the API base URL.
  * Swagger UI now displays the configured self-hosted URL as the sole server option when provided.
  * Existing production and local development server options remain available by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->