### PR TITLE
fix(api): make the conclusions semantic-search validation error actionable

### DIFF
--- a/src/routers/conclusions.py
+++ b/src/routers/conclusions.py
@@ -110,7 +110,10 @@ async def query_conclusions(
 
     if not observer or not observed:
         raise ValidationException(
-            "observer and observed must be specified for semantic search"
+            "observer and observed must be specified for semantic search. "
+            "Pass them inside the 'filters' object, e.g. "
+            '{"query": "...", "filters": {"observer": "alice", "observed": "bob"}}. '
+            "Both 'observer'/'observer_id' and 'observed'/'observed_id' are accepted."
         )
 
     with embedding_call_purpose(


### PR DESCRIPTION
## Problem
`POST /conclusions/query` raises `"observer and observed must be specified for semantic search"` when either is missing. The message states the requirement but not *where* the values belong, so a caller can't tell from the error whether they go at the top level of the request body or inside `filters`.

## Change
Extends the message to point at the `filters` object, show a minimal well-formed payload, and note that both key spellings are accepted — the handler already reads `observer` or `observer_id` (and `observed` / `observed_id`), which isn't discoverable from the old message.

Message-only change; no behavior or validation logic touched. Examples use the repo's existing `alice`/`bob` convention.

## Verification
- `py_compile` clean.
- Branch is based on current `origin/main` — diff is exactly the 4 changed lines.
- Confirmed the terse message is still present on `main` (`src/routers/conclusions.py:113`), so this is not already fixed.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved semantic-search validation guidance by listing accepted filter key variants.
  * Added an example request payload to clarify the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->