### PR TITLE
feat(docs): cookie consent on honcho.dev/docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -19,21 +19,14 @@
   },
   "favicon": "/favicon.svg",
   "contextual": {
-    "options": [
-      "copy",
-      "view",
-      "chatgpt",
-      "claude"
-    ]
+    "options": ["copy", "view", "chatgpt", "claude"]
   },
   "navigation": {
     "versions": [
       {
         "version": "v3.1.0",
         "api": {
-          "openapi": [
-            "v3/openapi.json"
-          ]
+          "openapi": ["v3/openapi.json"]
         },
         "tabs": [
           {
@@ -97,9 +90,7 @@
             "groups": [
               {
                 "group": "Overview",
-                "pages": [
-                  "v3/guides/overview"
-                ]
+                "pages": ["v3/guides/overview"]
               },
               {
                 "group": "Integrations",
@@ -139,9 +130,7 @@
               },
               {
                 "group": "Migrations",
-                "pages": [
-                  "v3/guides/migrations/mem0"
-                ]
+                "pages": ["v3/guides/migrations/mem0"]
               }
             ]
           },
@@ -171,9 +160,7 @@
             "groups": [
               {
                 "group": "API Documentation",
-                "pages": [
-                  "v3/api-reference/introduction"
-                ]
+                "pages": ["v3/api-reference/introduction"]
               },
               {
                 "group": "workspaces",
@@ -251,9 +238,7 @@
               },
               {
                 "group": "miscellaneous",
-                "pages": [
-                  "v3/api-reference/endpoint/keys/create-key"
-                ]
+                "pages": ["v3/api-reference/endpoint/keys/create-key"]
               }
             ]
           },
@@ -274,9 +259,7 @@
       {
         "version": "v2.5.1",
         "api": {
-          "openapi": [
-            "v2/openapi.json"
-          ]
+          "openapi": ["v2/openapi.json"]
         },
         "tabs": [
           {
@@ -323,15 +306,11 @@
             "groups": [
               {
                 "group": "Getting Started",
-                "pages": [
-                  "v2/guides/overview"
-                ]
+                "pages": ["v2/guides/overview"]
               },
               {
                 "group": "Migrations",
-                "pages": [
-                  "v2/migrations/from-mem0"
-                ]
+                "pages": ["v2/migrations/from-mem0"]
               },
               {
                 "group": "Integrations",
@@ -356,9 +335,7 @@
             "groups": [
               {
                 "group": "API Documentation",
-                "pages": [
-                  "v2/api-reference/introduction"
-                ]
+                "pages": ["v2/api-reference/introduction"]
               },
               {
                 "group": "workspaces",
@@ -462,9 +439,7 @@
       {
         "version": "v1.1.0",
         "api": {
-          "openapi": [
-            "openapi.json"
-          ]
+          "openapi": ["openapi.json"]
         },
         "tabs": [
           {
@@ -494,23 +469,15 @@
             "groups": [
               {
                 "group": "Getting Started",
-                "pages": [
-                  "v1/guides/overview",
-                  "v1/guides/streaming-response"
-                ]
+                "pages": ["v1/guides/overview", "v1/guides/streaming-response"]
               },
               {
                 "group": "Application Interfaces",
-                "pages": [
-                  "v1/guides/discord",
-                  "v1/guides/honcho-mcp"
-                ]
+                "pages": ["v1/guides/discord", "v1/guides/honcho-mcp"]
               },
               {
                 "group": "Personal Memory",
-                "pages": [
-                  "v1/guides/dialectic-endpoint"
-                ]
+                "pages": ["v1/guides/dialectic-endpoint"]
               }
             ]
           },
@@ -519,9 +486,7 @@
             "groups": [
               {
                 "group": "API Documentation",
-                "pages": [
-                  "v1/api-reference/introduction"
-                ]
+                "pages": ["v1/api-reference/introduction"]
               },
               {
                 "group": "apps",
@@ -569,9 +534,7 @@
               },
               {
                 "group": "keys",
-                "pages": [
-                  "v1/api-reference/endpoint/keys/create-key"
-                ]
+                "pages": ["v1/api-reference/endpoint/keys/create-key"]
               },
               {
                 "group": "metamessages",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -630,9 +630,6 @@
     }
   },
   "integrations": {
-    "posthog": {
-      "apiKey": "phc_1yrzzcgywqXGcerkkI4g7C0YfyPMcAKNOOvGcjTCiUk"
-    },
     "gtm": {
       "tagId": "GTM-NSPT9PJF"
     }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -19,14 +19,21 @@
   },
   "favicon": "/favicon.svg",
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude"]
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude"
+    ]
   },
   "navigation": {
     "versions": [
       {
         "version": "v3.1.0",
         "api": {
-          "openapi": ["v3/openapi.json"]
+          "openapi": [
+            "v3/openapi.json"
+          ]
         },
         "tabs": [
           {
@@ -90,7 +97,9 @@
             "groups": [
               {
                 "group": "Overview",
-                "pages": ["v3/guides/overview"]
+                "pages": [
+                  "v3/guides/overview"
+                ]
               },
               {
                 "group": "Integrations",
@@ -130,7 +139,9 @@
               },
               {
                 "group": "Migrations",
-                "pages": ["v3/guides/migrations/mem0"]
+                "pages": [
+                  "v3/guides/migrations/mem0"
+                ]
               }
             ]
           },
@@ -160,7 +171,9 @@
             "groups": [
               {
                 "group": "API Documentation",
-                "pages": ["v3/api-reference/introduction"]
+                "pages": [
+                  "v3/api-reference/introduction"
+                ]
               },
               {
                 "group": "workspaces",
@@ -238,7 +251,9 @@
               },
               {
                 "group": "miscellaneous",
-                "pages": ["v3/api-reference/endpoint/keys/create-key"]
+                "pages": [
+                  "v3/api-reference/endpoint/keys/create-key"
+                ]
               }
             ]
           },
@@ -259,7 +274,9 @@
       {
         "version": "v2.5.1",
         "api": {
-          "openapi": ["v2/openapi.json"]
+          "openapi": [
+            "v2/openapi.json"
+          ]
         },
         "tabs": [
           {
@@ -306,11 +323,15 @@
             "groups": [
               {
                 "group": "Getting Started",
-                "pages": ["v2/guides/overview"]
+                "pages": [
+                  "v2/guides/overview"
+                ]
               },
               {
                 "group": "Migrations",
-                "pages": ["v2/migrations/from-mem0"]
+                "pages": [
+                  "v2/migrations/from-mem0"
+                ]
               },
               {
                 "group": "Integrations",
@@ -335,7 +356,9 @@
             "groups": [
               {
                 "group": "API Documentation",
-                "pages": ["v2/api-reference/introduction"]
+                "pages": [
+                  "v2/api-reference/introduction"
+                ]
               },
               {
                 "group": "workspaces",
@@ -439,7 +462,9 @@
       {
         "version": "v1.1.0",
         "api": {
-          "openapi": ["openapi.json"]
+          "openapi": [
+            "openapi.json"
+          ]
         },
         "tabs": [
           {
@@ -469,15 +494,23 @@
             "groups": [
               {
                 "group": "Getting Started",
-                "pages": ["v1/guides/overview", "v1/guides/streaming-response"]
+                "pages": [
+                  "v1/guides/overview",
+                  "v1/guides/streaming-response"
+                ]
               },
               {
                 "group": "Application Interfaces",
-                "pages": ["v1/guides/discord", "v1/guides/honcho-mcp"]
+                "pages": [
+                  "v1/guides/discord",
+                  "v1/guides/honcho-mcp"
+                ]
               },
               {
                 "group": "Personal Memory",
-                "pages": ["v1/guides/dialectic-endpoint"]
+                "pages": [
+                  "v1/guides/dialectic-endpoint"
+                ]
               }
             ]
           },
@@ -486,7 +519,9 @@
             "groups": [
               {
                 "group": "API Documentation",
-                "pages": ["v1/api-reference/introduction"]
+                "pages": [
+                  "v1/api-reference/introduction"
+                ]
               },
               {
                 "group": "apps",
@@ -534,7 +569,9 @@
               },
               {
                 "group": "keys",
-                "pages": ["v1/api-reference/endpoint/keys/create-key"]
+                "pages": [
+                  "v1/api-reference/endpoint/keys/create-key"
+                ]
               },
               {
                 "group": "metamessages",
@@ -595,6 +632,9 @@
   "integrations": {
     "posthog": {
       "apiKey": "phc_1yrzzcgywqXGcerkkI4g7C0YfyPMcAKNOOvGcjTCiUk"
+    },
+    "gtm": {
+      "tagId": "GTM-NSPT9PJF"
     }
   }
 }

--- a/docs/posthog-consent.js
+++ b/docs/posthog-consent.js
@@ -22,11 +22,17 @@
       loaded = false
     }
     s.onload = function () {
+      // Consent withdrawn while array.js was downloading: skip init, allow a retry on re-grant.
+      if (!granted()) {
+        loaded = false
+        return
+      }
       window.posthog.init(KEY, {
         api_host: 'https://us.i.posthog.com',
         ui_host: 'https://us.posthog.com',
         cross_subdomain_cookie: true,
         person_profiles: 'identified_only',
+        capture_pageview: 'history_change',
       })
     }
     document.head.appendChild(s)

--- a/docs/posthog-consent.js
+++ b/docs/posthog-consent.js
@@ -1,0 +1,43 @@
+// Loads PostHog only when the CookieConsent cookie grants Statistics; the
+// cookie is host-scoped, so a landing-page answer covers the docs.
+;(function () {
+  var KEY = 'phc_1yrzzcgywqXGcerkkI4g7C0YfyPMcAKNOOvGcjTCiUk'
+  var loaded = false
+
+  function granted() {
+    var m = document.cookie.match(/CookieConsent=([^;]*)/)
+    if (!m) return false
+    var v = decodeURIComponent(m[1])
+    // "-1" is Cookiebot's consent-not-required marker.
+    return v === '-1' || /statistics\s*:\s*true/.test(v)
+  }
+
+  function loadPosthog() {
+    if (loaded) return
+    loaded = true
+    var s = document.createElement('script')
+    s.src = 'https://us-assets.i.posthog.com/static/array.js'
+    s.async = true
+    s.onload = function () {
+      window.posthog.init(KEY, {
+        api_host: 'https://us.i.posthog.com',
+        ui_host: 'https://us.posthog.com',
+        cross_subdomain_cookie: true,
+        person_profiles: 'identified_only',
+      })
+    }
+    document.head.appendChild(s)
+  }
+
+  if (granted()) {
+    loadPosthog()
+    return
+  }
+  // A grant made on the docs banner itself (step 2) loads it live.
+  var events = ['CookiebotOnConsentReady', 'CookiebotOnAccept']
+  for (var i = 0; i < events.length; i++) {
+    window.addEventListener(events[i], function () {
+      if (granted()) loadPosthog()
+    })
+  }
+})()

--- a/docs/posthog-consent.js
+++ b/docs/posthog-consent.js
@@ -5,7 +5,7 @@
   var loaded = false
 
   function granted() {
-    var m = document.cookie.match(/CookieConsent=([^;]*)/)
+    var m = document.cookie.match(/(?:^|;\s*)CookieConsent=([^;]*)/)
     if (!m) return false
     var v = decodeURIComponent(m[1])
     // "-1" is Cookiebot's consent-not-required marker.
@@ -18,6 +18,9 @@
     var s = document.createElement('script')
     s.src = 'https://us-assets.i.posthog.com/static/array.js'
     s.async = true
+    s.onerror = function () {
+      loaded = false
+    }
     s.onload = function () {
       window.posthog.init(KEY, {
         api_host: 'https://us.i.posthog.com',
@@ -29,15 +32,32 @@
     document.head.appendChild(s)
   }
 
-  if (granted()) {
-    loadPosthog()
-    return
+  function sync() {
+    if (granted()) {
+      if (!loaded) {
+        loadPosthog()
+      } else if (
+        window.posthog &&
+        window.posthog.has_opted_out_capturing &&
+        window.posthog.has_opted_out_capturing()
+      ) {
+        window.posthog.opt_in_capturing()
+      }
+      return
+    }
+    // Withdrawal mid-session: an already running instance must stop.
+    if (loaded && window.posthog && window.posthog.opt_out_capturing) {
+      window.posthog.opt_out_capturing()
+    }
   }
-  // A grant made on the docs banner itself (step 2) loads it live.
-  var events = ['CookiebotOnConsentReady', 'CookiebotOnAccept']
+
+  sync()
+  var events = [
+    'CookiebotOnConsentReady',
+    'CookiebotOnAccept',
+    'CookiebotOnDecline',
+  ]
   for (var i = 0; i < events.length; i++) {
-    window.addEventListener(events[i], function () {
-      if (granted()) loadPosthog()
-    })
+    window.addEventListener(events[i], sync)
   }
 })()


### PR DESCRIPTION
## Summary
Two changes for DEV-2465. Every docs page loads the GTM container, and PostHog loads only when the `CookieConsent` cookie grants Statistics.

## GTM container
`docs.json` swaps `integrations.posthog` for `integrations.gtm` with `GTM-NSPT9PJF`. Mintlify injects the container on every page. The published container (v10) excludes `/docs` from the Google tag, so it loads and fires nothing until Marc publishes Cookiebot and GA4 into it.

## PostHog loader
`docs/posthog-consent.js` runs once each page is interactive. It reads the `CookieConsent` cookie and loads `array.js` only when Statistics is granted or the value is `-1` (consent not required). The cookie is host-scoped, so a landing-page answer covers docs. It listens for `CookiebotOnConsentReady`, `OnAccept`, and `OnDecline`: withdrawal calls `opt_out_capturing()`, re-grant calls `opt_in_capturing()`. `onload` re-checks consent before `init`, so a decline during the download skips init. A failed script load resets the guard so the next event retries. `capture_pageview: 'history_change'` records Mintlify's client-side navigation, not only the first page.

## Trade-offs
PostHog no longer goes through `ph.mintlify.com`, so ad blockers drop some volume. Mintlify's built-in events (`$docs.content.view`, `docs.navitem.click`, `docs.search.*`, `code_block_copy`) stop. A visitor with no cookie, including a US visitor landing directly on docs, is not tracked until they answer on the landing page.

## Follow-up
After deploy: `gtm.js` loads on a docs page, no tags fire, no new cookies. Confirm Mintlify's production CSP allows `us-assets.i.posthog.com` and `us.i.posthog.com`; if not, revert the loader commits and restore `integrations.posthog`. Decide whether a custom listener recovers search analytics. The `ph_phc_*` identifier stays after decline; the Cookiebot declaration text covers that (Marc).