### PR TITLE
feat(telemetry): OpenTelemetry instrumentation for memory operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ dependencies = [
     "scikit-learn>=1.6.0",
     "prometheus_client>=0.21.0",
     "cloudevents>=1.12.0,<2.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
+    "opentelemetry-instrumentation-fastapi>=0.41b0",
+    "opentelemetry-instrumentation-httpx>=0.41b0",
 ]
 [dependency-groups]
 dev = [

--- a/src/config.py
+++ b/src/config.py
@@ -1146,6 +1146,22 @@ class MetricsSettings(HonchoSettings):
     NAMESPACE: str | None = None
 
 
+class OTelSettings(HonchoSettings):
+    """OpenTelemetry settings (memory-semconv v0.1.0).
+
+    Set OTEL_ENABLED=true to activate. When disabled all instrumentation calls
+    are no-ops through the OTel API's default no-op providers.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="OTEL_", extra="ignore")  # pyright: ignore
+
+    ENABLED: bool = False
+    SERVICE_NAME: str = "honcho"
+    # OTLP gRPC endpoint, e.g. "http://localhost:4317". Falls back to the
+    # OTEL_EXPORTER_OTLP_ENDPOINT standard env var when unset.
+    EXPORTER_OTLP_ENDPOINT: str | None = None
+
+
 class TelemetrySettings(HonchoSettings):
     """CloudEvents telemetry settings for analytics.
 
@@ -1465,6 +1481,7 @@ class AppSettings(HonchoSettings):
     WEBHOOK: WebhookSettings = Field(default_factory=WebhookSettings)
     METRICS: MetricsSettings = Field(default_factory=MetricsSettings)
     TELEMETRY: TelemetrySettings = Field(default_factory=TelemetrySettings)
+    OTEL: OTelSettings = Field(default_factory=OTelSettings)
     CACHE: CacheSettings = Field(default_factory=CacheSettings)
     DREAM: DreamSettings = Field(default_factory=DreamSettings)
     VECTOR_STORE: VectorStoreSettings = Field(default_factory=VectorStoreSettings)

--- a/src/crud/document.py
+++ b/src/crud/document.py
@@ -24,6 +24,19 @@ from src.exceptions import (
     ValidationException,
     VectorStoreError,
 )
+from src.telemetry.otel import (
+    MEMORY_ITEM_COUNT,
+    MEMORY_OBSERVED,
+    MEMORY_OBSERVER,
+    MEMORY_OPERATION,
+    MEMORY_QUERY,
+    MEMORY_RESULT_COUNT,
+    MEMORY_SYSTEM,
+    MEMORY_WORKSPACE,
+    get_meter,
+    get_otel_logger,
+    get_tracer,
+)
 from src.utils.filter import apply_filter
 from src.vector_store import (
     VectorRecord,
@@ -32,6 +45,25 @@ from src.vector_store import (
 )
 
 logger = getLogger(__name__)
+
+_tracer = get_tracer("honcho.memory.document")
+_meter = get_meter("honcho.memory.document")
+_otel_log = get_otel_logger("honcho.memory.document")
+
+_search_duration = _meter.create_histogram(
+    "memory.search.duration",
+    unit="ms",
+    description="Vector search latency in milliseconds",
+)
+_search_results = _meter.create_histogram(
+    "memory.search.results",
+    description="Number of results returned per search",
+)
+_operation_duration = _meter.create_histogram(
+    "memory.operation.duration",
+    unit="ms",
+    description="Memory add/delete operation latency in milliseconds",
+)
 
 
 def get_all_documents(
@@ -355,78 +387,118 @@ async def query_documents(
     Returns:
         Sequence of matching documents
     """
-    # Use provided embedding or generate one
-    if embedding is None:
-        try:
-            embedding = await embedding_client.embed(query)
-        except ValueError as e:
-            raise ValidationException(
-                "Query exceeds maximum token limit of "
-                + f"{settings.EMBEDDING.MAX_INPUT_TOKENS}."
-            ) from e
+    import time
 
-    if _uses_pgvector():
-        # pgvector path — pure DB, open a short session if none provided
-        if db is not None:
-            return await _query_documents_pgvector(
-                db,
-                workspace_name,
-                observer,
-                observed,
-                embedding,
-                filters,
-                max_distance,
-                top_k,
+    _t0 = time.monotonic()
+    with _tracer.start_as_current_span(
+        "memory.search",
+        attributes={
+            MEMORY_SYSTEM: "honcho",
+            MEMORY_OPERATION: "search",
+            MEMORY_WORKSPACE: workspace_name,
+            MEMORY_OBSERVER: observer,
+            MEMORY_OBSERVED: observed,
+            # Truncate query to avoid high-cardinality spans; omit if PII concern
+            MEMORY_QUERY: query[:200] if query else "",
+        },
+    ) as span:
+        # Use provided embedding or generate one
+        if embedding is None:
+            try:
+                embedding = await embedding_client.embed(query)
+            except ValueError as e:
+                raise ValidationException(
+                    "Query exceeds maximum token limit of "
+                    + f"{settings.EMBEDDING.MAX_INPUT_TOKENS}."
+                ) from e
+
+        if _uses_pgvector():
+            # pgvector path — pure DB, open a short session if none provided
+            if db is not None:
+                docs = await _query_documents_pgvector(
+                    db,
+                    workspace_name,
+                    observer,
+                    observed,
+                    embedding,
+                    filters,
+                    max_distance,
+                    top_k,
+                )
+            else:
+                async with tracked_db(
+                    "query_documents.pgvector", read_only=True
+                ) as managed_db:
+                    docs = await _query_documents_pgvector(
+                        managed_db,
+                        workspace_name,
+                        observer,
+                        observed,
+                        embedding,
+                        filters,
+                        max_distance,
+                        top_k,
+                    )
+                    for doc in docs:
+                        managed_db.expunge(doc)
+        else:
+            # External vector store — network call first, DB only for the ID fetch
+            document_ids = await query_external_vector_document_ids(
+                workspace_name=workspace_name,
+                observer=observer,
+                observed=observed,
+                embedding=embedding,
+                top_k=top_k,
+                max_distance=max_distance,
+                filters=filters,
             )
-        async with tracked_db("query_documents.pgvector", read_only=True) as managed_db:
-            docs = await _query_documents_pgvector(
-                managed_db,
-                workspace_name,
-                observer,
-                observed,
-                embedding,
-                filters,
-                max_distance,
-                top_k,
-            )
-            for doc in docs:
-                managed_db.expunge(doc)
-            return docs
 
-    # External vector store — network call first, DB only for the ID fetch
-    document_ids = await query_external_vector_document_ids(
-        workspace_name=workspace_name,
-        observer=observer,
-        observed=observed,
-        embedding=embedding,
-        top_k=top_k,
-        max_distance=max_distance,
-        filters=filters,
-    )
+            if not document_ids:
+                span.set_attribute(MEMORY_RESULT_COUNT, 0)
+                elapsed_ms = (time.monotonic() - _t0) * 1000
+                _search_duration.record(elapsed_ms, {MEMORY_SYSTEM: "honcho"})
+                _search_results.record(0, {MEMORY_SYSTEM: "honcho"})
+                return []
 
-    if not document_ids:
-        return []
+            if db is not None:
+                docs = await fetch_documents_by_ids(
+                    db=db,
+                    workspace_name=workspace_name,
+                    observer=observer,
+                    observed=observed,
+                    document_ids=document_ids,
+                    filters=filters,
+                )
+            else:
+                async with tracked_db(
+                    "query_documents.fetch", read_only=True
+                ) as managed_db:
+                    docs = await fetch_documents_by_ids(
+                        db=managed_db,
+                        workspace_name=workspace_name,
+                        observer=observer,
+                        observed=observed,
+                        document_ids=document_ids,
+                        filters=filters,
+                    )
+                    for doc in docs:
+                        managed_db.expunge(doc)
 
-    if db is not None:
-        return await fetch_documents_by_ids(
-            db=db,
-            workspace_name=workspace_name,
-            observer=observer,
-            observed=observed,
-            document_ids=document_ids,
-            filters=filters,
+        result_count = len(docs)
+        span.set_attribute(MEMORY_RESULT_COUNT, result_count)
+        elapsed_ms = (time.monotonic() - _t0) * 1000
+        _search_duration.record(elapsed_ms, {MEMORY_SYSTEM: "honcho"})
+        _search_results.record(result_count, {MEMORY_SYSTEM: "honcho"})
+        _otel_log.emit(
+            body=f"memory.search: {result_count} results in {elapsed_ms:.1f}ms",
+            severity_text="INFO",
+            attributes={
+                MEMORY_SYSTEM: "honcho",
+                MEMORY_OPERATION: "search",
+                MEMORY_WORKSPACE: workspace_name,
+                MEMORY_RESULT_COUNT: result_count,
+            },
         )
-    async with tracked_db("query_documents.fetch", read_only=True) as managed_db:
-        docs = await fetch_documents_by_ids(
-            db=managed_db,
-            workspace_name=workspace_name,
-            observer=observer,
-            observed=observed,
-            document_ids=document_ids,
-            filters=filters,
-        )
-        for doc in docs:
-            managed_db.expunge(doc)
         return docs
 
 
@@ -504,6 +576,20 @@ async def create_documents(
         List of DocumentCreate schemas that were actually inserted (excludes
         duplicates and failures).
     """
+    import time
+
+    _t0 = time.monotonic()
+    _span = _tracer.start_span(
+        "memory.add",
+        attributes={
+            MEMORY_SYSTEM: "honcho",
+            MEMORY_OPERATION: "add",
+            MEMORY_WORKSPACE: workspace_name,
+            MEMORY_OBSERVER: observer,
+            MEMORY_OBSERVED: observed,
+            MEMORY_ITEM_COUNT: len(documents),
+        },
+    )
     honcho_documents: list[models.Document] = []
     accepted_documents: list[schemas.DocumentCreate] = []
     # Store (document_model, embedding) pairs - IDs aren't available until after commit
@@ -770,13 +856,29 @@ async def create_documents(
             "Failed to create documents due to integrity constraint violation"
         ) from e
 
-    return CreateDocumentsResult(
+    result = CreateDocumentsResult(
         created_documents=accepted_documents,
         exact_dup_existing_count=exact_dup_existing_count,
         exact_dup_in_batch_count=exact_dup_in_batch_count,
         semantic_dup_rejected_count=semantic_dup_rejected_count,
         semantic_dup_replaced_count=semantic_dup_replaced_count,
     )
+    created_count = len(result.created_documents)
+    _span.set_attribute(MEMORY_ITEM_COUNT, created_count)
+    _span.end()
+    elapsed_ms = (time.monotonic() - _t0) * 1000
+    _operation_duration.record(elapsed_ms, {MEMORY_SYSTEM: "honcho", MEMORY_OPERATION: "add"})
+    _otel_log.emit(
+        body=f"memory.add: {created_count} documents created in {elapsed_ms:.1f}ms",
+        severity_text="INFO",
+        attributes={
+            MEMORY_SYSTEM: "honcho",
+            MEMORY_OPERATION: "add",
+            MEMORY_WORKSPACE: workspace_name,
+            MEMORY_ITEM_COUNT: created_count,
+        },
+    )
+    return result
 
 
 async def delete_document(
@@ -845,29 +947,60 @@ async def delete_documents(
     soft-deleted. IDs that didn't match are silently skipped; callers can diff
     the returned ids against the input to detect misses.
     """
+    import time
+
     if not document_ids:
         return []
 
-    conditions = [
-        models.Document.id.in_(document_ids),
-        models.Document.workspace_name == workspace_name,
-        models.Document.observer == observer,
-        models.Document.observed == observed,
-        models.Document.deleted_at.is_(None),
-    ]
-    if session_name is not None:
-        conditions.append(models.Document.session_name == session_name)
+    _t0 = time.monotonic()
+    with _tracer.start_as_current_span(
+        "memory.delete",
+        attributes={
+            MEMORY_SYSTEM: "honcho",
+            MEMORY_OPERATION: "delete",
+            MEMORY_WORKSPACE: workspace_name,
+            MEMORY_OBSERVER: observer,
+            MEMORY_OBSERVED: observed,
+            MEMORY_ITEM_COUNT: len(document_ids),
+        },
+    ) as span:
+        conditions = [
+            models.Document.id.in_(document_ids),
+            models.Document.workspace_name == workspace_name,
+            models.Document.observer == observer,
+            models.Document.observed == observed,
+            models.Document.deleted_at.is_(None),
+        ]
+        if session_name is not None:
+            conditions.append(models.Document.session_name == session_name)
 
-    stmt = (
-        update(models.Document)
-        .where(*conditions)
-        .values(deleted_at=func.now())
-        .returning(models.Document.id, models.Document.level)
-    )
-    result = await db.execute(stmt)
-    rows = result.all()
-    await db.commit()
-    return [(row.id, row.level) for row in rows]
+        stmt = (
+            update(models.Document)
+            .where(*conditions)
+            .values(deleted_at=func.now())
+            .returning(models.Document.id, models.Document.level)
+        )
+        result = await db.execute(stmt)
+        rows = result.all()
+        await db.commit()
+        deleted = [(row.id, row.level) for row in rows]
+        deleted_count = len(deleted)
+        span.set_attribute(MEMORY_ITEM_COUNT, deleted_count)
+        elapsed_ms = (time.monotonic() - _t0) * 1000
+        _operation_duration.record(
+            elapsed_ms, {MEMORY_SYSTEM: "honcho", MEMORY_OPERATION: "delete"}
+        )
+        _otel_log.emit(
+            body=f"memory.delete: {deleted_count} documents deleted in {elapsed_ms:.1f}ms",
+            severity_text="INFO",
+            attributes={
+                MEMORY_SYSTEM: "honcho",
+                MEMORY_OPERATION: "delete",
+                MEMORY_WORKSPACE: workspace_name,
+                MEMORY_ITEM_COUNT: deleted_count,
+            },
+        )
+        return deleted
 
 
 async def delete_document_by_id(
@@ -933,6 +1066,19 @@ async def create_observations(
     """
     if not observations:
         return []
+
+    import time
+
+    _t0_obs = time.monotonic()
+    _span_obs = _tracer.start_span(
+        "memory.add",
+        attributes={
+            MEMORY_SYSTEM: "honcho",
+            MEMORY_OPERATION: "add",
+            MEMORY_WORKSPACE: workspace_name,
+            MEMORY_ITEM_COUNT: len(observations),
+        },
+    )
 
     # Collect unique sessions and peer pairs to validate
     sessions_to_validate: set[str] = set()
@@ -1118,10 +1264,23 @@ async def create_observations(
             "Failed to create observations due to integrity constraint violation"
         ) from e
 
-    logger.debug(
-        "Created %d observations in workspace %s",
-        len(honcho_documents),
-        workspace_name,
+    obs_count = len(honcho_documents)
+    logger.debug("Created %d observations in workspace %s", obs_count, workspace_name)
+    _span_obs.set_attribute(MEMORY_ITEM_COUNT, obs_count)
+    _span_obs.end()
+    elapsed_obs_ms = (time.monotonic() - _t0_obs) * 1000
+    _operation_duration.record(
+        elapsed_obs_ms, {MEMORY_SYSTEM: "honcho", MEMORY_OPERATION: "add"}
+    )
+    _otel_log.emit(
+        body=f"memory.add (observations): {obs_count} created in {elapsed_obs_ms:.1f}ms",
+        severity_text="INFO",
+        attributes={
+            MEMORY_SYSTEM: "honcho",
+            MEMORY_OPERATION: "add",
+            MEMORY_WORKSPACE: workspace_name,
+            MEMORY_ITEM_COUNT: obs_count,
+        },
     )
     return honcho_documents
 

--- a/src/deriver/__main__.py
+++ b/src/deriver/__main__.py
@@ -13,6 +13,7 @@ from src.telemetry import (
     register_db_pool_collector,
     shutdown_telemetry,
 )
+from src.telemetry.otel import setup_otel
 
 from .queue_manager import main
 
@@ -63,6 +64,17 @@ def setup_logging():
 
 async def run_deriver():
     """Run the deriver with proper telemetry lifecycle management."""
+    # Initialize OpenTelemetry in the worker process. Without this the deriver's
+    # memory.add / derive spans stay in the OTel no-op provider and are silently
+    # dropped — the API process would be the ONLY source of spans, which is why
+    # background derivation showed up as missing (or the traces looked
+    # single-span). Opt-in via OTEL_ENABLED; no-op when disabled.
+    setup_otel(
+        enabled=settings.OTEL.ENABLED,
+        service_name=settings.OTEL.SERVICE_NAME,
+        otlp_endpoint=settings.OTEL.EXPORTER_OTLP_ENDPOINT,
+    )
+
     # Initialize async telemetry (CloudEvents emitter)
     await initialize_telemetry_async()
 

--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -42,6 +42,7 @@ from src.reconciler import (
 )
 from src.schemas import ResolvedConfiguration
 from src.telemetry import prometheus_metrics
+from src.telemetry.otel import get_tracer
 from src.telemetry.sentry import initialize_sentry
 from src.utils.work_unit import parse_work_unit_key
 from src.webhooks.events import (
@@ -50,6 +51,12 @@ from src.webhooks.events import (
 )
 
 logger = getLogger(__name__)
+
+# Deriver-side tracer. Each queue item/batch opens a root span so the downstream
+# memory.add / derive / summary spans nest into ONE trace per unit of work
+# instead of being exported as separate single-span traces. No-op when OTel is
+# disabled (default no-op TracerProvider).
+_deriver_tracer = get_tracer("honcho.deriver")
 
 load_dotenv(override=True)
 
@@ -659,16 +666,23 @@ class QueueManager:
                                     for item in items_to_process
                                     if item.message_id is not None
                                 ]
-                                await process_representation_batch(
-                                    messages_context,
-                                    message_level_configuration,
-                                    observers=observers,
-                                    observed=work_unit.observed,
-                                    queue_item_message_ids=queue_item_message_ids,
-                                    hit_batch_token_cap=batch_result.hit_batch_token_cap,
-                                    was_flush_enabled=batch_result.was_flush_enabled,
-                                    batch_max_tokens=batch_result.batch_max_tokens,
-                                )
+                                with _deriver_tracer.start_as_current_span(
+                                    "deriver.process_batch",
+                                    attributes={
+                                        "deriver.task_type": work_unit.task_type,
+                                        "deriver.item_count": len(items_to_process),
+                                    },
+                                ):
+                                    await process_representation_batch(
+                                        messages_context,
+                                        message_level_configuration,
+                                        observers=observers,
+                                        observed=work_unit.observed,
+                                        queue_item_message_ids=queue_item_message_ids,
+                                        hit_batch_token_cap=batch_result.hit_batch_token_cap,
+                                        was_flush_enabled=batch_result.was_flush_enabled,
+                                        batch_max_tokens=batch_result.batch_max_tokens,
+                                    )
                                 await self.mark_queue_items_as_processed(
                                     items_to_process, work_unit_key
                                 )
@@ -692,7 +706,13 @@ class QueueManager:
                                 break
 
                             try:
-                                await process_item(queue_item)
+                                with _deriver_tracer.start_as_current_span(
+                                    "deriver.process_item",
+                                    attributes={
+                                        "deriver.task_type": queue_item.task_type,
+                                    },
+                                ):
+                                    await process_item(queue_item)
                                 await self.mark_queue_items_as_processed(
                                     [queue_item], work_unit_key
                                 )

--- a/src/main.py
+++ b/src/main.py
@@ -37,6 +37,7 @@ from src.telemetry import (
     shutdown_telemetry,
 )
 from src.telemetry.logging import get_route_template
+from src.telemetry.otel import instrument_app, setup_otel
 from src.telemetry.sentry import initialize_sentry
 
 
@@ -101,7 +102,15 @@ if SENTRY_ENABLED:
 
 
 @asynccontextmanager
-async def lifespan(_: FastAPI):
+async def lifespan(app: FastAPI):
+    # NOTE: OpenTelemetry setup + FastAPI instrumentation happen at MODULE IMPORT
+    # time (see below, right after the app is constructed), NOT here. Attaching the
+    # OTel ASGI middleware inside the lifespan is too late: by the time the startup
+    # handler runs, Starlette has already frozen the middleware stack, so the
+    # server-span middleware would never execute — no request SERVER spans, no
+    # inbound W3C traceparent extraction, and memory.* / outbound LLM spans would
+    # be orphaned into single-span traces instead of one end-to-end trace.
+
     # Initialize CloudEvents telemetry
     await initialize_telemetry_async()
 
@@ -178,6 +187,21 @@ app.include_router(webhooks.router, prefix="/v3")
 
 # Prometheus metrics endpoint
 app.add_route("/metrics", metrics_endpoint, methods=["GET"])
+
+
+# Initialize OpenTelemetry and attach the FastAPI instrumentor at IMPORT time —
+# before Starlette builds (and freezes) the ASGI middleware stack on the first
+# request. This must run after every app.add_middleware() call above so the OTel
+# server-span middleware wraps them, and before the app serves traffic. Doing this
+# in the lifespan startup handler is too late (the stack is already built), which
+# silently yields zero SERVER spans, no inbound traceparent extraction, and
+# orphaned single-span memory.* traces. Both calls no-op when OTEL is disabled.
+setup_otel(
+    enabled=settings.OTEL.ENABLED,
+    service_name=settings.OTEL.SERVICE_NAME,
+    otlp_endpoint=settings.OTEL.EXPORTER_OTLP_ENDPOINT,
+)
+instrument_app(app)
 
 
 @app.get("/health")

--- a/src/telemetry/otel.py
+++ b/src/telemetry/otel.py
@@ -1,0 +1,192 @@
+"""OpenTelemetry setup for Honcho — memory-semconv v0.1.0.
+
+Opt-in via OTEL_ENABLED=true. When disabled, all tracer/meter/logger calls
+become no-ops through the OTel API's default no-op providers.
+
+Three signals are emitted:
+- **Traces**: memory.search / memory.add / memory.delete spans
+- **Metrics**: memory.search.duration, memory.search.results, memory.operation.duration
+- **Logs**: structured OTel log records on each memory operation
+"""
+
+from __future__ import annotations
+
+import logging
+
+from opentelemetry import _logs as otel_logs
+from opentelemetry import metrics, trace
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, ConsoleLogExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    ConsoleMetricExporter,
+    PeriodicExportingMetricReader,
+)
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+logger = logging.getLogger(__name__)
+
+# memory-semconv v0.1.0 attribute names
+MEMORY_SYSTEM = "memory.system"
+MEMORY_OPERATION = "memory.operation"
+MEMORY_QUERY = "memory.query"
+MEMORY_RESULT_COUNT = "memory.result_count"
+MEMORY_ITEM_COUNT = "memory.item_count"
+MEMORY_VECTOR_COUNT = "memory.vector_count"
+MEMORY_WORKSPACE = "memory.workspace"
+MEMORY_OBSERVER = "memory.observer"
+MEMORY_OBSERVED = "memory.observed"
+
+_initialized = False
+
+
+def setup_otel(
+    *,
+    enabled: bool = False,
+    service_name: str = "honcho",
+    otlp_endpoint: str | None = None,
+) -> None:
+    """Initialize OTel TracerProvider, MeterProvider, and LoggerProvider.
+
+    When *enabled* is False this is a no-op — the OTel API's default no-op
+    providers remain active so all instrumentation calls are safe zero-cost stubs.
+
+    Args:
+        enabled: Master toggle; False leaves OTel in no-op mode.
+        service_name: Value for the ``service.name`` resource attribute.
+        otlp_endpoint: OTLP gRPC endpoint (e.g. ``http://localhost:4317``).
+            When None, falls back to the ``OTEL_EXPORTER_OTLP_ENDPOINT`` env var.
+            If neither is set and enabled is True, console exporters are used.
+    """
+    global _initialized
+    if not enabled or _initialized:
+        return
+
+    resource = Resource.create({"service.name": service_name})
+
+    # --- Tracer ---
+    tracer_provider = TracerProvider(resource=resource)
+    if otlp_endpoint:
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                OTLPSpanExporter,
+            )
+
+            tracer_provider.add_span_processor(
+                BatchSpanProcessor(OTLPSpanExporter(endpoint=otlp_endpoint))
+            )
+            logger.info("OTel traces → OTLP gRPC at %s", otlp_endpoint)
+        except Exception:
+            logger.warning("OTLP span exporter unavailable; falling back to console")
+            tracer_provider.add_span_processor(
+                BatchSpanProcessor(ConsoleSpanExporter())
+            )
+    else:
+        tracer_provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+        logger.info("OTel traces → console (no OTLP endpoint configured)")
+
+    trace.set_tracer_provider(tracer_provider)
+
+    # --- Meter ---
+    if otlp_endpoint:
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+                OTLPMetricExporter,
+            )
+
+            reader = PeriodicExportingMetricReader(
+                OTLPMetricExporter(endpoint=otlp_endpoint)
+            )
+            logger.info("OTel metrics → OTLP gRPC at %s", otlp_endpoint)
+        except Exception:
+            logger.warning("OTLP metric exporter unavailable; falling back to console")
+            reader = PeriodicExportingMetricReader(ConsoleMetricExporter())
+    else:
+        reader = PeriodicExportingMetricReader(ConsoleMetricExporter())
+        logger.info("OTel metrics → console (no OTLP endpoint configured)")
+
+    meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(meter_provider)
+
+    # --- Logger ---
+    log_provider = LoggerProvider(resource=resource)
+    if otlp_endpoint:
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
+                OTLPLogExporter,
+            )
+
+            log_provider.add_log_record_processor(
+                BatchLogRecordProcessor(OTLPLogExporter(endpoint=otlp_endpoint))
+            )
+            logger.info("OTel logs → OTLP gRPC at %s", otlp_endpoint)
+        except Exception:
+            logger.warning("OTLP log exporter unavailable; falling back to console")
+            log_provider.add_log_record_processor(
+                BatchLogRecordProcessor(ConsoleLogExporter())
+            )
+    else:
+        log_provider.add_log_record_processor(
+            BatchLogRecordProcessor(ConsoleLogExporter())
+        )
+        logger.info("OTel logs → console (no OTLP endpoint configured)")
+
+    otel_logs.set_logger_provider(log_provider)
+
+    # --- Auto-instrumentation for outbound HTTP ---
+    # httpx underpins the Anthropic/OpenAI/embedding SDKs, so instrumenting it
+    # turns each LLM/embedding call into a CLIENT span. Combined with the FastAPI
+    # server span (see instrument_app), the memory.* spans nest into a single
+    # end-to-end trace per request instead of appearing as orphaned single-span
+    # traces.
+    try:
+        from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+        HTTPXClientInstrumentor().instrument()
+        logger.info("OTel httpx client instrumentation enabled")
+    except Exception:
+        logger.warning("OTel httpx instrumentation unavailable; skipping")
+
+    _initialized = True
+    logger.info("OpenTelemetry initialized (service=%s)", service_name)
+
+
+def instrument_app(app: object) -> None:
+    """Instrument a FastAPI app so each request opens a root SERVER span.
+
+    Without this, ``memory.*`` spans have no active parent context and each is
+    exported as its own single-span trace. Attaching the FastAPI instrumentor
+    makes the incoming HTTP request the root span; memory operations and the
+    downstream httpx (LLM/embedding) CLIENT spans then nest under it, yielding a
+    real end-to-end agent trace.
+
+    Safe to call unconditionally: no-ops when OTel was never initialized (the
+    global no-op TracerProvider produces no spans) and swallows import errors so
+    a missing optional dependency never breaks startup.
+    """
+    if not _initialized:
+        return
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+        FastAPIInstrumentor.instrument_app(app)
+        logger.info("OTel FastAPI instrumentation enabled (request root spans)")
+    except Exception:
+        logger.warning("OTel FastAPI instrumentation unavailable; skipping")
+
+
+def get_tracer(name: str = "honcho.memory") -> trace.Tracer:
+    """Return a tracer scoped to *name*."""
+    return trace.get_tracer(name)
+
+
+def get_meter(name: str = "honcho.memory") -> metrics.Meter:
+    """Return a meter scoped to *name*."""
+    return metrics.get_meter(name)
+
+
+def get_otel_logger(name: str = "honcho.memory") -> otel_logs.Logger:
+    """Return an OTel Logger scoped to *name* for structured log emission."""
+    return otel_logs.get_logger(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,8 @@ _RUNTIME_MOCK_TEST_BLOCKLIST_PREFIXES = (
     # Pure JWT scope tests — operate on src.security directly, no DB needed.
     "tests/test_security.py",
     "tests/test_generate_jwt_script.py",
+    # OTel unit tests — use in-memory span/metric exporters, no DB needed.
+    "tests/telemetry/test_otel.py",
 )
 
 _LIVE_LLM_MARKER = "live_llm"

--- a/tests/telemetry/test_otel.py
+++ b/tests/telemetry/test_otel.py
@@ -1,0 +1,381 @@
+"""Tests for OpenTelemetry instrumentation (memory-semconv v0.1.0).
+
+These tests use local TracerProvider/MeterProvider instances rather than
+replacing the global OTel providers, so they are safe to run in any order
+and alongside other test modules.
+"""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import InMemoryLogExporter, SimpleLogRecordProcessor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+@pytest.fixture()
+def local_tracer_and_exporter():
+    """Return a (tracer, exporter) pair backed by an in-process span exporter.
+
+    Does NOT replace the global TracerProvider — tests call
+    ``tracer.start_as_current_span`` directly.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    return tracer, exporter
+
+
+@pytest.fixture()
+def local_meter_and_reader():
+    """Return a (meter, reader) pair backed by InMemoryMetricReader."""
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    meter = provider.get_meter("test")
+    return meter, reader
+
+
+def test_setup_otel_noop_when_disabled():
+    """setup_otel with enabled=False must not replace the global providers."""
+    import opentelemetry.trace as trace_api
+
+    import src.telemetry.otel as otel_mod
+    from src.telemetry.otel import setup_otel
+
+    otel_mod._initialized = False
+    before = trace_api.get_tracer_provider()
+    setup_otel(enabled=False)
+    after = trace_api.get_tracer_provider()
+    assert before is after
+    assert not otel_mod._initialized
+
+
+def test_setup_otel_enabled_sets_sdk_provider():
+    """setup_otel with enabled=True installs a real TracerProvider."""
+    import opentelemetry.trace as trace_api
+    from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+
+    import src.telemetry.otel as otel_mod
+
+    otel_mod._initialized = False
+    original = trace_api.get_tracer_provider()
+    try:
+        from src.telemetry.otel import setup_otel
+
+        setup_otel(enabled=True, service_name="test-honcho")
+        assert isinstance(trace_api.get_tracer_provider(), SdkTracerProvider)
+        assert otel_mod._initialized
+    finally:
+        # Forcibly restore to avoid polluting subsequent tests.
+        # OTel uses a module-level _TRACER_PROVIDER variable guarded by a Once lock;
+        # we reset both to allow this test to be re-run safely.
+        import opentelemetry.trace as _trace_mod
+
+        _trace_mod._TRACER_PROVIDER = original  # type: ignore[attr-defined]
+        # Reset the "set once" guard so the global can be replaced again
+        if hasattr(_trace_mod, "_TRACER_PROVIDER_SET_ONCE"):
+            _trace_mod._TRACER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+        otel_mod._initialized = False
+
+
+def test_memory_semconv_attributes_present(local_tracer_and_exporter):
+    """Memory search spans must carry all memory-semconv v0.1.0 required attributes."""
+    tracer, exporter = local_tracer_and_exporter
+
+    from src.telemetry.otel import (
+        MEMORY_OBSERVED,
+        MEMORY_OBSERVER,
+        MEMORY_OPERATION,
+        MEMORY_QUERY,
+        MEMORY_RESULT_COUNT,
+        MEMORY_SYSTEM,
+        MEMORY_WORKSPACE,
+    )
+
+    with tracer.start_as_current_span(
+        "memory.search",
+        attributes={
+            MEMORY_SYSTEM: "honcho",
+            MEMORY_OPERATION: "search",
+            MEMORY_WORKSPACE: "ws1",
+            MEMORY_OBSERVER: "user-a",
+            MEMORY_OBSERVED: "user-a",
+            MEMORY_QUERY: "what did I say about dogs",
+            MEMORY_RESULT_COUNT: 3,
+        },
+    ):
+        pass
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    attrs = spans[0].attributes or {}
+    assert attrs[MEMORY_SYSTEM] == "honcho"
+    assert attrs[MEMORY_OPERATION] == "search"
+    assert attrs[MEMORY_RESULT_COUNT] == 3
+    assert MEMORY_QUERY in attrs
+
+
+def test_memory_add_attributes(local_tracer_and_exporter):
+    """Add spans must carry operation=add and item_count."""
+    tracer, exporter = local_tracer_and_exporter
+
+    from src.telemetry.otel import MEMORY_ITEM_COUNT, MEMORY_OPERATION, MEMORY_SYSTEM
+
+    with tracer.start_as_current_span(
+        "memory.add",
+        attributes={
+            MEMORY_SYSTEM: "honcho",
+            MEMORY_OPERATION: "add",
+            MEMORY_ITEM_COUNT: 5,
+        },
+    ):
+        pass
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    attrs = spans[0].attributes or {}
+    assert attrs[MEMORY_OPERATION] == "add"
+    assert attrs[MEMORY_ITEM_COUNT] == 5
+
+
+def test_memory_delete_attributes(local_tracer_and_exporter):
+    """Delete spans must carry operation=delete."""
+    tracer, exporter = local_tracer_and_exporter
+
+    from src.telemetry.otel import MEMORY_OPERATION, MEMORY_SYSTEM
+
+    with tracer.start_as_current_span(
+        "memory.delete",
+        attributes={MEMORY_SYSTEM: "honcho", MEMORY_OPERATION: "delete"},
+    ):
+        pass
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert (spans[0].attributes or {}).get(MEMORY_OPERATION) == "delete"
+
+
+def test_search_duration_metric_recorded(local_meter_and_reader):
+    """memory.search.duration histogram must record and export correctly."""
+    meter, reader = local_meter_and_reader
+
+    hist = meter.create_histogram("memory.search.duration", unit="ms")
+    hist.record(42.0, {"memory.system": "honcho"})
+
+    data = reader.get_metrics_data()
+    found = False
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == "memory.search.duration":
+                    found = True
+    assert found, "memory.search.duration metric not found in exported data"
+
+
+def test_search_results_metric_recorded(local_meter_and_reader):
+    """memory.search.results histogram must record and export correctly."""
+    meter, reader = local_meter_and_reader
+
+    hist = meter.create_histogram("memory.search.results")
+    hist.record(3, {"memory.system": "honcho"})
+
+    data = reader.get_metrics_data()
+    found = any(
+        metric.name == "memory.search.results"
+        for rm in data.resource_metrics
+        for sm in rm.scope_metrics
+        for metric in sm.metrics
+    )
+    assert found, "memory.search.results metric not found in exported data"
+
+
+def test_operation_duration_metric_recorded(local_meter_and_reader):
+    """memory.operation.duration histogram must record for add and delete ops."""
+    meter, reader = local_meter_and_reader
+
+    hist = meter.create_histogram("memory.operation.duration", unit="ms")
+    hist.record(10.5, {"memory.system": "honcho", "memory.operation": "add"})
+    hist.record(5.2, {"memory.system": "honcho", "memory.operation": "delete"})
+
+    data = reader.get_metrics_data()
+    found = any(
+        metric.name == "memory.operation.duration"
+        for rm in data.resource_metrics
+        for sm in rm.scope_metrics
+        for metric in sm.metrics
+    )
+    assert found, "memory.operation.duration metric not found in exported data"
+
+
+@pytest.fixture()
+def local_logger_and_exporter():
+    """Return an (otel_logger, exporter) pair backed by InMemoryLogExporter."""
+    exporter = InMemoryLogExporter()
+    provider = LoggerProvider()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+    otel_logger = provider.get_logger("test")
+    return otel_logger, exporter
+
+
+def test_memory_search_log_emitted(local_logger_and_exporter):
+    """memory.search operations must emit an OTel log record with required attributes."""
+    otel_logger, exporter = local_logger_and_exporter
+
+    from src.telemetry.otel import (
+        MEMORY_OPERATION,
+        MEMORY_RESULT_COUNT,
+        MEMORY_SYSTEM,
+        MEMORY_WORKSPACE,
+    )
+
+    otel_logger.emit(
+        body="memory.search: 3 results in 42.0ms",
+        severity_text="INFO",
+        attributes={
+            MEMORY_SYSTEM: "honcho",
+            MEMORY_OPERATION: "search",
+            MEMORY_WORKSPACE: "ws1",
+            MEMORY_RESULT_COUNT: 3,
+        },
+    )
+
+    records = exporter.get_finished_logs()
+    assert len(records) == 1
+    rec = records[0].log_record
+    assert str(rec.body) == "memory.search: 3 results in 42.0ms"
+    assert (rec.attributes or {}).get(MEMORY_OPERATION) == "search"
+    assert (rec.attributes or {}).get(MEMORY_RESULT_COUNT) == 3
+
+
+def test_memory_add_log_emitted(local_logger_and_exporter):
+    """memory.add operations must emit an OTel log record."""
+    otel_logger, exporter = local_logger_and_exporter
+
+    from src.telemetry.otel import MEMORY_ITEM_COUNT, MEMORY_OPERATION, MEMORY_SYSTEM
+
+    otel_logger.emit(
+        body="memory.add: 5 documents created in 15.0ms",
+        severity_text="INFO",
+        attributes={
+            MEMORY_SYSTEM: "honcho",
+            MEMORY_OPERATION: "add",
+            MEMORY_ITEM_COUNT: 5,
+        },
+    )
+
+    records = exporter.get_finished_logs()
+    assert len(records) == 1
+    assert (records[0].log_record.attributes or {}).get(MEMORY_OPERATION) == "add"
+
+
+def test_memory_delete_log_emitted(local_logger_and_exporter):
+    """memory.delete operations must emit an OTel log record."""
+    otel_logger, exporter = local_logger_and_exporter
+
+    from src.telemetry.otel import MEMORY_ITEM_COUNT, MEMORY_OPERATION, MEMORY_SYSTEM
+
+    otel_logger.emit(
+        body="memory.delete: 2 documents deleted in 5.0ms",
+        severity_text="INFO",
+        attributes={
+            MEMORY_SYSTEM: "honcho",
+            MEMORY_OPERATION: "delete",
+            MEMORY_ITEM_COUNT: 2,
+        },
+    )
+
+    records = exporter.get_finished_logs()
+    assert len(records) == 1
+    assert (records[0].log_record.attributes or {}).get(MEMORY_OPERATION) == "delete"
+
+
+# --------------------------------------------------------------------------- #
+# Regression: FastAPI instrumentation must attach BEFORE the ASGI
+# middleware stack is frozen, or no SERVER span is produced and inbound W3C
+# traceparent is never extracted (end-to-end traces collapse into orphaned
+# single-span traces). Starlette's ``add_middleware`` on an already-built stack
+# is a silent no-op, so attaching in the lifespan startup handler (which runs
+# after the stack is built) fails silently. main.py must call ``instrument_app``
+# at module import time. These tests lock in both the failure mode and the fix.
+# --------------------------------------------------------------------------- #
+
+_TRACEPARENT_TID = "a" * 32
+_TRACEPARENT = f"00-{_TRACEPARENT_TID}-{'b' * 16}-01"
+
+
+def test_fastapi_instrumentation_extracts_inbound_traceparent():
+    """The behavior the fix restores: an instrumented FastAPI app opens a SERVER
+    span that is a child of the inbound W3C traceparent, so a caller's trace and
+    Honcho's spans become one end-to-end trace (cross-process linkage)."""
+    from fastapi import FastAPI
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    from opentelemetry.trace import SpanKind
+    from starlette.testclient import TestClient
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    app = FastAPI()
+
+    @app.get("/ping")
+    async def ping():  # pragma: no cover - trivial handler
+        return {"ok": True}
+
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=provider)
+    try:
+        with TestClient(app) as client:
+            client.get("/ping", headers={"traceparent": _TRACEPARENT})
+        server_spans = [
+            s for s in exporter.get_finished_spans() if s.kind == SpanKind.SERVER
+        ]
+    finally:
+        FastAPIInstrumentor.uninstrument_app(app)
+
+    assert len(server_spans) == 1
+    # The server span must join the caller's trace, not start a new one.
+    assert format(server_spans[0].context.trace_id, "032x") == _TRACEPARENT_TID
+
+
+def test_main_calls_instrument_app_at_module_scope_not_in_lifespan():
+    """Regression guard. ``instrument_app`` MUST be invoked at module
+    import time — before Starlette freezes the ASGI middleware stack on the first
+    request. Attaching it inside the ``lifespan`` startup handler (which runs
+    after the stack is built) is a silent no-op: no SERVER spans, no inbound
+    traceparent extraction, orphaned single-span memory.* traces. This parses
+    src/main.py and fails if ``instrument_app`` is called inside any function
+    (e.g. moved back into ``lifespan``) instead of at module scope.
+    """
+    import ast
+    from pathlib import Path
+
+    main_src = Path("src/main.py").read_text(encoding="utf-8")
+    tree = ast.parse(main_src)
+
+    def _calls_instrument_app(node: ast.AST) -> bool:
+        return any(
+            isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name)
+            and n.func.id == "instrument_app"
+            for n in ast.walk(node)
+        )
+
+    module_level = any(
+        isinstance(stmt, ast.Expr) and _calls_instrument_app(stmt) for stmt in tree.body
+    )
+    in_function = any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and _calls_instrument_app(node)
+        for node in ast.walk(tree)
+    )
+
+    assert module_level, "instrument_app(app) must be called at module scope in main.py"
+    assert not in_function, (
+        "instrument_app must NOT be called inside a function (e.g. lifespan) — "
+        "it would attach after the middleware stack is frozen (regression)"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-07-25T12:28:24.732631003Z"
 exclude-newer-span = "P5D"
 
 [manifest]
@@ -204,6 +204,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
 ]
 
 [[package]]
@@ -1149,6 +1158,57 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.82.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/bc/656b89387d6f4ed7e0686c7b64c2ae7e554a759aa58122c8e5fb99392c32/grpcio-1.82.1.tar.gz", hash = "sha256:707b24abd90fcb1e45bcc080577da1dbf9971d107490589b9539af8e1e77b4b5", size = 13187300, upload-time = "2026-07-08T12:36:16.588Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/5b/e5092af97fa671ca279b3e373251af4bf87d5fbda7dc85f6a616899562a7/grpcio-1.82.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:0ddb18a9a9e1f46692b3567ae4abb3f8d117ce6afea48650f8eca06d8ab5d06f", size = 6181472, upload-time = "2026-07-08T12:34:31.009Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/18053a3a2ca03d0c2a1b8cc7271e705007a16aa5dae84bac00935c5b1a7f/grpcio-1.82.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:cf855b1af246720f567b0ce5d0724d45dfa4188eecc3296a2a69257b11b9e94b", size = 11970995, upload-time = "2026-07-08T12:34:33.603Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/21b1acb052876ad00959ec4d1b05fe08607d650bcfa282073bb164c2703c/grpcio-1.82.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb30cb13e25bc13cea70ffc69d6d90c49d36ea6c1d4549e6912f70177834cac", size = 6760127, upload-time = "2026-07-08T12:34:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/12/25eef9c245c54f0061317d13a302357fe8ea03bac240b2b02ececcf54da4/grpcio-1.82.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1e822b2774f719c017cbe700b6e47173b6ae290fb84906f52a5a3c2c60b62e1e", size = 7484377, upload-time = "2026-07-08T12:34:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/41/1a348767eb9d9bd7765dc4fa8a01723d3bb386d67f981ee5c6f9c02b8b1c/grpcio-1.82.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5dafb1ece8ed45dee7c738f166ec82e19673221ed5ab8967f72858a4685345b2", size = 6924269, upload-time = "2026-07-08T12:34:40.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b9/3aae7a03d34c86ea27988db859a6087c186f6c3f53f9b551e07afd989bfa/grpcio-1.82.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e06503106e7271e0a49fd5a1ac04747f1e47e87d900476db6fe45bc87ee411f4", size = 7531848, upload-time = "2026-07-08T12:34:43.277Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/3c4afa625d0dac9090707966916284c035fc5b2fb3e2c51e156accee6735/grpcio-1.82.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ff99bc8cafb6a952201c37b995f425e641c93ffa6e072258525feab57290141d", size = 8568217, upload-time = "2026-07-08T12:34:45.502Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9c/d8489c628e73e20a3d034e7f66912de7b1acb405f01d388f056a88e47924/grpcio-1.82.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:644ae1b94266ac785330f4590a69e52b6a7eb73029043a02209db81c81397d69", size = 7938771, upload-time = "2026-07-08T12:34:48.323Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b7/0a92cfd1658f3a896d4aa12d4efeb7dd4ddfc723725ae22741a5241ea710/grpcio-1.82.1-cp311-cp311-win32.whl", hash = "sha256:e203d2e19d471630084a16c815616f8211dff21c268ab3c5f5bf38417832e074", size = 4256432, upload-time = "2026-07-08T12:34:50.432Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/6a/2872c761b025d9ec74386f22a4a7d59c5a5b00ebf718761b33739ffc45de/grpcio-1.82.1-cp311-cp311-win_amd64.whl", hash = "sha256:0d8299c285fe6cc6a1f56badf8d3bc5078c8d20273ee64bafa3783b4bc29a769", size = 5009633, upload-time = "2026-07-08T12:34:52.67Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/88/d1350bf3343a2ed87d801584e40609f6c6bd3087926eeca03de50348cf4a/grpcio-1.82.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:c09bd5fa0d5b1fbd773ec349fe61441c3e4ebf168c229aa7538a820bdfad6a58", size = 6144689, upload-time = "2026-07-08T12:34:55.567Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/33/71875cdecd27c24ac1385d4783a09853f01b84a825a36aec2a2bc7d0d080/grpcio-1.82.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1eae24810720734598e3e6a1a528d5de0f265fe3fc86575e9ecce424b9ec7379", size = 11952034, upload-time = "2026-07-08T12:34:58.128Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b2/d9125df3d8a140dec12cc82c05b7deafedeababcff6496f28b2fd5634d10/grpcio-1.82.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a6bd5daf5bde7b24d7ad2cbaf8bf9eac620d96222016bb5e7ddde930dec0673f", size = 6710772, upload-time = "2026-07-08T12:35:01.33Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9b/69e2d1627398b964f34437dc476a5aff5a2cc8e7f247d26272b5674b5faf/grpcio-1.82.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1ecfde669cb687ac020d31ff76debe5dc7a62213335f02262eb6625628da1c03", size = 7450677, upload-time = "2026-07-08T12:35:03.926Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e7/8f855ca29c294956122a2a73023655b9b02602d5111dad2b9b00e7631c68/grpcio-1.82.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:011c8badee95734dee8bf05ce3464756a0ac3ebb8d443afd20c0e2b5e4640ad9", size = 6886855, upload-time = "2026-07-08T12:35:06.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f0/fa87e85f49925f44c479d07e58b051e69bcfef6b6d5fbc6749d140f6730a/grpcio-1.82.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b85f4564926fb23114d239392bdcae200db1e6179629edd7d7ab0ab89c96a197", size = 7501323, upload-time = "2026-07-08T12:35:08.49Z" },
+    { url = "https://files.pythonhosted.org/packages/67/55/2e0b10ae1d3ef9dcc480b91dc2158f4931fc4675d3af0a2836e39b2a744f/grpcio-1.82.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2c0c8270833395644c3fe6b6a806397955a2bc0538000a19a78b90c05a6c16e0", size = 8536899, upload-time = "2026-07-08T12:35:10.975Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/95/a3d8b0431fa221efc51ee39d73595ede74ba82a43b7c4313192e580face2/grpcio-1.82.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2ba199205ff46c7778290fe1673c91ac8e7e45678dd5c86e9e56fa33ec8788f6", size = 7913892, upload-time = "2026-07-08T12:35:13.944Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/92/f2651ec704d9852a56faef394775038afba435b50ce82ab2404d119c3355/grpcio-1.82.1-cp312-cp312-win32.whl", hash = "sha256:06127691866e295c14e84a1fb86356dd962254f6abd0da4ca4b001eea9e89438", size = 4240985, upload-time = "2026-07-08T12:35:16.048Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4f/a5fe8bf0d0a1b24855f370293075c931f27de4eb55f0f158786095bf3c11/grpcio-1.82.1-cp312-cp312-win_amd64.whl", hash = "sha256:1fa3223a3a2e1db74f4c2b255189eb7ea875dfba56e221d252ee3fc7b204778e", size = 5001580, upload-time = "2026-07-08T12:35:18.689Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3e/496992d08c0aaa11272eb6228dc8ab947da01fe835de243cd00521bce4c4/grpcio-1.82.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b454a2d97bfab7565683a02345f86bd182ab69fd7c2bdb7414171e7538f266b1", size = 6146068, upload-time = "2026-07-08T12:35:21.365Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8f/f263d6f14fdba6b56cfadd91fd3e158a52682b72c6016d1f8723d435659f/grpcio-1.82.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:3dde70abfc80b3be11de53ba0d601c439e7fb2afd3583ad1788d1146bec92fdc", size = 11948600, upload-time = "2026-07-08T12:35:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/14/3a02e6ee49c2d85bc15eaae321e0e11ab3542cad3c5b2de121ecce0c4296/grpcio-1.82.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5523099c98c292ea1ae08e617249db760c56a78f8deae879027fe7d1ffbcbf6", size = 6714591, upload-time = "2026-07-08T12:35:27.027Z" },
+    { url = "https://files.pythonhosted.org/packages/69/80/58e3738696f48ab7645347b98d8a7f93d10e00e6218388fbfcd6c9310e3d/grpcio-1.82.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5e5c4dc0a59b0f8490a6bdfd6fc8395b9d8ad8a8407c7d67ca7b5bba15c0877f", size = 7454995, upload-time = "2026-07-08T12:35:29.599Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6c/2557c1a889363072fbf2285ecd0e8c44860d4dbd60f017a32537c5b863e2/grpcio-1.82.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c40d94ba820329cc191981bc22fa6f6eed0799c6d921f3c6709521d59d4a2fd7", size = 6888621, upload-time = "2026-07-08T12:35:32.38Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/66/907706ccaff1223f1e10fd5b37fc16faead43392fccb4e786e7e390ac141/grpcio-1.82.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4c816180e31e273caaec6f8bd86a8392499d5bbb26f41da44e3dce48bde69095", size = 7505069, upload-time = "2026-07-08T12:35:35.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/ff97b0d0f635987ee5ec80dfedafa1aad629303745d48e8637d10eec5b80/grpcio-1.82.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e31fd780b261830720cb70b0fd8f0aa51d49e75a66d7464ad2e31d4b765f2580", size = 8535384, upload-time = "2026-07-08T12:35:37.954Z" },
+    { url = "https://files.pythonhosted.org/packages/62/9e/a97fddd970a8d1588cade06eca20443761c1858b0ad6590a5c835aa18062/grpcio-1.82.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d76152d7c31d7210d4a106e5d8b64da5bba5d6abf11be30e2f7b0a0c59bbcbf", size = 7910707, upload-time = "2026-07-08T12:35:40.797Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e4/eaba1517888af483a88d449eb7566f0f7f63446d46f339c5891798435875/grpcio-1.82.1-cp313-cp313-win32.whl", hash = "sha256:38e9dcb5258226fb3282630b31b16a968df52c8c6ad514af540646e0a4578f8a", size = 4240363, upload-time = "2026-07-08T12:35:43.298Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/66a98d47732e35290bef722f6149fed3709cd4cf61166f6f53a12f417302/grpcio-1.82.1-cp313-cp313-win_amd64.whl", hash = "sha256:3dbfb52c36d9511ac2b8e6c94fdde837b393ae520cc321f52a333a2deedf5a90", size = 5000980, upload-time = "2026-07-08T12:35:46.262Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/cb/cf9ae9e164c6e6dc8a494faa9771763df9da150eefe19671009624d1559f/grpcio-1.82.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:35f990f7784c8fd2872644f07f96ebb4d9e48e145a190ab80d0280af91a1bfb2", size = 6146901, upload-time = "2026-07-08T12:35:49.261Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2a/eccf26dbcfb7f7cab8027c5490a16c8937c5aa7a2ec20a3eab2cf7a43165/grpcio-1.82.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:46536a4a1f4434df3c851b9254ff6fc7df5705b273681a15ca277d5921c178a0", size = 11954756, upload-time = "2026-07-08T12:35:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/75/3b3b4a3cc9f084b026af96e1d3e539b1af29ec7f41ed0dfff3cb99cc8626/grpcio-1.82.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d6650a7c1ebb7921c70e12a385439a8118efb99e669fa9ed31cf25db1843937c", size = 6723087, upload-time = "2026-07-08T12:35:54.973Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/b0f0c9b1400a99a4da4c09b114f101b192f8f11192e76f620b8962f5d90b/grpcio-1.82.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b8e110c66df5204c0506d6c8787b35d48b8b699ef5aa366d6c4d67325c67fe9a", size = 7454542, upload-time = "2026-07-08T12:35:57.586Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bd/428e38868382aa193697a5aa53973f29c58e58ba4268aa0c86a2715ee58b/grpcio-1.82.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f853eae07235a51a27bb5d6a9a175a59ca55dc9b99edc6ce2f76f07332d333ae", size = 6889588, upload-time = "2026-07-08T12:36:00.012Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ce/03e01d5e10259bf5c08ee50570cc94724e79c956f61fd2f09b341af0956c/grpcio-1.82.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:60b0f2c95337694fc094b77d9f60f50566c84b5677393e342eb98daeee242d98", size = 7514166, upload-time = "2026-07-08T12:36:02.693Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/59/278b4b600329e2ba3849f3c1ea3c820b3a01b38a7ad184ba09595e8d2733/grpcio-1.82.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:b064fc444812bdaa9825d33c26f8d732d63ee6a5d78557c1faf92c98687fed27", size = 8536166, upload-time = "2026-07-08T12:36:05.349Z" },
+    { url = "https://files.pythonhosted.org/packages/44/27/7ccf2ef00f27a8e47a79d641c8ceaf7d3028c7a03d9a97b4c8a9a783c086/grpcio-1.82.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d7ede11d747b4e1bd05e3bc0260e155b65a88735a895a10f6521f19b889511e", size = 7912572, upload-time = "2026-07-08T12:36:08.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/be/33742482d2753f2d3a1b7641664b6622262d44f2f3b609f13425dd86d36f/grpcio-1.82.1-cp314-cp314-win32.whl", hash = "sha256:3d21f19838dc255ecbb79321b15ae9b98fbddff4c3d4aedb0a81bdd7f4ab572a", size = 4321856, upload-time = "2026-07-08T12:36:10.899Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/67/03329c847172c78ddeb1eb9be6b444fdbc12775a84c958b27e427e7b926d/grpcio-1.82.1-cp314-cp314-win_amd64.whl", hash = "sha256:e20f1edbb15f99e3128ec86433f9785fd5a451d8f115e74fe0056134f092a9d5", size = 5141114, upload-time = "2026-07-08T12:36:13.595Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1175,6 +1235,11 @@ dependencies = [
     { name = "langfuse" },
     { name = "nanoid" },
     { name = "openai" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-sdk" },
     { name = "pdfplumber" },
     { name = "pgvector" },
     { name = "prometheus-client" },
@@ -1229,6 +1294,11 @@ requires-dist = [
     { name = "langfuse", specifier = ">=3.3.2" },
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "openai", specifier = ">=1.99.7" },
+    { name = "opentelemetry-api", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20.0" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.41b0" },
+    { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.41b0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "pdfplumber", specifier = ">=0.11.7" },
     { name = "pgvector", specifier = ">=0.2.5" },
     { name = "prometheus-client", specifier = ">=0.21.0" },
@@ -2029,6 +2099,24 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/9b/e4503060b8695579dbaad187dc8cef4554188de68748c88060599b77489e/opentelemetry_exporter_otlp_proto_grpc-1.41.1.tar.gz", hash = "sha256:b05df8fa1333dc9a3fda36b676b96b5095ab6016d3f0c3296d430d629ba1443b", size = 25755, upload-time = "2026-04-24T13:15:41.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/f2/c54f33c92443d087703e57e52e55f22f111373a5c4c4aa349ea60efe512e/opentelemetry_exporter_otlp_proto_grpc-1.41.1-py3-none-any.whl", hash = "sha256:537926dcef951136992479af1d9cd88f25e33d56c530e9f020ed57774dca2f94", size = 20297, upload-time = "2026-04-24T13:15:20.212Z" },
+]
+
+[[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2044,6 +2132,69 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/4d/ef07ff2fc630849f2080ae0ae73a61f67257905b7ac79066640bfa0c5739/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4", size = 22673, upload-time = "2026-04-24T13:15:21.313Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/cb/0523b92c112a6cc70be43724343dc45225d3af134419844d7879a07755d4/opentelemetry_instrumentation-0.62b1.tar.gz", hash = "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45", size = 34043, upload-time = "2026-04-24T13:22:31.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/0f/45adbaea1f81b847cffdcee4f4b5f89297e42facf7fac78c7aaac4c38e75/opentelemetry_instrumentation-0.62b1-py3-none-any.whl", hash = "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257", size = 34163, upload-time = "2026-04-24T13:21:31.722Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/43/b2f0703ff46718ff7b17d7fbf8e9d7f20e26a23c7c325092dd762d09cf9d/opentelemetry_instrumentation_asgi-0.62b1.tar.gz", hash = "sha256:7cf5f5d5c493bbb1edd2bd6d51fa879d964e94048904017258a32ffa47329310", size = 26781, upload-time = "2026-04-24T13:22:37.158Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/41/968c1fe12fb90abffca6620e65d4af91451c02ecca8f74a17a62cac490de/opentelemetry_instrumentation_asgi-0.62b1-py3-none-any.whl", hash = "sha256:b7f89be48528512619bd54fa2459f72afb1695ba71d7024d382ad96d467e7fa8", size = 17011, upload-time = "2026-04-24T13:21:38.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/38/91780475a25370b6d483afbaed3e1e170459d6351c5f7c08d66b65e2172e/opentelemetry_instrumentation_fastapi-0.62b1.tar.gz", hash = "sha256:b377d4ba32868fb1ff0f64da3fcdd3aa154d698fc83d65f5d380ea21bf31ee19", size = 25054, upload-time = "2026-04-24T13:22:50.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/6f/602e4081d3fe82731aff7e3e9c2f1662d85701841d6dc25f16a1874e11cd/opentelemetry_instrumentation_fastapi-0.62b1-py3-none-any.whl", hash = "sha256:93fa9cc4f315819aee5f4fceb6196c1e5b0fbd789c5520c631de228bd3e5285b", size = 13484, upload-time = "2026-04-24T13:21:54.538Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/cb/7a418e69c7dad281803529cb4f6de1b747d802cca44c38032668690b4836/opentelemetry_instrumentation_httpx-0.62b1.tar.gz", hash = "sha256:a1fac9bcc3a6ef5996a7990563f1af0798468b2c146de535fd598369383fba7e", size = 24181, upload-time = "2026-04-24T13:22:52.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e0/eca824e9492ccec00e055bdd243aeda8eb7c5eda746d98af4d7a2d97ecf3/opentelemetry_instrumentation_httpx-0.62b1-py3-none-any.whl", hash = "sha256:88614015df451d61bc7e73f22524e6f223611f80b6caad2f6bdcbe05fa0df653", size = 17201, upload-time = "2026-04-24T13:21:58.072Z" },
 ]
 
 [[package]]
@@ -2083,6 +2234,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/1b/aa71b63e18d30a8384036b9937f40f7618f8030a7aa213155fb54f6f2b47/opentelemetry_util_http-0.62b1.tar.gz", hash = "sha256:adf6facbb89aef8f8bc566e2f04624942ba08a7b678b3479a91051a8f4dc70a3", size = 11393, upload-time = "2026-04-24T13:23:12.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/a9d9d32161c1ced61346267db4c9702da54f81ec5dc88214bc65c23f4e9d/opentelemetry_util_http-0.62b1-py3-none-any.whl", hash = "sha256:c57e8a6c19fc422c288e6074e882f506f85030b69b7376182f74f9257b9261f0", size = 9295, upload-time = "2026-04-24T13:22:28.078Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add opt-in OpenTelemetry instrumentation so Honcho emits uniform traces, metrics, and logs for its core memory operations, following the emerging memory-semconv semantic conventions for memory/RAG systems.

close issue #968

What this adds
- src/telemetry/otel.py: a small, self-contained OTel bootstrap (`setup_otel`) plus memory-semconv attribute/metric constants and `instrument_app`. Fully no-op unless `OTEL_ENABLED=true` — the global no-op providers stay installed, so there is zero overhead and zero behavior change when disabled.
- src/crud/document.py: `memory.search`, `memory.add`, and `memory.delete` spans on the core memory ops, each carrying the memory-semconv attributes (memory.system, memory.operation, memory.workspace, observer/observed, query, result_count/item_count); three histograms (search duration, search results, operation duration); and an INFO log record per operation.
- src/main.py: initialize OTel and attach `FastAPIInstrumentor` at import time (before Starlette freezes the middleware stack), and instrument httpx. This makes each API request a SERVER span, extracts the inbound W3C `traceparent`, and nests the memory.* + outbound LLM/embedding spans beneath it — so an agent's trace and Honcho's spans form a single end-to-end trace.
- src/deriver: initialize OTel in the worker and wrap each queue item in a root span, so background memory formation (memory.add) is traced too.
- src/config.py: `OTEL` settings block (enabled flag, service name, OTLP endpoint) sourced from standard `OTEL_*` env vars.
- tests/telemetry/test_otel.py: unit coverage for the semconv attributes, metrics, logs, and the instrument-at-import invariant.

Configuration is via the standard OpenTelemetry environment variables (`OTEL_ENABLED`, `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, …); no code changes are required to enable or disable it.


## Backward compatibility
No behavior change when `OTEL_ENABLED` is unset/false. No new required config. Existing tests unaffected; new tests are additive.

## Validation
Verified end-to-end against an OTLP collector (→ Tempo / Prometheus / Loki): a CrewAI agent driving real add/search operations produces **one linked trace** — `agent.turn` → `POST /chat` (SERVER, traceparent extracted) → `memory.search` (+ outbound LLM/embedding spans) — with the memory attributes and histograms present, and INFO log records per op. Unit suite green.

<img width="3387" height="1298" alt="image" src="https://github.com/user-attachments/assets/c7a519f7-27a3-4fd6-998e-739ec368cf3c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in observability with distributed tracing, metrics, and structured logs.
  * Added configurable service naming and OTLP exporter support.
  * Added monitoring for API requests, document operations, searches, and background processing.
  * Added automatic HTTP client and FastAPI instrumentation.

* **Bug Fixes**
  * Improved telemetry initialization, shutdown, and fallback handling without affecting existing processing flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->