### PR TITLE
perf(cache): hash-tag cache keys so a workspace lands on one shard

### DIFF
--- a/src/crud/collection.py
+++ b/src/crud/collection.py
@@ -20,7 +20,7 @@ from src.exceptions import ConflictException, ResourceNotFoundException
 logger = getLogger(__name__)
 
 COLLECTION_CACHE_KEY_TEMPLATE = (
-    "v2:workspace:{workspace_name}:collection:{observer}:{observed}"
+    "v2:workspace:{{{workspace_name}}}:collection:{observer}:{observed}"
 )
 COLLECTION_LOCK_PREFIX = f"{get_cache_namespace()}:lock:v2"
 

--- a/src/crud/peer.py
+++ b/src/crud/peer.py
@@ -31,7 +31,7 @@ logger = getLogger(__name__)
 # Matches the peers.name CHECK constraint and PeerCreate's max_length.
 PEER_NAME_MAX_LENGTH = 512
 
-PEER_CACHE_KEY_TEMPLATE = "v2:workspace:{workspace_name}:peer:{peer_name}"
+PEER_CACHE_KEY_TEMPLATE = "v2:workspace:{{{workspace_name}}}:peer:{peer_name}"
 PEER_LOCK_PREFIX = f"{get_cache_namespace()}:lock:v2"
 
 

--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -66,7 +66,7 @@ class SessionDeletionResult:
     conclusions_deleted: int
 
 
-SESSION_CACHE_KEY_TEMPLATE = "v2:workspace:{workspace_name}:session:{session_name}"
+SESSION_CACHE_KEY_TEMPLATE = "v2:workspace:{{{workspace_name}}}:session:{session_name}"
 SESSION_LOCK_PREFIX = f"{get_cache_namespace()}:lock:v2"
 
 

--- a/src/crud/workspace.py
+++ b/src/crud/workspace.py
@@ -39,7 +39,7 @@ class WorkspaceDeletionResult:
     conclusions_deleted: int
 
 
-WORKSPACE_CACHE_KEY_TEMPLATE = "v2:workspace:{workspace_name}"
+WORKSPACE_CACHE_KEY_TEMPLATE = "v2:workspace:{{{workspace_name}}}"
 WORKSPACE_LOCK_PREFIX = f"{get_cache_namespace()}:lock:v2"
 
 

--- a/tests/cache/test_cache_key_hash_tags.py
+++ b/tests/cache/test_cache_key_hash_tags.py
@@ -1,0 +1,54 @@
+"""Hash tags keep one workspace's cache keys on one Redis Cluster shard.
+
+Without them a pod opens a connection to every shard, because its keys hash
+all over the keyspace. The fleet was running ~4.45 Redis connections per pod
+against a 3-shard cluster for that reason.
+"""
+
+import pytest
+from redis.crc import key_slot
+
+from src.crud.collection import COLLECTION_CACHE_KEY_TEMPLATE, collection_cache_key
+from src.crud.peer import PEER_CACHE_KEY_TEMPLATE, peer_cache_key
+from src.crud.session import SESSION_CACHE_KEY_TEMPLATE, session_cache_key
+from src.crud.workspace import WORKSPACE_CACHE_KEY_TEMPLATE, workspace_cache_key
+
+WS = "ws-test"
+
+
+def _rendered() -> list[str]:
+    return [
+        workspace_cache_key(WS),
+        session_cache_key(WS, "sess-1"),
+        session_cache_key(WS, "sess-2"),
+        peer_cache_key(WS, "peer-1"),
+        collection_cache_key(WS, "obs-a", "obs-b"),
+    ]
+
+
+def test_every_template_tags_the_workspace() -> None:
+    for tpl in (
+        WORKSPACE_CACHE_KEY_TEMPLATE,
+        SESSION_CACHE_KEY_TEMPLATE,
+        PEER_CACHE_KEY_TEMPLATE,
+        COLLECTION_CACHE_KEY_TEMPLATE,
+    ):
+        assert "{{{workspace_name}}}" in tpl, tpl
+
+
+def test_one_workspace_is_one_slot() -> None:
+    slots = {key_slot(k.encode()) for k in _rendered()}
+    assert len(slots) == 1, f"expected one slot, got {slots} for {_rendered()}"
+
+
+def test_only_the_workspace_is_tagged() -> None:
+    # Exactly one brace pair per key. A second would make the tag the text
+    # between the first { and the first }, which is not what we want.
+    for k in _rendered():
+        assert k.count("{") == 1 and k.count("}") == 1, k
+
+
+@pytest.mark.parametrize("n", [300])
+def test_workspaces_still_spread_across_shards(n: int) -> None:
+    shards = {key_slot(workspace_cache_key(f"ws-{i}").encode()) % 3 for i in range(n)}
+    assert shards == {0, 1, 2}, shards


### PR DESCRIPTION
Cache keys embed the workspace name unhashed, so one tenant's keys scatter across all three Redis Cluster shards. redis-py keeps a connection pool per node, so each pod opens connections to every shard it touches.
