### PR TITLE
fix(embedding): validate model output dimension at startup

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -16,6 +16,9 @@ PERFORMANCE_LOG_FORMAT=compact # compact|rich
 
 # Embedding settings
 # EMBED_MESSAGES=true
+# Must match the configured embedding model's actual output dimension; startup
+# probes the model and fails fast if it returns a different length. Common local
+# OpenAI-compatible models: nomic-embed-text-v1.5=768, bge-small-en-v1.5=384.
 # EMBEDDING_VECTOR_DIMENSIONS=1536
 # EMBEDDING_MAX_INPUT_TOKENS=8192
 # EMBEDDING_MAX_TOKENS_PER_REQUEST=300000

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -226,6 +226,53 @@ class _EmbeddingClient:
             )
         return embedding
 
+    async def probe_model_dimensions(self) -> int:
+        """Return the configured embedding model's raw output dimension.
+
+        Startup validation needs the actual length returned by the provider,
+        before runtime dimension validation would reject it.
+        """
+        probe = "Honcho embedding dimension validation probe"
+        token_count = len(self.encoding.encode(probe))
+
+        if isinstance(self.client, genai.Client):
+            gemini_client = self.client
+
+            async def _call_gemini() -> int:
+                response = await gemini_client.aio.models.embed_content(
+                    model=self.model,
+                    contents=probe,
+                    config={"output_dimensionality": self.vector_dimensions},
+                )
+                if not response.embeddings or not response.embeddings[0].values:
+                    raise ValueError("No embedding returned from Gemini API")
+                return len(response.embeddings[0].values)
+
+            return await _emit_embedding_call(
+                provider=self.transport,
+                model=self.model,
+                texts=[probe],
+                input_tokens_estimate=token_count,
+                fn=_call_gemini,
+            )
+
+        openai_client = self.client
+
+        async def _call_openai() -> int:
+            openai_kwargs: dict[str, Any] = {"model": self.model, "input": [probe]}
+            if self.send_dimensions:
+                openai_kwargs["dimensions"] = self.vector_dimensions
+            response = await openai_client.embeddings.create(**openai_kwargs)
+            return len(response.data[0].embedding)
+
+        return await _emit_embedding_call(
+            provider=self.transport,
+            model=self.model,
+            texts=[probe],
+            input_tokens_estimate=token_count,
+            fn=_call_openai,
+        )
+
     async def embed(self, query: str) -> list[float]:
         token_count = len(self.encoding.encode(query))
 
@@ -642,6 +689,16 @@ class EmbeddingClient:
     async def embed(self, query: str) -> list[float]:
         """Embed a single query string."""
         return await self._get_client().embed(query)
+
+    async def validate_model_dimensions(self) -> int:
+        """Probe the configured embedding model and return its output dimension.
+
+        Startup uses this as a fail-fast configuration check. The probe goes
+        through the same embedding path as runtime callers, so provider/client
+        quirks and dimensions-mode handling are validated before traffic is
+        served.
+        """
+        return await self._get_client().probe_model_dimensions()
 
     async def simple_batch_embed(self, texts: list[str]) -> list[list[float]]:
         """Batch embed a list of text strings (each must fit token limit)."""

--- a/src/startup/embedding_validator.py
+++ b/src/startup/embedding_validator.py
@@ -14,6 +14,7 @@ ones. Full enumeration is available via `uv run python scripts/configure_embeddi
 from __future__ import annotations
 
 import logging
+from typing import Protocol
 
 from sqlalchemy import select, text
 from sqlalchemy.exc import SQLAlchemyError
@@ -58,12 +59,19 @@ class StartupValidationError(HonchoException):
     """
 
 
+class EmbeddingDimensionProbe(Protocol):
+    async def validate_model_dimensions(self) -> int:
+        """Return the configured embedding model's output dimension."""
+        ...
+
+
 async def validate_embedding_schema(
     engine: AsyncEngine,
     *,
     app_settings: AppSettings | None = None,
+    embedding_client: EmbeddingDimensionProbe | None = None,
 ) -> None:
-    """Validate that the embedding schema matches the configured dimension.
+    """Validate that the embedding model and schema match the configured dimension.
 
     Run after the DB pool is initialized and before the embedding client is
     constructed. Fails closed: any unrecoverable introspection error raises
@@ -75,9 +83,51 @@ async def validate_embedding_schema(
 
     dims = await _introspect_pgvector_dims_with_retry(engine, schema)
     _assert_pgvector_dims_match(dims, schema=schema, target_dim=target_dim)
+    await _assert_embedding_model_dim_matches_config(
+        s,
+        target_dim=target_dim,
+        embedding_client=embedding_client,
+    )
 
     if s.VECTOR_STORE.TYPE in ("turbopuffer", "lancedb"):
         await _sample_external_namespaces(engine, target_dim=target_dim)
+
+
+async def _assert_embedding_model_dim_matches_config(
+    app_settings: AppSettings,
+    *,
+    target_dim: int,
+    embedding_client: EmbeddingDimensionProbe | None = None,
+) -> None:
+    """Probe the configured embedding model and compare its actual output dim.
+
+    The pgvector schema check catches config-vs-storage drift. This probe
+    catches config-vs-model drift before runtime writes can start failing with
+    provider or pgvector dimension errors.
+    """
+    if embedding_client is None:
+        from src.embedding_client import embedding_client as default_embedding_client
+
+        embedding_client = default_embedding_client
+    try:
+        actual_dim = await embedding_client.validate_model_dimensions()
+    except Exception as exc:
+        configured_model = app_settings.EMBEDDING.MODEL_CONFIG
+        raise StartupValidationError(
+            "could not validate embedding model output dimension for "
+            + f"{configured_model.transport}:{configured_model.model}: {exc}"
+        ) from exc
+
+    if actual_dim != target_dim:
+        configured_model = app_settings.EMBEDDING.MODEL_CONFIG
+        raise StartupValidationError(
+            "Embedding model output dimension mismatch for "
+            + f"{configured_model.transport}:{configured_model.model}: "
+            + f"model returned {actual_dim}, but EMBEDDING_VECTOR_DIMENSIONS "
+            + f"is {target_dim}. Set EMBEDDING_VECTOR_DIMENSIONS to match the "
+            + "model output or choose an embedding model with the configured "
+            + "dimension."
+        )
 
 
 async def _introspect_pgvector_dims_with_retry(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,9 @@ _RUNTIME_MOCK_TEST_BLOCKLIST_PREFIXES = (
     "tests/live_llm/",
     # Pure llm unit tests should stay isolated from the broader app/runtime fixtures.
     "tests/llm/",
+    # This module opts into db_engine only for its two schema integration tests;
+    # its pure startup-validation tests must not acquire Postgres via autouse mocks.
+    "tests/startup/test_embedding_validator.py",
     # LLM transport tests mock providers directly and don't need database/runtime setup.
     "tests/utils/test_length_finish_reason.py",
     "tests/utils/test_clients.py",

--- a/tests/llm/test_embedding_client.py
+++ b/tests/llm/test_embedding_client.py
@@ -102,6 +102,36 @@ async def test_openai_embedding_client_rejects_dimension_mismatch(
 
 
 @pytest.mark.asyncio
+async def test_probe_model_dimensions_returns_raw_mismatched_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup can diagnose model-vs-config drift before runtime validation fails."""
+    fake_embeddings = FakeOpenAIEmbeddingsAPI([0.1] * 7)
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key: str | None, base_url: str | None) -> None:
+            self.embeddings: FakeOpenAIEmbeddingsAPI = fake_embeddings
+
+    monkeypatch.setattr("src.embedding_client.AsyncOpenAI", FakeOpenAIClient)
+
+    client = _EmbeddingClient(
+        EmbeddingModelConfig(
+            transport="openai",
+            model="text-embedding-nomic-embed-text-v1.5",
+            api_key="test-key",
+        ),
+        vector_dimensions=1536,
+        max_input_tokens=8192,
+        max_tokens_per_request=300_000,
+        send_dimensions=False,
+    )
+
+    assert await client.probe_model_dimensions() == 7
+    with pytest.raises(ValueError, match="Expected 1536, got 7"):
+        await client.embed("hello world")
+
+
+@pytest.mark.asyncio
 async def test_gemini_embedding_client_uses_output_dimensionality(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/startup/test_embedding_validator.py
+++ b/tests/startup/test_embedding_validator.py
@@ -14,9 +14,10 @@ from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from src.config import settings
+from src.config import AppSettings, settings
 from src.startup.embedding_validator import (
     StartupValidationError,
+    _assert_embedding_model_dim_matches_config,  # pyright: ignore[reportPrivateUsage]
     _assert_pgvector_dims_match,  # pyright: ignore[reportPrivateUsage]
     validate_embedding_schema,
 )
@@ -81,6 +82,72 @@ def test_assert_pgvector_dims_match_respects_non_public_schema() -> None:
         )
 
 
+class FakeEmbeddingDimensionProbe:
+    def __init__(self, dimension: int) -> None:
+        self.dimension: int = dimension
+        self.calls: int = 0
+
+    async def validate_model_dimensions(self) -> int:
+        self.calls += 1
+        return self.dimension
+
+
+def _app_settings_with_embedding_model(
+    *,
+    vector_dimensions: int,
+    model: str = "text-embedding-nomic-embed-text-v1.5",
+) -> AppSettings:
+    return settings.model_copy(
+        deep=True,
+        update={
+            "EMBEDDING": settings.EMBEDDING.model_copy(
+                deep=True,
+                update={
+                    "VECTOR_DIMENSIONS": vector_dimensions,
+                    "MODEL_CONFIG": settings.EMBEDDING.MODEL_CONFIG.model_copy(
+                        deep=True,
+                        update={"transport": "openai", "model": model},
+                    ),
+                },
+            )
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_assert_embedding_model_dim_matches_config_accepts_actual_dim() -> None:
+    probe = FakeEmbeddingDimensionProbe(768)
+    app_settings = _app_settings_with_embedding_model(vector_dimensions=768)
+
+    await _assert_embedding_model_dim_matches_config(
+        app_settings,
+        target_dim=768,
+        embedding_client=probe,
+    )
+
+    assert probe.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_assert_embedding_model_dim_matches_config_reports_model_mismatch() -> (
+    None
+):
+    probe = FakeEmbeddingDimensionProbe(768)
+    app_settings = _app_settings_with_embedding_model(vector_dimensions=1536)
+
+    with pytest.raises(StartupValidationError) as excinfo:
+        await _assert_embedding_model_dim_matches_config(
+            app_settings,
+            target_dim=1536,
+            embedding_client=probe,
+        )
+
+    msg = str(excinfo.value)
+    assert "text-embedding-nomic-embed-text-v1.5" in msg
+    assert "model returned 768" in msg
+    assert "EMBEDDING_VECTOR_DIMENSIONS is 1536" in msg
+
+
 # ---------------------------------------------------------------------------
 # Fail-closed retry behavior
 # ---------------------------------------------------------------------------
@@ -128,7 +195,12 @@ async def test_validator_passes_against_test_database(
     # conftest provisions the test tables in `public`; pin the validator to it
     # so a developer's local .env DB_SCHEMA can't point it at another schema.
     monkeypatch.setattr(settings.DB, "SCHEMA", "public")
-    await validate_embedding_schema(db_engine)
+    await validate_embedding_schema(
+        db_engine,
+        embedding_client=FakeEmbeddingDimensionProbe(
+            settings.EMBEDDING.VECTOR_DIMENSIONS
+        ),
+    )
 
 
 @pytest.mark.asyncio
@@ -148,7 +220,12 @@ async def test_validator_raises_when_schema_dim_diverges_from_settings(
         )
     try:
         with pytest.raises(StartupValidationError, match="dim .* does not match"):
-            await validate_embedding_schema(db_engine)
+            await validate_embedding_schema(
+                db_engine,
+                embedding_client=FakeEmbeddingDimensionProbe(
+                    settings.EMBEDDING.VECTOR_DIMENSIONS
+                ),
+            )
     finally:
         async with db_engine.begin() as conn:
             await conn.execute(
@@ -179,9 +256,9 @@ def test_vector_store_dimensions_explicit_set_warns(
     messages = [
         str(w.message) for w in captured if issubclass(w.category, DeprecationWarning)
     ]
-    assert any(
-        "VECTOR_STORE_DIMENSIONS is deprecated" in m for m in messages
-    ), f"expected deprecation warning, got {messages!r}"
+    assert any("VECTOR_STORE_DIMENSIONS is deprecated" in m for m in messages), (
+        f"expected deprecation warning, got {messages!r}"
+    )
 
 
 def test_non_1536_pgvector_without_migrated_no_longer_raises_at_config_time() -> None:


### PR DESCRIPTION
## Summary

- probe the configured embedding model during startup validation
- fail fast with the provider, model, configured dimension, and returned dimension when they differ
- document common local-model dimensions and keep focused provider/schema coverage isolated

Closes #1002

## Testing

- `DB_CONNECTION_URI=postgresql+psycopg://postgres@localhost:55432/postgres uv run pytest -n 0 -q tests/startup/test_embedding_validator.py tests/llm/test_embedding_client.py` (36 passed; temporary `pgvector/pgvector:pg16`)
- `uv run ruff check src/embedding_client.py src/startup/embedding_validator.py tests/conftest.py tests/llm/test_embedding_client.py tests/startup/test_embedding_validator.py`
- `uv run ruff format --check src/embedding_client.py src/startup/embedding_validator.py tests/conftest.py tests/llm/test_embedding_client.py tests/startup/test_embedding_validator.py`
- `uv run basedpyright src/embedding_client.py src/startup/embedding_validator.py tests/llm/test_embedding_client.py tests/startup/test_embedding_validator.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added startup validation to confirm the configured embedding model’s output dimensions match the application setting.
  - Added support for checking dimensions from Gemini and OpenAI embedding models.
  - Added configuration guidance and examples for common embedding dimensions.

- **Bug Fixes**
  - Startup now fails early with a clear validation error when dimensions are missing, unavailable, or mismatched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->