### PR TITLE
docs: add DeepSeek Harness integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ hermes memory setup   # select "honcho", point at api.honcho.dev or your local s
 
 Details: [Hermes guide](https://honcho.dev/docs/v3/guides/integrations/hermes).
 
+### DeepSeek Harness
+
+```bash
+dsh plugin --profile web add link:https://github.com/nanpaidashi/dsh-honcho-sync dsh web
+```
+
+Auto-syncs every conversation turn to Honcho with built-in recall, search, remember, and context tools. Configure via the visual settings panel (DSH Settings → "Honcho Memory") — no YAML editing required. Details: [dsh-honcho-sync](https://github.com/nanpaidashi/dsh-honcho-sync).
+
 ### Add Honcho to your own codebase (agent skill)
 
 For wiring the Honcho SDK into an existing application, install the integration skill — it explores your codebase, asks about integration preferences, generates the SDK setup, and verifies it works:


### PR DESCRIPTION
## Summary

Add [dsh-honcho-sync](https://github.com/nanpaidashi/dsh-honcho-sync) to the Integrations section of the README.

**What it does:**
- Auto-syncs every conversation turn to Honcho (debounced, with deduplication)
- Provides built-in AI tools: `honcho_recall`, `honcho_search`, `honcho_remember`, `honcho_context`, `honcho_status`
- Visual settings panel in DSH (Settings → Honcho Memory) — no YAML editing required
- Context auto-injection on session start

**Installation:**
```bash
dsh plugin --profile web add link:https://github.com/nanpaidashi/dsh-honcho-sync dsh web
```

This follows the same pattern as the existing Hermes, OpenClaw, and OpenCode integrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added integration guidance for DeepSeek Harness.
  * Included installation instructions, automatic conversation synchronization details, available memory tools, and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->