### PR TITLE
fix(deriver): healthcheck queue progress + quarantine malformed work units

### DIFF
--- a/scripts/deriver-healthcheck.py
+++ b/scripts/deriver-healthcheck.py
@@ -1,0 +1,63 @@
+"""Container healthcheck for Deriver queue progress.
+
+The API health endpoint only proves that the separate API container is alive.
+This probe runs inside Deriver and checks the queue state it is responsible for.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import psycopg
+
+
+def main() -> int:
+    uri = os.environ["DB_CONNECTION_URI"].replace(
+        "postgresql+psycopg://", "postgresql://", 1
+    )
+    max_pending_seconds = int(
+        os.environ.get("DERIVER_HEALTH_MAX_PENDING_SECONDS", "3600")
+    )
+
+    with (
+        psycopg.connect(uri, connect_timeout=5) as connection,
+        connection.cursor() as cursor,
+    ):
+        cursor.execute(
+            """
+            SELECT
+                COUNT(*) FILTER (
+                    WHERE task_type = 'representation'
+                      AND work_unit_key NOT LIKE 'representation:%'
+                ),
+                COALESCE(
+                    EXTRACT(EPOCH FROM (NOW() - MIN(created_at)))::bigint,
+                    0
+                ),
+                COUNT(*)
+            FROM queue
+            WHERE processed = false
+              AND task_type IN ('representation', 'summary', 'dream')
+            """
+        )
+        malformed, oldest_pending_seconds, pending = cursor.fetchone()
+
+    if malformed:
+        print(f"unhealthy: {malformed} malformed representation work unit(s)")
+        return 1
+    if pending and oldest_pending_seconds > max_pending_seconds:
+        print(
+            "unhealthy: oldest pending user-facing work unit is "
+            f"{oldest_pending_seconds}s old (limit {max_pending_seconds}s)"
+        )
+        return 1
+
+    print(
+        f"healthy: pending={pending}, oldest_pending_seconds={oldest_pending_seconds}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deriver-healthcheck.py
+++ b/scripts/deriver-healthcheck.py
@@ -27,9 +27,18 @@ def main() -> int:
         cursor.execute(
             """
             SELECT
+                -- Mirrors parse_work_unit_key(): a representation key must be
+                -- prefixed 'representation:' AND have either 4 segments
+                -- (workspace:session:observed) or 5 (legacy, with observer).
+                -- Any other shape raises in the parser and would be quarantined,
+                -- so counting only the prefix mismatch would under-report.
                 COUNT(*) FILTER (
                     WHERE task_type = 'representation'
-                      AND work_unit_key NOT LIKE 'representation:%'
+                      AND (
+                        work_unit_key NOT LIKE 'representation:%'
+                        OR array_length(string_to_array(work_unit_key, ':'), 1)
+                             NOT IN (4, 5)
+                      )
                 ),
                 COALESCE(
                     EXTRACT(EPOCH FROM (NOW() - MIN(created_at)))::bigint,

--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -625,6 +625,7 @@ class QueueManager:
         """
         ownership = self.worker_ownership.get(worker_id)
         error_msg = f"Invalid work unit key: {error.__class__.__name__}: {error}"
+        quarantined = False
         try:
             async with tracked_db("quarantine_invalid_work_unit") as db:
                 await db.execute(
@@ -642,6 +643,7 @@ class QueueManager:
                         )
                     )
                 await db.commit()
+                quarantined = True
         except Exception as quarantine_error:
             logger.error(
                 "Failed to quarantine invalid work unit %s: %s",
@@ -654,7 +656,21 @@ class QueueManager:
         finally:
             self.untrack_worker_work_unit(worker_id, work_unit_key)
 
-        logger.error("Quarantined invalid work unit %s: %s", work_unit_key, error)
+        # Only claim quarantine when the transaction actually committed —
+        # otherwise the item is still unprocessed (and may still hold an
+        # ActiveQueueSession row), and an unconditional success log would
+        # misdirect anyone reading these during an outage.
+        if quarantined:
+            logger.error("Quarantined invalid work unit %s: %s", work_unit_key, error)
+        else:
+            logger.error(
+                "Invalid work unit %s NOT quarantined (quarantine write failed); "
+                "it remains unprocessed: %s",
+                work_unit_key,
+                error,
+            )
+        # The parse failure itself is worth reporting either way; the quarantine
+        # failure, if any, is captured separately in the except branch above.
         if settings.SENTRY.ENABLED:
             sentry_sdk.capture_exception(error)
 

--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -610,10 +610,62 @@ class QueueManager:
         if settings.SENTRY.ENABLED:
             sentry_sdk.capture_exception(error)
 
+    async def _quarantine_invalid_work_unit(
+        self,
+        work_unit_key: str,
+        worker_id: str,
+        error: Exception,
+    ) -> None:
+        """Mark an unparseable work unit errored and release worker ownership.
+
+        Work-unit parsing happens before task-specific processing. Without this
+        guard, a malformed producer can raise before the normal ``finally``
+        block, leaving the worker owned forever and starving the queue when the
+        Deriver is configured with a single worker.
+        """
+        ownership = self.worker_ownership.get(worker_id)
+        error_msg = f"Invalid work unit key: {error.__class__.__name__}: {error}"
+        try:
+            async with tracked_db("quarantine_invalid_work_unit") as db:
+                await db.execute(
+                    update(models.QueueItem)
+                    .where(models.QueueItem.work_unit_key == work_unit_key)
+                    .where(~models.QueueItem.processed)
+                    .values(processed=True, error=error_msg[:65535])
+                )
+                if ownership and ownership.work_unit_key == work_unit_key:
+                    await db.execute(
+                        delete(models.ActiveQueueSession)
+                        .where(models.ActiveQueueSession.id == ownership.aqs_id)
+                        .where(
+                            models.ActiveQueueSession.work_unit_key == work_unit_key
+                        )
+                    )
+                await db.commit()
+        except Exception as quarantine_error:
+            logger.error(
+                "Failed to quarantine invalid work unit %s: %s",
+                work_unit_key,
+                quarantine_error,
+                exc_info=True,
+            )
+            if settings.SENTRY.ENABLED:
+                sentry_sdk.capture_exception(quarantine_error)
+        finally:
+            self.untrack_worker_work_unit(worker_id, work_unit_key)
+
+        logger.error("Quarantined invalid work unit %s: %s", work_unit_key, error)
+        if settings.SENTRY.ENABLED:
+            sentry_sdk.capture_exception(error)
+
     async def process_work_unit(self, work_unit_key: str, worker_id: str) -> None:
         """Process all queue items for a specific work unit by routing to the correct handler."""
         logger.debug(f"Starting to process work unit {work_unit_key}")
-        work_unit = parse_work_unit_key(work_unit_key)
+        try:
+            work_unit = parse_work_unit_key(work_unit_key)
+        except Exception as error:
+            await self._quarantine_invalid_work_unit(work_unit_key, worker_id, error)
+            return
         async with self.semaphore:
             queue_item_count = 0
             try:

--- a/tests/deriver/test_queue_processing.py
+++ b/tests/deriver/test_queue_processing.py
@@ -2,7 +2,7 @@ import asyncio
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from nanoid import generate as generate_nanoid
@@ -18,6 +18,21 @@ from src.utils.work_unit import construct_work_unit_key
 @pytest.mark.asyncio
 class TestQueueProcessing:
     """Test suite for queue processing functionality"""
+
+    async def test_invalid_work_unit_is_quarantined_before_processing(self) -> None:
+        qm = QueueManager()
+        work_unit_key = "hermes:invalid-test-session"
+        worker_id = "test_worker"
+
+        with patch.object(
+            qm, "_quarantine_invalid_work_unit", new_callable=AsyncMock
+        ) as quarantine:
+            await qm.process_work_unit(work_unit_key, worker_id)
+
+        quarantine.assert_awaited_once()
+        args = quarantine.await_args.args
+        assert args[:2] == (work_unit_key, worker_id)
+        assert isinstance(args[2], ValueError)
 
     async def _add_representation_work_unit(
         self,


### PR DESCRIPTION
## Summary
- Adds a deriver healthcheck script (`scripts/deriver-healthcheck.py`) that reports queue processing progress, for monitoring whether the deriver's work-unit queue is actually draining or stuck.
- Quarantines malformed work units in `src/deriver/queue_manager.py` instead of letting them repeatedly fail/retry indefinitely, with a regression test covering the quarantine path.

## Verification
- Rebased onto current `origin/main` (fresh, no conflicts) so this diff reflects only the intended change (3 files, +132/-2).
- `py_compile` clean on all three changed files.
- Full pytest run isn't possible from this machine (Windows) — `tests/conftest.py` unconditionally imports `fcntl` (POSIX-only) via `src/telemetry/reasoning_traces.py`, a pre-existing, unrelated issue confirmed to also affect a completely clean `origin/main` checkout on Windows, not something this PR introduces.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added health monitoring for Deriver containers, including detection of stalled or malformed queue work.
  * Health checks now report failure when pending work exceeds the configured age limit.

* **Bug Fixes**
  * Invalid queue work units are quarantined safely before processing, preventing worker interruptions and releasing associated resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->