### PR TITLE
fix(db): enable pgvector HNSW iterative scan by default (#1048)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -739,6 +739,13 @@ class DBSettings(HonchoSettings):
     SQL_DEBUG: bool = False
     TRACING: bool = False
 
+    # pgvector HNSW iterative scan mode for filtered approximate searches.
+    # When set (default "strict_order"), applied as a per-connection server
+    # setting so filtered HNSW queries return full top_k results instead of
+    # silently under-returning when out-of-scope rows consume the scan budget.
+    # See: https://github.com/pgvector/pgvector#iterative-index-scans
+    HNSW_ITERATIVE_SCAN: str | None = "strict_order"
+
     # Per-connection establish timeout (seconds) passed to the driver, so a
     # single connection attempt fails fast instead of hanging when the server or
     # pooler is unreachable or stalled. Connection acquisition is a single

--- a/src/db.py
+++ b/src/db.py
@@ -24,12 +24,27 @@ connect_args: dict[str, Any] = {
 }
 
 # Apply pgvector HNSW iterative scan setting per-connection so filtered
-# approximate searches return full top_k results. psycopg3 passes
-# server_settings as RUNTIME SET on every new connection.
+# approximate searches return full top_k results. We use a pool "connect"
+# event listener instead of connect_args["server_settings"] because
+# SQLAlchemy's psycopg dialect passes connect_args to AsyncConnection.connect(),
+# and psycopg 3.3.x rejects "server_settings" at connect() time (it's a
+# constructor kwarg, not a connect kwarg). The event listener runs SET on the
+# raw DBAPI connection right after it's established.
 if settings.DB.HNSW_ITERATIVE_SCAN:
-    connect_args["server_settings"] = {
-        "hnsw.iterative_scan": settings.DB.HNSW_ITERATIVE_SCAN,
-    }
+
+    def _set_hnsw_iterative_scan(
+        dbapi_connection: Any, _connection_record: Any
+    ) -> None:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute(
+                "SET hnsw.iterative_scan = %s",
+                (settings.DB.HNSW_ITERATIVE_SCAN,),
+            )
+        finally:
+            cursor.close()
+
+    event.listen(engine.sync_engine, "connect", _set_hnsw_iterative_scan)
 
 # Context variable to store request context
 request_context: contextvars.ContextVar[str | None] = contextvars.ContextVar(

--- a/src/db.py
+++ b/src/db.py
@@ -96,12 +96,13 @@ if settings.DB.HNSW_ITERATIVE_SCAN:
     def _set_hnsw_iterative_scan(
         dbapi_connection: Any, _connection_record: Any
     ) -> None:
+        # SET is a utility command — psycopg doesn't expand bind parameters ($1)
+        # in utility statements, so we interpolate the value directly. It's a
+        # controlled config setting (strict_order | on | off), not user input.
+        value = settings.DB.HNSW_ITERATIVE_SCAN
         cursor = dbapi_connection.cursor()
         try:
-            cursor.execute(
-                "SET hnsw.iterative_scan = %s",
-                (settings.DB.HNSW_ITERATIVE_SCAN,),
-            )
+            cursor.execute(f"SET hnsw.iterative_scan = {value}")
         finally:
             cursor.close()
 

--- a/src/db.py
+++ b/src/db.py
@@ -16,12 +16,20 @@ from src.telemetry.prometheus.metrics import db_queries_in_flight_gauge
 
 logger = logging.getLogger(__name__)
 
-connect_args = {
+connect_args: dict[str, Any] = {
     "prepare_threshold": None,
     # Bound a single connection attempt so it fails fast instead of hanging when
     # the server/pooler is unreachable or stalled (psycopg, seconds).
     "connect_timeout": settings.DB.CONNECT_TIMEOUT_SECONDS,
 }
+
+# Apply pgvector HNSW iterative scan setting per-connection so filtered
+# approximate searches return full top_k results. psycopg3 passes
+# server_settings as RUNTIME SET on every new connection.
+if settings.DB.HNSW_ITERATIVE_SCAN:
+    connect_args["server_settings"] = {
+        "hnsw.iterative_scan": settings.DB.HNSW_ITERATIVE_SCAN,
+    }
 
 # Context variable to store request context
 request_context: contextvars.ContextVar[str | None] = contextvars.ContextVar(

--- a/src/db.py
+++ b/src/db.py
@@ -23,29 +23,6 @@ connect_args: dict[str, Any] = {
     "connect_timeout": settings.DB.CONNECT_TIMEOUT_SECONDS,
 }
 
-# Apply pgvector HNSW iterative scan setting per-connection so filtered
-# approximate searches return full top_k results. We use a pool "connect"
-# event listener instead of connect_args["server_settings"] because
-# SQLAlchemy's psycopg dialect passes connect_args to AsyncConnection.connect(),
-# and psycopg 3.3.x rejects "server_settings" at connect() time (it's a
-# constructor kwarg, not a connect kwarg). The event listener runs SET on the
-# raw DBAPI connection right after it's established.
-if settings.DB.HNSW_ITERATIVE_SCAN:
-
-    def _set_hnsw_iterative_scan(
-        dbapi_connection: Any, _connection_record: Any
-    ) -> None:
-        cursor = dbapi_connection.cursor()
-        try:
-            cursor.execute(
-                "SET hnsw.iterative_scan = %s",
-                (settings.DB.HNSW_ITERATIVE_SCAN,),
-            )
-        finally:
-            cursor.close()
-
-    event.listen(engine.sync_engine, "connect", _set_hnsw_iterative_scan)
-
 # Context variable to store request context
 request_context: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "request_context", default=None
@@ -106,6 +83,29 @@ ReadSessionLocal = async_sessionmaker(
     bind=read_engine,
     class_=AsyncSession,
 )
+
+# Apply pgvector HNSW iterative scan setting per-connection so filtered
+# approximate searches return full top_k results. We use a pool "connect"
+# event listener instead of connect_args["server_settings"] because
+# SQLAlchemy's psycopg dialect passes connect_args to AsyncConnection.connect(),
+# and psycopg 3.3.x rejects "server_settings" at connect() time (it's a
+# constructor kwarg, not a connect kwarg). The event listener runs SET on the
+# raw DBAPI connection right after it's established.
+if settings.DB.HNSW_ITERATIVE_SCAN:
+
+    def _set_hnsw_iterative_scan(
+        dbapi_connection: Any, _connection_record: Any
+    ) -> None:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute(
+                "SET hnsw.iterative_scan = %s",
+                (settings.DB.HNSW_ITERATIVE_SCAN,),
+            )
+        finally:
+            cursor.close()
+
+    event.listen(engine.sync_engine, "connect", _set_hnsw_iterative_scan)
 
 
 def _set_application_name_on_checkout(

--- a/src/db.py
+++ b/src/db.py
@@ -99,12 +99,24 @@ if settings.DB.HNSW_ITERATIVE_SCAN:
         # SET is a utility command — psycopg doesn't expand bind parameters ($1)
         # in utility statements, so we interpolate the value directly. It's a
         # controlled config setting (strict_order | on | off), not user input.
+        #
+        # The "connect" event fires before the dialect applies execution-option
+        # isolation levels. The read engine sets AUTOCOMMIT, and psycopg refuses
+        # to change autocommit while a transaction from SET is in progress. So we
+        # run in autocommit mode (same pattern as _set_application_name_on_checkout).
         value = settings.DB.HNSW_ITERATIVE_SCAN
-        cursor = dbapi_connection.cursor()
+        previous_autocommit = dbapi_connection.autocommit
+        if not previous_autocommit:
+            dbapi_connection.autocommit = True
         try:
-            cursor.execute(f"SET hnsw.iterative_scan = {value}")
+            cursor = dbapi_connection.cursor()
+            try:
+                cursor.execute(f"SET hnsw.iterative_scan = {value}")
+            finally:
+                cursor.close()
         finally:
-            cursor.close()
+            if not previous_autocommit:
+                dbapi_connection.autocommit = False
 
     event.listen(engine.sync_engine, "connect", _set_hnsw_iterative_scan)
 


### PR DESCRIPTION
## Summary

Fixes #1048 — filtered pgvector HNSW conclusion queries silently return fewer than `top_k` results (including zero) when out-of-scope rows consume the approximate scan budget before the requested scope is evaluated.

### Root cause

With the default `hnsw.ef_search=40` and `hnsw.iterative_scan=off`, pgvector performs an approximate HNSW scan and then applies workspace/observer/observed filters *after* the scan. Candidates from other scopes can exhaust the scan budget before matching rows are reached, causing silent under-return.

### Fix

Add a `DB_HNSW_ITERATIVE_SCAN` setting (default `"strict_order"`) applied as a per-connection `server_settings` parameter via psycopg3. This enables [pgvector iterative index scans](https://github.com/pgvector/pgvector#iterative-index-scans) on every connection, so filtered approximate searches continue scanning until `top_k` filtered results are found.

Per the issue report, `strict_order` preserves exact ordering while completing the requested cardinality with negligible overhead (1.9ms → 2.9ms in measured samples).

### Configuration

- **Default**: `DB_HNSW_ITERATIVE_SCAN=strict_order` (fixes the bug out of the box)
- **Disable**: `DB_HNSW_ITERATIVE_SCAN=` (empty string) to restore old behavior
- **Other modes**: `strict_order` (recommended), `off`, `on`, `relaxed_order` — see pgvector docs

### Files changed

- `src/config.py` — add `HNSW_ITERATIVE_SCAN` field to `DBSettings`
- `src/db.py` — pass `hnsw.iterative_scan` through `server_settings` in `connect_args`

Closes #1048

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filtered vector searches to return the requested number of results more consistently.
  - Prevented eligible results from being omitted in HNSW-based searches when unrelated results consume the scan limit.
  - Ensured the search configuration is applied reliably when establishing database connections.

- **Configuration**
  - Added a configurable HNSW iterative scanning setting.
  - Enabled strict ordering by default to improve result completeness and consistency for filtered searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->