### PR TITLE
fix(embedding): add none transport + EMBED_OBSERVATIONS gate and default-mismatch warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `none` embedding transport (`EMBEDDING_MODEL_CONFIG__TRANSPORT=none`): a no-op embedder that makes no network call and returns zero-vectors of `EMBEDDING_VECTOR_DIMENSIONS`. Lets self-hosted deployments without an embedding provider complete writes (degraded vector search) instead of 401-ing on the default OpenAI embedder (#915)
+- `EMBED_OBSERVATIONS` setting (default `true`, parallel to `EMBED_MESSAGES`): when `false`, `create_observations` skips the embedding provider entirely and stores zero-vectors, so conclusion writes succeed without an embedding provider configured (#915)
+- Startup warning when the embedder is silently defaulting to OpenAI (because `EMBEDDING_MODEL_CONFIG` is unset) while the primary LLM transport is not plain OpenAI — pointing operators at `EMBEDDING_MODEL_CONFIG__*`, `EMBED_OBSERVATIONS=false`, or `transport=none`. Silent on an all-OpenAI setup (#915)
+
 ## [3.0.11] - 2026-06-24
 
 ### Added

--- a/config.toml.example
+++ b/config.toml.example
@@ -12,6 +12,11 @@ GET_CONTEXT_MAX_TOKENS = 100000
 MAX_FILE_SIZE = 5242880  # 5MB
 MAX_MESSAGE_SIZE = 25000 # Characters
 EMBED_MESSAGES = true
+# Gate embedding on the observation (conclusion) write path. Set to false on a
+# self-hosted deployment without an embedding provider so conclusion writes
+# succeed with zero-vectors instead of calling (and 401-ing on) the embedder.
+# Vector search over observations is degraded while this is off.
+EMBED_OBSERVATIONS = true
 # LANGFUSE_HOST = "https://api.langfuse.com"
 # LANGFUSE_PUBLIC_KEY = "your-public-key-here"
 # COLLECT_METRICS_LOCAL = false
@@ -72,6 +77,10 @@ MAX_INPUT_TOKENS = 8192
 MAX_TOKENS_PER_REQUEST = 300000
 
 [embedding.model_config]
+# transport: "openai", "gemini", or "none".
+# "none" is a no-op embedder — it makes no network call and stores zero-vectors
+# of VECTOR_DIMENSIONS. Use it (or EMBED_OBSERVATIONS = false above) when running
+# a non-OpenAI LLM without an embedding provider, to avoid 401s on writes.
 transport = "openai"
 model = "text-embedding-3-small"
 

--- a/docs/v3/contributing/configuration.mdx
+++ b/docs/v3/contributing/configuration.mdx
@@ -243,13 +243,22 @@ EMBEDDING_MAX_INPUT_TOKENS=8192
 EMBEDDING_MAX_TOKENS_PER_REQUEST=300000
 
 # Embedding transport/model selection
-EMBEDDING_MODEL_CONFIG__TRANSPORT=openai  # openai, gemini
+EMBEDDING_MODEL_CONFIG__TRANSPORT=openai  # openai, gemini, none
 EMBEDDING_MODEL_CONFIG__MODEL=text-embedding-3-small
 
 # Optional endpoint overrides
 EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL=http://localhost:8000/v1
 EMBEDDING_MODEL_CONFIG__OVERRIDES__API_KEY_ENV=EMBEDDING_CUSTOM_API_KEY
 ```
+
+#### Running without an embedding provider
+
+If you self-host with a non-OpenAI LLM and have no embedding endpoint, the embedder still defaults to OpenAI — so every conclusion write would call the OpenAI embedding API and fail with a 401 if `LLM_OPENAI_API_KEY` is unset. Honcho logs a startup warning when it detects this mismatch (embedder defaulting to OpenAI while the primary LLM is not plain OpenAI). Two ways to opt out:
+
+- **Disable embedding on the observation write path**: set `EMBED_OBSERVATIONS=false`. Conclusion writes then store zero-vectors of `EMBEDDING_VECTOR_DIMENSIONS` and succeed without any embedding call. (Parallel to `EMBED_MESSAGES`, which gates message embedding.)
+- **Use the no-op embedder globally**: set `EMBEDDING_MODEL_CONFIG__TRANSPORT=none`. This makes no network call anywhere and returns zero-vectors of the configured dimension.
+
+Both degrade vector search (results become effectively random over zero-vectors) but let writes complete. Point `EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL` at an OpenAI-compatible embedding endpoint if you want real embeddings.
 
 Forwarding `dimensions=` to OpenAI-compatible providers is controlled by `EMBEDDING_MODEL_CONFIG__DIMENSIONS_MODE`:
 

--- a/src/config.py
+++ b/src/config.py
@@ -23,8 +23,16 @@ if not os.getenv("PYTHON_DOTENV_DISABLED"):
 logger = logging.getLogger(__name__)
 
 ModelTransport = Literal["anthropic", "openai", "gemini"]
-EmbeddingTransport = Literal["openai", "gemini"]
+# "none" is a no-op embedder: it makes no network call and returns zero-vectors
+# of the configured dimension. Intended for self-hosted deployments with a
+# non-OpenAI LLM and no embedding provider — it lets observation/message writes
+# complete (at the cost of degraded vector search) instead of 401-ing on the
+# default OpenAI embedder.
+EmbeddingTransport = Literal["openai", "gemini", "none"]
 EmbeddingDimensionsMode = Literal["auto", "always", "never"]
+
+# Sentinel model name used when the embedding transport is "none".
+_EMBEDDING_NONE_MODEL = "none"
 
 # OpenAI-compatible models that reject the `dimensions=` request parameter.
 _EMBEDDING_KNOWN_REJECTING_MODELS: frozenset[str] = frozenset(
@@ -35,6 +43,8 @@ _EMBEDDING_KNOWN_REJECTING_MODELS: frozenset[str] = frozenset(
 def _default_embedding_model_for_transport(transport: EmbeddingTransport) -> str:
     if transport == "gemini":
         return "gemini-embedding-001"
+    if transport == "none":
+        return _EMBEDDING_NONE_MODEL
     return "text-embedding-3-small"
 
 
@@ -482,11 +492,15 @@ def resolve_model_config(configured: ConfiguredModelSettings) -> ModelConfig:
 
 
 def _default_embedding_api_key(transport: EmbeddingTransport) -> str | None:
-    """Fall back to the global LLM API key for the matching transport."""
+    """Fall back to the global LLM API key for the matching transport.
+
+    The "none" transport makes no network call, so it needs no key.
+    """
     if transport == "openai":
         return settings.LLM.OPENAI_API_KEY
     if transport == "gemini":
         return settings.LLM.GEMINI_API_KEY
+    return None
 
 
 def resolve_embedding_model_config(
@@ -1413,6 +1427,11 @@ class AppSettings(HonchoSettings):
 
     MAX_MESSAGE_SIZE: Annotated[int, Field(default=25_000, gt=0)] = 25_000
     EMBED_MESSAGES: bool = True
+    # Gates embedding on the observation (conclusion) write path. When False,
+    # `create_observations` skips the embedding provider entirely and stores
+    # zero-vectors, so writes succeed without an embedding provider configured
+    # (vector search over observations is degraded until re-embedded).
+    EMBED_OBSERVATIONS: bool = True
     LANGFUSE_HOST: str | None = None
     LANGFUSE_PUBLIC_KEY: str | None = None
     # How Langfuse traces are produced:

--- a/src/deriver/__main__.py
+++ b/src/deriver/__main__.py
@@ -7,7 +7,10 @@ from prometheus_client import start_http_server
 
 from src.config import settings
 from src.db import engine, register_db_query_instrumentation
-from src.startup import validate_embedding_schema
+from src.startup import (
+    validate_embedding_schema,
+    warn_if_embedder_defaults_mismatch_llm,
+)
 from src.telemetry import (
     initialize_telemetry_async,
     register_db_pool_collector,
@@ -71,6 +74,9 @@ async def run_deriver():
         # gate the API runs in its lifespan. Inside the try block so the
         # telemetry buffer is still flushed if validation raises.
         await validate_embedding_schema(engine)
+        # Non-fatal: warn if the embedder is silently defaulting to OpenAI while
+        # the primary LLM is not plain OpenAI (issue #915).
+        warn_if_embedder_defaults_mismatch_llm()
         await main()
     finally:
         # Shutdown telemetry (flush CloudEvents buffer)

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -179,6 +179,22 @@ class _EmbeddingClient:
         self.vector_dimensions: int = vector_dimensions
         self.send_dimensions: bool = send_dimensions
 
+        self.client: genai.Client | AsyncOpenAI | None
+        self.max_embedding_tokens: int
+        self.max_batch_size: int
+
+        if self.transport == "none":
+            # No-op embedder: no provider client, no network call. `embed` and
+            # `simple_batch_embed` return zero-vectors of `vector_dimensions`.
+            # No API key or base_url required. Chunking/token limits are
+            # irrelevant since nothing is sent to a provider.
+            self.client = None
+            self.max_embedding_tokens = max_input_tokens
+            self.max_batch_size = 1
+            self.encoding: tiktoken.Encoding = tiktoken.get_encoding("cl100k_base")
+            self.max_embedding_tokens_per_request: int = max_tokens_per_request
+            return
+
         if self.transport == "gemini":
             if not config.api_key:
                 raise ValueError("Gemini API key is required")
@@ -187,14 +203,14 @@ class _EmbeddingClient:
                 if config.base_url
                 else None
             )
-            self.client: genai.Client | AsyncOpenAI = genai.Client(
+            self.client = genai.Client(
                 api_key=config.api_key,
                 http_options=http_options,
             )
             # Gemini has a 2048 token limit
-            self.max_embedding_tokens: int = min(max_input_tokens, 2048)
+            self.max_embedding_tokens = min(max_input_tokens, 2048)
             # Gemini batch size is not documented, using conservative estimate
-            self.max_batch_size: int = 100
+            self.max_batch_size = 100
         else:  # openai
             if not config.api_key:
                 raise ValueError("OpenAI API key is required")
@@ -206,10 +222,10 @@ class _EmbeddingClient:
             self.max_batch_size = 2048  # OpenAI batch limit
 
         try:
-            self.encoding: tiktoken.Encoding = tiktoken.encoding_for_model(self.model)
+            self.encoding = tiktoken.encoding_for_model(self.model)
         except KeyError:
             self.encoding = tiktoken.get_encoding("cl100k_base")
-        self.max_embedding_tokens_per_request: int = max_tokens_per_request
+        self.max_embedding_tokens_per_request = max_tokens_per_request
 
     @property
     def provider(self) -> str:
@@ -223,7 +239,20 @@ class _EmbeddingClient:
             )
         return embedding
 
+    def _zero_vector(self) -> list[float]:
+        """Build a zero-vector for the no-op ("none") transport.
+
+        Returns:
+            A list of ``vector_dimensions`` zeros. The width matches the
+            pgvector column so writes succeed even though no real embedding
+            was computed.
+        """
+        return [0.0] * self.vector_dimensions
+
     async def embed(self, query: str) -> list[float]:
+        if self.client is None:  # transport == "none": no-op, no network call
+            return self._zero_vector()
+
         token_count = len(self.encoding.encode(query))
 
         if token_count > self.max_embedding_tokens:
@@ -294,6 +323,9 @@ class _EmbeddingClient:
         if not texts:
             return []
 
+        if self.client is None:  # transport == "none": no-op, no network call
+            return [self._zero_vector() for _ in texts]
+
         # Validate per-input token limit and collect token counts for batching
         token_counts: list[int] = []
         for idx, text in enumerate(texts):
@@ -346,6 +378,16 @@ class _EmbeddingClient:
         """
         if not id_resource_dict:
             return {}
+
+        if self.client is None:  # transport == "none": no-op, no network call
+            # Mirror the real path's structure: chunk long texts and return one
+            # zero-vector per prepared chunk, so a text that splits into N chunks
+            # yields N zero-vectors (not a single one).
+            no_op_chunks = self._prepare_chunks(id_resource_dict)
+            return {
+                text_id: [self._zero_vector() for _ in chunks]
+                for text_id, chunks in no_op_chunks.items()
+            }
 
         # 1. Prepare chunks for all texts if needed
         text_chunks = self._prepare_chunks(id_resource_dict)
@@ -459,7 +501,7 @@ class _EmbeddingClient:
                             result[item.text_id][item.chunk_index] = (
                                 self._validate_embedding_dimensions(embedding.values)
                             )
-            else:  # openai
+            elif isinstance(self.client, AsyncOpenAI):  # openai
                 openai_kwargs: dict[str, Any] = {
                     "model": self.model,
                     "input": [item.text for item in batch],

--- a/src/main.py
+++ b/src/main.py
@@ -28,7 +28,10 @@ from src.routers import (
     webhooks,
     workspaces,
 )
-from src.startup import validate_embedding_schema
+from src.startup import (
+    validate_embedding_schema,
+    warn_if_embedder_defaults_mismatch_llm,
+)
 from src.telemetry import (
     initialize_telemetry_async,
     metrics_endpoint,
@@ -114,6 +117,10 @@ async def lifespan(_: FastAPI):
     # pgvector columns, the process refuses to start rather than silently
     # writing wrong-dim vectors.
     await validate_embedding_schema(engine)
+
+    # Non-fatal: warn if the embedder is silently defaulting to OpenAI while the
+    # primary LLM is not plain OpenAI (issue #915).
+    warn_if_embedder_defaults_mismatch_llm()
 
     try:
         await init_cache()

--- a/src/startup/__init__.py
+++ b/src/startup/__init__.py
@@ -3,6 +3,11 @@
 from src.startup.embedding_validator import (
     StartupValidationError,
     validate_embedding_schema,
+    warn_if_embedder_defaults_mismatch_llm,
 )
 
-__all__ = ("StartupValidationError", "validate_embedding_schema")
+__all__ = (
+    "StartupValidationError",
+    "validate_embedding_schema",
+    "warn_if_embedder_defaults_mismatch_llm",
+)

--- a/src/startup/embedding_validator.py
+++ b/src/startup/embedding_validator.py
@@ -58,6 +58,78 @@ class StartupValidationError(HonchoException):
     """
 
 
+def _embedding_transport_is_openai_by_default(s: AppSettings) -> bool:
+    """Detect an unconfigured, OpenAI-by-default embedding transport.
+
+    Args:
+        s: Application settings to inspect.
+
+    Returns:
+        True when the embedding transport is OpenAI purely because nothing was
+        configured (i.e. the operator did not set ``EMBEDDING_MODEL_CONFIG__*``).
+    """
+    mc = s.EMBEDDING.MODEL_CONFIG
+    explicitly_set = (
+        "MODEL_CONFIG" in s.EMBEDDING.model_fields_set
+        and "transport" in mc.model_fields_set
+    )
+    return mc.transport == "openai" and not explicitly_set
+
+
+def _primary_llm_is_non_openai(s: AppSettings) -> bool:
+    """Detect whether the deriver's primary LLM is not plain OpenAI.
+
+    Args:
+        s: Application settings to inspect.
+
+    Returns:
+        True when the deriver's primary LLM is not plain OpenAI — either a
+        non-OpenAI transport, or the OpenAI transport pointed at a custom
+        base_url (an OpenAI-compatible proxy such as OpenRouter/vLLM/Ollama),
+        set either on the deriver model config or globally via
+        ``LLM_OPENAI_BASE_URL``.
+    """
+    deriver_mc = s.DERIVER.MODEL_CONFIG
+    if deriver_mc.transport != "openai":
+        return True
+    # OpenAI-compatible proxy: a base_url override on the deriver model config
+    # or a global OpenAI base_url both signal a non-OpenAI endpoint.
+    return bool(deriver_mc.overrides.base_url or s.LLM.OPENAI_BASE_URL)
+
+
+def warn_if_embedder_defaults_mismatch_llm(
+    s: AppSettings | None = None,
+) -> bool:
+    """Warn once when the embedder is silently defaulting to OpenAI while the
+    primary LLM is not plain OpenAI.
+
+    This is the common self-hosted footgun (issue #915): with a non-OpenAI LLM
+    and ``EMBEDDING_*`` unset, every ``create_observations`` write would 401 on
+    the default OpenAI embedder. Non-fatal — silent on an all-OpenAI setup.
+
+    Args:
+        s: Application settings to inspect. Defaults to the process-global
+            ``settings`` when ``None``.
+
+    Returns:
+        True if the mismatch warning was emitted, False otherwise. The return
+        value lets callers/tests assert on whether the warning fired.
+    """
+    s = s if s is not None else settings
+    if _embedding_transport_is_openai_by_default(s) and _primary_llm_is_non_openai(s):
+        logger.warning(
+            "Embedding transport is defaulting to OpenAI (EMBEDDING_MODEL_CONFIG"
+            + " is unset) while the primary LLM transport is not plain OpenAI."
+            + " Observation writes will call the OpenAI embedding API and fail if"
+            + " LLM_OPENAI_API_KEY is not set. Configure the embedder via"
+            + " EMBEDDING_MODEL_CONFIG__* (e.g. TRANSPORT/MODEL/OVERRIDES__BASE_URL),"
+            + " or disable embedding on the observation path with"
+            + " EMBED_OBSERVATIONS=false / EMBEDDING_MODEL_CONFIG__TRANSPORT=none."
+        )
+        return True
+    return False
+
+
 async def validate_embedding_schema(
     engine: AsyncEngine,
     *,

--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -923,22 +923,32 @@ async def create_observations(
     # Compute embeddings (no DB needed)
     contents = [obs.content for obs in normalized_observations]
     embeddings_by_index: dict[int, list[float]] | None = None
-    try:
-        with embedding_call_purpose(
-            EmbeddingCallPurpose.CREATE_OBSERVATIONS.value,
-            workspace_name=workspace_name,
-            run_id=run_id,
-            parent_category=parent_category,
-        ):
-            embeddings = await embedding_client.simple_batch_embed(contents)
-        embeddings_by_index = dict(
-            zip(range(len(normalized_observations)), embeddings, strict=True)
-        )
-    except Exception as e:
-        logger.warning(
-            "Batch embedding failed for create_observations; falling back to per-observation embedding: %s",
-            e,
-        )
+    if not settings.EMBED_OBSERVATIONS:
+        # Embedding disabled for the observation write path: skip the provider
+        # entirely and store zero-vectors of the configured dimension so writes
+        # succeed without an embedding provider (vector search is degraded).
+        zero_vector = [0.0] * settings.EMBEDDING.VECTOR_DIMENSIONS
+        embeddings_by_index = {
+            i: list(zero_vector) for i in range(len(normalized_observations))
+        }
+    else:
+        try:
+            with embedding_call_purpose(
+                EmbeddingCallPurpose.CREATE_OBSERVATIONS.value,
+                workspace_name=workspace_name,
+                run_id=run_id,
+                parent_category=parent_category,
+            ):
+                embeddings = await embedding_client.simple_batch_embed(contents)
+            embeddings_by_index = dict(
+                zip(range(len(normalized_observations)), embeddings, strict=True)
+            )
+        except Exception as e:
+            logger.warning(
+                "Batch embedding failed for create_observations; falling back"
+                + " to per-observation embedding: %s",
+                e,
+            )
 
     # Build document objects with pre-computed embeddings
     documents: list[schemas.DocumentCreate] = []
@@ -1010,7 +1020,12 @@ async def create_observations(
                     workspace_name=workspace_name,
                     observer=observer,
                     observed=observed,
-                    deduplicate=True,
+                    # Only run embedding-based semantic dedup when observations
+                    # are actually embedded. With EMBED_OBSERVATIONS disabled the
+                    # documents share an identical zero-vector, so semantic dedup
+                    # is meaningless and could reject distinct content as a false
+                    # duplicate. Exact-content dedup runs regardless of this flag.
+                    deduplicate=settings.EMBED_OBSERVATIONS,
                 )
             ).created_documents
         logger.info(

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -7,6 +7,22 @@ from src.config import EmbeddingModelConfig
 from src.embedding_client import _EmbeddingClient  # pyright: ignore[reportPrivateUsage]
 
 
+def _raise_no_provider(*_args: Any, **_kwargs: Any) -> None:
+    """Fail loudly if a provider client is constructed (the ``none`` transport must never build one)."""
+    raise AssertionError("no provider client may be constructed for the none transport")
+
+
+def _forbid_provider_construction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch both embedding backends so constructing either fails the test.
+
+    Args:
+        monkeypatch: pytest fixture used to replace ``AsyncOpenAI`` and
+            ``genai.Client`` with a raising stub.
+    """
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", _raise_no_provider)
+    monkeypatch.setattr("src.embedding_client.genai.Client", _raise_no_provider)
+
+
 class FakeOpenAIEmbeddingsAPI:
     def __init__(self, embedding: list[float]) -> None:
         self.embedding: list[float] = embedding
@@ -150,6 +166,86 @@ async def test_gemini_embedding_client_uses_output_dimensionality(
     ]
 
 
+@pytest.mark.asyncio
+async def test_none_transport_returns_zero_vectors_without_provider_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """transport="none" is a no-op: zero-vectors of the configured dimension
+    from both embed and simple_batch_embed, and no provider client is ever
+    constructed or invoked."""
+    _forbid_provider_construction(monkeypatch)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="none",
+            model="none",
+            api_key=None,
+            base_url=None,
+        ),
+        vector_dimensions=16,
+        max_input_tokens=8192,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+    single = await client.embed("hello world")
+    assert single == [0.0] * 16
+
+    batch = await client.simple_batch_embed(["a", "b", "c"])
+    assert batch == [[0.0] * 16, [0.0] * 16, [0.0] * 16]
+
+
+@pytest.mark.asyncio
+async def test_none_transport_batch_embed_returns_one_zero_vector_per_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """batch_embed on the none transport must mirror the real path's structure:
+    a text long enough to split into multiple chunks yields one zero-vector per
+    prepared chunk (not a single vector), with no provider client constructed."""
+    _forbid_provider_construction(monkeypatch)
+
+    # Small per-input token cap so a moderately long text splits into >1 chunk.
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(transport="none", model="none"),
+        vector_dimensions=16,
+        max_input_tokens=10,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+    short_text = "hello"
+    long_text = ("word " * 50).strip()
+
+    # Ground truth for the expected chunk count comes from the same chunking
+    # helper the real path uses, so the assertion tracks the client's behavior.
+    expected_chunks = client.prepare_chunks({"long": long_text})["long"]
+    assert len(expected_chunks) > 1, "test text must split into multiple chunks"
+
+    result = await client.batch_embed({"short": short_text, "long": long_text})
+
+    assert result["short"] == [[0.0] * 16]
+    assert len(result["long"]) == len(expected_chunks)
+    assert all(vec == [0.0] * 16 for vec in result["long"])
+
+
+@pytest.mark.asyncio
+async def test_none_transport_empty_batch_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty batch on the none transport yields an empty list (no vectors)."""
+    _forbid_provider_construction(monkeypatch)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(transport="none", model="none"),
+        vector_dimensions=4,
+        max_input_tokens=8192,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+    assert await client.simple_batch_embed([]) == []
+
+
 def _build_openai_client(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -276,6 +372,31 @@ def _build_embedding_settings(
     for key, value in env.items():
         monkeypatch.setenv(key, value)
     return EmbeddingSettings()
+
+
+def test_resolve_embedding_config_none_transport_needs_no_key() -> None:
+    """transport="none" resolves with a sentinel model, no api_key, no base_url."""
+    from src.config import (
+        ConfiguredEmbeddingModelSettings,
+        resolve_embedding_model_config,
+    )
+
+    resolved = resolve_embedding_model_config(
+        ConfiguredEmbeddingModelSettings(transport="none")
+    )
+    assert resolved.transport == "none"
+    assert resolved.model == "none"
+    assert resolved.api_key is None
+    assert resolved.base_url is None
+
+
+def test_default_embedding_model_for_none_transport() -> None:
+    """``_default_embedding_model_for_transport("none")`` returns the ``none`` sentinel model."""
+    from src.config import (
+        _default_embedding_model_for_transport,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    assert _default_embedding_model_for_transport("none") == "none"
 
 
 def test_resolve_send_dimensions_auto_default_dim_returns_false(

--- a/tests/startup/test_embedding_validator.py
+++ b/tests/startup/test_embedding_validator.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 import warnings
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -19,6 +21,7 @@ from src.startup.embedding_validator import (
     StartupValidationError,
     _assert_pgvector_dims_match,  # pyright: ignore[reportPrivateUsage]
     validate_embedding_schema,
+    warn_if_embedder_defaults_mismatch_llm,
 )
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -182,6 +185,133 @@ def test_vector_store_dimensions_explicit_set_warns(
     assert any(
         "VECTOR_STORE_DIMENSIONS is deprecated" in m for m in messages
     ), f"expected deprecation warning, got {messages!r}"
+
+
+# ---------------------------------------------------------------------------
+# Startup warning: embedder defaulting to OpenAI while LLM is non-OpenAI (#915)
+# ---------------------------------------------------------------------------
+
+
+_EMBEDDING_ENV_KEYS = (
+    "EMBEDDING_MODEL_CONFIG__TRANSPORT",
+    "EMBEDDING_MODEL_CONFIG__MODEL",
+    "EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL",
+    "EMBEDDING_MODEL_CONFIG",
+)
+_DERIVER_ENV_KEYS = (
+    "DERIVER_MODEL_CONFIG__TRANSPORT",
+    "DERIVER_MODEL_CONFIG__MODEL",
+    "DERIVER_MODEL_CONFIG__OVERRIDES__BASE_URL",
+    "DERIVER_MODEL_CONFIG",
+)
+_LLM_ENV_KEYS = ("LLM_OPENAI_BASE_URL",)
+
+
+def _build_app_settings_stub(
+    embedding_env: dict[str, str],
+    deriver_env: dict[str, str],
+    llm_env: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> Any:
+    """Assemble a settings-shaped stub from freshly-constructed nested settings.
+
+    Real EmbeddingSettings/DeriverSettings/LLMSettings are built so that
+    ``model_fields_set`` reflects only the env we set here (isolated from the
+    ambient environment), then bundled into a SimpleNamespace the helper reads
+    like an AppSettings.
+    """
+    from src.config import DeriverSettings, EmbeddingSettings, LLMSettings
+
+    monkeypatch.setenv("PYTHON_DOTENV_DISABLED", "1")
+    for key in (*_EMBEDDING_ENV_KEYS, *_DERIVER_ENV_KEYS, *_LLM_ENV_KEYS):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in {**embedding_env, **deriver_env, **llm_env}.items():
+        monkeypatch.setenv(key, value)
+
+    return SimpleNamespace(
+        EMBEDDING=EmbeddingSettings(),
+        DERIVER=DeriverSettings(),
+        LLM=LLMSettings(),
+    )
+
+
+def test_warn_fires_when_embedder_defaults_and_llm_is_gemini(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A defaulted (OpenAI) embedder alongside a Gemini LLM triggers the warning."""
+    s = _build_app_settings_stub(
+        embedding_env={},  # unset -> defaults to openai
+        deriver_env={
+            "DERIVER_MODEL_CONFIG__TRANSPORT": "gemini",
+            "DERIVER_MODEL_CONFIG__MODEL": "gemini-2.5-flash",
+        },
+        llm_env={},
+        monkeypatch=monkeypatch,
+    )
+    assert warn_if_embedder_defaults_mismatch_llm(s) is True
+
+
+def test_warn_fires_when_embedder_defaults_and_llm_uses_openai_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI transport pointed at a custom base_url (proxy) still counts as
+    a non-plain-OpenAI LLM and triggers the warning."""
+    s = _build_app_settings_stub(
+        embedding_env={},
+        deriver_env={
+            "DERIVER_MODEL_CONFIG__OVERRIDES__BASE_URL": "http://vllm.local/v1",
+        },
+        llm_env={},
+        monkeypatch=monkeypatch,
+    )
+    assert warn_if_embedder_defaults_mismatch_llm(s) is True
+
+
+def test_warn_fires_when_embedder_defaults_and_llm_uses_global_openai_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A global LLM_OPENAI_BASE_URL override (proxy) with default embedding and
+    default deriver settings still counts as a non-plain-OpenAI LLM and triggers
+    the warning (the global-proxy branch of _primary_llm_is_non_openai)."""
+    s = _build_app_settings_stub(
+        embedding_env={},  # unset -> defaults to openai
+        deriver_env={},  # default openai deriver, no per-model base_url
+        llm_env={"LLM_OPENAI_BASE_URL": "http://vllm.local/v1"},
+        monkeypatch=monkeypatch,
+    )
+    assert warn_if_embedder_defaults_mismatch_llm(s) is True
+
+
+def test_warn_silent_on_all_openai_setup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An all-OpenAI setup (defaulted embedder, default OpenAI LLM) stays silent."""
+    s = _build_app_settings_stub(
+        embedding_env={},
+        deriver_env={},  # default openai, no base_url
+        llm_env={},
+        monkeypatch=monkeypatch,
+    )
+    assert warn_if_embedder_defaults_mismatch_llm(s) is False
+
+
+def test_warn_silent_when_embedder_explicitly_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even with a non-OpenAI LLM, an explicitly-set embedding transport means
+    the operator made a choice — no warning."""
+    s = _build_app_settings_stub(
+        embedding_env={
+            "EMBEDDING_MODEL_CONFIG__TRANSPORT": "none",
+        },
+        deriver_env={
+            "DERIVER_MODEL_CONFIG__TRANSPORT": "gemini",
+            "DERIVER_MODEL_CONFIG__MODEL": "gemini-2.5-flash",
+        },
+        llm_env={},
+        monkeypatch=monkeypatch,
+    )
+    assert warn_if_embedder_defaults_mismatch_llm(s) is False
 
 
 def test_non_1536_pgvector_without_migrated_no_longer_raises_at_config_time() -> None:

--- a/tests/utils/test_agent_tools.py
+++ b/tests/utils/test_agent_tools.py
@@ -541,6 +541,78 @@ class TestCreateObservations:
         batch_embed.assert_not_awaited()
         create_documents.assert_not_awaited()
 
+    async def test_embed_observations_false_skips_embedding_uses_zero_vectors(
+        self,
+        tool_test_data: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """With EMBED_OBSERVATIONS=False, no embedding call is made and every
+        document gets a zero-vector of the configured dimension."""
+        workspace, peer1, peer2, session, _, _ = tool_test_data
+
+        async def boom_batch_embed(_texts: list[str]) -> list[list[float]]:
+            """Fail the test if batch embedding is invoked (it must be skipped)."""
+            raise AssertionError("simple_batch_embed must not be called")
+
+        async def boom_embed(_content: str) -> list[float]:
+            """Fail the test if single embedding is invoked (it must be skipped)."""
+            raise AssertionError("embed must not be called")
+
+        created_documents: list[Any] = []
+        dedup_flags: list[bool] = []
+
+        async def fake_create_documents(
+            _db: AsyncSession,
+            documents: list[Any],
+            workspace_name: str,
+            *,
+            observer: str,
+            observed: str,
+            deduplicate: bool = False,
+        ) -> crud.CreateDocumentsResult:
+            """Capture the documents (and dedup flag) passed to create_documents."""
+            _ = (workspace_name, observer, observed)
+            dedup_flags.append(deduplicate)
+            created_documents.extend(documents)
+            return crud.CreateDocumentsResult(created_documents=documents)
+
+        monkeypatch.setattr(settings, "EMBED_OBSERVATIONS", False)
+        monkeypatch.setattr(
+            "src.utils.agent_tools.embedding_client.simple_batch_embed",
+            boom_batch_embed,
+        )
+        monkeypatch.setattr(
+            "src.utils.agent_tools.embedding_client.embed",
+            boom_embed,
+        )
+        monkeypatch.setattr(
+            "src.utils.agent_tools.crud.create_documents", fake_create_documents
+        )
+
+        result = await create_observations(
+            observations=[
+                schemas.ObservationInput(content="First obs", level="explicit"),
+                schemas.ObservationInput(content="Second obs", level="explicit"),
+            ],
+            observer=peer1.name,
+            observed=peer2.name,
+            session_name=session.name,
+            workspace_name=workspace.name,
+            message_ids=[],
+            message_created_at=str(datetime.now(timezone.utc)),
+        )
+
+        assert isinstance(result, ObservationsCreatedResult)
+        assert result.created_count == 2
+        assert len(result.failed) == 0
+        assert len(created_documents) == 2
+        expected_dim = settings.EMBEDDING.VECTOR_DIMENSIONS
+        for doc in created_documents:
+            assert doc.embedding == [0.0] * expected_dim
+        # Semantic dedup must be disabled when observations aren't embedded, so
+        # distinct zero-vector observations aren't collapsed as false duplicates.
+        assert dedup_flags == [False]
+
 
 class TestNormalizeObservationId:
     """Unit tests for _normalize_observation_id."""


### PR DESCRIPTION
Fixes #915

## Problem

On a self-hosted Honcho with a non-OpenAI LLM, if `EMBEDDING_*` is left unset the embedder silently defaults to OpenAI. Every `create_observations` (conclusion write) then calls the OpenAI embedding API and 401s when `LLM_OPENAI_API_KEY` isn't set. Two defects:

1. Silent OpenAI fallback with no warning.
2. No way to disable embedding on the observations write path — `EMBED_MESSAGES=false` only gates message/retrieval embedding, and `EmbeddingTransport` had no no-op.

## Fix (additive, no schema migration)

1. **`transport="none"` no-op embedder.** Added `"none"` to `EmbeddingTransport`. The embedding client treats it as a no-op: no provider client is constructed, no network call is made, and `embed` / `simple_batch_embed` / `batch_embed` return **zero-vectors of the configured embedding dimension** (`EMBEDDING_VECTOR_DIMENSIONS`). No API key or base_url required.
2. **`EMBED_OBSERVATIONS` setting** (default `true`, parallel to `EMBED_MESSAGES`). When `false`, `create_observations` skips the embedding provider entirely and stores zero-vectors for every document — writes complete without any embedding call.
3. **Startup warning.** At API and deriver startup, if the embedder is OpenAI purely by default (`EMBEDDING_MODEL_CONFIG` unset) while the primary LLM transport is not plain OpenAI (non-OpenAI transport, or OpenAI pointed at a custom base_url), a single non-fatal `logger.warning` explains how to override (`EMBEDDING_MODEL_CONFIG__*`) or disable (`EMBED_OBSERVATIONS=false` / `transport=none`). Silent on a normal all-OpenAI setup.

### Zero-vector design choice

The `none` transport and `EMBED_OBSERVATIONS=false` both store zero-vectors sized to `EMBEDDING_VECTOR_DIMENSIONS` — the same value the startup schema validator pins the pgvector columns to — so inserts always match the column width. This **degrades vector search** (similarity over zero-vectors is meaningless) but lets writes complete, which is the point: an operator without an embedding provider gets working conclusion writes instead of hard 401 failures.

## Tested

- `none` transport returns zero-vectors of the right dimension from both `embed` and `simple_batch_embed`, and never constructs/invokes a provider client (asserted via monkeypatch).
- `EMBED_OBSERVATIONS=False`: `create_observations` never calls `simple_batch_embed`/`embed` (monkeypatched to raise) and still builds documents with zero-vectors.
- Config resolution and default-model handling for `transport="none"`.
- Startup warning fires on the genuine mismatch (non-OpenAI LLM / OpenAI-proxy base_url) and is silent on all-OpenAI or when the embedder is explicitly configured.

`ruff check`, `ruff format`, and `basedpyright` are clean on the changed files. The `none`-transport and config tests run without infra; the DB-backed tests (observation write path, startup-warning wiring) require the `pgvector` extension and run in CI.

## Out of scope (deliberate follow-up)

Not implemented here: having embeddings **inherit the LLM provider's base_url/API key** (e.g. reuse an OpenAI-compatible proxy for embeddings automatically). That's a separate design decision — this PR intentionally keeps the change minimal (opt-out + clear warning) and leaves provider-config inheritance for a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a no-op embedding mode that avoids network calls and stores zero-vectors.
  * Added an option to disable observation embeddings while preserving observation creation.
  * Added startup warnings for potentially mismatched embedding and language-model providers.

* **Documentation**
  * Updated configuration guidance for no-op embeddings, disabled observation embeddings, and provider setup.
  * Documented the impact of zero-vectors on vector search.

* **Tests**
  * Added coverage for no-op embeddings, disabled observation embeddings, and configuration warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->