### PR TITLE
fix: force LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell entrypoints are executed with sh/dash inside the container image. A
+# Windows checkout with core.autocrlf=true rewrites them to CRLF, and dash
+# then aborts with "set: Illegal option" because the carriage return becomes
+# part of the "-e" flag argument (docker/entrypoint.sh).
+*.sh text eol=lf


### PR DESCRIPTION
## Problem

docker/entrypoint.sh is executed with dash/sh inside the container image. On a Windows checkout with core.autocrlf=true (Git's default on Windows), the script is rewritten to CRLF and the container startup aborts with:

    docker/entrypoint.sh: 2: set: Illegal option -

because the carriage return becomes part of the -e flag argument.

## Fix

Add a .gitattributes pinning shell scripts to LF. This is the standard fix and makes container builds reproducible on Windows checkouts regardless of the local autocrlf setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized shell script line endings to LF to improve compatibility when running scripts in containers.
  * Added guidance documenting potential issues caused by CRLF conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->