### PR TITLE
feat(llm): forward-port opt-in Responses API mode to 3.0.12

### DIFF
--- a/src/llm/backends/openai.py
+++ b/src/llm/backends/openai.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator
 from typing import Any, cast
 
 from openai import BadRequestError, LengthFinishReasonError
+from openai.lib._pydantic import to_strict_json_schema
 from pydantic import BaseModel, ValidationError
 
 from src.exceptions import ValidationException
@@ -166,6 +167,21 @@ class OpenAIBackend:
         max_output_tokens: int | None = None,
         extra_params: dict[str, Any] | None = None,
     ) -> CompletionResult:
+        if extra_params and extra_params.get("api_mode") == "responses":
+            return await self._complete_responses(
+                model=model,
+                messages=messages,
+                max_tokens=max_output_tokens or max_tokens,
+                temperature=temperature,
+                stop=stop,
+                thinking_budget_tokens=thinking_budget_tokens,
+                tools=tools,
+                tool_choice=tool_choice,
+                response_format=response_format,
+                thinking_effort=thinking_effort,
+                extra_params=extra_params,
+            )
+
         params = self._build_params(
             model=model,
             messages=messages,
@@ -286,6 +302,23 @@ class OpenAIBackend:
         max_output_tokens: int | None = None,
         extra_params: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:
+        if extra_params and extra_params.get("api_mode") == "responses":
+            async for chunk in self._stream_responses(
+                model=model,
+                messages=messages,
+                max_tokens=max_output_tokens or max_tokens,
+                temperature=temperature,
+                stop=stop,
+                thinking_budget_tokens=thinking_budget_tokens,
+                tools=tools,
+                tool_choice=tool_choice,
+                response_format=response_format,
+                thinking_effort=thinking_effort,
+                extra_params=extra_params,
+            ):
+                yield chunk
+            return
+
         params = self._build_params(
             model=model,
             messages=messages,
@@ -334,6 +367,486 @@ class OpenAIBackend:
 
         if not usage_chunk_received and finish_reason:
             yield StreamChunk(is_done=True, finish_reason=finish_reason)
+
+    async def _complete_responses(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        temperature: float | None,
+        stop: list[str] | None,
+        thinking_budget_tokens: int | None,
+        tools: list[dict[str, Any]] | None,
+        tool_choice: str | dict[str, Any] | None,
+        response_format: type[BaseModel] | dict[str, Any] | None,
+        thinking_effort: str | None,
+        extra_params: dict[str, Any],
+    ) -> CompletionResult:
+        self._validate_responses_options(
+            stop=stop,
+            thinking_budget_tokens=thinking_budget_tokens,
+            extra_params=extra_params,
+        )
+        params = self._build_responses_params(
+            model=model,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            thinking_effort=thinking_effort,
+            extra_params=extra_params,
+        )
+        text_parts: list[str] = []
+        output_items: list[Any] = []
+        completed_response: Any = None
+        async with self._client.responses.stream(**params) as stream:
+            async for event in stream:
+                event_type = self._response_value(event, "type")
+                if event_type == "response.output_text.delta":
+                    delta = self._response_value(event, "delta")
+                    if isinstance(delta, str):
+                        text_parts.append(delta)
+                elif event_type == "response.output_item.done":
+                    item = self._response_value(event, "item")
+                    if item is not None:
+                        output_items.append(item)
+                elif event_type == "response.completed":
+                    completed_response = self._response_value(event, "response")
+            response = await stream.get_final_response()
+        # ChatGPT's Codex Responses endpoint currently omits ``output`` from
+        # response.completed, even though it streams all deltas/items. Rebuild
+        # that losslessly while retaining status/usage from the completed event.
+        if text_parts or output_items:
+            metadata = completed_response or response
+            response = {
+                "output_text": "".join(text_parts),
+                "output": output_items,
+                "status": self._response_value(metadata, "status"),
+                "incomplete_details": self._response_value(
+                    metadata, "incomplete_details"
+                ),
+                "refusal": self._response_value(metadata, "refusal"),
+                "usage": self._response_value(metadata, "usage"),
+            }
+        self._validate_responses_status(response)
+        return self._normalize_responses_response(
+            response,
+            response_format=response_format,
+            model=model,
+        )
+
+    async def _stream_responses(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        temperature: float | None,
+        stop: list[str] | None,
+        thinking_budget_tokens: int | None,
+        tools: list[dict[str, Any]] | None,
+        tool_choice: str | dict[str, Any] | None,
+        response_format: type[BaseModel] | dict[str, Any] | None,
+        thinking_effort: str | None,
+        extra_params: dict[str, Any],
+    ) -> AsyncIterator[StreamChunk]:
+        self._validate_responses_options(
+            stop=stop,
+            thinking_budget_tokens=thinking_budget_tokens,
+            extra_params=extra_params,
+        )
+        params = self._build_responses_params(
+            model=model,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            thinking_effort=thinking_effort,
+            extra_params=extra_params,
+        )
+        terminal_response: Any = None
+        output_items: list[Any] = []
+        async with self._client.responses.stream(**params) as stream:
+            async for event in stream:
+                event_type = self._response_value(event, "type")
+                if event_type == "response.output_text.delta":
+                    delta = self._response_value(event, "delta")
+                    if isinstance(delta, str) and delta:
+                        yield StreamChunk(content=delta)
+                elif event_type == "response.output_item.done":
+                    item = self._response_value(event, "item")
+                    if item is not None:
+                        output_items.append(item)
+                elif event_type in {
+                    "response.completed",
+                    "response.incomplete",
+                    "response.failed",
+                    "response.cancelled",
+                }:
+                    terminal_response = self._response_value(event, "response")
+            if terminal_response is None:
+                terminal_response = await stream.get_final_response()
+            validation_response = terminal_response
+            if output_items and not self._response_value(terminal_response, "output"):
+                validation_response = {
+                    "status": self._response_value(terminal_response, "status"),
+                    "incomplete_details": self._response_value(
+                        terminal_response, "incomplete_details"
+                    ),
+                    "refusal": self._response_value(terminal_response, "refusal"),
+                    "output": output_items,
+                }
+            self._validate_responses_status(validation_response)
+            usage = self._response_value(terminal_response, "usage")
+            output_tokens = self._response_value(usage, "output_tokens")
+            yield StreamChunk(
+                is_done=True,
+                finish_reason=self._responses_finish_reason(terminal_response),
+                output_tokens=(
+                    int(output_tokens) if isinstance(output_tokens, int) else None
+                ),
+            )
+
+    def _build_responses_params(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        temperature: float | None = None,
+        tools: list[dict[str, Any]] | None,
+        tool_choice: str | dict[str, Any] | None,
+        response_format: type[BaseModel] | dict[str, Any] | None,
+        thinking_effort: str | None,
+        extra_params: dict[str, Any],
+    ) -> dict[str, Any]:
+        instructions, response_input = self._messages_to_responses_input(messages)
+        params: dict[str, Any] = {
+            "model": model,
+            "input": response_input,
+            "store": False,
+        }
+        if temperature is not None:
+            params["temperature"] = temperature
+        if "top_p" in extra_params and extra_params["top_p"] is not None:
+            params["top_p"] = extra_params["top_p"]
+        if not extra_params.get("omit_max_output_tokens"):
+            params["max_output_tokens"] = max_tokens
+        if instructions:
+            params["instructions"] = instructions
+        if thinking_effort:
+            params["reasoning"] = {"effort": thinking_effort}
+        if tools:
+            params["tools"] = self._convert_responses_tools(tools)
+            converted_choice = self._convert_responses_tool_choice(tool_choice)
+            if converted_choice is not None:
+                params["tool_choice"] = converted_choice
+        text_config = self._responses_text_config(response_format, extra_params)
+        if text_config:
+            params["text"] = text_config
+        apply_sdk_passthroughs(params, extra_params)
+        timeout = request_timeout_from_extra_params(extra_params)
+        if timeout is not None:
+            params["timeout"] = timeout
+        return params
+
+    @staticmethod
+    def _validate_responses_options(
+        *,
+        stop: list[str] | None,
+        thinking_budget_tokens: int | None,
+        extra_params: dict[str, Any],
+    ) -> None:
+        unsupported = {
+            "stop": stop,
+            "presence_penalty": extra_params.get("presence_penalty"),
+            "frequency_penalty": extra_params.get("frequency_penalty"),
+            "seed": extra_params.get("seed"),
+            "thinking_budget_tokens": thinking_budget_tokens,
+        }
+        used = [name for name, value in unsupported.items() if value is not None]
+        if used:
+            raise ValidationException(
+                "Responses API does not support non-null provider options: "
+                + ", ".join(used)
+            )
+
+    @classmethod
+    def _convert_responses_tool_choice(
+        cls,
+        tool_choice: str | dict[str, Any] | None,
+    ) -> str | dict[str, Any] | None:
+        if tool_choice is None:
+            return None
+        if isinstance(tool_choice, dict):
+            name = tool_choice.get("name")
+            if name is None and isinstance(tool_choice.get("function"), dict):
+                name = tool_choice["function"].get("name")
+            if name is not None:
+                return {"type": "function", "name": name}
+            return tool_choice
+        if tool_choice in {"any", "required"}:
+            return "required"
+        if tool_choice in {"auto", "none"}:
+            return tool_choice
+        return {"type": "function", "name": tool_choice}
+
+    @classmethod
+    def _messages_to_responses_input(
+        cls, messages: list[dict[str, Any]]
+    ) -> tuple[str, list[dict[str, Any]]]:
+        instructions: list[str] = []
+        response_input: list[dict[str, Any]] = []
+        for message in messages:
+            role = str(message.get("role") or "user")
+            content = message.get("content")
+            if role in {"system", "developer"}:
+                if isinstance(content, str) and content:
+                    instructions.append(content)
+                continue
+            if role == "tool":
+                response_input.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": str(message.get("tool_call_id") or ""),
+                        "output": content
+                        if isinstance(content, str)
+                        else json.dumps(content),
+                    }
+                )
+                continue
+            raw_reasoning_details = message.get("reasoning_details")
+            if isinstance(raw_reasoning_details, list):
+                for raw_reasoning in cast(list[Any], raw_reasoning_details):
+                    if isinstance(raw_reasoning, BaseModel):
+                        reasoning = raw_reasoning.model_dump()
+                    elif isinstance(raw_reasoning, dict):
+                        reasoning = dict(cast(dict[str, Any], raw_reasoning))
+                    else:
+                        continue
+                    if reasoning.get("type") == "reasoning":
+                        response_input.append(reasoning)
+            if isinstance(content, str) and content:
+                response_input.append({"role": role, "content": content})
+            raw_tool_calls = message.get("tool_calls")
+            if isinstance(raw_tool_calls, list):
+                tool_call_values = cast(list[Any], raw_tool_calls)
+                for raw_tool_call in tool_call_values:
+                    if not isinstance(raw_tool_call, dict):
+                        continue
+                    tool_call = cast(dict[str, Any], raw_tool_call)
+                    raw_function = tool_call.get("function")
+                    function = (
+                        cast(dict[str, Any], raw_function)
+                        if isinstance(raw_function, dict)
+                        else {}
+                    )
+                    response_input.append(
+                        {
+                            "type": "function_call",
+                            "call_id": str(tool_call.get("id") or ""),
+                            "name": str(function.get("name") or ""),
+                            "arguments": str(function.get("arguments") or "{}"),
+                        }
+                    )
+        return "\n\n".join(instructions), response_input
+
+    @staticmethod
+    def _convert_responses_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        converted: list[dict[str, Any]] = []
+        for tool in tools:
+            function = tool.get("function") if tool.get("type") == "function" else tool
+            function = function or {}
+            converted.append(
+                {
+                    "type": "function",
+                    "name": function.get("name", ""),
+                    "description": function.get("description", ""),
+                    "parameters": function.get(
+                        "parameters",
+                        function.get(
+                            "input_schema", {"type": "object", "properties": {}}
+                        ),
+                    ),
+                    "strict": False,
+                }
+            )
+        return converted
+
+    @staticmethod
+    def _responses_text_config(
+        response_format: type[BaseModel] | dict[str, Any] | None,
+        extra_params: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        text: dict[str, Any] = {}
+        verbosity = extra_params.get("verbosity")
+        if verbosity:
+            text["verbosity"] = verbosity
+        if isinstance(response_format, type):
+            text["format"] = {
+                "type": "json_schema",
+                "name": response_format.__name__,
+                "schema": to_strict_json_schema(response_format),
+                "strict": True,
+            }
+        elif isinstance(response_format, dict):
+            if response_format.get("type") == "json_schema":
+                raw_schema = response_format.get("json_schema")
+                schema = (
+                    cast(dict[str, Any], raw_schema)
+                    if isinstance(raw_schema, dict)
+                    else {}
+                )
+                text["format"] = {
+                    "type": "json_schema",
+                    "name": schema.get("name", "response"),
+                    "schema": schema.get("schema", {}),
+                    "strict": schema.get("strict", True),
+                }
+            elif response_format.get("type") == "json_object":
+                text["format"] = {"type": "json_object"}
+        elif extra_params.get("json_mode"):
+            text["format"] = {"type": "json_object"}
+        return text or None
+
+    def _normalize_responses_response(
+        self,
+        response: Any,
+        *,
+        response_format: type[BaseModel] | dict[str, Any] | None,
+        model: str,
+    ) -> CompletionResult:
+        raw_output = self._response_value(response, "output")
+        output: list[Any] = (
+            cast(list[Any], raw_output) if isinstance(raw_output, list) else []
+        )
+        raw_text = self._response_value(response, "output_text")
+        text = raw_text if isinstance(raw_text, str) else ""
+        tool_calls: list[ToolCallResult] = []
+        reasoning_details: list[dict[str, Any]] = []
+        for item in output:
+            item_type = self._response_value(item, "type")
+            if item_type == "function_call":
+                arguments = self._response_value(item, "arguments") or "{}"
+                try:
+                    parsed_arguments: Any = json.loads(arguments)
+                except (json.JSONDecodeError, TypeError):
+                    parsed_arguments = {}
+                tool_input = (
+                    cast(dict[str, Any], parsed_arguments)
+                    if isinstance(parsed_arguments, dict)
+                    else {}
+                )
+                tool_calls.append(
+                    ToolCallResult(
+                        id=str(
+                            self._response_value(item, "call_id")
+                            or self._response_value(item, "id")
+                            or ""
+                        ),
+                        name=str(self._response_value(item, "name") or ""),
+                        input=tool_input,
+                    )
+                )
+            elif item_type == "reasoning":
+                if isinstance(item, BaseModel):
+                    reasoning_details.append(item.model_dump())
+                elif isinstance(item, dict):
+                    reasoning_details.append(cast(dict[str, Any], item))
+        content: Any = text
+        if isinstance(response_format, type) and text:
+            try:
+                content = validate_structured_output(text, response_format)
+            except (StructuredOutputError, ValidationError):
+                content = repair_response_model_json(text, response_format, model)
+        usage = self._response_value(response, "usage")
+        input_tokens = self._response_value(usage, "input_tokens") or 0
+        output_tokens = self._response_value(usage, "output_tokens") or 0
+        details = self._response_value(usage, "input_tokens_details")
+        cached_tokens = self._response_value(details, "cached_tokens") or 0
+        return CompletionResult(
+            content=content,
+            input_tokens=int(input_tokens),
+            output_tokens=int(output_tokens),
+            cache_read_input_tokens=int(cached_tokens),
+            finish_reason=self._responses_finish_reason(response),
+            tool_calls=tool_calls,
+            reasoning_details=reasoning_details,
+            raw_response=response,
+        )
+
+    @classmethod
+    def _responses_finish_reason(cls, response: Any) -> str:
+        status = cls._response_value(response, "status")
+        if status == "completed":
+            return "stop"
+        if status == "incomplete":
+            incomplete = cls._response_value(response, "incomplete_details")
+            reason = cls._response_value(incomplete, "reason")
+            if reason in {"max_output_tokens", "max_tokens"}:
+                return "length"
+        raise cls._responses_status_error(response)
+
+    @classmethod
+    def _responses_refusal(cls, response: Any) -> str | None:
+        refusal = cls._response_value(response, "refusal")
+        if isinstance(refusal, str) and refusal:
+            return refusal
+        raw_output = cls._response_value(response, "output")
+        output: list[Any] = (
+            cast(list[Any], raw_output) if isinstance(raw_output, list) else []
+        )
+        for item in output:
+            item_refusal = cls._response_value(item, "refusal")
+            if isinstance(item_refusal, str) and item_refusal:
+                return item_refusal
+            raw_content = cls._response_value(item, "content")
+            content: list[Any] = (
+                cast(list[Any], raw_content) if isinstance(raw_content, list) else []
+            )
+            for part in content:
+                if cls._response_value(part, "type") != "refusal":
+                    continue
+                part_refusal = cls._response_value(part, "refusal")
+                if isinstance(part_refusal, str) and part_refusal:
+                    return part_refusal
+        return None
+
+    @classmethod
+    def _responses_status_error(cls, response: Any) -> Exception:
+        status = cls._response_value(response, "status") or "unknown"
+        refusal = cls._responses_refusal(response)
+        if refusal is not None or status == "refused":
+            return ValidationException("Responses provider refusal")
+        return ValidationException(
+            f"Responses provider returned non-success status: {status}"
+        )
+
+    @classmethod
+    def _validate_responses_status(cls, response: Any) -> None:
+        if cls._responses_refusal(response) is not None:
+            raise cls._responses_status_error(response)
+        status = cls._response_value(response, "status")
+        if status == "completed":
+            return
+        if status == "incomplete":
+            incomplete = cls._response_value(response, "incomplete_details")
+            reason = cls._response_value(incomplete, "reason")
+            if reason in {"max_output_tokens", "max_tokens"}:
+                return
+        raise cls._responses_status_error(response)
+
+    @staticmethod
+    def _response_value(value: Any, key: str) -> Any:
+        if isinstance(value, dict):
+            mapping = cast(dict[str, Any], value)
+            return mapping.get(key)
+        return getattr(value, key, None)
 
     def _build_params(
         self,

--- a/tests/llm/test_backends/test_openai.py
+++ b/tests/llm/test_backends/test_openai.py
@@ -9,9 +9,15 @@ from unittest.mock import AsyncMock, Mock
 import httpx
 import pytest
 from openai import BadRequestError
+from openai.types.responses import (
+    ResponseOutputMessage,
+    ResponseOutputRefusal,
+    ResponseReasoningItem,
+)
 from pydantic import BaseModel
 
 from src.exceptions import ValidationException
+from src.llm.backend import StreamChunk
 from src.llm.backends.openai import (
     OpenAIBackend,
     _json_object_instruction,  # pyright: ignore[reportPrivateUsage]
@@ -1210,3 +1216,815 @@ async def test_openai_backend_structured_without_tools_still_uses_parse() -> Non
 
     assert result.content is parsed
     client.chat.completions.create.assert_not_awaited()
+
+
+class _FakeResponsesStream:
+    _events: list[Any]
+    _final_response: Any
+
+    def __init__(self, events: list[Any], final_response: Any) -> None:
+        self._events = events
+        self._final_response = final_response
+
+    async def __aenter__(self) -> "_FakeResponsesStream":
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        return None
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        async def _iter() -> AsyncIterator[Any]:
+            for event in self._events:
+                yield event
+
+        return _iter()
+
+    async def get_final_response(self) -> Any:
+        return self._final_response
+
+
+def _responses_final_response(
+    *,
+    text: str = "ok",
+    output: list[Any] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        output_text=text,
+        output=output
+        if output is not None
+        else [
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text=text)],
+            )
+        ],
+        usage=SimpleNamespace(
+            input_tokens=11,
+            output_tokens=7,
+            input_tokens_details=SimpleNamespace(cached_tokens=3),
+        ),
+        status="completed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_responses_mode_builds_and_normalizes_completion() -> None:
+    client = Mock()
+    final = _responses_final_response(text="", output=[])
+    stream = _FakeResponsesStream(
+        [
+            SimpleNamespace(
+                type="response.output_text.delta", delta='{"answer":"yes"}'
+            ),
+            SimpleNamespace(type="response.completed", response=final),
+        ],
+        final,
+    )
+    client.responses.stream = Mock(return_value=stream)
+
+    backend = OpenAIBackend(client)
+    result = await backend.complete(
+        model="gpt-5.6-luna",
+        messages=[
+            {"role": "system", "content": "Be precise."},
+            {"role": "user", "content": "Answer."},
+        ],
+        max_tokens=100,
+        response_format=_StructuredResponse,
+        thinking_effort="low",
+        extra_params={"api_mode": "responses"},
+    )
+
+    assert result.content == _StructuredResponse(answer="yes")
+    assert result.input_tokens == 11
+    assert result.output_tokens == 7
+    assert result.cache_read_input_tokens == 3
+    call = client.responses.stream.call_args.kwargs
+    assert call["model"] == "gpt-5.6-luna"
+    assert call["instructions"] == "Be precise."
+    assert call["input"] == [{"role": "user", "content": "Answer."}]
+    assert call["max_output_tokens"] == 100
+    assert call["reasoning"] == {"effort": "low"}
+    assert call["text"]["format"]["type"] == "json_schema"
+    assert call["text"]["format"]["name"] == "_StructuredResponse"
+    assert call["text"]["format"]["schema"]["additionalProperties"] is False
+    assert call["store"] is False
+
+
+@pytest.mark.asyncio
+async def test_responses_sdk_reasoning_survives_completion_normalization() -> None:
+    client = Mock()
+    reasoning = ResponseReasoningItem(
+        id="reasoning_sdk",
+        summary=[],
+        type="reasoning",
+        encrypted_content="encrypted-sdk-reasoning",
+        status="completed",
+    )
+    function_call = SimpleNamespace(
+        type="function_call",
+        call_id="call_sdk_reasoning",
+        name="lookup",
+        arguments='{"topic":"memory"}',
+    )
+    final = _responses_final_response(
+        text="reasoned sdk answer", output=[reasoning, function_call]
+    )
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [SimpleNamespace(type="response.completed", response=final)], final
+        )
+    )
+
+    result = await OpenAIBackend(client).complete(
+        model="gpt-5.6-luna",
+        messages=[{"role": "user", "content": "Reason, then look it up"}],
+        max_tokens=100,
+        extra_params={"api_mode": "responses"},
+    )
+
+    assert result.content == "reasoned sdk answer"
+    assert result.tool_calls[0].id == "call_sdk_reasoning"
+    assert result.tool_calls[0].name == "lookup"
+    assert result.tool_calls[0].input == {"topic": "memory"}
+    assert result.input_tokens == 11
+    assert result.output_tokens == 7
+    assert result.cache_read_input_tokens == 3
+    assert result.finish_reason == "stop"
+    assert result.reasoning_details == [reasoning.model_dump()]
+
+
+@pytest.mark.asyncio
+async def test_responses_dict_reasoning_survives_completion_normalization() -> None:
+    client = Mock()
+    reasoning: dict[str, Any] = {
+        "id": "reasoning_dict",
+        "summary": [{"type": "summary_text", "text": "Checked memory"}],
+        "type": "reasoning",
+        "status": "completed",
+    }
+    final: dict[str, Any] = {
+        "output_text": "reasoned dict answer",
+        "output": [
+            reasoning,
+            {
+                "type": "function_call",
+                "call_id": "call_dict_reasoning",
+                "name": "lookup",
+                "arguments": '{"topic":"memory"}',
+            },
+        ],
+        "usage": {
+            "input_tokens": 13,
+            "output_tokens": 8,
+            "input_tokens_details": {"cached_tokens": 5},
+        },
+        "status": "completed",
+    }
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [{"type": "response.completed", "response": final}], final
+        )
+    )
+
+    result = await OpenAIBackend(client).complete(
+        model="gpt-5.6-luna",
+        messages=[{"role": "user", "content": "Reason, then look it up"}],
+        max_tokens=100,
+        extra_params={"api_mode": "responses"},
+    )
+
+    assert result.content == "reasoned dict answer"
+    assert result.tool_calls[0].id == "call_dict_reasoning"
+    assert result.tool_calls[0].name == "lookup"
+    assert result.tool_calls[0].input == {"topic": "memory"}
+    assert result.input_tokens == 13
+    assert result.output_tokens == 8
+    assert result.cache_read_input_tokens == 5
+    assert result.finish_reason == "stop"
+    assert result.reasoning_details == [reasoning]
+
+
+@pytest.mark.asyncio
+async def test_responses_reasoning_details_are_replayed_for_tool_continuation() -> None:
+    client = Mock()
+    reasoning = ResponseReasoningItem(
+        id="reasoning_replay",
+        summary=[],
+        type="reasoning",
+        encrypted_content="encrypted-replay",
+        status="completed",
+    ).model_dump()
+    final = _responses_final_response(text="done")
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [SimpleNamespace(type="response.completed", response=final)], final
+        )
+    )
+
+    await OpenAIBackend(client).complete(
+        model="gpt-5.6-luna",
+        messages=[
+            {"role": "user", "content": "Look it up"},
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning_details": [reasoning],
+                "tool_calls": [
+                    {
+                        "id": "call_replay",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "arguments": '{"topic":"memory"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_replay",
+                "content": "found it",
+            },
+        ],
+        max_tokens=100,
+        extra_params={"api_mode": "responses"},
+    )
+
+    response_input = client.responses.stream.call_args.kwargs["input"]
+    assert response_input == [
+        {"role": "user", "content": "Look it up"},
+        reasoning,
+        {
+            "type": "function_call",
+            "call_id": "call_replay",
+            "name": "lookup",
+            "arguments": '{"topic":"memory"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_replay",
+            "output": "found it",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_responses_mode_supports_tools_with_structured_output() -> None:
+    client = Mock()
+    function_call = SimpleNamespace(
+        type="function_call",
+        call_id="call_structured",
+        name="search",
+        arguments='{"query":"honcho"}',
+    )
+    final = _responses_final_response(text="", output=[])
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [
+                SimpleNamespace(
+                    type="response.output_text.delta", delta='{"answer":"yes"}'
+                ),
+                SimpleNamespace(type="response.output_item.done", item=function_call),
+                SimpleNamespace(type="response.completed", response=final),
+            ],
+            final,
+        )
+    )
+
+    result = await OpenAIBackend(client).complete(
+        model="gpt-5.6-luna",
+        messages=[{"role": "user", "content": "Search and answer"}],
+        max_tokens=100,
+        tools=[AGENT_TOOL],
+        response_format=_StructuredResponse,
+        extra_params={"api_mode": "responses"},
+    )
+
+    assert result.content == _StructuredResponse(answer="yes")
+    assert result.tool_calls[0].name == "search"
+    assert result.tool_calls[0].input == {"query": "honcho"}
+    call = client.responses.stream.call_args.kwargs
+    assert call["tools"][0]["name"] == "search"
+    assert call["text"]["format"]["type"] == "json_schema"
+    assert call["text"]["format"]["name"] == "_StructuredResponse"
+
+
+@pytest.mark.asyncio
+async def test_responses_dict_events_reconstruct_completion_without_usage() -> None:
+    client = Mock()
+    final = {"status": "completed", "usage": None}
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [
+                {"type": "response.output_text.delta", "delta": "dict "},
+                {"type": "response.output_text.delta", "delta": "ok"},
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "function_call",
+                        "call_id": "call_dict",
+                        "name": "lookup",
+                        "arguments": '{"topic":"memory"}',
+                    },
+                },
+                {"type": "response.completed", "response": final},
+            ],
+            final,
+        )
+    )
+
+    result = await OpenAIBackend(client).complete(
+        model="gpt-5.6-luna",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        extra_params={"api_mode": "responses"},
+    )
+
+    assert result.content == "dict ok"
+    assert result.tool_calls[0].id == "call_dict"
+    assert result.tool_calls[0].input == {"topic": "memory"}
+    assert result.input_tokens == 0
+    assert result.output_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_responses_dict_stream_fallback_preserves_refusal() -> None:
+    client = Mock()
+    final: dict[str, Any] = {"status": "completed", "output": [], "usage": None}
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "message",
+                        "content": [{"type": "refusal", "refusal": "unsafe request"}],
+                    },
+                }
+            ],
+            final,
+        )
+    )
+
+    chunks: list[StreamChunk] = []
+    with pytest.raises(ValidationException, match="^Responses provider refusal$"):
+        async for chunk in OpenAIBackend(client).stream(
+            model="gpt-5.6-luna",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            extra_params={"api_mode": "responses"},
+        ):
+            chunks.append(chunk)
+
+    assert not any(chunk.is_done for chunk in chunks)
+
+
+def test_openai_backend_responses_mode_can_omit_max_output_tokens() -> None:
+    backend = OpenAIBackend(Mock())
+    params = backend._build_responses_params(  # pyright: ignore[reportPrivateUsage]
+        model="gpt-5.6-luna",
+        messages=[{"role": "user", "content": "Answer."}],
+        max_tokens=100,
+        tools=None,
+        tool_choice=None,
+        response_format=None,
+        thinking_effort=None,
+        extra_params={"api_mode": "responses", "omit_max_output_tokens": True},
+    )
+    assert "max_output_tokens" not in params
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_responses_mode_converts_tools_and_tool_history() -> None:
+    client = Mock()
+    function_call = SimpleNamespace(
+        type="function_call",
+        call_id="call_123",
+        name="lookup",
+        arguments='{"topic":"memory"}',
+    )
+    final = _responses_final_response(text="", output=[])
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [
+                SimpleNamespace(type="response.output_item.done", item=function_call),
+                SimpleNamespace(type="response.completed", response=final),
+            ],
+            final,
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    result = await backend.complete(
+        model="gpt-5.6-luna",
+        messages=[
+            {"role": "user", "content": "Look it up"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_old",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": '{"topic":"old"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_old", "content": "old result"},
+        ],
+        max_tokens=100,
+        tools=[
+            {
+                "name": "lookup",
+                "description": "Look up a topic",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"topic": {"type": "string"}},
+                },
+            }
+        ],
+        tool_choice="required",
+        extra_params={"api_mode": "responses"},
+    )
+
+    assert result.tool_calls[0].id == "call_123"
+    assert result.tool_calls[0].name == "lookup"
+    assert result.tool_calls[0].input == {"topic": "memory"}
+    call = client.responses.stream.call_args.kwargs
+    assert call["tools"][0] == {
+        "type": "function",
+        "name": "lookup",
+        "description": "Look up a topic",
+        "parameters": {
+            "type": "object",
+            "properties": {"topic": {"type": "string"}},
+        },
+        "strict": False,
+    }
+    assert call["tool_choice"] == "required"
+    assert any(item.get("type") == "function_call" for item in call["input"])
+    assert any(item.get("type") == "function_call_output" for item in call["input"])
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_responses_mode_streams_text_and_done_usage() -> None:
+    client = Mock()
+    events = [
+        SimpleNamespace(type="response.output_text.delta", delta="hel"),
+        SimpleNamespace(type="response.output_text.delta", delta="lo"),
+        SimpleNamespace(
+            type="response.completed",
+            response=_responses_final_response(text="hello"),
+        ),
+    ]
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            events, _responses_final_response(text="hello")
+        )
+    )
+
+    backend = OpenAIBackend(client)
+    chunks = [
+        chunk
+        async for chunk in backend.stream(
+            model="gpt-5.6-luna",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            extra_params={"api_mode": "responses"},
+        )
+    ]
+
+    assert [chunk.content for chunk in chunks if chunk.content] == ["hel", "lo"]
+    assert chunks[-1].is_done is True
+    assert chunks[-1].finish_reason == "stop"
+    assert chunks[-1].output_tokens == 7
+
+
+@pytest.mark.asyncio
+async def test_responses_forwards_temperature_top_p_timeout_and_passthroughs() -> None:
+    client = Mock()
+    final = _responses_final_response()
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [SimpleNamespace(type="response.completed", response=final)], final
+        )
+    )
+    await OpenAIBackend(client).complete(
+        model="gpt-5.6-luna",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        temperature=0.2,
+        extra_params={
+            "api_mode": "responses",
+            "top_p": 0.7,
+            "timeout": "12.5",
+            "extra_body": {"operator": "wins"},
+            "extra_headers": {"x-request": "yes"},
+            "extra_query": {"trace": "abc"},
+        },
+    )
+    call = client.responses.stream.call_args.kwargs
+    assert call["temperature"] == 0.2
+    assert call["top_p"] == 0.7
+    assert call["timeout"] == 12.5
+    assert call["extra_body"] == {"operator": "wins"}
+    assert call["extra_headers"] == {"x-request": "yes"}
+    assert call["extra_query"] == {"trace": "abc"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "incomplete_details", "expected_finish"),
+    [
+        ("completed", None, "stop"),
+        ("incomplete", SimpleNamespace(reason="max_output_tokens"), "length"),
+    ],
+    ids=["completed", "max-output-incomplete"],
+)
+async def test_responses_status_maps_success_and_length(
+    status: str,
+    incomplete_details: Any,
+    expected_finish: str,
+) -> None:
+    client = Mock()
+    final = _responses_final_response()
+    final.status = status
+    final.incomplete_details = incomplete_details
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [SimpleNamespace(type="response.completed", response=final)], final
+        )
+    )
+
+    result = await OpenAIBackend(client).complete(
+        model="gpt-5.6-luna",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+        extra_params={"api_mode": "responses"},
+    )
+
+    assert result.finish_reason == expected_finish
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["failed", "cancelled", "in_progress"])
+async def test_responses_status_failures_raise(status: str) -> None:
+    client = Mock()
+    final = _responses_final_response()
+    final.status = status
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [SimpleNamespace(type="response.completed", response=final)], final
+        )
+    )
+
+    with pytest.raises(ValidationException, match="non-success status"):
+        await OpenAIBackend(client).complete(
+            model="gpt-5.6-luna",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            extra_params={"api_mode": "responses"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_responses_refusal_is_explicit() -> None:
+    client = Mock()
+    final = _responses_final_response(text="")
+    final.status = "refused"
+    final.refusal = "unsafe request"
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [SimpleNamespace(type="response.completed", response=final)], final
+        )
+    )
+
+    with pytest.raises(ValidationException, match="provider refusal"):
+        await OpenAIBackend(client).complete(
+            model="gpt-5.6-luna",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            extra_params={"api_mode": "responses"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_responses_completed_output_refusal_raises() -> None:
+    client = Mock()
+    refusal_message = ResponseOutputMessage(
+        id="msg_refusal",
+        content=[ResponseOutputRefusal(type="refusal", refusal="unsafe request")],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+    final = _responses_final_response(text="", output=[refusal_message])
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [SimpleNamespace(type="response.completed", response=final)], final
+        )
+    )
+
+    with pytest.raises(ValidationException, match="^Responses provider refusal$"):
+        await OpenAIBackend(client).complete(
+            model="gpt-5.6-luna",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            extra_params={"api_mode": "responses"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_responses_refusal_error_does_not_expose_provider_payload() -> None:
+    client = Mock()
+    provider_payload = "secret-token\r\nforged-log-line" * 30
+    refusal_message = ResponseOutputMessage(
+        id="msg_sensitive_refusal",
+        content=[ResponseOutputRefusal(type="refusal", refusal=provider_payload)],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+    final = _responses_final_response(text="", output=[refusal_message])
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [SimpleNamespace(type="response.completed", response=final)], final
+        )
+    )
+
+    with pytest.raises(ValidationException) as exc_info:
+        await OpenAIBackend(client).complete(
+            model="gpt-5.6-luna",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            extra_params={"api_mode": "responses"},
+        )
+
+    error_text = str(exc_info.value)
+    assert error_text == "Responses provider refusal"
+    assert provider_payload not in error_text
+    assert "\r" not in error_text
+    assert "\n" not in error_text
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_output_refusal_raises_without_terminal_chunk() -> None:
+    client = Mock()
+    refusal_message = ResponseOutputMessage(
+        id="msg_refusal",
+        content=[ResponseOutputRefusal(type="refusal", refusal="unsafe request")],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+    # The Codex Responses endpoint can omit output from the completed response,
+    # so the adapter must preserve refusal output-item events for validation.
+    final = _responses_final_response(text="", output=[])
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [
+                SimpleNamespace(type="response.output_item.done", item=refusal_message),
+                SimpleNamespace(type="response.completed", response=final),
+            ],
+            final,
+        )
+    )
+
+    chunks: list[StreamChunk] = []
+    with pytest.raises(ValidationException, match="^Responses provider refusal$"):
+        async for chunk in OpenAIBackend(client).stream(
+            model="gpt-5.6-luna",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            extra_params={"api_mode": "responses"},
+        ):
+            chunks.append(chunk)
+
+    assert not any(chunk.is_done for chunk in chunks)
+
+
+@pytest.mark.parametrize(
+    ("tool_choice", "expected"),
+    [
+        ("any", "required"),
+        ("required", "required"),
+        ("auto", "auto"),
+        ("none", "none"),
+        (
+            {"type": "function", "function": {"name": "lookup"}},
+            {"type": "function", "name": "lookup"},
+        ),
+    ],
+    ids=["any", "required", "auto", "none", "named"],
+)
+def test_responses_tool_choice_uses_flat_named_function_shape(
+    tool_choice: Any,
+    expected: Any,
+) -> None:
+    params = OpenAIBackend(Mock())._build_responses_params(  # pyright: ignore[reportPrivateUsage]
+        model="gpt-5.6-luna",
+        messages=[{"role": "user", "content": "Look up"}],
+        max_tokens=100,
+        tools=[
+            {
+                "name": "lookup",
+                "description": "Look up a topic",
+                "input_schema": {"type": "object", "properties": {}},
+            }
+        ],
+        tool_choice=tool_choice,
+        response_format=None,
+        thinking_effort=None,
+        extra_params={"api_mode": "responses"},
+    )
+    assert params["tool_choice"] == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"stop": ["END"]},
+        {"extra_params": {"api_mode": "responses", "presence_penalty": 0.2}},
+        {"extra_params": {"api_mode": "responses", "frequency_penalty": 0.2}},
+        {"extra_params": {"api_mode": "responses", "seed": 7}},
+        {"thinking_budget_tokens": 32},
+    ],
+    ids=["stop", "presence-penalty", "frequency-penalty", "seed", "thinking-budget"],
+)
+async def test_responses_rejects_unsupported_options_before_provider_call(
+    kwargs: dict[str, Any],
+) -> None:
+    client = Mock()
+    client.responses.stream = Mock()
+    call_kwargs: dict[str, Any] = {
+        "model": "gpt-5.6-luna",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "max_tokens": 100,
+        "extra_params": {"api_mode": "responses"},
+    }
+    call_kwargs.update(kwargs)
+
+    with pytest.raises(ValidationException, match="does not support"):
+        await OpenAIBackend(client).complete(**call_kwargs)
+    client.responses.stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["failed", "cancelled"])
+async def test_responses_stream_status_failures_raise(status: str) -> None:
+    client = Mock()
+    final = _responses_final_response(text="partial")
+    final.status = status
+    event_type = f"response.{status}"
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [SimpleNamespace(type=event_type, response=final)], final
+        )
+    )
+
+    with pytest.raises(ValidationException, match="non-success status"):
+        _ = [
+            chunk
+            async for chunk in OpenAIBackend(client).stream(
+                model="gpt-5.6-luna",
+                messages=[{"role": "user", "content": "Hello"}],
+                max_tokens=100,
+                extra_params={"api_mode": "responses"},
+            )
+        ]
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_fallback_emits_one_terminal_chunk_without_usage() -> (
+    None
+):
+    client = Mock()
+    final = _responses_final_response(text="hello")
+    final.usage = None
+    client.responses.stream = Mock(
+        return_value=_FakeResponsesStream(
+            [
+                SimpleNamespace(type="response.output_text.delta", delta="hel"),
+                SimpleNamespace(type="response.output_text.delta", delta="lo"),
+            ],
+            final,
+        )
+    )
+
+    chunks = [
+        chunk
+        async for chunk in OpenAIBackend(client).stream(
+            model="gpt-5.6-luna",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=100,
+            extra_params={"api_mode": "responses"},
+        )
+    ]
+
+    assert [chunk.content for chunk in chunks if chunk.content] == ["hel", "lo"]
+    terminal = [chunk for chunk in chunks if chunk.is_done]
+    assert len(terminal) == 1
+    assert terminal[0].finish_reason == "stop"
+    assert terminal[0].output_tokens is None

--- a/tests/llm/test_request_builder.py
+++ b/tests/llm/test_request_builder.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from src.config import ModelConfig
 from src.exceptions import ValidationException
 from src.llm.caching import PromptCachePolicy
-from src.llm.request_builder import execute_completion
+from src.llm.request_builder import execute_completion, execute_stream
 from tests.llm.conftest import FakeBackend
 
 
@@ -94,6 +94,31 @@ async def test_provider_params_are_merged_into_extra_params(
         max_tokens=100,
     )
 
+    call = fake_backend.calls[0]
+    assert call["extra_params"]["top_p"] == 0.9
+    assert call["extra_params"]["custom_flag"] is True
+
+
+async def test_provider_params_are_merged_into_stream_extra_params(
+    fake_backend: FakeBackend,
+) -> None:
+    """The shared config translation also reaches the streaming backend call."""
+    config = ModelConfig(
+        model="gpt-4.1-mini",
+        transport="openai",
+        top_p=0.9,
+        provider_params={"custom_flag": True},
+    )
+
+    stream = await execute_stream(
+        fake_backend,
+        config,
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=100,
+    )
+    chunks = [chunk async for chunk in stream]
+
+    assert len(chunks) == 1
     call = fake_backend.calls[0]
     assert call["extra_params"]["top_p"] == 0.9
     assert call["extra_params"]["custom_flag"] is True

--- a/tests/utils/test_clients.py
+++ b/tests/utils/test_clients.py
@@ -10,6 +10,8 @@ Tests cover:
 """
 
 import contextlib
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -47,6 +49,60 @@ class SampleTestModel(BaseModel):
     name: str
     age: int
     active: bool = Field(default=True)
+
+
+class _PublicResponsesStream:
+    """Minimal Responses stream used to exercise the public retry boundary."""
+
+    _events: list[Any]
+    _final_response: Any
+
+    def __init__(self, events: list[Any], final_response: Any) -> None:
+        self._events = events
+        self._final_response = final_response
+
+    async def __aenter__(self) -> "_PublicResponsesStream":
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        return None
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        async def _iter() -> AsyncIterator[Any]:
+            for event in self._events:
+                yield event
+
+        return _iter()
+
+    async def get_final_response(self) -> Any:
+        return self._final_response
+
+
+def _public_responses_terminal(
+    status: str,
+    *,
+    refusal: str | None = None,
+    incomplete_reason: str | None = None,
+) -> SimpleNamespace:
+    output = []
+    if refusal is not None:
+        output = [
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="refusal", refusal=refusal)],
+            )
+        ]
+    return SimpleNamespace(
+        status=status,
+        output_text="",
+        output=output,
+        incomplete_details=(
+            SimpleNamespace(reason=incomplete_reason)
+            if incomplete_reason is not None
+            else None
+        ),
+        usage=SimpleNamespace(input_tokens=1, output_tokens=0),
+    )
 
 
 class TestLLMCallResponse:
@@ -888,6 +944,230 @@ class TestMainLLMCallFunction:
             assert chunks[0].content == "Stream"
             assert chunks[1].content == " test"
             assert chunks[2].is_done is True
+
+    async def test_responses_refusal_before_text_is_unretried_during_drain(self):
+        """Retry wraps stream setup, not an explicit refusal found while draining."""
+        response = _public_responses_terminal("completed", refusal="unsafe")
+        mock_client = Mock()
+        mock_client.responses.stream = Mock(
+            return_value=_PublicResponsesStream(
+                [SimpleNamespace(type="response.completed", response=response)],
+                response,
+            )
+        )
+
+        with patch.dict(CLIENTS, {"openai": mock_client}):
+            stream = await honcho_llm_call(
+                model_config=ModelConfig(
+                    model="gpt-5.4-mini",
+                    transport="openai",
+                    provider_params={"api_mode": "responses"},
+                ),
+                prompt="Hello",
+                max_tokens=100,
+                stream=True,
+                enable_retry=True,
+                retry_attempts=3,
+            )
+            chunks: list[HonchoLLMCallStreamChunk] = []
+            with pytest.raises(ValidationException, match="provider refusal"):
+                async for chunk in stream:
+                    chunks.append(chunk)
+
+        assert mock_client.responses.stream.call_count == 1
+        assert chunks == []
+
+    @pytest.mark.parametrize(
+        ("status", "event_type", "incomplete_reason"),
+        [
+            ("failed", "response.failed", None),
+            ("cancelled", "response.cancelled", None),
+            ("queued", "response.queued", None),
+            ("incomplete", "response.incomplete", "content_filter"),
+        ],
+    )
+    async def test_responses_drain_status_failures_are_explicit_and_unretried(
+        self,
+        status: str,
+        event_type: str,
+        incomplete_reason: str | None,
+    ) -> None:
+        response = _public_responses_terminal(
+            status, incomplete_reason=incomplete_reason
+        )
+        mock_client = Mock()
+        mock_client.responses.stream = Mock(
+            return_value=_PublicResponsesStream(
+                [SimpleNamespace(type=event_type, response=response)],
+                response,
+            )
+        )
+
+        with patch.dict(CLIENTS, {"openai": mock_client}):
+            stream = await honcho_llm_call(
+                model_config=ModelConfig(
+                    model="gpt-5.4-mini",
+                    transport="openai",
+                    provider_params={"api_mode": "responses"},
+                ),
+                prompt="Hello",
+                max_tokens=100,
+                stream=True,
+                enable_retry=True,
+                retry_attempts=3,
+            )
+            chunks: list[HonchoLLMCallStreamChunk] = []
+            with pytest.raises(
+                ValidationException,
+                match=f"non-success status: {status}",
+            ):
+                async for chunk in stream:
+                    chunks.append(chunk)
+
+        assert mock_client.responses.stream.call_count == 1
+        assert chunks == []
+
+    async def test_responses_refusal_after_text_never_retries_or_emits_done(self):
+        """Visible text cannot be retracted, so a later refusal fails in place."""
+        response = _public_responses_terminal("completed", refusal="unsafe")
+        mock_client = Mock()
+        mock_client.responses.stream = Mock(
+            return_value=_PublicResponsesStream(
+                [
+                    SimpleNamespace(type="response.output_text.delta", delta="partial"),
+                    SimpleNamespace(type="response.completed", response=response),
+                ],
+                response,
+            )
+        )
+
+        with patch.dict(CLIENTS, {"openai": mock_client}):
+            stream = await honcho_llm_call(
+                model_config=ModelConfig(
+                    model="gpt-5.4-mini",
+                    transport="openai",
+                    provider_params={"api_mode": "responses"},
+                ),
+                prompt="Hello",
+                max_tokens=100,
+                stream=True,
+                enable_retry=True,
+                retry_attempts=3,
+            )
+            chunks: list[HonchoLLMCallStreamChunk] = []
+            with pytest.raises(ValidationException, match="provider refusal"):
+                async for chunk in stream:
+                    chunks.append(chunk)
+
+        assert mock_client.responses.stream.call_count == 1
+        assert [chunk.content for chunk in chunks] == ["partial"]
+        assert not any(chunk.is_done for chunk in chunks)
+
+    async def test_stream_final_only_runs_tool_turns_non_streaming(self):
+        """The public stream-final-only path keeps tools off the final stream."""
+        from openai import AsyncOpenAI
+
+        mock_client = AsyncMock(spec=AsyncOpenAI)
+        tool_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="tool_calls",
+                    message=SimpleNamespace(
+                        content="",
+                        tool_calls=[
+                            SimpleNamespace(
+                                id="call_1",
+                                function=SimpleNamespace(
+                                    name="lookup", arguments='{"q":"memory"}'
+                                ),
+                            )
+                        ],
+                        reasoning_details=[],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=3,
+                completion_tokens=2,
+                prompt_tokens_details=None,
+            ),
+        )
+        answer_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        content="The answer",
+                        tool_calls=[],
+                        reasoning_details=[],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=4,
+                completion_tokens=3,
+                prompt_tokens_details=None,
+            ),
+        )
+
+        async def final_stream():
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="Final answer"),
+                        finish_reason=None,
+                    )
+                ]
+            )
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content=None), finish_reason="stop"
+                    )
+                ],
+                usage=SimpleNamespace(completion_tokens=5),
+            )
+
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[tool_response, answer_response, final_stream()]
+        )
+        executed_tools: list[tuple[str, dict[str, Any]]] = []
+
+        async def execute_tool(name: str, arguments: dict[str, Any]) -> str:
+            executed_tools.append((name, arguments))
+            return "lookup result"
+
+        with patch.dict(CLIENTS, {"openai": mock_client}):
+            stream = await honcho_llm_call(
+                model_config=ModelConfig(model="gpt-4.1", transport="openai"),
+                prompt="Find the memory",
+                max_tokens=100,
+                stream=True,
+                stream_final_only=True,
+                tools=[
+                    {
+                        "name": "lookup",
+                        "description": "Look up a memory",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {"q": {"type": "string"}},
+                        },
+                    }
+                ],
+                tool_executor=execute_tool,
+                enable_retry=False,
+            )
+            chunks = [chunk async for chunk in stream]
+
+        assert executed_tools == [("lookup", {"q": "memory"})]
+        calls = mock_client.chat.completions.create.call_args_list
+        assert len(calls) == 3
+        assert "tools" in calls[0].kwargs
+        assert "tools" in calls[1].kwargs
+        assert "tools" not in calls[2].kwargs
+        assert "tool_choice" not in calls[2].kwargs
+        assert [chunk.content for chunk in chunks if chunk.content] == ["Final answer"]
+        assert chunks[-1].is_done is True
 
     async def test_retry_disabled(self):
         """Test that retry can be disabled"""


### PR DESCRIPTION
## Summary

Forward-ports the custom opt-in OpenAI Responses transport onto current Honcho 3.0.12 upstream while preserving Chat Completions as the default.

- adds `api_mode="responses"` routing for completion and streaming
- preserves tools, structured output, usage/cache accounting, reasoning details, status/refusal handling, and dictionary/SDK-shaped event compatibility
- retains upstream scope backfill/removal and deriver polling-backoff changes
- preserves the inherited streaming boundary: pre-iterator setup may retry; deferred SDK acquisition, context entry, and drain are unretried

## Review fixes included

- sanitizes provider refusal errors so provider-controlled text cannot reach logs or public error responses
- replays Responses reasoning items during stateless tool continuations (`store=False`)

Both fixes were added under RED → GREEN regressions.

## Validation

- focused Responses/request/client suite: `156 passed`
- full pytest: `2085 passed, 40 skipped`
- BasedPyright on touched source/tests: `0 errors, 0 warnings, 0 notes`
- Ruff check on touched source/tests: passed
- Ruff format on touched files: unchanged
- `git diff --check`: passed

## Known unrelated baseline issues

- full-tree Ruff formatting reports 26 untouched files on both the upstream base and this candidate
- Alembic executes all 25 migrations, then the shared fixture teardown reports the same five leaked sessions on the upstream base and this candidate

## Narrow follow-up notes

Independent reviewers also suggested broader hardening for output-item-only text reconstruction, multipart message input, malformed tool arguments, and terminal-payload reconciliation. Those behaviors predate this forward-port and are intentionally not expanded in this PR.

## CI / review gate

Do not merge until:

- unit/static PR checks pass
- one maintainer approval is recorded
- an authorized CODEOWNER triggers and passes `Unified Tests (Fly Runner)` with the `run-unified-tests` label

No production or main-branch mutation is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAI’s Responses API.
  * Supports structured outputs, JSON mode, tool calls, reasoning, refusals, usage details, and streaming responses.
  * Preserves streamed text when a response ends with a refusal or unsuccessful status.
  * Supports replaying reasoning and handling intermediate tool calls during streamed interactions.

* **Bug Fixes**
  * Provider parameters, including `top_p` and custom options, are now preserved for streaming requests.
  * Unsupported options and unsuccessful responses now return clear validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->