### PR TITLE
fix(deriver): exclude agent self-narration from observation extraction

### DIFF
--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -71,6 +71,14 @@ RULES:
 - Extract ALL observations from the target peer's messages, using others as context.
 - Contextualize each observation sufficiently (e.g. "Ann is nervous about the job interview at the pharmacy" not just "Ann is nervous")
 
+EXCLUSIONS — DO NOT extract any of the following:
+- **Self-narrating agent output**: lines that quote the target peer as the subject of an utterance about its own tooling state — "<peer> said X", "<peer> reported Y", "<peer> confirmed Z", "<peer> noted ...", "<peer> acknowledged ...", "<peer> replied ...", "<peer> stated ..." (e.g. "alice said the file is clean", "alice reported the test passed"). These narrate an agent's own state, not facts about the peer.
+- **Debug-status broadcasts**: lines about peer-card contents, observation counts, file hashes, commit hashes, PR numbers, or other tooling state. These are agent self-narration, not facts about the target peer.
+- **Quoted agent-side relay content**: lines that quote or paraphrase an agent's prior output (e.g. "the bot said ...", "the relay reported ..."). These are meta-observations, not facts about the target peer.
+- **Self-referential summaries**: lines describing the target peer's own conversational state (e.g. "alice said it ran the test"). These are agent self-narration, not facts.
+
+The third-person form ("alice is 25", "alice has a dog") is correct for extracting facts ABOUT the target peer from their utterances. It is NOT correct for extracting agent-self state, which would only inflate the target peer's representation with noise about the agent itself.
+
 <examples>
 These examples are fabricated illustrations of the output format. Never emit a conclusion for which content comes from these examples. Every conclusion must be supported by the <messages> block only.
 
@@ -78,6 +86,9 @@ EXAMPLES (using `alice` as the target peer id):
 - EXPLICIT: "I just turned 25" → "alice is 25 years old"
 - EXPLICIT: "I took my dog for a walk in NYC" → "alice has a dog", "alice walked her dog in NYC"
 - EXPLICIT: "I've lived in NYC for six years" → "alice lives in NYC", "alice has lived in NYC for six years"
+- EXCLUSION: "alice said the peer card is clean" → DO NOT extract; agent self-narration, not a fact about alice as a peer.
+- EXCLUSION: "alice reported the three-way check passed" → DO NOT extract; debug-status broadcast.
+- EXCLUSION: "the bot replied 4 🙂" → DO NOT extract; quoted agent-side relay content.
 </examples>
 
 {custom_instructions_section}

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -72,8 +72,8 @@ RULES:
 - Contextualize each observation sufficiently (e.g. "Ann is nervous about the job interview at the pharmacy" not just "Ann is nervous")
 
 EXCLUSIONS — DO NOT extract any of the following:
-- **Self-narrating agent output**: lines that quote the target peer as the subject of an utterance about its own tooling state — "<peer> said X", "<peer> reported Y", "<peer> confirmed Z", "<peer> noted ...", "<peer> acknowledged ...", "<peer> replied ...", "<peer> stated ..." (e.g. "alice said the file is clean", "alice reported the test passed"). These narrate an agent's own state, not facts about the peer.
-- **Debug-status broadcasts**: lines about peer-card contents, observation counts, file hashes, commit hashes, PR numbers, or other tooling state. These are agent self-narration, not facts about the target peer.
+- **Self-narrating agent output**: lines that quote the target peer as the subject of an utterance about its own tooling state — "alice said X", "alice reported Y", "alice confirmed Z", "alice noted ...", "alice acknowledged ...", "alice replied ...", "alice stated ..." (e.g. "alice said the file is clean", "alice reported the test passed"). These narrate an agent's own state, not facts about the peer.
+- **Debug-status broadcasts**: lines about peer card contents, observation counts, file hashes, commit hashes, PR numbers, or other tooling state. These are agent self-narration, not facts about the target peer.
 - **Quoted agent-side relay content**: lines that quote or paraphrase an agent's prior output (e.g. "the bot said ...", "the relay reported ..."). These are meta-observations, not facts about the target peer.
 - **Self-referential summaries**: lines describing the target peer's own conversational state (e.g. "alice said it ran the test"). These are agent self-narration, not facts.
 


### PR DESCRIPTION
## Problem
The observation-extraction prompt treats every line attributable to the target peer as a candidate fact *about* that peer. That holds for human peers, but peers can also be AI agents, bots, or services (the prompt says so explicitly). When such a peer relays its own tooling state — "alice said the file is clean", "alice reported the test passed" — those lines get extracted as facts about the peer, filling its representation with noise about the agent's own operation rather than anything true about it.

Observed in practice against a Honcho workspace backing an AI agent: peer representations accumulated observations that were really the agent narrating its own status back into the session.

## Change
Adds an `EXCLUSIONS` block to `minimal_deriver_prompt` covering four shapes seen in real sessions:
- self-narrating agent output (`<peer> said/reported/confirmed …` about its own state)
- debug-status broadcasts (peer-card contents, counts, hashes, PR numbers)
- quoted agent-side relay content ("the bot said …")
- self-referential conversational summaries

Also clarifies that the existing third-person extraction form is correct for facts about a peer but not for agent-self state, and adds three `EXCLUSION:` counter-examples alongside the existing positive ones.

Prompt-text only — no code paths, schemas, or extraction logic changed. Uses the file's existing `alice` target-peer convention.

## Verification
- `py_compile` clean.
- Branch based on current `origin/main`; diff is +11 lines in one file.
- Confirmed `main` has no equivalent exclusion guidance today.

Note: this is prompt engineering, so it's a judgement call on wording — happy to adjust phrasing or trim the examples if maintainers prefer a lighter touch.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction accuracy by excluding agent self-narration, debugging updates, tool status messages, quoted relays, and self-referential summaries.
  * Added examples clarifying which content should not be treated as an explicit fact.
  * Reduced the risk of internal commentary or repeated summaries appearing as extracted facts in results.
  * Produces cleaner, more reliable extracted facts from conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->