### PR TITLE
fix(session): cascade delete to derived conclusions with no session_name

### DIFF
--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -16,9 +16,11 @@ from sqlalchemy import (
     exists,
     func,
     insert,
+    or_,
     select,
     update,
 )
+from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
@@ -668,11 +670,48 @@ async def delete_session(
         )
         documents = doc_result.all()
 
+        # Dreamer-produced deductive/inductive conclusions are stored with
+        # session_name=None by design (the session-purity invariant, see
+        # crud/document.py:_dedup_key) even though they were derived from this
+        # session's explicit conclusions via `source_ids`. The session_name
+        # filter above therefore can't reach them - walk `source_ids`
+        # transitively (mirrors the fail-closed cascade in
+        # deriver/scope_backfill.py:process_scope_removal) so a deduction
+        # resting on this session's evidence, and any induction resting on
+        # that deduction, are cascaded too. Document ids are globally unique
+        # nanoids, so a plain workspace-scoped `has_any` is enough - no need
+        # to further partition by (observer, observed) collection.
+        derived_documents: list[Any] = []
+        seen_derived: set[str] = set()
+        frontier = [doc.id for doc in documents]
+        while frontier:
+            derived_result = await db.execute(
+                select(
+                    models.Document.id,
+                    models.Document.observer,
+                    models.Document.observed,
+                ).where(
+                    models.Document.workspace_name == workspace_name,
+                    models.Document.level != "explicit",
+                    models.Document.source_ids.has_any(array(frontier)),
+                )
+            )
+            new_rows = [
+                row for row in derived_result.all() if row.id not in seen_derived
+            ]
+            if not new_rows:
+                break
+            seen_derived.update(row.id for row in new_rows)
+            derived_documents.extend(new_rows)
+            frontier = [row.id for row in new_rows]
+
+        all_documents = list(documents) + derived_documents
+
         # Only delete from external vector store if one exists
-        if external_vector_store is not None and documents:
+        if external_vector_store is not None and all_documents:
             # Group document IDs by namespace (observer/observed)
             docs_by_namespace: dict[str, list[str]] = {}
-            for doc in documents:
+            for doc in all_documents:
                 namespace = external_vector_store.get_vector_namespace(
                     "document",
                     workspace_name,
@@ -694,12 +733,17 @@ async def delete_session(
                         f"Failed to delete document vectors from {namespace}: {e}"
                     )
 
-        # Delete Document entries associated with this session in batches
+        # Delete Document entries associated with this session in batches,
+        # plus any derived conclusions transitively resting on this session's
+        # evidence (see comment above).
         conclusions_deleted = await _batch_delete_matching(
             db,
             models.Document,
             [
-                models.Document.session_name == session_name,
+                or_(
+                    models.Document.session_name == session_name,
+                    models.Document.id.in_([d.id for d in derived_documents]),
+                ),
                 models.Document.workspace_name == workspace_name,
             ],
             batch_size=5000,

--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -16,7 +16,6 @@ from sqlalchemy import (
     exists,
     func,
     insert,
-    or_,
     select,
     update,
 )
@@ -516,6 +515,14 @@ async def update_session(
     return honcho_session
 
 
+# Chunk size for splitting an in-memory ID list before binding it into an
+# `id.in_(...)` predicate, so a large fan-out can't build a single query with
+# an unbounded number of parameters. Separate from _batch_delete_matching's
+# batch_size (that one bounds rows per DELETE via a LIMIT subquery, not bound
+# parameters).
+_ID_CHUNK_SIZE = 5000
+
+
 async def _batch_delete_matching(
     db: AsyncSession,
     model: Any,
@@ -735,19 +742,31 @@ async def delete_session(
 
         # Delete Document entries associated with this session in batches,
         # plus any derived conclusions transitively resting on this session's
-        # evidence (see comment above).
+        # evidence (see comment above). The derived-id list is chunked before
+        # being bound into an `id.in_(...)` predicate so a session with an
+        # unusually large derived closure can't build a single query with an
+        # unbounded number of parameters (mirrors the batch_size=5000 chunking
+        # already used for the rest of this cascade).
         conclusions_deleted = await _batch_delete_matching(
             db,
             models.Document,
             [
-                or_(
-                    models.Document.session_name == session_name,
-                    models.Document.id.in_([d.id for d in derived_documents]),
-                ),
+                models.Document.session_name == session_name,
                 models.Document.workspace_name == workspace_name,
             ],
             batch_size=5000,
         )
+        derived_ids = [d.id for d in derived_documents]
+        for i in range(0, len(derived_ids), _ID_CHUNK_SIZE):
+            conclusions_deleted += await _batch_delete_matching(
+                db,
+                models.Document,
+                [
+                    models.Document.id.in_(derived_ids[i : i + _ID_CHUNK_SIZE]),
+                    models.Document.workspace_name == workspace_name,
+                ],
+                batch_size=5000,
+            )
 
         # Delete Message entries in batches
         messages_deleted = await _batch_delete_matching(

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -1,7 +1,10 @@
+from typing import Any
+
 import pytest
 from nanoid import generate as generate_nanoid
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.operators import in_op
 
 from src import crud, models, schemas
 from src.exceptions import ResourceNotFoundException
@@ -255,6 +258,33 @@ class TestSessionCRUD:
 
         monkeypatch.setattr(session_crud, "_ID_CHUNK_SIZE", 2)
 
+        # Spy on _batch_delete_matching (the function that actually issues
+        # each chunked `id.in_(...)` delete - see the loop in delete_session)
+        # so we can assert the chunking itself happened, not just the end
+        # state. Asserting only remaining rows/counts would pass just as well
+        # if someone reverted to one unbounded `id.in_(derived_ids)` delete.
+        derived_id_chunk_sizes: list[int] = []
+        original_batch_delete = (
+            session_crud._batch_delete_matching  # pyright: ignore[reportPrivateUsage]
+        )
+
+        async def spy_batch_delete_matching(
+            db: AsyncSession, model: Any, filter_conditions: list[Any], **kwargs: Any
+        ) -> int:
+            for condition in filter_conditions:
+                if (
+                    model is models.Document
+                    and getattr(condition, "left", None) is not None
+                    and str(condition.left) == "documents.id"
+                    and condition.operator is in_op
+                ):
+                    derived_id_chunk_sizes.append(len(condition.right.value))
+            return await original_batch_delete(db, model, filter_conditions, **kwargs)
+
+        monkeypatch.setattr(
+            session_crud, "_batch_delete_matching", spy_batch_delete_matching
+        )
+
         test_workspace, test_peer = sample_data
 
         test_session = models.Session(
@@ -318,3 +348,12 @@ class TestSessionCRUD:
         # 1 explicit + 5 derived, deleted across the explicit call plus 3
         # chunked derived-id calls.
         assert result.conclusions_deleted == 6
+
+        # The actual assertion this test exists for: the derived ids were
+        # bound into 3 separate `id.in_(...)` deletes (chunk sizes 2, 2, 1),
+        # not one unbounded `id.in_(derived_ids)` call. Without this, a
+        # revert to the unbounded form would still pass every assertion
+        # above (the end state - which rows are gone - is identical either
+        # way).
+        assert derived_id_chunk_sizes == [2, 2, 1]
+        assert all(size <= 2 for size in derived_id_chunk_sizes)

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -1,5 +1,6 @@
 import pytest
 from nanoid import generate as generate_nanoid
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, models, schemas
@@ -132,3 +133,106 @@ class TestSessionCRUD:
             await crud.clone_session(
                 db_session, test_workspace.name, test_session.name, "invalid_message_id"
             )
+
+    @pytest.mark.asyncio
+    async def test_delete_session_cascades_to_derived_conclusions(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        """delete_session must also remove Dreamer-produced deductive/inductive
+        conclusions that rest on this session's evidence, even though those
+        documents carry session_name=None by design (the session-purity
+        invariant in crud/document.py:_dedup_key). Reproduces honcho#997's
+        real, still-live gap: such conclusions are invisible to a cascade
+        filtered only on Document.session_name and previously survived
+        session deletion forever.
+        """
+        test_workspace, test_peer = sample_data
+
+        test_session = models.Session(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        db_session.add(test_session)
+
+        collection = models.Collection(
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer.name,
+        )
+        db_session.add(collection)
+        await db_session.flush()
+
+        explicit_doc = models.Document(
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer.name,
+            content="explicit fact from this session",
+            level="explicit",
+            session_name=test_session.name,
+        )
+        db_session.add(explicit_doc)
+        await db_session.flush()
+
+        # One-hop: a deduction resting directly on the session's explicit doc.
+        deductive_doc = models.Document(
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer.name,
+            content="deduction resting on this session's evidence",
+            level="deductive",
+            session_name=None,
+            source_ids=[explicit_doc.id],
+        )
+        db_session.add(deductive_doc)
+        await db_session.flush()
+
+        # Two-hop: an induction resting on the deduction above, not on the
+        # explicit doc directly - exercises the transitive frontier expansion
+        # (an induction whose support left with a deleted session must leave
+        # too, mirroring scope_backfill.py's process_scope_removal cascade).
+        inductive_doc = models.Document(
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer.name,
+            content="induction resting on the deduction above",
+            level="inductive",
+            session_name=None,
+            source_ids=[deductive_doc.id],
+        )
+        db_session.add(inductive_doc)
+
+        # An unrelated derived doc in the same collection, resting on
+        # unrelated evidence - must survive the session deletion.
+        unrelated_doc = models.Document(
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer.name,
+            content="unrelated deduction",
+            level="deductive",
+            session_name=None,
+            source_ids=["some-other-doc-id-not-in-this-session"],
+        )
+        db_session.add(unrelated_doc)
+        await db_session.commit()
+
+        explicit_id, deductive_id, inductive_id, unrelated_id = (
+            explicit_doc.id,
+            deductive_doc.id,
+            inductive_doc.id,
+            unrelated_doc.id,
+        )
+
+        await crud.delete_session(db_session, test_workspace.name, test_session.name)
+
+        result = await db_session.execute(
+            select(models.Document.id).where(
+                models.Document.workspace_name == test_workspace.name,
+            )
+        )
+        remaining_ids = {row[0] for row in result.all()}
+
+        assert explicit_id not in remaining_ids
+        assert deductive_id not in remaining_ids
+        assert inductive_id not in remaining_ids
+        assert unrelated_id in remaining_ids

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -236,3 +236,85 @@ class TestSessionCRUD:
         assert deductive_id not in remaining_ids
         assert inductive_id not in remaining_ids
         assert unrelated_id in remaining_ids
+
+    @pytest.mark.asyncio
+    async def test_delete_session_chunks_large_derived_conclusion_fanout(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """The derived-conclusion id list is bound into an `id.in_(...)`
+        predicate in chunks (crud/session.py's _ID_CHUNK_SIZE) rather than as
+        one unbounded parameter list, so a session with a large derived
+        closure can't build a single query with an unbounded number of bind
+        parameters. Shrinks the chunk size instead of creating thousands of
+        rows to exercise the multi-chunk path cheaply.
+        """
+        from src.crud import session as session_crud
+
+        monkeypatch.setattr(session_crud, "_ID_CHUNK_SIZE", 2)
+
+        test_workspace, test_peer = sample_data
+
+        test_session = models.Session(
+            name=str(generate_nanoid()), workspace_name=test_workspace.name
+        )
+        db_session.add(test_session)
+
+        collection = models.Collection(
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer.name,
+        )
+        db_session.add(collection)
+        await db_session.flush()
+
+        explicit_doc = models.Document(
+            workspace_name=test_workspace.name,
+            observer=test_peer.name,
+            observed=test_peer.name,
+            content="explicit fact from this session",
+            level="explicit",
+            session_name=test_session.name,
+        )
+        db_session.add(explicit_doc)
+        await db_session.flush()
+
+        # Five one-hop deductions resting directly on the session's explicit
+        # doc - with _ID_CHUNK_SIZE monkeypatched to 2, deleting these
+        # requires 3 chunked `id.in_(...)` deletes (2 + 2 + 1).
+        derived_docs = [
+            models.Document(
+                workspace_name=test_workspace.name,
+                observer=test_peer.name,
+                observed=test_peer.name,
+                content=f"deduction {i} resting on this session's evidence",
+                level="deductive",
+                session_name=None,
+                source_ids=[explicit_doc.id],
+            )
+            for i in range(5)
+        ]
+        db_session.add_all(derived_docs)
+        await db_session.commit()
+
+        derived_ids = [d.id for d in derived_docs]
+
+        result = await crud.delete_session(
+            db_session, test_workspace.name, test_session.name
+        )
+
+        remaining = await db_session.execute(
+            select(models.Document.id).where(
+                models.Document.workspace_name == test_workspace.name,
+            )
+        )
+        remaining_ids = {row[0] for row in remaining.all()}
+
+        assert explicit_doc.id not in remaining_ids
+        for derived_id in derived_ids:
+            assert derived_id not in remaining_ids
+        # 1 explicit + 5 derived, deleted across the explicit call plus 3
+        # chunked derived-id calls.
+        assert result.conclusions_deleted == 6


### PR DESCRIPTION
## Description

`delete_session()` cleans up `Document` rows by filtering on
`Document.session_name == session_name`, but Dreamer-produced deductive and
inductive conclusions are always stored with `session_name=None` by design
(the session-purity invariant in `src/crud/document.py`'s `_dedup_key`,
~line 575), even when they were derived from that session's explicit
conclusions via `source_ids`. Those rows are structurally invisible to the
existing cascade and survive `delete_session()` forever, orphaned from a
session that no longer exists.

Note: the reproduction originally described in #997 (session-scoped
conclusions and peer rows surviving deletion) was already fixed
independently before this PR, in the existing `session_name`-filtered
cascade at `src/crud/session.py` and the `SessionPeer` cleanup. This PR
addresses a deeper, still-live structural gap in the same area: derived
conclusions reachable only through a `source_ids` chain rooted in the
session's explicit documents, which the `session_name` filter can never
match because those rows don't carry a `session_name` at all.

The fix walks `source_ids` transitively from the session's explicit
documents — one hop for a deduction resting directly on the session's
evidence, further hops for an induction resting on that deduction, and so
on — mirroring the same fail-closed traversal `process_scope_removal`
already uses in `src/deriver/scope_backfill.py` for the sibling "remove a
scope" problem. Matched document ids are folded into both the external
vector-store cleanup and the hard-delete, so derived conclusions are
actually removed rather than left as orphans. An unrelated derived
document in the same workspace (resting on evidence outside this session)
is left untouched, since it isn't reachable from the frontier.

## Proofs

New regression test `tests/crud/test_session.py::TestSessionCRUD::test_delete_session_cascades_to_derived_conclusions`
builds a two-hop chain (explicit → deductive → inductive, plus an unrelated
deductive doc) and asserts `delete_session()` removes all three
session-derived rows while leaving the unrelated one:

```
$ uv run pytest -q tests/crud/test_session.py -v
6 passed in 4.32s
```

Full suite, before and after this change, with the repo's baseline
(`ddbb90e3`) already at 88 pre-existing failures unrelated to this path
(SDK `httpx`/`httpx2` TestClient incompatibility and a FastAPI-introspection
gap in `test_auth_route_policy.py` / `test_scope_route_policy.py` — see
`.oss-work/honcho/CONTEXT.md`):

```
$ uv run pytest -q
88 failed, 2031 passed, 47 skipped in 31.69s
```

Same 88 failures, same three categories (2 `sdk_typescript`, 83 `sdk`, 3
`routes`) as the pre-change baseline (2030 passed) — the one extra pass is
the new regression test. No new failures introduced.

Fixes #997

## Checklist

- [x] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.

<!-- Fixes #997 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a session now also removes all transitively derived documents associated with it.
  * Related entries are consistently cleaned up from external vector storage.
  * Unrelated derived documents remain preserved during session deletion.
  * Large groups of derived documents are deleted reliably in batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->