### PR TITLE
feat(mcp): search conclusions via search tool

### DIFF
--- a/mcp/bun.lock
+++ b/mcp/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "honcho-mcp-proxy",
       "dependencies": {
-        "@honcho-ai/sdk": "^2.1.0",
+        "@honcho-ai/sdk": "^2.2.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "agents": "^0.4.0",
         "nanoid": "^5.1.7",

--- a/mcp/bun.lock
+++ b/mcp/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "honcho-mcp-proxy",
       "dependencies": {
-        "@honcho-ai/sdk": "^2.0.0",
+        "@honcho-ai/sdk": "^2.1.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "agents": "^0.4.0",
         "nanoid": "^5.1.7",
@@ -107,7 +107,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.4", "", { "os": "win32", "cpu": "x64" }, "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ=="],
 
-    "@honcho-ai/sdk": ["@honcho-ai/sdk@2.0.1", "", { "dependencies": { "@types/node": "^24.0.1", "zod": "4.0.0" } }, "sha512-y/Wk49C0N1miI9BZTNWFIbzdUkMZfP4Do/EJ1q4lEIK+FAOKxQgces/zET3kPKV3zF9sOUl2pXrFb/XKYayeYw=="],
+    "@honcho-ai/sdk": ["@honcho-ai/sdk@2.2.0", "", { "dependencies": { "zod": "4.0.0" } }, "sha512-SyygN+BrpUB2fRjhwcYmT+tcEhHrKmbj9nOZLVUFY7M5YBswJ+mZb/CeLpNbRh+QQTU8F8JWY3lQat95c6nwmA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
@@ -176,8 +176,6 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/lodash": ["@types/lodash@4.17.23", "", {}, "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA=="],
-
-    "@types/node": ["@types/node@24.1.0", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
@@ -470,8 +468,6 @@
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
     "undici": ["undici@7.12.0", "", {}, "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug=="],
-
-    "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 
     "unenv": ["unenv@2.0.0-rc.17", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.4", "ohash": "^2.0.11", "pathe": "^2.0.3", "ufo": "^1.6.1" } }, "sha512-B06u0wXkEd+o5gOCMl/ZHl5cfpYbDZKAT+HWTL+Hws6jWu7dCiqBBXXXzMFcFVJb8D4ytAnYmxJA83uwOQRSsg=="],
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -15,7 +15,7 @@
     "deploy:staging": "wrangler deploy --env staging"
   },
   "dependencies": {
-    "@honcho-ai/sdk": "^2.1.0",
+    "@honcho-ai/sdk": "^2.2.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "agents": "^0.4.0",
     "nanoid": "^5.1.7",

--- a/mcp/src/tools/conclusions.ts
+++ b/mcp/src/tools/conclusions.ts
@@ -149,6 +149,7 @@ export function register(server: McpServer, ctx: ToolContext) {
     {
       description: [
         "Delete a specific conclusion by ID.",
+        "Use query_conclusions or list_conclusions to find the ID first.",
         "Use this to remove incorrect or outdated knowledge.",
       ].join("\n"),
       inputSchema: {

--- a/mcp/src/tools/conclusions.ts
+++ b/mcp/src/tools/conclusions.ts
@@ -71,19 +71,26 @@ export function register(server: McpServer, ctx: ToolContext) {
           .number()
           .optional()
           .describe("Max results to return."),
+        filters: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe(
+            'Optional: filter criteria, e.g. {"level": ["deductive", "inductive"]} to only return conclusions derived during dreaming. Levels: explicit (extracted directly from messages), deductive, inductive, contradiction. See https://honcho.dev/docs/v3/documentation/features/advanced/using-filters',
+          ),
       },
     },
-    async ({ peer_id, query, target_peer_id, top_k }) => {
+    async ({ peer_id, query, target_peer_id, top_k, filters }) => {
       try {
         const peer = await ctx.honcho.peer(peer_id);
         const scope = target_peer_id
           ? peer.conclusionsOf(target_peer_id)
           : peer.conclusions;
-        const conclusions = await scope.query(query, top_k);
+        const conclusions = await scope.query(query, top_k, undefined, filters);
         return textResult(
           conclusions.map((c) => ({
             id: c.id,
             content: c.content,
+            level: c.level,
             observer_id: c.observerId,
             observed_id: c.observedId,
             session_id: c.sessionId,

--- a/mcp/src/tools/workspace.ts
+++ b/mcp/src/tools/workspace.ts
@@ -74,11 +74,13 @@ export function register(server: McpServer, ctx: ToolContext) {
     "search",
     {
       description: [
-        "Semantic search across messages. Scope is determined by which optional params are provided:",
+        "Semantic search across messages and, when peer_id is given, that peer's saved conclusions.",
+        "Message scope is determined by which optional params are provided:",
         "- No scope params: search all messages in the workspace.",
         "- peer_id only: search messages authored by that peer across all sessions.",
         "- session_id only: search messages within that session.",
-        "Returns an array of matching messages with their content, peer, and session info.",
+        "Conclusions require peer_id (self-conclusions are searched; conclusion IDs are usable with delete_conclusion).",
+        "Returns {messages, conclusions}.",
       ].join("\n"),
       inputSchema: {
         query: z.string().describe("Search query."),
@@ -94,17 +96,28 @@ export function register(server: McpServer, ctx: ToolContext) {
     },
     async ({ query, peer_id, session_id }) => {
       try {
-        let messages;
-        if (session_id) {
-          const session = await ctx.honcho.session(session_id);
-          messages = await session.search(query);
-        } else if (peer_id) {
-          const peer = await ctx.honcho.peer(peer_id);
-          messages = await peer.search(query);
-        } else {
-          messages = await ctx.honcho.search(query);
-        }
-        return textResult(formatMessages(messages));
+        const peer = peer_id ? await ctx.honcho.peer(peer_id) : null;
+        const [messages, conclusions] = await Promise.all([
+          session_id
+            ? ctx.honcho
+                .session(session_id)
+                .then((session) => session.search(query))
+            : peer
+              ? peer.search(query)
+              : ctx.honcho.search(query),
+          // Conclusion search requires an (observer, observed) pair, so it
+          // only runs when peer_id is given; degrades to [] on error so
+          // search never gets worse than message-only search.
+          peer ? peer.conclusions.query(query).catch(() => []) : [],
+        ]);
+        return textResult({
+          messages: formatMessages(messages),
+          conclusions: conclusions.map((c) => ({
+            id: c.id,
+            content: c.content,
+            created_at: c.createdAt,
+          })),
+        });
       } catch (e) {
         return errorResult(
           `Search failed: ${e instanceof Error ? e.message : String(e)}`,

--- a/mcp/src/tools/workspace.ts
+++ b/mcp/src/tools/workspace.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { BadRequestError, UnprocessableEntityError } from "@honcho-ai/sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ToolContext } from "../types.js";
 import { textResult, errorResult, formatMessages } from "../types.js";
@@ -155,7 +156,13 @@ export function register(server: McpServer, ctx: ToolContext) {
               conclusion_filters,
             );
           } catch (e) {
-            if (conclusion_filters) throw e;
+            if (
+              conclusion_filters &&
+              (e instanceof BadRequestError ||
+                e instanceof UnprocessableEntityError)
+            ) {
+              throw e;
+            }
             return [];
           }
         };

--- a/mcp/src/tools/workspace.ts
+++ b/mcp/src/tools/workspace.ts
@@ -92,29 +92,70 @@ export function register(server: McpServer, ctx: ToolContext) {
           .string()
           .optional()
           .describe("Optional: scope search to messages in this session."),
+        message_limit: z
+          .number()
+          .optional()
+          .describe("Optional: max message results (1-100, default 10)."),
+        message_filters: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe(
+            'Optional: filters for the message search, e.g. {"created_at": {"gte": "2026-01-01"}}. See https://honcho.dev/docs/v3/documentation/features/advanced/using-filters',
+          ),
+        conclusion_top_k: z
+          .number()
+          .optional()
+          .describe("Optional: max conclusion results (default 10)."),
+        conclusion_filters: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe(
+            'Optional: filters for the conclusion search, e.g. {"level": ["deductive", "inductive"]} to only return conclusions derived during dreaming. Levels: explicit (extracted directly from messages), deductive, inductive, contradiction. The session_id param does not scope conclusions; use {"session_id": ...} here for that.',
+          ),
       },
     },
-    async ({ query, peer_id, session_id }) => {
+    async ({
+      query,
+      peer_id,
+      session_id,
+      message_limit,
+      message_filters,
+      conclusion_top_k,
+      conclusion_filters,
+    }) => {
       try {
         const peer = peer_id ? await ctx.honcho.peer(peer_id) : null;
+        const messageOptions = {
+          filters: message_filters,
+          limit: message_limit,
+        };
         const [messages, conclusions] = await Promise.all([
           session_id
             ? ctx.honcho
                 .session(session_id)
-                .then((session) => session.search(query))
+                .then((session) => session.search(query, messageOptions))
             : peer
-              ? peer.search(query)
-              : ctx.honcho.search(query),
-          // Conclusion search requires an (observer, observed) pair, so it
-          // only runs when peer_id is given; degrades to [] on error so
-          // search never gets worse than message-only search.
-          peer ? peer.conclusions.query(query).catch(() => []) : [],
+              ? peer.search(query, messageOptions)
+              : ctx.honcho.search(query, messageOptions),
+          // Conclusion search needs an (observer, observed) pair, so it only
+          // runs when peer_id is given. Errors degrade to [] so message search
+          // still works, except when the caller passed filters: a bad filter
+          // must fail loudly, not look like zero matches.
+          peer
+            ? peer.conclusions
+                .query(query, conclusion_top_k, undefined, conclusion_filters)
+                .catch((e) => {
+                  if (conclusion_filters) throw e;
+                  return [];
+                })
+            : [],
         ]);
         return textResult({
           messages: formatMessages(messages),
           conclusions: conclusions.map((c) => ({
             id: c.id,
             content: c.content,
+            level: c.level,
             created_at: c.createdAt,
           })),
         });

--- a/mcp/src/tools/workspace.ts
+++ b/mcp/src/tools/workspace.ts
@@ -129,26 +129,40 @@ export function register(server: McpServer, ctx: ToolContext) {
           filters: message_filters,
           limit: message_limit,
         };
+
+        const searchMessages = async () => {
+          if (session_id) {
+            const session = await ctx.honcho.session(session_id);
+            return session.search(query, messageOptions);
+          }
+          if (peer) {
+            return peer.search(query, messageOptions);
+          }
+          return ctx.honcho.search(query, messageOptions);
+        };
+
+        // Conclusion search needs an (observer, observed) pair, so it only
+        // runs when peer_id is given.
+        const searchConclusions = async () => {
+          if (!peer) {
+            return [];
+          }
+          try {
+            return await peer.conclusions.query(
+              query,
+              conclusion_top_k,
+              undefined,
+              conclusion_filters,
+            );
+          } catch (e) {
+            if (conclusion_filters) throw e;
+            return [];
+          }
+        };
+
         const [messages, conclusions] = await Promise.all([
-          session_id
-            ? ctx.honcho
-                .session(session_id)
-                .then((session) => session.search(query, messageOptions))
-            : peer
-              ? peer.search(query, messageOptions)
-              : ctx.honcho.search(query, messageOptions),
-          // Conclusion search needs an (observer, observed) pair, so it only
-          // runs when peer_id is given. Errors degrade to [] so message search
-          // still works, except when the caller passed filters: a bad filter
-          // must fail loudly, not look like zero matches.
-          peer
-            ? peer.conclusions
-                .query(query, conclusion_top_k, undefined, conclusion_filters)
-                .catch((e) => {
-                  if (conclusion_filters) throw e;
-                  return [];
-                })
-            : [],
+          searchMessages(),
+          searchConclusions(),
         ]);
         return textResult({
           messages: formatMessages(messages),


### PR DESCRIPTION
Part of plastic-labs/claude-honcho#113 to the standalone MCP worker. The search tool only queried the message store, so saved conclusions were unreachable through search (findable only by paging list_conclusions or via query_conclusions with a known scope).

search now also queries conclusions in parallel with the message search, returning {messages, conclusions}. Since the conclusions query API requires an explicit (observer, observed) pair, the conclusion leg runs only when peer_id is given (self-conclusions, matching list_conclusions/query_conclusions defaults) and degrades to \[\] on error so search never gets worse than before. Conclusion results include IDs usable with delete_conclusion.

Also syncs mcp/bun.lock with package.json's @honcho-ai/sdk ^2.1.0 and points delete_conclusion's description at query_conclusions/list_conclusions for ID discovery.

## Summary by CodeRabbit

* **New Features**
  * Search results now include matching messages and peer conclusions when a peer is specified.
  * Added separate limits and filters for message and conclusion searches.
  * Conclusion results now include IDs, content, levels, and timestamps.
  * Conclusion queries support optional filtering criteria.
  * Unfiltered conclusion-search failures no longer prevent message results from being returned.
* **Documentation**
  * Added guidance to locate conclusion IDs before deleting conclusions.