### PR TITLE
fix(deriver): clear dangling session hint on pending dreams at session delete

### DIFF
--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -7,13 +7,24 @@ from typing import cast as typing_cast
 
 from cashews import NOT_NONE
 from nanoid import generate as generate_nanoid
-from sqlalchemy import Select, and_, case, cast, delete, func, insert, select, update
+from sqlalchemy import (
+    Select,
+    and_,
+    case,
+    cast,
+    delete,
+    func,
+    insert,
+    literal,
+    select,
+    update,
+)
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import make_transient_to_detached
-from sqlalchemy.types import BigInteger, Boolean
+from sqlalchemy.types import BigInteger, Boolean, Text
 
 from src import models, schemas
 from src.cache.client import (
@@ -505,6 +516,29 @@ async def delete_session(
         await db.execute(
             delete(models.QueueItem).where(
                 models.QueueItem.session_id == honcho_session.id
+            )
+        )
+
+        # Pending dreams referencing this session: a dream consolidates the whole
+        # (observer, observed) collection rather than one session — its
+        # payload.session_name is only a config/context hint (the session of the
+        # most recent explicit document, see DreamScheduler._execute_dream). Those
+        # dreams carry session_id=None and a work_unit_key without the session, so
+        # the deletes above miss them and run_dream would then fail resolving the
+        # gone session. Drop the dangling hint instead of the dream, leaving it in
+        # the workspace-scoped state the orchestrator already supports.
+        await db.execute(
+            update(models.QueueItem)
+            .where(
+                and_(
+                    models.QueueItem.task_type == "dream",
+                    models.QueueItem.workspace_name == workspace_name,
+                    models.QueueItem.processed.is_(False),
+                    models.QueueItem.payload["session_name"].astext == session_name,
+                )
+            )
+            .values(
+                payload=models.QueueItem.payload.op("-")(literal("session_name", Text))
             )
         )
 

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -1,8 +1,10 @@
 import pytest
 from nanoid import generate as generate_nanoid
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, models, schemas
+from src.deriver.enqueue import create_dream_record
 from src.exceptions import ResourceNotFoundException
 
 
@@ -132,3 +134,76 @@ class TestSessionCRUD:
             await crud.clone_session(
                 db_session, test_workspace.name, test_session.name, "invalid_message_id"
             )
+
+    @pytest.mark.asyncio
+    async def test_delete_session_clears_dangling_dream_session_hint(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """delete_session drops payload.session_name from dreams referencing it.
+
+        Dream queue items carry session_id=None and a work_unit_key without the
+        session name, so they survive the deletes above and would fail resolving
+        the gone session. Other dreams must be left untouched.
+        """
+        test_workspace, test_peer = sample_data
+
+        test_session = models.Session(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        other_session = models.Session(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        db_session.add_all([test_session, other_session])
+        await db_session.flush()
+
+        def dream(observed: str, session_name: str | None) -> models.QueueItem:
+            # Distinct observed peers: the dream work_unit_key omits session_name,
+            # so same-peer dreams would collide on the pending-dream unique index.
+            return models.QueueItem(
+                **create_dream_record(
+                    test_workspace.name,
+                    observer=test_peer.name,
+                    observed=observed,
+                    dream_type=schemas.DreamType.OMNI,
+                    session_name=session_name,
+                )
+            )
+
+        db_session.add_all(
+            [
+                dream("observed-deleted", test_session.name),
+                dream("observed-other", other_session.name),
+                dream("observed-global", None),
+            ]
+        )
+        await db_session.flush()
+
+        await crud.delete_session(
+            db_session,
+            workspace_name=test_workspace.name,
+            session_name=test_session.name,
+        )
+
+        dreams = (
+            (
+                await db_session.execute(
+                    select(models.QueueItem).where(
+                        models.QueueItem.workspace_name == test_workspace.name
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # All three dreams survive; only the one pointing at the deleted session
+        # loses its hint, leaving it workspace-scoped.
+        assert {
+            item.payload["observed"]: item.payload.get("session_name")
+            for item in dreams
+        } == {
+            "observed-deleted": None,
+            "observed-other": other_session.name,
+            "observed-global": None,
+        }


### PR DESCRIPTION
## What

`delete_session` now strips `payload.session_name` from pending dream queue items that reference the session being deleted.

## Why

Surfaced while reviewing #801 / #799. `delete_session` already deletes the session's `QueueItem` and `ActiveQueueSession` rows, but dreams slip through both:

- Dream records carry `session_id=None` (`src/deriver/enqueue.py:441`), so the `session_id` delete misses them.
- The dream work-unit key is `dream:{dream_type}:{workspace}:{observer}:{observed}` — no session component — so the `split_part(key, ':', 3) == session_name` match misses them too.

A dream isn't scoped to a session in the first place: it consolidates the whole `(observer, observed)` collection. `payload.session_name` is only a config/context hint, set by `DreamScheduler._execute_dream` to the session of the most recent explicit document for that pair (`src/dreamer/dream_scheduler.py:195-205`).

So the stale row isn't stale *work* — it's a stale *tag*. Left alone, `run_dream` resolves that session for configuration (`src/dreamer/orchestrator.py:112`), raises `ResourceNotFoundException`, and the dream errors out for no good reason.

## How

Clear the hint rather than delete the dream, leaving it workspace-scoped — a state the orchestrator already handles (`session_name is None` → workspace config), and one the manual dream route produces whenever `session_id` is omitted (`src/routers/workspaces.py:232`).

Scoped to `processed = false`; historical rows are left to the reconciler.

## Testing

`tests/crud/test_session.py::TestSessionCRUD::test_delete_session_clears_dangling_dream_session_hint` — three dreams (one on the deleted session, one on another session, one workspace-wide); asserts all three survive and only the first loses its hint. Fails without the fix.

`uv run pytest tests/crud/ tests/routes/test_sessions.py` → 116 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a session now removes its reference from related unprocessed dream queue items without deleting those items.
  * Unrelated session-linked and global dream items remain unchanged.

* **Tests**
  * Added regression coverage to verify queue item preservation and correct cleanup of deleted session references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->