### PR TITLE
fix(crud): preserve joined_at for active peers on set_peers upsert

### DIFF
--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -945,13 +945,17 @@ async def set_peers_for_session(
             f"Session {session_name} not found in workspace {workspace_name}"
         )
 
-    # Soft delete specified session peers by setting left_at timestamp
+    # Soft delete session peers by setting left_at timestamp. Peers being
+    # (re)set in this call are excluded so active members keep their original
+    # joined_at (perspective search window not truncated); only peers actually
+    # removed/replaced leave.
     update_stmt = (
         update(models.SessionPeer)
         .where(
             models.SessionPeer.session_name == session_name,
             models.SessionPeer.workspace_name == workspace_name,
             models.SessionPeer.left_at.is_(None),  # Only update active peers
+            models.SessionPeer.peer_name.notin_(peer_names.keys()),
         )
         .values(left_at=func.now())
     )
@@ -1062,10 +1066,16 @@ async def _get_or_add_peers_to_session(
     # On conflict, update joined_at and clear left_at (rejoin scenario)
     # If left_at is not None (peer has left the session): Use the new configuration (stmt.excluded.configuration)
     # If left_at is None (peer is still active): Keep the existing configuration (models.SessionPeer.configuration)
+    # Keep the original joined_at for peers that are still active
+    # (left_at IS NULL) so perspective search still covers older messages;
+    # a genuine rejoin (left_at IS NOT NULL) gets the new timestamp.
     stmt = stmt.on_conflict_do_update(
         index_elements=["session_name", "peer_name", "workspace_name"],
         set_={
-            "joined_at": func.now(),
+            "joined_at": case(
+                (models.SessionPeer.left_at.is_not(None), stmt.excluded.joined_at),
+                else_=models.SessionPeer.joined_at,
+            ),
             "left_at": None,
             "configuration": case(
                 (models.SessionPeer.left_at.is_not(None), stmt.excluded.configuration),


### PR DESCRIPTION
Follow-up to #940. This fixes the path that the existing PRs don't cover.

## Root cause

`set_peers_for_session` (the `PUT .../sessions/{id}/peers` endpoint) soft-deletes every active peer in the session first, then upserts the incoming peer set. The upsert's on-conflict branch rewrites `joined_at` unconditionally, so every call re-stamps the join time of peers that never actually left.

That silently breaks `peer_perspective` search: `src/utils/search.py` joins `session_peers` and filters `message.created_at >= joined_at`. After any client re-adds peers at startup (the Hermes Agent Honcho plugin does this on every session init), everything written before the latest re-add disappears from perspective-filtered results. On my self-hosted v3.0.11 the main session ended up with a 0-message search window, with no error raised anywhere.

## Why #981/#986 don't fix this path

Both guard the upsert with a CASE on `left_at`:

```python
"joined_at": case(
    (models.SessionPeer.left_at.is_not(None), func.now()),
    else_=models.SessionPeer.joined_at,
),
```

That only works when the row still has `left_at IS NULL` at upsert time. In `set_peers_for_session` the soft delete runs **before** the upsert, so every active member's row is already stamped with `left_at = now()` — the CASE then always takes the "rejoin" branch and refreshes `joined_at` anyway. Their tests pass because they exercise `get_or_create_session`, which doesn't soft-delete first.

## The fix

Two changes in `src/crud/session.py`:

1. **Exclude the peers being (re)set from the soft delete**, so active members keep `left_at IS NULL` and their original `joined_at` (only peers actually being removed/replaced leave).
2. **In the upsert conflict branch**, keep the original `joined_at` when `left_at` is still NULL; only a genuine rejoin (row already left) gets the caller-provided fresh timestamp.

## Verification

Against a live Postgres on self-hosted v3.0.11: after the patch, hitting the peers endpoint leaves `joined_at` unchanged for already-active members, and `peer_perspective` searches return historical messages again (previously an empty window). The same holds across a full client restart (soft-delete + re-add cycle).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session peer management by preserving active peers’ existing settings and join times.
  * Correctly refreshes join times and applies updated settings when previously removed peers rejoin.
  * Prevents unnecessary removal of active peers when updating a session’s peer list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->