### PR TITLE
fix: isolate per-text embedding failures in reconciler

### DIFF
--- a/src/reconciler/sync_vectors.py
+++ b/src/reconciler/sync_vectors.py
@@ -425,33 +425,31 @@ async def _sync_message_embeddings(
     freshly_embedded: dict[int, list[float]] = {}
 
     if embs_needing_embed:
-        try:
-            contents = [emb.content for emb in embs_needing_embed]
-            # MESSAGE_CREATE (not VECTOR_SYNC): these rows come from create_messages
-            # as pending chunks; document re-embeds stay on VECTOR_SYNC below.
-            workspaces = {emb.workspace_name for emb in embs_needing_embed}
-            with embedding_call_purpose(
-                EmbeddingCallPurpose.MESSAGE_CREATE.value,
-                workspace_name=workspaces.pop() if len(workspaces) == 1 else None,
-                parent_category="reconciliation",
-            ):
-                new_embeddings = await embedding_client.simple_batch_embed(contents)
-
-            if len(new_embeddings) != len(embs_needing_embed):
-                logger.warning(
-                    "Re-embedded %s/%s message embeddings; remaining will be retried",
-                    len(new_embeddings),
-                    len(embs_needing_embed),
-                )
-
-            for emb, new_emb in zip(embs_needing_embed, new_embeddings, strict=False):
-                freshly_embedded[emb.id] = new_emb
-                if store_in_postgres:
-                    emb.embedding = new_emb
-        except Exception:
-            logger.exception(
-                "Failed to re-embed %s message embeddings", len(embs_needing_embed)
-            )
+        # Embed each text individually so a single oversized text (rejected by
+        # the provider) can't poison the whole batch. The chunking tokenizer
+        # can undercount a provider's real token count (e.g. tiktoken o200k vs
+        # nomic-embed-text), so oversized texts can still slip through the chunk
+        # cap and get rejected by the provider. Isolating per-text keeps the
+        # rest of the batch embeddable and lets genuinely-oversized rows fail
+        # on their own instead of taking the whole batch down with them.
+        workspaces = {emb.workspace_name for emb in embs_needing_embed}
+        with embedding_call_purpose(
+            EmbeddingCallPurpose.MESSAGE_CREATE.value,
+            workspace_name=workspaces.pop() if len(workspaces) == 1 else None,
+            parent_category="reconciliation",
+        ):
+            for emb in embs_needing_embed:
+                try:
+                    new_emb = await embedding_client.simple_batch_embed([emb.content])
+                    freshly_embedded[emb.id] = new_emb[0]
+                    if store_in_postgres:
+                        emb.embedding = new_emb[0]
+                except Exception:
+                    logger.warning(
+                        "Failed to embed message %s chunk %s; will retry",
+                        emb.message_id,
+                        emb.id,
+                    )
 
     # Mark embeddings that failed to get a vector
     failed_to_embed: list[models.MessageEmbedding] = [

--- a/src/reconciler/sync_vectors.py
+++ b/src/reconciler/sync_vectors.py
@@ -423,6 +423,10 @@ async def _sync_message_embeddings(
         emb for emb in embeddings if emb.embedding is None
     ]
     freshly_embedded: dict[int, list[float]] = {}
+    # Rows rejected with a permanent validation error (ValueError) — not
+    # retryable, so mark them failed immediately instead of burning
+    # MAX_SYNC_ATTEMPTS retries.
+    permanently_failed: set[int] = set()
 
     if embs_needing_embed:
         # Embed each text individually so a single oversized text (rejected by
@@ -444,9 +448,19 @@ async def _sync_message_embeddings(
                     freshly_embedded[emb.id] = new_emb[0]
                     if store_in_postgres:
                         emb.embedding = new_emb[0]
-                except Exception:
+                except ValueError as e:
+                    # Expected validation failure (oversized input, dimension
+                    # mismatch). Not retryable — mark failed immediately.
                     logger.warning(
-                        "Failed to embed message %s chunk %s; will retry",
+                        "Message %s chunk %s rejected by embedding provider: %s",
+                        emb.message_id,
+                        emb.id,
+                        e,
+                    )
+                    permanently_failed.add(emb.id)
+                except Exception:
+                    logger.exception(
+                        "Unexpected error embedding message %s chunk %s; will retry",
                         emb.message_id,
                         emb.id,
                     )
@@ -456,8 +470,20 @@ async def _sync_message_embeddings(
         emb for emb in embs_needing_embed if emb.id not in freshly_embedded
     ]
     if failed_to_embed:
-        await _bump_message_embedding_sync_attempts(db, failed_to_embed)
-        failed_count += len(failed_to_embed)
+        # Expected validation failures are permanent — mark them failed
+        # directly instead of retrying MAX_SYNC_ATTEMPTS times.
+        permanent = [emb for emb in failed_to_embed if emb.id in permanently_failed]
+        if permanent:
+            await db.execute(
+                update(models.MessageEmbedding)
+                .where(models.MessageEmbedding.id.in_([emb.id for emb in permanent]))
+                .values(sync_state="failed", last_sync_at=func.now())
+            )
+            failed_count += len(permanent)
+        retryable = [emb for emb in failed_to_embed if emb.id not in permanently_failed]
+        if retryable:
+            await _bump_message_embedding_sync_attempts(db, retryable)
+            failed_count += len(retryable)
 
     # pgvector-only mode: no external store to upsert to. Any row that now
     # has an embedding (either pre-existing or freshly embedded) is fully


### PR DESCRIPTION
## Description

The message-embedding reconciler (`_sync_message_embeddings` in `src/reconciler/sync_vectors.py`) sent **all pending texts in a single `simple_batch_embed` call**. If any one text exceeded the embedding provider's context window, the entire batch returned a 400 and **every row in the batch was marked `failed`** — including small, perfectly-embeddable messages that were only collateral damage.

### Root cause

Two compounding issues:

1. **Batch poisoning.** `simple_batch_embed(contents)` sends the whole list in one provider call. A single oversized text 400s the whole batch. The reconciler's `except Exception` then marks *all* rows in the batch as failed via `_bump_message_embedding_sync_attempts`, and after `MAX_SYNC_ATTEMPTS` they're permanently `failed` (manual intervention required).

2. **Tokenizer undercount.** The chunking tokenizer (tiktoken `o200k_base`) can undercount a provider's real token count. In our deployment (nomic-embed-text via Ollama), tiktoken undercounts by ~4–5×, so texts that passed the chunk cap still exceeded the provider's context window and got rejected.

### Fix

Embed each text **individually** instead of as one batch. A single oversized text now fails on its own (and is retried/backed off independently), while the rest of the batch stays embeddable.

### Impact observed

In our deployment this had left **54 message embeddings permanently failed** (clustered into exactly 3 poisoned batches) and 2 stuck in a retry loop. After this fix plus re-queueing, all recovered rows embedded cleanly: `synced 70 message embeddings; failed 0`, then `synced 5; failed 0`. No further `input length exceeds context length` errors.

### Test plan

- [x] Manual verification: reconciler now syncs pending rows with `failed 0`
- [ ] Unit tests pass (existing reconciler tests)

### Note for maintainers

This fixes the batch-poisoning failure mode generally. The tokenizer-undercount issue is deployment-specific (depends on the embedding model), so the per-text isolation is the durable fix — operators should also size `EMBEDDING_MAX_INPUT_TOKENS` conservatively for their provider.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message embedding reliability by processing missing vectors individually.
  * A failed embedding no longer prevents other embeddings from completing.
  * Retryable failures are recorded for affected items, while successful embeddings continue normally.
  * Invalid embedding requests are marked as permanently failed without using retry attempts.
  * Workspace telemetry remains correctly aggregated when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->