### PR TITLE
feat(embedding): asymmetric task prefixes for query vs document

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,6 +23,10 @@ PERFORMANCE_LOG_FORMAT=compact # compact|rich
 # EMBEDDING_MODEL_CONFIG__MODEL=text-embedding-3-small
 # EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL=
 # EMBEDDING_MODEL_CONFIG__OVERRIDES__API_KEY_ENV=
+# Task prefixes for asymmetric embedding models (E5, BGE, EmbeddingGemma, ...).
+# Leave unset for models that do not use prefixes, such as OpenAI's.
+# EMBEDDING_MODEL_CONFIG__QUERY_PREFIX=
+# EMBEDDING_MODEL_CONFIG__DOCUMENT_PREFIX=
 
 # LANGFUSE_HOST=
 # LANGFUSE_PUBLIC_KEY=

--- a/config.toml.example
+++ b/config.toml.example
@@ -75,6 +75,14 @@ MAX_TOKENS_PER_REQUEST = 300000
 transport = "openai"
 model = "text-embedding-3-small"
 
+# Task prefixes for asymmetric embedding models (E5, BGE, GTE, Nomic,
+# EmbeddingGemma, Qwen3-Embedding, ...). These models are trained to receive a
+# short instruction prefix that differs for queries and documents; embedding
+# both sides identically measurably degrades retrieval. Leave empty for models
+# that do not use prefixes, such as OpenAI's.
+# query_prefix = "task: search result | query: "
+# document_prefix = "title: none | text: "
+
 # Optional module-level endpoint overrides
 # [embedding.model_config.overrides]
 # base_url = "https://embedding-proxy.internal.example/v1"

--- a/src/config.py
+++ b/src/config.py
@@ -382,6 +382,18 @@ class EmbeddingModelConfig(BaseModel):
     transport: EmbeddingTransport = "openai"
     api_key: str | None = None
     base_url: str | None = None
+    # Task prefixes for asymmetric embedding models. Many open-weight retrieval
+    # models (E5, BGE, GTE, Nomic, EmbeddingGemma, Qwen3-Embedding) are trained
+    # to receive a short instruction prefix that differs for the text being
+    # searched *for* and the text being searched *through*; embedding both sides
+    # identically measurably degrades retrieval. Empty by default, so models
+    # that do not want prefixes (OpenAI's, for instance) are unaffected.
+    #
+    # Example for EmbeddingGemma:
+    #   query_prefix = "task: search result | query: "
+    #   document_prefix = "title: none | text: "
+    query_prefix: str = ""
+    document_prefix: str = ""
 
     @model_validator(mode="before")
     @classmethod

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -18,6 +18,11 @@ logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
 
+# Which side of a retrieval pair a text belongs to. Asymmetric embedding models
+# want a different instruction prefix for each; symmetric ones ignore the
+# distinction entirely (both prefixes default to empty).
+InputType = Literal["query", "document"]
+
 
 async def _emit_embedding_call(
     *,
@@ -152,7 +157,13 @@ def _publish_embedding_event(
 
 
 class BatchItem(NamedTuple):
-    """A single item in a batch with its metadata."""
+    """A single item in a batch with its metadata.
+
+    `text` is the raw text, never the prefixed form: chunking, token accounting
+    and `prepare_chunks` all deal in raw text, and the task prefix is applied
+    once at the provider-call boundary. Persisted chunks therefore stay free of
+    prefix text even when the prefix later changes.
+    """
 
     text: str
     text_id: str
@@ -211,6 +222,26 @@ class _EmbeddingClient:
             self.encoding = tiktoken.get_encoding("cl100k_base")
         self.max_embedding_tokens_per_request: int = max_tokens_per_request
 
+        self._prefixes: dict[InputType, str] = {
+            "query": config.query_prefix,
+            "document": config.document_prefix,
+        }
+        # The prefix is sent to the provider but is not part of the text being
+        # chunked, so it has to be reserved out of the per-input budget or a
+        # text that only just fits will overflow the model once prefixed.
+        self._prefix_tokens: dict[InputType, int] = {
+            input_type: len(self.encoding.encode(prefix)) if prefix else 0
+            for input_type, prefix in self._prefixes.items()
+        }
+
+    def _budget(self, input_type: InputType) -> int:
+        """Per-input token budget with room reserved for the task prefix."""
+        return self.max_embedding_tokens - self._prefix_tokens[input_type]
+
+    def _apply_prefix(self, texts: list[str], input_type: InputType) -> list[str]:
+        prefix = self._prefixes[input_type]
+        return [prefix + text for text in texts] if prefix else texts
+
     @property
     def provider(self) -> str:
         return self.transport
@@ -223,13 +254,25 @@ class _EmbeddingClient:
             )
         return embedding
 
-    async def embed(self, query: str) -> list[float]:
-        token_count = len(self.encoding.encode(query))
+    async def embed(
+        self, query: str, *, input_type: InputType = "query"
+    ) -> list[float]:
+        """Embed a single text.
 
-        if token_count > self.max_embedding_tokens:
+        Defaults to `input_type="query"` because that is what nearly every
+        caller wants; pass `"document"` when embedding stored content through
+        this path (for example a single-item fallback around
+        `simple_batch_embed`), so both paths land in the same vector space.
+        """
+        token_count = len(self.encoding.encode(query))
+        budget = self._budget(input_type)
+
+        if token_count > budget:
             raise ValueError(
-                f"Query exceeds maximum token limit of {self.max_embedding_tokens} tokens (got {token_count} tokens)"
+                f"Query exceeds maximum token limit of {budget} tokens (got {token_count} tokens)"
             )
+
+        prefixed = self._apply_prefix([query], input_type)[0]
 
         # Bind the typed client at the dispatch site so pyright can narrow it
         # for the closures without needing `assert isinstance(...)` (bandit
@@ -240,7 +283,7 @@ class _EmbeddingClient:
             async def _call_gemini() -> list[float]:
                 response = await gemini_client.aio.models.embed_content(
                     model=self.model,
-                    contents=query,
+                    contents=prefixed,
                     config={"output_dimensionality": self.vector_dimensions},
                 )
                 if not response.embeddings or not response.embeddings[0].values:
@@ -260,7 +303,7 @@ class _EmbeddingClient:
         openai_client = self.client
 
         async def _call_openai() -> list[float]:
-            openai_kwargs: dict[str, Any] = {"model": self.model, "input": [query]}
+            openai_kwargs: dict[str, Any] = {"model": self.model, "input": [prefixed]}
             if self.send_dimensions:
                 openai_kwargs["dimensions"] = self.vector_dimensions
             response = await openai_client.embeddings.create(**openai_kwargs)
@@ -274,16 +317,22 @@ class _EmbeddingClient:
             fn=_call_openai,
         )
 
-    async def simple_batch_embed(self, texts: list[str]) -> list[list[float]]:
+    async def simple_batch_embed(
+        self, texts: list[str], *, input_type: InputType = "document"
+    ) -> list[list[float]]:
         """
         Batch-embed a list of text strings. Each input must already fit within
-        `max_embedding_tokens`; this method does not sub-chunk oversized inputs.
+        the per-input token budget; this method does not sub-chunk oversized
+        inputs.
 
         Internally goes through the same token-aware batching pipeline as
         `batch_embed()` so the per-request token cap is respected.
 
         Args:
             texts: List of text strings to embed
+            input_type: Which side of a retrieval pair these texts are. Defaults
+                to "document"; pass "query" when batching search queries, so
+                they get the same treatment as a single `embed()` call.
 
         Returns:
             List of embedding vectors, one per input text (in order)
@@ -294,13 +343,15 @@ class _EmbeddingClient:
         if not texts:
             return []
 
+        budget = self._budget(input_type)
+
         # Validate per-input token limit and collect token counts for batching
         token_counts: list[int] = []
         for idx, text in enumerate(texts):
             tokens = len(self.encoding.encode(text))
-            if tokens > self.max_embedding_tokens:
+            if tokens > budget:
                 raise ValueError(
-                    f"Text at index {idx} exceeds maximum token limit of {self.max_embedding_tokens} tokens (got {tokens} tokens)"
+                    f"Text at index {idx} exceeds maximum token limit of {budget} tokens (got {tokens} tokens)"
                 )
             token_counts.append(tokens)
 
@@ -311,7 +362,7 @@ class _EmbeddingClient:
 
         batches = self._create_batches(text_chunks)
         batch_results = await asyncio.gather(
-            *[self._process_batch(batch) for batch in batches],
+            *[self._process_batch(batch, input_type=input_type) for batch in batches],
         )
 
         combined: dict[str, list[list[float]]] = self._accumulate_embeddings(
@@ -319,27 +370,34 @@ class _EmbeddingClient:
         )
         return [combined[str(i)][0] for i in range(len(texts))]
 
-    def prepare_chunks(self, id_resource_dict: dict[str, str]) -> dict[str, list[str]]:
+    def prepare_chunks(
+        self, id_resource_dict: dict[str, str], *, input_type: InputType = "document"
+    ) -> dict[str, list[str]]:
         """
         Public helper: tokenize and chunk texts using the same rules as
         `batch_embed()`. Returns ordered chunk texts per input id.
 
         Intended for callers that want to persist embeddable chunks
-        before later embedding them off the request path.
+        before later embedding them off the request path. Chunks are returned
+        unprefixed; the task prefix is applied when they are embedded.
         """
         return {
             text_id: [chunk_text for chunk_text, _ in chunks]
-            for text_id, chunks in self._prepare_chunks(id_resource_dict).items()
+            for text_id, chunks in self._prepare_chunks(
+                id_resource_dict, input_type=input_type
+            ).items()
         }
 
     async def batch_embed(
-        self, id_resource_dict: dict[str, str]
+        self, id_resource_dict: dict[str, str], *, input_type: InputType = "document"
     ) -> dict[str, list[list[float]]]:
         """
         Embed multiple texts, chunking long ones and batching API calls.
 
         Args:
             id_resource_dict: Maps text IDs to text content
+            input_type: Which side of a retrieval pair these texts are.
+                Defaults to "document", which is what this path is for.
 
         Returns:
             Maps text IDs to lists of embedding vectors (one per chunk)
@@ -348,39 +406,46 @@ class _EmbeddingClient:
             return {}
 
         # 1. Prepare chunks for all texts if needed
-        text_chunks = self._prepare_chunks(id_resource_dict)
+        text_chunks = self._prepare_chunks(id_resource_dict, input_type=input_type)
 
         # 2. Create batches that fit API limits (max 2048 embeddings per request, max 300,000 tokens per request)
         batches = self._create_batches(text_chunks)
 
         # 3. Process all batches concurrently
         batch_results = await asyncio.gather(
-            *[self._process_batch(batch) for batch in batches],
+            *[self._process_batch(batch, input_type=input_type) for batch in batches],
         )
 
         # 4. Accumulate results preserving chunk order
         return self._accumulate_embeddings(batch_results)
 
     def _prepare_chunks(
-        self, id_resource_dict: dict[str, str]
+        self, id_resource_dict: dict[str, str], *, input_type: InputType = "document"
     ) -> dict[str, list[tuple[str, int]]]:
         """
         Chunk texts that exceed token limits.
+
+        Chunk sizes are computed against the budget net of the task prefix, so
+        every chunk still fits once the prefix is prepended at call time. The
+        chunk text itself stays unprefixed.
 
         Args:
             id_resource_dict: Maps text IDs to text content. We tokenize with
                 the embedding client's own encoding so token IDs match the
                 decoder vocabulary used by the target embedding API.
+            input_type: Which side of a retrieval pair these texts are; selects
+                which prefix to reserve budget for.
 
         Returns:
             Maps text IDs to lists of (chunk_text, token_count) tuples
         """
+        budget = self._budget(input_type)
         out: dict[str, list[tuple[str, int]]] = {}
         for text_id, text in id_resource_dict.items():
             tokens = self.encoding.encode(text)
-            if len(tokens) > self.max_embedding_tokens:
+            if len(tokens) > budget:
                 out[text_id] = _chunk_text_with_tokens(
-                    text, tokens, self.max_embedding_tokens, self.encoding
+                    text, tokens, budget, self.encoding
                 )
             else:
                 out[text_id] = [(text, len(tokens))]
@@ -427,7 +492,11 @@ class _EmbeddingClient:
         return batches
 
     async def _process_batch(
-        self, batch: list[BatchItem], max_retries: int = 3
+        self,
+        batch: list[BatchItem],
+        max_retries: int = 3,
+        *,
+        input_type: InputType = "document",
     ) -> dict[str, dict[int, list[float]]]:
         """
         Process a single batch through the embeddings API with retry logic.
@@ -435,6 +504,7 @@ class _EmbeddingClient:
         Args:
             batch: List of BatchItem objects to embed
             max_retries: Maximum number of retry attempts (default: 3)
+            input_type: Which task prefix to apply to this batch
 
         Returns:
             Maps text IDs to {chunk_index: embedding_vector} dictionaries
@@ -447,10 +517,15 @@ class _EmbeddingClient:
             attempt is a distinct provider hit and shows up as its own line
             item in analytics."""
             result: dict[str, dict[int, list[float]]] = defaultdict(dict)
+            prefixed = self._apply_prefix([item.text for item in batch], input_type)
             if isinstance(self.client, genai.Client):
                 response = await self.client.aio.models.embed_content(
                     model=self.model,
-                    contents=[item.text for item in batch],
+                    # Spread rather than passing `prefixed` directly: the
+                    # parameter's list type is invariant, so a declared
+                    # list[str] is rejected while a list literal infers
+                    # bidirectionally into the wider element union.
+                    contents=[*prefixed],
                     config={"output_dimensionality": self.vector_dimensions},
                 )
                 if response.embeddings:
@@ -462,7 +537,7 @@ class _EmbeddingClient:
             else:  # openai
                 openai_kwargs: dict[str, Any] = {
                     "model": self.model,
-                    "input": [item.text for item in batch],
+                    "input": prefixed,
                 }
                 if self.send_dimensions:
                     openai_kwargs["dimensions"] = self.vector_dimensions
@@ -623,29 +698,41 @@ class EmbeddingClient:
             runtime_config.model,
             runtime_config.api_key,
             runtime_config.base_url,
+            runtime_config.query_prefix,
+            runtime_config.document_prefix,
             settings.EMBEDDING.VECTOR_DIMENSIONS,
             settings.EMBEDDING.MAX_INPUT_TOKENS,
             settings.EMBEDDING.MAX_TOKENS_PER_REQUEST,
             settings.EMBEDDING.resolve_send_dimensions(),
         )
 
-    async def embed(self, query: str) -> list[float]:
-        """Embed a single query string."""
-        return await self._get_client().embed(query)
+    async def embed(
+        self, query: str, *, input_type: InputType = "query"
+    ) -> list[float]:
+        """Embed a single string. Defaults to the query side."""
+        return await self._get_client().embed(query, input_type=input_type)
 
-    async def simple_batch_embed(self, texts: list[str]) -> list[list[float]]:
+    async def simple_batch_embed(
+        self, texts: list[str], *, input_type: InputType = "document"
+    ) -> list[list[float]]:
         """Batch embed a list of text strings (each must fit token limit)."""
-        return await self._get_client().simple_batch_embed(texts)
+        return await self._get_client().simple_batch_embed(texts, input_type=input_type)
 
-    def prepare_chunks(self, id_resource_dict: dict[str, str]) -> dict[str, list[str]]:
+    def prepare_chunks(
+        self, id_resource_dict: dict[str, str], *, input_type: InputType = "document"
+    ) -> dict[str, list[str]]:
         """Chunk texts using the same rules as `batch_embed` (no network)."""
-        return self._get_client().prepare_chunks(id_resource_dict)
+        return self._get_client().prepare_chunks(
+            id_resource_dict, input_type=input_type
+        )
 
     async def batch_embed(
-        self, id_resource_dict: dict[str, str]
+        self, id_resource_dict: dict[str, str], *, input_type: InputType = "document"
     ) -> dict[str, list[list[float]]]:
         """Embed multiple texts, chunking long ones and batching API calls."""
-        return await self._get_client().batch_embed(id_resource_dict)
+        return await self._get_client().batch_embed(
+            id_resource_dict, input_type=input_type
+        )
 
     @property
     def provider(self) -> str:

--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -955,7 +955,9 @@ async def create_observations(
                     run_id=run_id,
                     parent_category=parent_category,
                 ):
-                    embedding = await embedding_client.embed(obs.content)
+                    embedding = await embedding_client.embed(
+                        obs.content, input_type="document"
+                    )
             except Exception as e:
                 logger.warning(
                     "Error embedding observation content for level '%s': %s",
@@ -1287,7 +1289,9 @@ async def extract_preferences(
     # If batching fails, each search call will generate its own embedding.
     query_embeddings_by_query: dict[str, list[float]] | None = None
     try:
-        query_embeddings = await embedding_client.simple_batch_embed(semantic_queries)
+        query_embeddings = await embedding_client.simple_batch_embed(
+            semantic_queries, input_type="query"
+        )
         query_embeddings_by_query = dict(
             zip(semantic_queries, query_embeddings, strict=True)
         )

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -444,3 +444,170 @@ def test_prepare_chunks_returns_ordered_chunks(
     assert len(out["long"]) > 1
     # Order preserved
     assert isinstance(out["long"][0], str)
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric task prefixes
+# ---------------------------------------------------------------------------
+
+
+def _client_with_prefixes(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_embeddings: FakeOpenAIEmbeddingsAPI,
+    *,
+    max_input_tokens: int = 8192,
+) -> _EmbeddingClient:
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+
+    return _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai",
+            model="embeddinggemma-300m",
+            api_key="test-key",
+            query_prefix="task: search result | query: ",
+            document_prefix="title: none | text: ",
+        ),
+        vector_dimensions=8,
+        max_input_tokens=max_input_tokens,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_embed_applies_the_query_prefix_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeOpenAIEmbeddingsAPI([0.1] * 8)
+    client = _client_with_prefixes(monkeypatch, fake)
+
+    await client.embed("who is alice")
+
+    assert fake.calls[0]["input"] == ["task: search result | query: who is alice"]
+
+
+@pytest.mark.asyncio
+async def test_embed_can_be_asked_for_the_document_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The single-embed fallback around `simple_batch_embed` embeds stored
+    content, so it has to be able to land in the document space too."""
+    fake = FakeOpenAIEmbeddingsAPI([0.1] * 8)
+    client = _client_with_prefixes(monkeypatch, fake)
+
+    await client.embed("alice lives in berlin", input_type="document")
+
+    assert fake.calls[0]["input"] == ["title: none | text: alice lives in berlin"]
+
+
+@pytest.mark.asyncio
+async def test_simple_batch_embed_defaults_to_the_document_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeOpenAIEmbeddingsAPI([0.1] * 8)
+    client = _client_with_prefixes(monkeypatch, fake)
+
+    await client.simple_batch_embed(["one", "two"])
+
+    assert fake.calls[0]["input"] == [
+        "title: none | text: one",
+        "title: none | text: two",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_simple_batch_embed_can_be_asked_for_the_query_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Batching several search queries must produce the same vectors as
+    embedding them one at a time through `embed`."""
+    fake = FakeOpenAIEmbeddingsAPI([0.1] * 8)
+    client = _client_with_prefixes(monkeypatch, fake)
+
+    await client.simple_batch_embed(["what does she want"], input_type="query")
+
+    assert fake.calls[0]["input"] == ["task: search result | query: what does she want"]
+
+
+@pytest.mark.asyncio
+async def test_batch_embed_applies_the_document_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeOpenAIEmbeddingsAPI([0.1] * 8)
+    client = _client_with_prefixes(monkeypatch, fake)
+
+    await client.batch_embed({"a": "hello"})
+
+    assert fake.calls[0]["input"] == ["title: none | text: hello"]
+
+
+@pytest.mark.asyncio
+async def test_no_prefix_configured_leaves_input_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default config must be byte-identical to before this feature existed."""
+    fake = FakeOpenAIEmbeddingsAPI([0.1] * 8)
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: FakeOpenAIEmbeddingsAPI = fake
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai", model="text-embedding-3-small", api_key="test-key"
+        ),
+        vector_dimensions=8,
+        max_input_tokens=8192,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+    await client.embed("plain")
+    await client.simple_batch_embed(["also plain"])
+
+    assert fake.calls[0]["input"] == ["plain"]
+    assert fake.calls[1]["input"] == ["also plain"]
+
+
+@pytest.mark.asyncio
+async def test_prefix_tokens_are_reserved_from_the_input_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A text that fits the raw cap but not the cap-minus-prefix must be
+    rejected, otherwise the prefixed payload silently overruns the model."""
+    fake = FakeOpenAIEmbeddingsAPI([0.1] * 8)
+    client = _client_with_prefixes(monkeypatch, fake, max_input_tokens=12)
+
+    prefix_tokens = client._prefix_tokens["query"]  # pyright: ignore[reportPrivateUsage]
+    assert prefix_tokens > 0
+    text = "word " * (12 - prefix_tokens + 1)
+
+    with pytest.raises(ValueError, match="maximum token limit"):
+        await client.embed(text.strip())
+
+
+@pytest.mark.asyncio
+async def test_chunking_leaves_room_for_the_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chunks are sized against the net budget and stay unprefixed, so every
+    prefixed chunk still fits."""
+    fake = FakeOpenAIEmbeddingsAPI([0.1] * 8)
+    client = _client_with_prefixes(monkeypatch, fake, max_input_tokens=24)
+
+    long_text = "alpha beta gamma delta epsilon zeta eta theta " * 8
+    chunks = client.prepare_chunks({"a": long_text})["a"]
+
+    budget = client._budget("document")  # pyright: ignore[reportPrivateUsage]
+    document_prefix = "title: none | text: "
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert not chunk.startswith(document_prefix)
+        assert len(client.encoding.encode(document_prefix + chunk)) <= (
+            budget + client._prefix_tokens["document"]  # pyright: ignore[reportPrivateUsage]
+        )

--- a/tests/utils/test_agent_tools.py
+++ b/tests/utils/test_agent_tools.py
@@ -334,10 +334,17 @@ class TestCreateObservations:
         """If batch embedding fails but individual embeds succeed, all observations are created."""
         workspace, peer1, peer2, session, _, _ = tool_test_data
 
-        async def fail_batch_embed(_texts: list[str]) -> list[list[float]]:
+        async def fail_batch_embed(
+            _texts: list[str], *, input_type: str = "document"
+        ) -> list[list[float]]:
+            _ = input_type
             raise RuntimeError("embedding provider timeout")
 
-        async def succeed_single_embed(_content: str) -> list[float]:
+        async def succeed_single_embed(
+            _content: str, *, input_type: str = "query"
+        ) -> list[float]:
+            # See the partial-failure test: the fallback is a document embed.
+            assert input_type == "document"
             return [0.1, 0.2, 0.3]
 
         created_documents: list[Any] = []
@@ -393,10 +400,19 @@ class TestCreateObservations:
         """If batch embedding fails and some individual embeds also fail, only successful ones are created."""
         workspace, peer1, peer2, session, _, _ = tool_test_data
 
-        async def fail_batch_embed(_texts: list[str]) -> list[list[float]]:
+        async def fail_batch_embed(
+            _texts: list[str], *, input_type: str = "document"
+        ) -> list[list[float]]:
+            _ = input_type
             raise RuntimeError("embedding provider timeout")
 
-        async def embed_per_observation(content: str) -> list[float]:
+        async def embed_per_observation(
+            content: str, *, input_type: str = "query"
+        ) -> list[float]:
+            # The fallback embeds stored observations, so it must ask for the
+            # document side or it lands in a different vector space than the
+            # batch path it is standing in for.
+            assert input_type == "document"
             if content == "Fails embed":
                 raise RuntimeError("single-item embed failure")
             return [0.1, 0.2, 0.3]


### PR DESCRIPTION
## What

Adds optional `query_prefix` / `document_prefix` to the embedding model config, and an `input_type` argument threaded through `embed`, `simple_batch_embed`, `batch_embed` and `prepare_chunks`.

## Why

Many open-weight retrieval models are trained to receive a short instruction prefix that differs depending on whether the text is the thing being searched **for** or the thing being searched **through**: E5 (`query:` / `passage:`), BGE, GTE, Nomic (`search_query:` / `search_document:`), EmbeddingGemma (`task: search result | query:` / `title: none | text:`), Qwen3-Embedding. Honcho currently sends both sides identically, so any of these models runs below its ceiling.

Measured on EmbeddingGemma-300m, 40-document corpus, 20 queries:

| prompting | nDCG@10 | recall@5 | MRR |
|---|---|---|---|
| asymmetric (this PR) | **0.871** | **0.796** | **1.000** |
| both sides as documents | 0.782 | 0.771 | 0.892 |
| no prefix either side | 0.828 | 0.746 | 0.957 |

This matters for self-hosters in particular: pointing `EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL` at a local vLLM/TEI/Ollama endpoint is already supported, and most models people serve that way are prefix-trained. Today there is no way to express that, and the endpoint cannot infer it either: `embed()` sends `input: [query]`, a one-element list, which is byte-identical on the wire to a one-item document batch.

## Two call sites were already inconsistent

Independent of prefixes, these are primary/fallback pairs whose halves take different paths. Once prefixes are configured, the two halves land in different vector spaces:

- `create_observations` batch-embeds observations, and falls back to `embed()` per observation when the batch call fails. Observations are documents, but `embed()` defaults to the query side.
- `extract_preferences` batch-embeds its search queries via `simple_batch_embed` (document side), while its own fallback embeds them one at a time through `search_messages` → `embed()` (query side).

Both now pass `input_type` explicitly.

## Design notes

- **Defaults preserve current behaviour.** Both prefixes default to empty, so a default config is byte-identical on the wire to before this change. `embed` defaults to `query`, the batch paths to `document`, matching how they are already used.
- **Prefix tokens are reserved from the budget.** Both the per-input cap and the chunking budget subtract the prefix length, so a text that only just fits cannot overflow the model once prefixed.
- **Chunks stay unprefixed.** The prefix is applied once at the provider-call boundary, not during chunking, so anything persisted via `prepare_chunks` remains valid if the prefix is later changed.
- **Cache signature includes the prefixes**, so changing one rebuilds the client rather than silently serving the old configuration.

## Not included

Gemini's native `task_type` (`RETRIEVAL_QUERY` / `RETRIEVAL_DOCUMENT`) would be the more idiomatic mechanism on that transport, but wiring it in would change vectors for existing Gemini deployments, so I left it out. Prefixes apply uniformly to both transports and are inert unless configured. Happy to follow up with the Gemini path if you'd want it.

## Testing

- 8 new tests in `tests/llm/test_embedding_client.py`: prefix applied per input type on both single and batch paths, defaults unchanged when unconfigured, budget reservation rejects an over-long input, and chunking leaves room for the prefix.
- 2 existing `test_agent_tools` doubles updated to accept `input_type`, asserting the fallback asks for the document side.
- Full offline suite: 1746 passed. (`tests/vector_store` needs the `lancedb` extra and `tests/sdk_typescript` needs `bun`; neither is touched by this change.)
- `ruff check`, `ruff format`, `basedpyright` clean on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for asymmetric embedding models that use separate query and document prefixes.
  * Added optional configuration for query and document prefixes.
  * Updated embedding and batching workflows to apply the appropriate prefix and respect token limits.
  * Improved handling of query and document embeddings across agent tools.

* **Documentation**
  * Documented prefix configuration and noted that prefixes are optional for compatible models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->