### PR TITLE
chore: adding server schema

### DIFF
--- a/docs/v3/guides/integrations/mcp.mdx
+++ b/docs/v3/guides/integrations/mcp.mdx
@@ -37,13 +37,10 @@ Edit `%APPDATA%\Claude\claude_desktop_config.json`:
         "mcp-remote",
         "https://mcp.honcho.dev",
         "--header",
-        "Authorization:${AUTH_HEADER}",
-        "--header",
-        "X-Honcho-User-Name:${USER_NAME}"
+        "Authorization:${AUTH_HEADER}"
       ],
       "env": {
-        "AUTH_HEADER": "Bearer hch-your-key-here",
-        "USER_NAME": "YourName"
+        "AUTH_HEADER": "Bearer hch-your-key-here"
       }
     }
   }
@@ -62,8 +59,7 @@ For best results, create a project and paste these [instructions](https://raw.gi
 claude mcp add honcho \
   --transport http \
   --url "https://mcp.honcho.dev" \
-  --header "Authorization: Bearer hch-your-key-here" \
-  --header "X-Honcho-User-Name: YourName"
+  --header "Authorization: Bearer hch-your-key-here"
 ```
 
 Or if you prefer the [Claude Code Honcho plugin](/v3/guides/integrations/claudecode) for a deeper integration with persistent memory, git awareness, and agent skills:
@@ -83,9 +79,7 @@ args = [
   "mcp-remote",
   "https://mcp.honcho.dev",
   "--header",
-  "Authorization:Bearer hch-your-key-here",
-  "--header",
-  "X-Honcho-User-Name:YourName"
+  "Authorization:Bearer hch-your-key-here"
 ]
 ```
 
@@ -103,8 +97,7 @@ Cursor supports MCP servers natively via HTTP. Add to your global config at `~/.
     "honcho": {
       "url": "https://mcp.honcho.dev",
       "headers": {
-        "Authorization": "Bearer hch-your-key-here",
-        "X-Honcho-User-Name": "YourName"
+        "Authorization": "Bearer hch-your-key-here"
       }
     }
   }
@@ -123,8 +116,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
     "honcho": {
       "serverUrl": "https://mcp.honcho.dev",
       "headers": {
-        "Authorization": "Bearer hch-your-key-here",
-        "X-Honcho-User-Name": "YourName"
+        "Authorization": "Bearer hch-your-key-here"
       }
     }
   }
@@ -146,8 +138,7 @@ Add to your workspace `.vscode/mcp.json`:
       "type": "http",
       "url": "https://mcp.honcho.dev",
       "headers": {
-        "Authorization": "Bearer hch-your-key-here",
-        "X-Honcho-User-Name": "YourName"
+        "Authorization": "Bearer hch-your-key-here"
       }
     }
   }
@@ -164,8 +155,7 @@ Or add to your User Settings JSON (`Cmd+Shift+P` → "Preferences: Open User Set
         "type": "http",
         "url": "https://mcp.honcho.dev",
         "headers": {
-          "Authorization": "Bearer hch-your-key-here",
-          "X-Honcho-User-Name": "YourName"
+          "Authorization": "Bearer hch-your-key-here"
         }
       }
     }
@@ -192,8 +182,7 @@ Cline supports remote MCP servers natively. Open Cline's MCP settings at:
     "honcho": {
       "url": "https://mcp.honcho.dev",
       "headers": {
-        "Authorization": "Bearer hch-your-key-here",
-        "X-Honcho-User-Name": "YourName"
+        "Authorization": "Bearer hch-your-key-here"
       }
     }
   }
@@ -212,8 +201,7 @@ Add to `~/.config/zed/settings.json`:
     "honcho": {
       "url": "https://mcp.honcho.dev",
       "headers": {
-        "Authorization": "Bearer hch-your-key-here",
-        "X-Honcho-User-Name": "YourName"
+        "Authorization": "Bearer hch-your-key-here"
       }
     }
   }
@@ -228,7 +216,7 @@ Zed uses `context_servers` instead of `mcpServers`. Native HTTP support requires
 
 [Goose](https://goose-docs.ai/) supports remote MCP servers natively over Streamable HTTP.
 
-The easiest way is to run `goose configure`, choose **Add Extension → Remote Extension (Streamable HTTP)**, and enter the name `honcho`, the URI `https://mcp.honcho.dev`, and the headers `Authorization: Bearer hch-your-key-here` and `X-Honcho-User-Name: YourName`.
+The easiest way is to run `goose configure`, choose **Add Extension → Remote Extension (Streamable HTTP)**, and enter the name `honcho`, the URI `https://mcp.honcho.dev`, and the header `Authorization: Bearer hch-your-key-here`.
 
 Or edit your `config.yaml` directly (on Linux, `~/.config/goose/config.yaml`):
 
@@ -242,7 +230,6 @@ extensions:
     uri: https://mcp.honcho.dev
     headers:
       Authorization: "Bearer hch-your-key-here"
-      X-Honcho-User-Name: "YourName"
     timeout: 60
 ```
 
@@ -254,13 +241,11 @@ To teach Goose the recommended memory flow, save the [instructions](https://raw.
 
 ## Optional Configuration
 
-You can customize the assistant name and workspace ID by adding extra headers. Both are optional.
+You can target a specific workspace by adding an extra header. It's optional.
 
 | Header | Default | Description |
 |--------|---------|-------------|
 | `Authorization` | *required* | `Bearer hch-your-key-here` |
-| `X-Honcho-User-Name` | *required* | What the AI should call you |
-| `X-Honcho-Assistant-Name` | `"Assistant"` | Name for the AI peer |
 | `X-Honcho-Workspace-ID` | `"default"` | Isolate memory per project |
 
 Example with all headers (Claude Desktop format):
@@ -276,16 +261,10 @@ Example with all headers (Claude Desktop format):
         "--header",
         "Authorization:${AUTH_HEADER}",
         "--header",
-        "X-Honcho-User-Name:${USER_NAME}",
-        "--header",
-        "X-Honcho-Assistant-Name:${ASSISTANT_NAME}",
-        "--header",
         "X-Honcho-Workspace-ID:${WORKSPACE_ID}"
       ],
       "env": {
         "AUTH_HEADER": "Bearer hch-your-key-here",
-        "USER_NAME": "YourName",
-        "ASSISTANT_NAME": "Claude",
         "WORKSPACE_ID": "my-project"
       }
     }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.plastic-labs/honcho",
+  "title": "Honcho",
+  "description": "Memory that reasons: continual learning for stateful agents. Better context, fewer tokens.",
+  "version": "3.0.0",
+  "repository": {
+    "url": "https://github.com/plastic-labs/honcho",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.honcho.dev",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Honcho API key as a Bearer token. Create one at https://app.honcho.dev (starts with hch-). Send as: Bearer hch-...",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "X-Honcho-Workspace-ID",
+          "description": "Optional. Target Honcho workspace; defaults to 'default' when omitted.",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -15,7 +15,7 @@
       "headers": [
         {
           "name": "Authorization",
-          "description": "Honcho API key as a Bearer token. Create one at https://app.honcho.dev (starts with hch-). Send as: Bearer hch-...",
+          "description": "Authorization header for Honcho. Use either an OAuth access token or a Honcho API key from https://app.honcho.dev (API keys start with hch-). Send as: Bearer <token>.",
           "isRequired": true,
           "isSecret": true
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP server integration for Honcho.
  * Supports streamable HTTP connections with Bearer-token authentication.
  * Allows optional workspace selection.

* **Documentation**
  * Updated MCP client setup examples to use Bearer-token authentication.
  * Clarified workspace configuration and removed obsolete user and assistant name settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->