### PR TITLE
feat(conclusions): support cross-peer semantic query on the pgvector backend

### DIFF
--- a/src/crud/document.py
+++ b/src/crud/document.py
@@ -291,22 +291,28 @@ async def fetch_documents_by_ids(
 async def _query_documents_pgvector(
     db: AsyncSession,
     workspace_name: str,
-    observer: str,
-    observed: str,
+    observer: str | None,
+    observed: str | None,
     embedding: list[float],
     filters: dict[str, Any] | None,
     max_distance: float | None,
     top_k: int,
 ) -> list[models.Document]:
-    """pgvector similarity search — pure DB operation."""
+    """pgvector similarity search — pure DB operation.
+
+    A None observer/observed omits that constraint, so omitting both searches
+    across all peer relationships in the workspace (cross-peer search, #520).
+    """
     stmt = (
         select(models.Document)
         .where(models.Document.workspace_name == workspace_name)
-        .where(models.Document.observer == observer)
-        .where(models.Document.observed == observed)
         .where(models.Document.embedding.isnot(None))
         .where(models.Document.deleted_at.is_(None))
     )
+    if observer is not None:
+        stmt = stmt.where(models.Document.observer == observer)
+    if observed is not None:
+        stmt = stmt.where(models.Document.observed == observed)
 
     if max_distance is not None:
         stmt = stmt.where(
@@ -327,8 +333,8 @@ async def query_documents(
     workspace_name: str,
     query: str,
     *,
-    observer: str,
-    observed: str,
+    observer: str | None = None,
+    observed: str | None = None,
     filters: dict[str, Any] | None = None,
     max_distance: float | None = None,
     top_k: int = 5,
@@ -345,8 +351,12 @@ async def query_documents(
         db: Database session, or None to let the function manage its own
         workspace_name: Name of the workspace
         query: Search query text
-        observer: Name of the observing peer
-        observed: Name of the observed peer
+        observer: Name of the observing peer. Optional on the pgvector backend
+            (omitting it searches across observers); required on external
+            vector stores.
+        observed: Name of the observed peer. Optional on the pgvector backend
+            (omitting it searches across observed peers); required on external
+            vector stores.
         filters: Optional filters to apply at vector store level (supports: level, session_name)
         max_distance: Maximum cosine distance for results
         top_k: Number of results to return
@@ -354,6 +364,11 @@ async def query_documents(
 
     Returns:
         Sequence of matching documents
+
+    Raises:
+        ValidationException: If observer or observed is omitted on a deployment
+            using an external vector store, or the query exceeds the embedding
+            token limit.
     """
     if top_k <= 0:
         return []
@@ -396,7 +411,17 @@ async def query_documents(
                 managed_db.expunge(doc)
             return docs
 
-    # External vector store — network call first, DB only for the ID fetch
+    # External vector store — network call first, DB only for the ID fetch.
+    # Namespaces are derived from the (workspace, observer, observed) triple,
+    # so a cross-peer query would need a fan-out across namespaces; require
+    # both until that is supported (#520).
+    if observer is None or observed is None:
+        raise ValidationException(
+            "Cross-peer semantic search is only supported on the pgvector "
+            + "backend. This deployment uses an external vector store, which "
+            + "requires both 'observer' and 'observed' to be specified."
+        )
+
     document_ids = await query_external_vector_document_ids(
         workspace_name=workspace_name,
         observer=observer,

--- a/src/routers/conclusions.py
+++ b/src/routers/conclusions.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, schemas
 from src.dependencies import db, read_db
-from src.exceptions import ResourceNotFoundException, ValidationException
+from src.exceptions import ResourceNotFoundException
 from src.security import require_auth
 from src.telemetry.events import EmbeddingCallPurpose
 from src.utils.types import embedding_call_purpose
@@ -108,13 +108,10 @@ async def query_conclusions(
         observer = body.filters.get("observer") or body.filters.get("observer_id")
         observed = body.filters.get("observed") or body.filters.get("observed_id")
 
-    if not observer or not observed:
-        raise ValidationException(
-            "observer and observed must be specified for semantic search. "
-            + "Pass them inside the 'filters' object, e.g. "
-            + '{"query": "...", "filters": {"observer": "alice", "observed": "bob"}}. '
-            + "Both 'observer'/'observer_id' and 'observed'/'observed_id' are accepted."
-        )
+    # observer/observed may be omitted on the pgvector backend, in which case
+    # the query searches across all peer relationships in the workspace
+    # (cross-peer search). crud.query_documents raises a 422 for external
+    # vector store deployments, where both are still required.
 
     with embedding_call_purpose(
         EmbeddingCallPurpose.GENERIC_DOCUMENT_SEARCH.value,

--- a/tests/crud/test_document.py
+++ b/tests/crud/test_document.py
@@ -7,8 +7,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, models, schemas
+from src.config import settings
 from src.crud.document import SemanticRejectionResult, is_rejected_duplicate
-from src.exceptions import ResourceNotFoundException
+from src.exceptions import ResourceNotFoundException, ValidationException
 
 
 class TestDocumentCRUD:
@@ -275,6 +276,118 @@ class TestDocumentCRUD:
 
         assert len(results) == 1
         assert results[0].id == times_derived_map[2]
+
+    @pytest.mark.asyncio
+    async def test_query_documents_cross_peer_pgvector(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Omitting observer/observed searches across all peer relationships"""
+        test_workspace, test_peer = sample_data
+        test_peer2, test_session, _ = await self._setup_test_data(
+            db_session, test_workspace, test_peer
+        )
+
+        # A second, distinct (observer, observed) pair with its own collection
+        test_peer3 = models.Peer(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        db_session.add(test_peer3)
+        await db_session.flush()
+        db_session.add(
+            models.Collection(
+                workspace_name=test_workspace.name,
+                observer=test_peer3.name,
+                observed=test_peer2.name,
+            )
+        )
+        await db_session.flush()
+
+        await crud.create_documents(
+            db_session,
+            [
+                schemas.DocumentCreate(
+                    content="User likes pizza",
+                    embedding=[0.9] * 1536,
+                    session_name=test_session.name,
+                    metadata=schemas.DocumentMetadata(
+                        message_ids=[1],
+                        message_created_at="2025-01-01T00:00:00Z",
+                    ),
+                ),
+            ],
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer2.name,
+        )
+        await crud.create_documents(
+            db_session,
+            [
+                schemas.DocumentCreate(
+                    content="Teammate enjoys hiking",
+                    embedding=[0.8] * 1536,
+                    session_name=test_session.name,
+                    metadata=schemas.DocumentMetadata(
+                        message_ids=[2],
+                        message_created_at="2025-01-01T00:00:00Z",
+                    ),
+                ),
+            ],
+            workspace_name=test_workspace.name,
+            observer=test_peer3.name,
+            observed=test_peer2.name,
+        )
+
+        # Cross-peer: no observer/observed returns documents from both pairs
+        results = await crud.query_documents(
+            db_session,
+            workspace_name=test_workspace.name,
+            query="food preferences",
+            top_k=10,
+        )
+        contents = {doc.content for doc in results}
+        assert "User likes pizza" in contents
+        assert "Teammate enjoys hiking" in contents
+
+        # Partially scoped: only observer given returns just that observer's docs
+        results = await crud.query_documents(
+            db_session,
+            workspace_name=test_workspace.name,
+            query="food preferences",
+            observer=test_peer3.name,
+            top_k=10,
+        )
+        contents = {doc.content for doc in results}
+        assert "Teammate enjoys hiking" in contents
+        assert "User likes pizza" not in contents
+
+    @pytest.mark.asyncio
+    async def test_query_documents_external_store_requires_observer_observed(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """External vector stores still require observer and observed"""
+        test_workspace, _test_peer = sample_data
+        monkeypatch.setattr(settings.VECTOR_STORE, "MIGRATED", True)
+        monkeypatch.setattr(settings.VECTOR_STORE, "TYPE", "external")
+
+        # Both omitted, and each parameter omitted on its own, all 422
+        for kwargs in (
+            {},
+            {"observer": "some-peer"},
+            {"observed": "some-peer"},
+        ):
+            with pytest.raises(ValidationException, match="Cross-peer"):
+                await crud.query_documents(
+                    db_session,
+                    workspace_name=test_workspace.name,
+                    query="food preferences",
+                    top_k=10,
+                    **kwargs,
+                )
 
     @pytest.mark.asyncio
     async def test_most_derived_orders_by_recency_when_reinforcement_ties(

--- a/tests/crud/test_document.py
+++ b/tests/crud/test_document.py
@@ -363,6 +363,206 @@ class TestDocumentCRUD:
         assert "User likes pizza" not in contents
 
     @pytest.mark.asyncio
+    async def test_query_documents_cross_peer_never_crosses_workspace(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Cross-peer search must never return another workspace's documents,
+        even when the foreign document's embedding would rank first (#520)."""
+        test_workspace, test_peer = sample_data
+        test_peer2, test_session, _ = await self._setup_test_data(
+            db_session, test_workspace, test_peer
+        )
+
+        # A second, distinct (observer, observed) pair in the same workspace
+        test_peer3 = models.Peer(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        db_session.add(test_peer3)
+        await db_session.flush()
+        db_session.add(
+            models.Collection(
+                workspace_name=test_workspace.name,
+                observer=test_peer3.name,
+                observed=test_peer2.name,
+            )
+        )
+        await db_session.flush()
+
+        # A different workspace with its own (observer, observed) pair
+        other_workspace = models.Workspace(name=str(generate_nanoid()))
+        db_session.add(other_workspace)
+        await db_session.flush()
+        other_observer = models.Peer(
+            name=str(generate_nanoid()), workspace_name=other_workspace.name
+        )
+        other_observed = models.Peer(
+            name=str(generate_nanoid()), workspace_name=other_workspace.name
+        )
+        db_session.add_all([other_observer, other_observed])
+        await db_session.flush()
+        other_session = models.Session(
+            name=str(generate_nanoid()), workspace_name=other_workspace.name
+        )
+        db_session.add(other_session)
+        await db_session.flush()
+        db_session.add(
+            models.Collection(
+                workspace_name=other_workspace.name,
+                observer=other_observer.name,
+                observed=other_observed.name,
+            )
+        )
+        await db_session.flush()
+
+        await crud.create_documents(
+            db_session,
+            [
+                schemas.DocumentCreate(
+                    content="User likes pizza",
+                    embedding=[0.9] * 1536,
+                    session_name=test_session.name,
+                    metadata=schemas.DocumentMetadata(
+                        message_ids=[1],
+                        message_created_at="2025-01-01T00:00:00Z",
+                    ),
+                ),
+            ],
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer2.name,
+        )
+        await crud.create_documents(
+            db_session,
+            [
+                schemas.DocumentCreate(
+                    content="Teammate enjoys hiking",
+                    embedding=[0.8] * 1536,
+                    session_name=test_session.name,
+                    metadata=schemas.DocumentMetadata(
+                        message_ids=[2],
+                        message_created_at="2025-01-01T00:00:00Z",
+                    ),
+                ),
+            ],
+            workspace_name=test_workspace.name,
+            observer=test_peer3.name,
+            observed=test_peer2.name,
+        )
+        # Foreign-workspace document with the same embedding as the first
+        # pair's, so a missing workspace predicate would surface it here.
+        await crud.create_documents(
+            db_session,
+            [
+                schemas.DocumentCreate(
+                    content="Stranger collects stamps",
+                    embedding=[0.9] * 1536,
+                    session_name=other_session.name,
+                    metadata=schemas.DocumentMetadata(
+                        message_ids=[3],
+                        message_created_at="2025-01-01T00:00:00Z",
+                    ),
+                ),
+            ],
+            workspace_name=other_workspace.name,
+            observer=other_observer.name,
+            observed=other_observed.name,
+        )
+
+        results = await crud.query_documents(
+            db_session,
+            workspace_name=test_workspace.name,
+            query="food preferences",
+            top_k=10,
+        )
+        contents = {doc.content for doc in results}
+        assert "User likes pizza" in contents
+        assert "Teammate enjoys hiking" in contents
+        assert "Stranger collects stamps" not in contents
+        assert all(doc.workspace_name == test_workspace.name for doc in results)
+
+    @pytest.mark.asyncio
+    async def test_query_documents_cross_peer_observed_only(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """Passing only observed scopes the cross-peer search to documents
+        about that observed peer (#520)."""
+        test_workspace, test_peer = sample_data
+        test_peer2, test_session, _ = await self._setup_test_data(
+            db_session, test_workspace, test_peer
+        )
+
+        # A second (observer, observed) pair sharing neither peer with the first
+        test_peer3 = models.Peer(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        test_peer4 = models.Peer(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        db_session.add_all([test_peer3, test_peer4])
+        await db_session.flush()
+        db_session.add(
+            models.Collection(
+                workspace_name=test_workspace.name,
+                observer=test_peer3.name,
+                observed=test_peer4.name,
+            )
+        )
+        await db_session.flush()
+
+        await crud.create_documents(
+            db_session,
+            [
+                schemas.DocumentCreate(
+                    content="User likes pizza",
+                    embedding=[0.9] * 1536,
+                    session_name=test_session.name,
+                    metadata=schemas.DocumentMetadata(
+                        message_ids=[1],
+                        message_created_at="2025-01-01T00:00:00Z",
+                    ),
+                ),
+            ],
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer2.name,
+        )
+        await crud.create_documents(
+            db_session,
+            [
+                schemas.DocumentCreate(
+                    content="Teammate enjoys hiking",
+                    embedding=[0.8] * 1536,
+                    session_name=test_session.name,
+                    metadata=schemas.DocumentMetadata(
+                        message_ids=[2],
+                        message_created_at="2025-01-01T00:00:00Z",
+                    ),
+                ),
+            ],
+            workspace_name=test_workspace.name,
+            observer=test_peer3.name,
+            observed=test_peer4.name,
+        )
+
+        # Observed-only: returns docs about test_peer2, never docs about a
+        # different observed peer.
+        results = await crud.query_documents(
+            db_session,
+            workspace_name=test_workspace.name,
+            query="food preferences",
+            observed=test_peer2.name,
+            top_k=10,
+        )
+        contents = {doc.content for doc in results}
+        assert "User likes pizza" in contents
+        assert "Teammate enjoys hiking" not in contents
+        assert all(doc.observed == test_peer2.name for doc in results)
+
+    @pytest.mark.asyncio
     async def test_query_documents_external_store_requires_observer_observed(
         self,
         db_session: AsyncSession,

--- a/tests/routes/test_conclusions.py
+++ b/tests/routes/test_conclusions.py
@@ -4,6 +4,7 @@ from nanoid import generate as generate_nanoid
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import models
+from src.config import settings
 from src.models import Peer, Workspace
 
 
@@ -511,14 +512,24 @@ class TestConclusionRoutes:
         assert isinstance(data, list)
 
     @pytest.mark.asyncio
-    async def test_query_conclusions_requires_observer_observed(
+    async def test_query_conclusions_cross_peer_pgvector(
         self,
         client: TestClient,
         db_session: AsyncSession,
         sample_data: tuple[Workspace, Peer],
     ):
-        """Test query conclusions requires observer and observed in filters"""
-        test_workspace, _test_peer = sample_data
+        """Omitting observer/observed searches across peer relationships (pgvector)"""
+        test_workspace, test_peer = sample_data
+
+        # Two more peers so two distinct (observer, observed) pairs exist
+        test_peer2 = models.Peer(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        test_peer3 = models.Peer(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        db_session.add_all([test_peer2, test_peer3])
+        await db_session.flush()
 
         # Create a session
         test_session = models.Session(
@@ -527,10 +538,64 @@ class TestConclusionRoutes:
         db_session.add(test_session)
         await db_session.commit()
 
-        # Query without observer/observed filters should fail
+        # Create conclusions for two different observer/observed pairs
+        create_response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/conclusions",
+            json={
+                "conclusions": [
+                    {
+                        "content": "User loves pizza and pasta",
+                        "observer_id": test_peer.name,
+                        "observed_id": test_peer2.name,
+                        "session_id": test_session.name,
+                    },
+                    {
+                        "content": "Teammate enjoys hiking on weekends",
+                        "observer_id": test_peer3.name,
+                        "observed_id": test_peer2.name,
+                        "session_id": test_session.name,
+                    },
+                ]
+            },
+        )
+        assert create_response.status_code == 201
+
+        # Query without observer/observed filters returns both pairs' conclusions
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/conclusions/query",
+            json={"query": "food preferences", "top_k": 10},
+        )
+
+        assert response.status_code == 200
+        contents = {c["content"] for c in response.json()}
+        assert "User loves pizza and pasta" in contents
+        assert "Teammate enjoys hiking on weekends" in contents
+
+    @pytest.mark.asyncio
+    async def test_query_conclusions_cross_peer_external_store_requires_observer_observed(
+        self,
+        client: TestClient,
+        db_session: AsyncSession,
+        sample_data: tuple[Workspace, Peer],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """External vector stores still require observer and observed (422)"""
+        test_workspace, _test_peer = sample_data
+        monkeypatch.setattr(settings.VECTOR_STORE, "MIGRATED", True)
+        monkeypatch.setattr(settings.VECTOR_STORE, "TYPE", "external")
+
+        # Query without observer/observed filters is rejected on external stores
         response = client.post(
             f"/v3/workspaces/{test_workspace.name}/conclusions/query",
             json={"query": "test"},
+        )
+
+        assert response.status_code == 422
+
+        # Providing only one of the two is rejected as well
+        response = client.post(
+            f"/v3/workspaces/{test_workspace.name}/conclusions/query",
+            json={"query": "test", "filters": {"observer": "some-peer"}},
         )
 
         assert response.status_code == 422


### PR DESCRIPTION
## Description

Implements the minimum viable approach scoped in #520 (pgvector-only, informative error on external stores). On pgvector deployments, `POST /v3/workspaces/{workspace_id}/conclusions/query` may now omit `observer`/`observed` in `filters` to run semantic search across all peer relationships in the workspace. External vector store deployments (Turbopuffer/LanceDB) keep the old requirement, and omitting either parameter there now returns a 422 explaining the pgvector-only limitation, since namespaces are derived from the (workspace, observer, observed) triple and cross-peer search would need a namespace fan-out.

Prior art: #492 (closed for inactivity) and #541 (closed as duplicate) attempted this before the scope was settled; this PR implements exactly the scope from the issue body. External-store fan-out is deliberately not included.

## Proofs

Tests ran in WSL (Ubuntu, Python 3.12) against a throwaway `pgvector/pgvector:pg16` Docker container with `POSTGRES_HOST_AUTH_METHOD=trust` (same as CI). The suite cannot run on native Windows: `src/telemetry/reasoning_traces.py` imports Unix-only `fcntl` at module load (pre-existing, unrelated to this change).

```
$ uv run --frozen pytest tests/crud/ tests/routes/ tests/utils/test_agent_tools.py tests/test_session_allowlist.py -q
639 passed, 106 warnings in 28.01s
```

This covers the 4 new/updated tests: cross-peer query returns documents from two distinct (observer, observed) pairs and observer-only scoping still applies (crud level); end-to-end 200 over two peer pairs and 422 when observer/observed are omitted under external-store settings (route level, monkeypatched `VECTOR_STORE` settings).

```
$ uv run ruff check src/crud/document.py src/routers/conclusions.py tests/crud/test_document.py tests/routes/test_conclusions.py
All checks passed!
$ uv run ruff format --check <same 4 files>
4 files already formatted
$ uv run basedpyright src/crud/document.py src/routers/conclusions.py
0 errors, 1 warning, 0 notes
```

(The 1 warning is pre-existing: partially unknown `apaginate` type from fastapi-pagination on an untouched line. A full-project `basedpyright` run reports 22 errors, all in `src/vector_store/lancedb.py`, `tests/vector_store/` and `tests/bench/` -- lancedb typing in this environment; none in touched files.)

Not run: the remainder of the test suite beyond the paths above, TypeScript SDK tests (no TS changes), and the pre-commit-only hooks (bandit etc.; not part of CI -- the diff introduces no asserts/exec/hardcoded secrets).

## Checklist

- [x] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.

Fixes #520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Semantic document and conclusion searches can omit peer filters with the pgvector backend, enabling cross-peer results.
  * Searches can be scoped using either peer filter independently.
  * Cross-peer results remain limited to the selected workspace.

* **Bug Fixes**
  * External vector-store searches now require both peer identifiers and return clear validation errors when either is missing.
  * Improved validation responses for unfiltered and partially filtered searches across supported backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->