### PR TITLE
fix(crud): preserve active session peer joined_at on re-add

### DIFF
--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -1060,13 +1060,16 @@ async def _get_or_add_peers_to_session(
         ]
     )
 
-    # On conflict, update joined_at and clear left_at (rejoin scenario)
-    # If left_at is not None (peer has left the session): Use the new configuration (stmt.excluded.configuration)
-    # If left_at is None (peer is still active): Keep the existing configuration (models.SessionPeer.configuration)
+    # On conflict, clear left_at and reset joined_at only when rejoining
+    # If left_at is not None (peer has left the session): Start a fresh membership window
+    # If left_at is None (peer is still active): Preserve joined_at and the existing configuration
     stmt = stmt.on_conflict_do_update(
         index_elements=["session_name", "peer_name", "workspace_name"],
         set_={
-            "joined_at": func.now(),
+            "joined_at": case(
+                (models.SessionPeer.left_at.is_not(None), func.now()),
+                else_=models.SessionPeer.joined_at,
+            ),
             "left_at": None,
             "configuration": case(
                 (models.SessionPeer.left_at.is_not(None), stmt.excluded.configuration),

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -1,5 +1,8 @@
+from datetime import datetime, timezone
+
 import pytest
 from nanoid import generate as generate_nanoid
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, models, schemas
@@ -8,6 +11,62 @@ from src.exceptions import ResourceNotFoundException
 
 class TestSessionCRUD:
     """Test suite for session CRUD operations"""
+
+    @pytest.mark.asyncio
+    async def test_session_peer_joined_at_readd_semantics(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Test preserving active membership start time while resetting rejoined peers."""
+        test_workspace, test_peer = sample_data
+        session_name = str(generate_nanoid())
+        session_create = schemas.SessionCreate(
+            name=session_name,
+            peers={test_peer.name: schemas.SessionPeerConfig()},
+        )
+        session_peer_stmt = select(
+            models.SessionPeer.joined_at,
+            models.SessionPeer.left_at,
+        ).where(
+            models.SessionPeer.session_name == session_name,
+            models.SessionPeer.peer_name == test_peer.name,
+            models.SessionPeer.workspace_name == test_workspace.name,
+        )
+
+        await crud.get_or_create_session(
+            db_session, session_create, test_workspace.name
+        )
+        first_result = await db_session.execute(session_peer_stmt)
+        first_joined_at, first_left_at = first_result.one()
+        assert first_left_at is None
+
+        await crud.get_or_create_session(
+            db_session, session_create, test_workspace.name
+        )
+        second_result = await db_session.execute(session_peer_stmt)
+        second_joined_at, second_left_at = second_result.one()
+        assert abs((second_joined_at - first_joined_at).total_seconds()) < 1
+        assert second_left_at is None
+
+        session_peer_result = await db_session.execute(
+            select(models.SessionPeer).where(
+                models.SessionPeer.session_name == session_name,
+                models.SessionPeer.peer_name == test_peer.name,
+                models.SessionPeer.workspace_name == test_workspace.name,
+            )
+        )
+        session_peer = session_peer_result.scalar_one()
+        session_peer.left_at = datetime.now(timezone.utc)
+        await db_session.commit()
+
+        await crud.get_or_create_session(
+            db_session, session_create, test_workspace.name
+        )
+        rejoined_result = await db_session.execute(session_peer_stmt)
+        rejoined_joined_at, rejoined_left_at = rejoined_result.one()
+        assert rejoined_joined_at >= first_joined_at
+        assert rejoined_left_at is None
 
     @pytest.mark.asyncio
     async def test_get_session_peer_configuration(

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -21,13 +21,24 @@ class TestSessionCRUD:
         """Test preserving active membership start time while resetting rejoined peers."""
         test_workspace, test_peer = sample_data
         session_name = str(generate_nanoid())
-        session_create = schemas.SessionCreate(
+        original_config = schemas.SessionPeerConfig(
+            observe_others=True, observe_me=False
+        )
+        updated_config = schemas.SessionPeerConfig(
+            observe_others=False, observe_me=True
+        )
+        session_create_original = schemas.SessionCreate(
             name=session_name,
-            peers={test_peer.name: schemas.SessionPeerConfig()},
+            peers={test_peer.name: original_config},
+        )
+        session_create_updated = schemas.SessionCreate(
+            name=session_name,
+            peers={test_peer.name: updated_config},
         )
         session_peer_stmt = select(
             models.SessionPeer.joined_at,
             models.SessionPeer.left_at,
+            models.SessionPeer.configuration,
         ).where(
             models.SessionPeer.session_name == session_name,
             models.SessionPeer.peer_name == test_peer.name,
@@ -35,19 +46,22 @@ class TestSessionCRUD:
         )
 
         await crud.get_or_create_session(
-            db_session, session_create, test_workspace.name
+            db_session, session_create_original, test_workspace.name
         )
         first_result = await db_session.execute(session_peer_stmt)
-        first_joined_at, first_left_at = first_result.one()
+        first_joined_at, first_left_at, first_config = first_result.one()
         assert first_left_at is None
+        assert first_config == original_config.model_dump()
 
+        # Re-adding an ACTIVE peer must preserve joined_at AND the stored config
         await crud.get_or_create_session(
-            db_session, session_create, test_workspace.name
+            db_session, session_create_updated, test_workspace.name
         )
         second_result = await db_session.execute(session_peer_stmt)
-        second_joined_at, second_left_at = second_result.one()
-        assert abs((second_joined_at - first_joined_at).total_seconds()) < 1
+        second_joined_at, second_left_at, second_config = second_result.one()
+        assert second_joined_at == first_joined_at
         assert second_left_at is None
+        assert second_config == original_config.model_dump()
 
         session_peer_result = await db_session.execute(
             select(models.SessionPeer).where(
@@ -60,13 +74,15 @@ class TestSessionCRUD:
         session_peer.left_at = datetime.now(timezone.utc)
         await db_session.commit()
 
+        # A peer that LEFT and rejoins gets a fresh window AND the new config
         await crud.get_or_create_session(
-            db_session, session_create, test_workspace.name
+            db_session, session_create_updated, test_workspace.name
         )
         rejoined_result = await db_session.execute(session_peer_stmt)
-        rejoined_joined_at, rejoined_left_at = rejoined_result.one()
-        assert rejoined_joined_at >= first_joined_at
+        rejoined_joined_at, rejoined_left_at, rejoined_config = rejoined_result.one()
+        assert rejoined_joined_at > second_joined_at
         assert rejoined_left_at is None
+        assert rejoined_config == updated_config.model_dump()
 
     @pytest.mark.asyncio
     async def test_get_session_peer_configuration(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,9 +4,10 @@ import datetime
 
 import pytest
 from nanoid import generate as generate_nanoid
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src import crud, models
+from src import crud, models, schemas
 from src.utils.search import search
 
 
@@ -704,3 +705,88 @@ async def test_grep_messages_observer_scoping_left_session_still_visible(
     matched_ids = [m.public_id for matches, _ in results for m in matches]
     assert msg_during.public_id in matched_ids
     assert msg_after.public_id in matched_ids
+
+
+@pytest.mark.asyncio
+async def test_peer_perspective_search_after_active_readd(
+    db_session: AsyncSession,
+):
+    """Re-adding an ACTIVE peer must not hide pre-existing messages; a genuine
+    rejoin starts a new visibility window (issue #940 regression)."""
+    workspace = models.Workspace(name=generate_nanoid())
+    db_session.add(workspace)
+    await db_session.flush()
+
+    peer1 = models.Peer(name="peer1", workspace_name=workspace.name)
+    peer2 = models.Peer(name="peer2", workspace_name=workspace.name)
+    db_session.add_all([peer1, peer2])
+    await db_session.flush()
+
+    session = models.Session(name="session1", workspace_name=workspace.name)
+    db_session.add(session)
+    await db_session.flush()
+
+    # peer1 joined 1 hour ago — a long-lived membership with an established
+    # window start, well before any timestamp minted during this test.
+    past_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        hours=1
+    )
+    await db_session.execute(
+        models.session_peers_table.insert().values(
+            workspace_name=workspace.name,
+            session_name=session.name,
+            peer_name=peer1.name,
+            joined_at=past_time,
+            left_at=None,
+        )
+    )
+
+    # Message created while peer1 is an active member (inside the old window)
+    msg_old = models.Message(
+        content="old persistent message",
+        session_name=session.name,
+        peer_name=peer2.name,
+        workspace_name=workspace.name,
+        seq_in_session=1,
+        created_at=past_time + datetime.timedelta(minutes=1),
+    )
+    db_session.add(msg_old)
+    await db_session.commit()
+
+    session_create = schemas.SessionCreate(
+        name=session.name,
+        peers={peer1.name: schemas.SessionPeerConfig()},
+    )
+
+    # Re-add while STILL ACTIVE via the CRUD path: the membership window must
+    # not move, so the pre-existing message stays visible. On the pre-fix
+    # code this re-add reset joined_at to now(), hiding the message.
+    await crud.get_or_create_session(db_session, session_create, workspace.name)
+    results = await search(
+        "persistent",
+        filters={"peer_perspective": peer1.name, "workspace_id": workspace.name},
+        limit=10,
+    )
+    assert msg_old.public_id in [m.public_id for m in results]
+
+    # Peer leaves...
+    await db_session.execute(
+        update(models.SessionPeer)
+        .where(
+            models.SessionPeer.session_name == session.name,
+            models.SessionPeer.peer_name == peer1.name,
+            models.SessionPeer.workspace_name == workspace.name,
+        )
+        .values(left_at=datetime.datetime.now(datetime.timezone.utc))
+    )
+    await db_session.commit()
+
+    # ...and rejoins: a NEW window starts (now() is guaranteed to be after
+    # past_time + 1min), so the old message is hidden.
+    await crud.get_or_create_session(db_session, session_create, workspace.name)
+    results = await search(
+        "persistent",
+        filters={"peer_perspective": peer1.name, "workspace_id": workspace.name},
+        limit=10,
+    )
+    assert msg_old.public_id not in [m.public_id for m in results]


### PR DESCRIPTION
Fixes #940.

## Impact

Re-adding a peer who never left moves their `joined_at` window start forward. `peer_perspective` search only returns messages with `created_at >= joined_at`, so any client that re-adds peers at every process start (e.g. the Hermes Agent honcho integration) loses access to messages older than the last re-add after each restart, with no error raised. Two independent reports on #940.

## Problem

`get_or_create_session` re-runs `_get_or_add_peers_to_session` on every call, and the `ON CONFLICT` upsert in `src/crud/session.py` unconditionally reset `joined_at = now()` for every re-added peer — including peers who never left (`left_at IS NULL`). Since `peer_perspective` search filters on `message.created_at >= joined_at` (src/utils/search.py), any client that re-adds peers on each process start silently loses visibility into all messages older than the last restart.

## Change

Only start a fresh membership window (`joined_at = now()`) when the existing row has `left_at IS NOT NULL` — a genuine rejoin. Active peers keep their original `joined_at`:

```python
"joined_at": case(
    (models.SessionPeer.left_at.is_not(None), func.now()),
    else_=models.SessionPeer.joined_at,
),
```

No other behavior touched: observer-count logic, configuration merge, and `left_at` clearing are unchanged.

## Why this PR (relation to #941)

PR #941 proposed the same fix but bundled an out-of-scope observer-count refactor that the maintainer requested to revert (CHANGES_REQUESTED 2026-07-28); the author has not responded since. This PR is the minimal version: 2 files, only the joined_at conditional plus a regression test.

## Tests

- `test_session_peer_joined_at_readd_semantics` (tests/crud/test_session.py): re-adding an active peer preserves `joined_at` and the stored configuration; a peer that left and rejoins gets a fresh `joined_at` and the incoming configuration.
- `test_peer_perspective_search_after_active_readd` (tests/test_search.py): an active re-add keeps pre-existing messages visible through `peer_perspective` search (fails on pre-fix code); a genuine rejoin starts a new visibility window.
- `pytest tests/test_search.py tests/crud/test_session.py tests/crud/test_document.py` → **39 passed** (keyless environment, mirrors CI after #955)
- `ruff check` clean.
