### PR TITLE
fix: resolve tiktoken encoding without requiring an embedding API key

### DIFF
--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -674,8 +674,19 @@ class EmbeddingClient:
 
     @property
     def encoding(self) -> tiktoken.Encoding:
-        """Get the tiktoken encoding."""
-        return self._get_client().encoding
+        """Get the tiktoken encoding.
+
+        Resolved without constructing the underlying client: tiktoken needs no
+        API key, and token-counting callers (e.g. the document dedup tie-break)
+        must work in environments with no embedding credentials, such as CI for
+        pull requests from forks.
+        """
+        if self._instance is not None:
+            return self._instance.encoding
+        try:
+            return tiktoken.encoding_for_model(self._resolve_runtime_config().model)
+        except KeyError:
+            return tiktoken.get_encoding("cl100k_base")
 
 
 # Shared singleton embedding client instance


### PR DESCRIPTION
## Summary

`EmbeddingClient.encoding` forced full construction of the underlying embedding client, which raises `ValueError: OpenAI API key is required` — even though tiktoken needs no credentials. The document dedup tie-break (`src/crud/document.py`, unique-token comparison) only needs `.encoding` for token counting, so any test exercising that path fails in environments with no embedding keys.

Concretely: **CI for pull requests from forks** gets no repo secrets, so `test-python` fails on `tests/crud/test_document.py::TestDocumentCRUD::test_duplicate_rejection_reinforces_existing` for every fork PR (currently the only red check on #908, which is fork-based).

## Fix

The wrapper's `encoding` property now resolves tiktoken directly from the configured model (falling back to `cl100k_base`), and only delegates to the underlying client's encoding when that client has already been constructed. No behavior change when credentials are present.

## Testing

- Reproduced the exact CI failure locally on `main` with no `LLM_OPENAI_API_KEY` set; after the fix, `tests/crud/test_document.py` passes (21/21) with no key.
- `tests/llm/test_embedding_client.py`, `tests/deriver/test_vector_reconciliation.py`, `tests/deriver/test_embed_now.py`: 52 passed.
- `ruff` clean, `basedpyright` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encoding lookup to avoid unnecessary client initialization.
  * Added a fallback encoding for unsupported models, improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->