### PR TITLE
perf(search): materialise message tsvector so ts_rank stops re-parsing content (48s -> 0.9s)

### DIFF
--- a/migrations/versions/a1c0ffee5eed_materialise_message_content_tsvector.py
+++ b/migrations/versions/a1c0ffee5eed_materialise_message_content_tsvector.py
@@ -1,0 +1,57 @@
+"""materialise message content tsvector for ts_rank
+
+A GIN index accelerates full-text *matching*, but `ts_rank` needs the tsvector
+VALUE, which a GIN index cannot return. The previous query form therefore
+re-derived `to_tsvector('english', content)` for every candidate row on every
+search, purely to order the results.
+
+Measured on a 230 MB / 33,098-message workspace (PostgreSQL 15 + pgvector):
+
+    COUNT(*)                                     6 ms
+    full scan reading all content            1,239 ms
+    to_tsvector(content) @@ tsquery  (GIN)      25 ms
+    ts_rank(to_tsvector(content), ...)      48,813 ms   <-- entire cost
+
+Against a stored column the same workload runs in 1,593 ms, and the real
+query shape (WHERE + ORDER BY ts_rank + LIMIT) drops from 48,813 ms to 872 ms
+- roughly 56x. Storage cost is ~127 MB on that workspace (230 MB -> 357 MB
+including the index).
+
+The backfill is a one-time table rewrite (~73 s for 33k rows on a 2013 i5) and
+holds an ACCESS EXCLUSIVE lock for its duration. Schedule accordingly on large
+deployments.
+
+Revision ID: a1c0ffee5eed
+Revises: e4eba9cfaa6f
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "a1c0ffee5eed"
+down_revision: str | None = "e4eba9cfaa6f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # STORED generated column: computed once on write, read directly by ts_rank.
+    op.execute(
+        """
+        ALTER TABLE messages
+        ADD COLUMN IF NOT EXISTS content_tsv tsvector
+        GENERATED ALWAYS AS (to_tsvector('english', content)) STORED
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_messages_content_tsv_gin
+        ON messages USING gin (content_tsv)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_messages_content_tsv_gin")
+    op.execute("ALTER TABLE messages DROP COLUMN IF EXISTS content_tsv")

--- a/src/models.py
+++ b/src/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     Column,
+    Computed,
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,
@@ -20,7 +21,7 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
-from sqlalchemy.dialects.postgresql import JSONB, TEXT
+from sqlalchemy.dialects.postgresql import JSONB, TEXT, TSVECTOR
 from sqlalchemy.orm import Mapped, MappedColumn, mapped_column, relationship
 from sqlalchemy.sql import func
 from typing_extensions import override
@@ -214,6 +215,16 @@ class Message(Base):
     # We have since assigned all of these messages to a default session.
     session_name: Mapped[str] = mapped_column(TEXT, nullable=False)
     content: Mapped[str] = mapped_column(TEXT)
+    # Materialised full-text vector. A GIN index accelerates *matching*, but
+    # ts_rank needs the tsvector VALUE, which a GIN index cannot return — so
+    # ranking otherwise re-parses every candidate row's text on every query.
+    # Measured on a 230 MB / 33k-message workspace: ts_rank over to_tsvector(content)
+    # took 48.8 s, versus 0.87 s reading this stored column (56x).
+    content_tsv: Mapped[Any] = mapped_column(
+        TSVECTOR,
+        Computed("to_tsvector('english', content)", persisted=True),
+        nullable=True,
+    )
     h_metadata: Mapped[dict[str, Any]] = mapped_column(
         "metadata", JSONB, default=dict, server_default=text("'{}'::jsonb")
     )
@@ -261,6 +272,14 @@ class Message(Base):
         Index(
             "ix_messages_content_gin",
             text("to_tsvector('english', content)"),
+            postgresql_using="gin",
+        ),
+        # Index over the materialised vector. Matching can use either index;
+        # this one exists so the planner can satisfy both the match and the
+        # ts_rank ordering from stored data instead of re-parsing content.
+        Index(
+            "ix_messages_content_tsv_gin",
+            "content_tsv",
             postgresql_using="gin",
         ),
     )

--- a/src/utils/search.py
+++ b/src/utils/search.py
@@ -277,8 +277,13 @@ async def _fulltext_search(
             models.Message.created_at.desc()
         )
     else:
-        # For natural language queries, use full text search with ranking
-        fts_condition = func.to_tsvector("english", models.Message.content).op("@@")(
+        # For natural language queries, use full text search with ranking.
+        # Match and rank against the materialised `content_tsv` column rather
+        # than re-deriving to_tsvector(content) per row. ts_rank needs the
+        # vector VALUE, which a GIN index cannot supply, so the previous form
+        # re-parsed every candidate row's text on every query. Measured on a
+        # 230 MB / 33k-message workspace: 48.8s -> 0.87s.
+        fts_condition = models.Message.content_tsv.op("@@")(
             func.plainto_tsquery("english", query)
         )
 
@@ -294,7 +299,7 @@ async def _fulltext_search(
             # Order by FTS relevance first, then by creation time
             func.coalesce(
                 func.ts_rank(
-                    func.to_tsvector("english", models.Message.content),
+                    models.Message.content_tsv,
                     func.plainto_tsquery("english", query),
                 ),
                 0,


### PR DESCRIPTION
## Summary

`message_search()` re-derives `to_tsvector('english', content)` for every candidate row on every query, purely to order results by `ts_rank`. A GIN index makes *matching* fast, but `ts_rank` needs the tsvector **value**, which a GIN index cannot return — so ranking falls back to parsing the text from scratch.

This adds a `STORED` generated column plus a GIN index over it, and points both the match condition and the ordering at that column.

## Measurements

Real workspace: **230 MB across 33,098 messages** (PostgreSQL 15 + pgvector, 2 cores, spinning up from cache-cold). Content is unremarkable — max message 25 KB, average 7.3 KB, nothing over 100 KB.

Isolating each stage of the existing query:

| Operation | Time |
|---|---|
| `COUNT(*)` | 6 ms |
| Full scan reading all 230 MB of content | 1,239 ms |
| `to_tsvector(content) @@ plainto_tsquery(...)` — GIN | **25 ms** |
| `ts_rank(to_tsvector(content), ...)` | **48,813 ms** |

Matching is already fast. Ranking is ~2000x slower and accounts for essentially all wall-clock time.

After this change, same workspace and hardware:

| | Before | After |
|---|---|---|
| SQL `ts_rank` aggregate | 48,813 ms | **263 ms** |
| `POST /v3/workspaces/{id}/search` | ~48 s | **0.53 – 1.84 s** |

We also confirmed this is not a hardware problem — the same query on an Apple M4 took 24.1 s versus 48.8 s on a 2013 i5. Faster silicon halves it; this change removes it.

## Trade-offs

- **Storage**: the `messages` table grows roughly 55% (230 MB → 357 MB including the new index) on our workspace.
- **Migration cost**: adding a `STORED` generated column is a full table rewrite holding `ACCESS EXCLUSIVE`. It took ~4 minutes on 33k rows for us, during which reads and writes block. This is called out in the migration docstring so operators can schedule it rather than discover it.
- **Additive**: the existing `ix_messages_content_gin` expression index is left in place, so this is safe to roll back by dropping the column.

## Notes / open questions

- We kept the `unicode61`-equivalent `'english'` config to match the existing index exactly, so behaviour is unchanged.
- The `OR content ILIKE '%…%'` fallback is untouched. We separately tried a `pg_trgm` index for that branch; it improved the bitmap index scan to ~1.7 ms but did not move total latency, because ranking dominated. Once ranking is fixed the ILIKE branch is no longer a bottleneck at our scale, but maintainers may have views on whether it's still needed.
- Happy to adjust the column name, split the migration, or gate it behind a setting if you'd prefer it opt-in for existing deployments given the rewrite cost.

We may be unusual in hitting this — our workspace is fed by ambient audio capture rather than chat, so it's roughly 30x larger than a typical conversational workspace. But the cost is superlinear in corpus size for every deployment, so it seemed worth reporting upstream rather than just carrying locally.

Thanks for Honcho — happy to iterate on this however suits you.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English full-text search support for message content.
  * Search results now support indexed relevance matching for faster retrieval and ranking.

* **Performance Improvements**
  * Improved full-text search efficiency by using a stored search index instead of processing message content during each query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->