### PR TITLE
docs: document pgvector preinstall for least-privilege DB roles

### DIFF
--- a/docs/v3/contributing/self-hosting.mdx
+++ b/docs/v3/contributing/self-hosting.mdx
@@ -178,6 +178,12 @@ CREATE EXTENSION IF NOT EXISTS vector;
 \q
 ```
 
+<Note>
+**Least-privilege database roles.** Honcho runs `CREATE EXTENSION IF NOT EXISTS vector` before migrations and again at startup, so if the role in `DB_CONNECTION_URI` can't create extensions, both fail with a privilege error — `IF NOT EXISTS` doesn't help, because Postgres checks the privilege first.
+
+Run the statement above once as a superuser (or `rds_superuser`) and the application role needs no extension privileges. See [Troubleshooting](/v3/contributing/troubleshooting) if you hit this.
+</Note>
+
 ### 4. Configure Environment
 
 Create a `.env` file with your settings:

--- a/docs/v3/contributing/troubleshooting.mdx
+++ b/docs/v3/contributing/troubleshooting.mdx
@@ -204,6 +204,20 @@ uv run alembic history
 uv run alembic upgrade head
 ```
 
+### "permission denied to create extension \"vector\""
+
+**Cause:** The role in `DB_CONNECTION_URI` is not a superuser and lacks privileges to create extensions. Honcho issues `CREATE EXTENSION IF NOT EXISTS vector` both before running migrations and again at server startup, so this fails in both places. `IF NOT EXISTS` does not help — Postgres checks the privilege before checking whether the extension exists.
+
+**Fix:** Preinstall pgvector once with a privileged role (superuser, or `rds_superuser` on RDS) in the Honcho database:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+The `IF NOT EXISTS` calls then short-circuit and the application role needs no extension privileges. This is the supported path for deployments where the platform, not the application, owns extension management.
+
+You won't hit this with `docker compose` — the bundled database service runs `database/init.sql` as an initdb script, which creates the extension before Honcho ever connects. It comes up on managed Postgres, Kubernetes operators, and other setups where you bring your own database and its role is deliberately not a superuser.
+
 ## Cache & Redis
 
 ### Redis is optional

--- a/docs/v3/contributing/troubleshooting.mdx
+++ b/docs/v3/contributing/troubleshooting.mdx
@@ -216,7 +216,7 @@ CREATE EXTENSION IF NOT EXISTS vector;
 
 The `IF NOT EXISTS` calls then short-circuit and the application role needs no extension privileges. This is the supported path for deployments where the platform, not the application, owns extension management.
 
-You won't hit this with `docker compose` — the bundled database service runs `database/init.sql` as an initdb script, which creates the extension before Honcho ever connects. It comes up on managed Postgres, Kubernetes operators, and other setups where you bring your own database and its role is deliberately not a superuser.
+You won't hit this with `docker compose` — the bundled stack connects as `postgres`, a superuser, and its database service also creates the extension from `database/init.sql` on first boot. It comes up on managed Postgres, Kubernetes operators, and other setups where you bring your own database and its role is deliberately not a superuser.
 
 ## Cache & Redis
 


### PR DESCRIPTION
Document `CREATE EXTENSION IF NOT EXISTS vector` before migrations and again at server startup
Fixes #614 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added self-hosting guidance for configuring the pgvector database extension with appropriate privileges.
  * Added troubleshooting steps for permission errors, including preinstalling the extension with a privileged role.
  * Clarified that Docker Compose handles extension initialization automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->