### PR TITLE
fix(docker): ship pyproject.toml in the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,9 @@ COPY --chown=app:app migrations/ /app/migrations/
 COPY --chown=app:app scripts/ /app/scripts/
 COPY --chown=app:app docker/ /app/docker/
 COPY --chown=app:app alembic.ini /app/alembic.ini
+# src/_version.py reads the service version from here at runtime, so this
+# is a runtime input as well as a build input.
+COPY --chown=app:app pyproject.toml /app/pyproject.toml
 # Copy config files - this will copy config.toml if it exists, and config.toml.example
 COPY --chown=app:app config.toml* /app/
 


### PR DESCRIPTION
## Problem

The service reports its version as `unknown` instead of its real version. This shows up in the OpenAPI schema (`info.version` in `/openapi.json`) and in telemetry event tagging.

`src/_version.py` resolves the version in three steps:

1. Read `pyproject.toml` next to the package.
2. Fall back to `importlib.metadata.version("honcho")`.
3. Fall back to the string `unknown`.

Both real lookups fail inside the container:

- The builder stage copies `pyproject.toml`, but the runtime stage copies only `src/`, `migrations/`, `scripts/`, `docker/`, `alembic.ini` and `config.toml*`. The shipped image has no `pyproject.toml`, so step 1 fails.
- The build installs dependencies with `uv sync --no-install-project`, so no `honcho` distribution exists in the virtualenv and step 2 raises `PackageNotFoundError`.

Step 3 returns `unknown`, and anything reading the version sees that.

## Fix

Copy `pyproject.toml` into the runtime stage. It is the file `_version.py` prefers, and it keeps the version tied to the single source of truth rather than duplicating it into a build argument or an env var.

## Verification

Built both images and read the constant out of each:

```
$ docker run --rm --entrypoint python honcho:before -c \
    "from src._version import HONCHO_VERSION; print(HONCHO_VERSION)"
unknown

$ docker run --rm --entrypoint python honcho:after -c \
    "from src._version import HONCHO_VERSION; print(HONCHO_VERSION)"
3.1.0
```

`src/main.py` passes the same constant to FastAPI as `version=`, so the OpenAPI schema picks this up directly.

## Image size

`pyproject.toml` is under 4 KB. Measured image size is unchanged, so this does not undo the runtime image slimming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime version loading by ensuring package metadata is available in the deployed application image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->