### PR TITLE
fix(deriver): Prioritize deletion work

### DIFF
--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 from nanoid import generate as generate_nanoid
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
-from sqlalchemy import and_, delete, or_, select, update
+from sqlalchemy import and_, case, delete, or_, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -391,6 +391,16 @@ class QueueManager:
                     .exists()
                 )
                 .order_by(
+                    case(
+                        (
+                            work_units_subq.c.work_unit_key.like(
+                                "deletion:%:workspace:%"
+                            ),
+                            0,
+                        ),
+                        (work_units_subq.c.work_unit_key.startswith("deletion:"), 1),
+                        else_=2,
+                    ).asc(),
                     work_units_subq.c.oldest_created_at.asc(),
                     work_units_subq.c.work_unit_key.asc(),
                 )

--- a/tests/deriver/test_queue_processing.py
+++ b/tests/deriver/test_queue_processing.py
@@ -122,6 +122,61 @@ class TestQueueProcessing:
         ).scalars()
         assert set(tracked_keys) == set(work_units.keys())
 
+    async def test_workspace_deletion_preempts_older_queue_work(
+        self,
+        db_session: AsyncSession,
+        sample_session_with_peers: tuple[models.Session, list[models.Peer]],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        session, _peers = sample_session_with_peers
+        workspace = session.workspace_name
+        now = datetime.now(timezone.utc)
+        summary_key = f"summary:{workspace}:old-session:observer:observed"
+        session_deletion_key = f"deletion:{workspace}:session:old-session"
+        workspace_deletion_key = f"deletion:{workspace}:workspace:{workspace}"
+        db_session.add_all(
+            [
+                models.QueueItem(
+                    task_type="summary",
+                    work_unit_key=summary_key,
+                    payload={"task_type": "summary"},
+                    processed=False,
+                    workspace_name=workspace,
+                    created_at=now - timedelta(minutes=2),
+                ),
+                models.QueueItem(
+                    task_type="deletion",
+                    work_unit_key=session_deletion_key,
+                    payload={
+                        "task_type": "deletion",
+                        "deletion_type": "session",
+                        "resource_id": "old-session",
+                    },
+                    processed=False,
+                    workspace_name=workspace,
+                    created_at=now - timedelta(minutes=1),
+                ),
+                models.QueueItem(
+                    task_type="deletion",
+                    work_unit_key=workspace_deletion_key,
+                    payload={
+                        "task_type": "deletion",
+                        "deletion_type": "workspace",
+                        "resource_id": workspace,
+                    },
+                    processed=False,
+                    workspace_name=workspace,
+                    created_at=now,
+                ),
+            ]
+        )
+        await db_session.commit()
+        monkeypatch.setattr(settings.DERIVER, "WORKERS", 1)
+
+        claimed = await QueueManager().get_and_claim_work_units()
+
+        assert list(claimed) == [workspace_deletion_key]
+
     async def test_work_unit_claiming(
         self,
         db_session: AsyncSession,


### PR DESCRIPTION
Prioritize accepted workspace deletions ahead of subordinate session cleanup and ordinary FIFO derivation work.

A single busy deriver could leave workspace deletion queued behind long-running summary or reconciliation work. The API returned 202, but cleanup verification could time out even though the deletion eventually completed.

This adds explicit queue ordering so workspace deletions are claimed first, followed by other deletion work, while preserving FIFO ordering within each priority. A regression covers one-worker capacity with older summary and session deletion work already queued.

Verified against the full deriver queue-processing suite and a live synthetic workspace cleanup.