### PR TITLE
chore: bump honcho-cli to 0.1.3

### DIFF
--- a/honcho-cli/CHANGELOG.md
+++ b/honcho-cli/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-08-25
+
 ### Added
 
-- `honcho session view` — session transcript table (`--last N`, `--page N --size M`, `--all`, `--reverse`, `--ids`, peer filter via `-p`). Content is shown verbatim, timestamps are normalized to UTC, and the command is read-only: unlike the other session commands it never get-or-creates the session
+- `honcho start`, `honcho stop`, and `honcho status` — run a personal Honcho stack in Docker (API, deriver, Postgres, Redis). Profiles live under `~/.honcho/profiles/`. First start pins `ghcr.io/plastic-labs/honcho:latest` by digest and copies the image `config.toml`. Optional `--setup basic` / `--setup advanced` wizard writes LLM overrides to `.env` (#1029)
+- `honcho session view` — session transcript table (`--last N`, `--page N --size M`, `--all`, `--reverse`, `--ids`, peer filter via `-p`). Content is shown verbatim, timestamps are normalized to UTC, and the command is read-only: unlike the other session commands it never get-or-creates the session (#1006)
 
 ### Fixed
 
-- `honcho message list --last N` no longer stops at the first page of 50 — it walks pages to fill the requested window
+- `honcho message list --last N` no longer stops at the first page of 50 — it walks pages to fill the requested window (#1006)
 
 ## [0.1.2] - 2026-07-20
 

--- a/honcho-cli/pyproject.toml
+++ b/honcho-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "honcho-cli"
-version = "0.1.2"
+version = "0.1.3"
 description = "A terminal for Honcho — memory that reasons."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/honcho-cli/src/honcho_cli/__init__.py
+++ b/honcho-cli/src/honcho_cli/__init__.py
@@ -1,3 +1,3 @@
 """Honcho CLI — a terminal for Honcho."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1170,7 +1170,7 @@ dev = [{ name = "ruff", specifier = ">=0.11.13" }]
 
 [[package]]
 name = "honcho-cli"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "honcho-cli" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump `honcho-cli` from 0.1.2 → 0.1.3 so PyPI can pick up `honcho start` / `stop` / `status` (#1029) plus `session view` and the `message list --last` pagination fix already on main.
- Fold `[Unreleased]` into the 0.1.3 changelog; version is updated in `pyproject.toml`, `__init__.py`, and `uv.lock`.

## Test plan
- [ ] `honcho --version` from this checkout prints `0.1.3`
- [ ] After merge, `uv build --package honcho-cli && uv publish --package honcho-cli`
- [ ] `uv tool upgrade honcho-cli` then `honcho --version` and `honcho start --help`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker-based stack lifecycle commands.
  * Added a session transcript viewer.
  * Improved pagination for `honcho message list --last`.

* **Chores**
  * Updated the Honcho CLI release version to 0.1.3.
  * Documented the latest changes in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->