### PR TITLE
fix(deriver): update extraction examples

### DIFF
--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -72,9 +72,9 @@ RULES:
 - Contextualize each observation sufficiently (e.g. "Ann is nervous about the job interview at the pharmacy" not just "Ann is nervous")
 
 EXAMPLES (using `alice` as the target peer id):
-- EXPLICIT: "I just had my 25th birthday last Saturday" → "alice is 25 years old", "alice's birthday is June 21st"
-- EXPLICIT: "I took my dog for a walk in NYC" → "alice has a dog", "alice lives in NYC"
-- EXPLICIT: "alice attended college" + general knowledge → "alice completed high school or equivalent"
+- EXPLICIT: "I just turned 25" → "alice is 25 years old"
+- EXPLICIT: "I took my dog for a walk in NYC" → "alice has a dog", "alice walked her dog in NYC"
+- EXPLICIT: "I've lived in NYC for six years" → "alice lives in NYC"
 
 {custom_instructions_section}
 

--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -74,7 +74,7 @@ RULES:
 EXAMPLES (using `alice` as the target peer id):
 - EXPLICIT: "I just turned 25" → "alice is 25 years old"
 - EXPLICIT: "I took my dog for a walk in NYC" → "alice has a dog", "alice walked her dog in NYC"
-- EXPLICIT: "I've lived in NYC for six years" → "alice lives in NYC"
+- EXPLICIT: "I've lived in NYC for six years" → "alice lives in NYC", "alice has lived in NYC for six years"
 
 {custom_instructions_section}
 


### PR DESCRIPTION
Closes #626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated examples to clarify that age, pet ownership, activity location, and residence should be derived only from explicit statements.
  * Removed examples that encouraged inferring birthdays, residence from walk locations, or education level from general knowledge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->