### PR TITLE
fix(windows): guard Unix-only APIs so the server and deriver start on native Windows

### DIFF
--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import random
 import signal
+import sys
 import time
 from asyncio import Task
 from collections.abc import Iterable, Sequence
@@ -200,14 +201,30 @@ class QueueManager:
         """Setup signal handlers, initialize client, and start the main polling loop"""
         logger.debug(f"Initializing QueueManager with {self.workers} workers")
 
-        # Set up signal handlers
+        # Set up signal handlers.
+        # loop.add_signal_handler() is not implemented on Windows (it raises
+        # NotImplementedError, whose str() is empty). Fall back to signal.signal(),
+        # which Windows does support for SIGINT/SIGTERM, so Ctrl+C and a service
+        # stop still trigger the same graceful shutdown path.
         loop = asyncio.get_running_loop()
         signals = (signal.SIGTERM, signal.SIGINT)
-        for sig in signals:
-            loop.add_signal_handler(
-                sig, lambda s=sig: asyncio.create_task(self.shutdown(s))
-            )
-        logger.debug("Signal handlers registered")
+        if sys.platform != "win32":
+            for sig in signals:
+                loop.add_signal_handler(
+                    sig, lambda s=sig: asyncio.create_task(self.shutdown(s))
+                )
+            logger.debug("Signal handlers registered")
+        else:
+
+            def _win_signal_handler(signum: int, _frame: object) -> None:
+                # Runs in the main thread outside the loop; hand off thread-safely.
+                loop.call_soon_threadsafe(
+                    lambda: asyncio.create_task(self.shutdown(signal.Signals(signum)))
+                )
+
+            for sig in signals:
+                signal.signal(sig, _win_signal_handler)
+            logger.debug("Signal handlers registered via signal.signal (Windows)")
 
         # Start the reconciler scheduler
         try:

--- a/src/telemetry/reasoning_traces.py
+++ b/src/telemetry/reasoning_traces.py
@@ -6,25 +6,13 @@ This module provides structured JSONL logging of LLM inputs/outputs.
 
 import contextlib
 import json
-import os
 import sys
 import time
 from collections.abc import Generator
 from contextlib import contextmanager
+from importlib import import_module
 from pathlib import Path
 from typing import IO, Any
-
-fcntl: Any = None
-msvcrt: Any = None
-if sys.platform == "win32":
-    import msvcrt as _msvcrt
-
-    msvcrt = _msvcrt
-else:
-    import fcntl as _fcntl
-
-    fcntl = _fcntl
-
 
 from pydantic import BaseModel
 
@@ -33,6 +21,8 @@ from src.config import (
     ModelConfig,
     settings,
 )
+
+locking_module: Any = import_module("msvcrt" if sys.platform == "win32" else "fcntl")
 
 
 @contextmanager
@@ -45,23 +35,27 @@ def _locked(f: IO[str]) -> Generator[None, None, None]:
     write still proceeds unlocked rather than losing the trace.
     """
     if sys.platform != "win32":
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        locking_module.flock(f.fileno(), locking_module.LOCK_EX)
         try:
             yield
         finally:
-            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            locking_module.flock(f.fileno(), locking_module.LOCK_UN)
     elif sys.platform == "win32":
-        f.seek(0, os.SEEK_END)
+        # Every writer must coordinate on the same byte range. Keep the lock
+        # offset so it can be restored before LK_UNLCK after the append.
+        lock_offset = 0
+        f.seek(lock_offset)
         try:
-            msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+            locking_module.locking(f.fileno(), locking_module.LK_LOCK, 1)
         except OSError:  # lock unavailable after retries — do not drop the trace
             yield
             return
         try:
             yield
         finally:
+            f.seek(lock_offset)
             with contextlib.suppress(OSError):
-                msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+                locking_module.locking(f.fileno(), locking_module.LK_UNLCK, 1)
     else:  # pragma: no cover - no locking primitive available
         yield
 

--- a/src/telemetry/reasoning_traces.py
+++ b/src/telemetry/reasoning_traces.py
@@ -4,11 +4,25 @@ Utility for logging traces from LLM calls.
 This module provides structured JSONL logging of LLM inputs/outputs.
 """
 
-import fcntl
+import contextlib
 import json
+import os
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
+
+try:  # POSIX
+    import fcntl
+except ImportError:  # pragma: no cover - platform dependent
+    fcntl = None  # type: ignore[assignment]
+
+try:  # Windows
+    import msvcrt
+except ImportError:  # pragma: no cover - platform dependent
+    msvcrt = None  # type: ignore[assignment]
+
 
 from pydantic import BaseModel
 
@@ -17,6 +31,37 @@ from src.config import (
     ModelConfig,
     settings,
 )
+
+
+@contextmanager
+def _locked(f: IO[str]) -> Iterator[None]:
+    """Exclusively lock an open file for the duration of the block.
+
+    Multiple processes (API server and deriver) append to the same traces file, so
+    writes must be serialized. POSIX uses fcntl.flock; Windows uses msvcrt.locking,
+    which locks a byte range from the current offset. If neither is available the
+    write still proceeds unlocked rather than losing the trace.
+    """
+    if fcntl is not None:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+    elif msvcrt is not None:
+        f.seek(0, os.SEEK_END)
+        try:
+            msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+        except OSError:  # lock unavailable after retries — do not drop the trace
+            yield
+            return
+        try:
+            yield
+        finally:
+            with contextlib.suppress(OSError):
+                msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+    else:  # pragma: no cover - no locking primitive available
+        yield
 
 
 def get_reasoning_traces_file_path() -> Path | None:
@@ -97,7 +142,5 @@ def log_reasoning_trace(
         trace_entry["output"]["tool_calls"] = response.tool_calls_made
 
     # Use file locking to handle concurrent writes from multiple processes
-    with open(traces_file, "a") as f:
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+    with open(traces_file, "a") as f, _locked(f):
         f.write(json.dumps(trace_entry) + "\n")
-        fcntl.flock(f.fileno(), fcntl.LOCK_UN)

--- a/src/telemetry/reasoning_traces.py
+++ b/src/telemetry/reasoning_traces.py
@@ -41,11 +41,17 @@ def _locked(f: IO[str]) -> Generator[bool, None, None]:
     writes must be serialized. POSIX uses fcntl.flock; Windows uses msvcrt.locking
     on a fixed byte range, retried under an explicit policy.
 
-    Yields True when the lock is held. If Windows cannot acquire it within the
-    retry budget the block is entered with False and the caller must skip the
-    write: an unlocked append can interleave with another process and corrupt the
-    JSONL file, so a dropped trace is preferable. Tracing is an opt-in debugging
-    aid, so failure is logged rather than raised into the LLM call path.
+    Acquisition failure is logged rather than raised: tracing is an opt-in
+    debugging aid, and callers invoke it from the LLM call path.
+
+    Args:
+        f: Open file handle to lock for the duration of the block.
+
+    Yields:
+        True while the lock is held, False when Windows cannot acquire it
+            within the retry budget. Callers must skip the write when False,
+            because an unlocked append can interleave with another process
+            and corrupt the JSONL file.
     """
     if sys.platform != "win32":
         locking_module.flock(f.fileno(), locking_module.LOCK_EX)

--- a/src/telemetry/reasoning_traces.py
+++ b/src/telemetry/reasoning_traces.py
@@ -6,6 +6,7 @@ This module provides structured JSONL logging of LLM inputs/outputs.
 
 import contextlib
 import json
+import logging
 import sys
 import time
 from collections.abc import Generator
@@ -22,42 +23,63 @@ from src.config import (
     settings,
 )
 
+logger = logging.getLogger(__name__)
+
 locking_module: Any = import_module("msvcrt" if sys.platform == "win32" else "fcntl")
+
+# Windows has no blocking whole-file lock, so acquisition is retried explicitly
+# rather than relying on msvcrt's implicit LK_LOCK retry policy.
+_LOCK_RETRIES = 10
+_LOCK_RETRY_DELAY_SECONDS = 0.1
 
 
 @contextmanager
-def _locked(f: IO[str]) -> Generator[None, None, None]:
+def _locked(f: IO[str]) -> Generator[bool, None, None]:
     """Exclusively lock an open file for the duration of the block.
 
     Multiple processes (API server and deriver) append to the same traces file, so
-    writes must be serialized. POSIX uses fcntl.flock; Windows uses msvcrt.locking,
-    which locks a byte range from the current offset. If neither is available the
-    write still proceeds unlocked rather than losing the trace.
+    writes must be serialized. POSIX uses fcntl.flock; Windows uses msvcrt.locking
+    on a fixed byte range, retried under an explicit policy.
+
+    Yields True when the lock is held. If Windows cannot acquire it within the
+    retry budget the block is entered with False and the caller must skip the
+    write: an unlocked append can interleave with another process and corrupt the
+    JSONL file, so a dropped trace is preferable. Tracing is an opt-in debugging
+    aid, so failure is logged rather than raised into the LLM call path.
     """
     if sys.platform != "win32":
         locking_module.flock(f.fileno(), locking_module.LOCK_EX)
         try:
-            yield
+            yield True
         finally:
             locking_module.flock(f.fileno(), locking_module.LOCK_UN)
-    elif sys.platform == "win32":
-        # Every writer must coordinate on the same byte range. Keep the lock
-        # offset so it can be restored before LK_UNLCK after the append.
-        lock_offset = 0
+        return
+
+    # Every writer must coordinate on the same byte range. Keep the lock offset
+    # so it can be restored before LK_UNLCK after the append.
+    lock_offset = 0
+    for attempt in range(_LOCK_RETRIES):
         f.seek(lock_offset)
         try:
-            locking_module.locking(f.fileno(), locking_module.LK_LOCK, 1)
-        except OSError:  # lock unavailable after retries — do not drop the trace
-            yield
-            return
+            locking_module.locking(f.fileno(), locking_module.LK_NBLCK, 1)
+        except OSError:
+            if attempt < _LOCK_RETRIES - 1:
+                time.sleep(_LOCK_RETRY_DELAY_SECONDS)
+            continue
         try:
-            yield
+            yield True
         finally:
             f.seek(lock_offset)
             with contextlib.suppress(OSError):
                 locking_module.locking(f.fileno(), locking_module.LK_UNLCK, 1)
-    else:  # pragma: no cover - no locking primitive available
-        yield
+        return
+
+    logger.warning(
+        "Could not lock reasoning traces file after %d attempts; dropping trace "
+        "rather than appending without a lock.",
+        _LOCK_RETRIES,
+    )
+    yield False
 
 
 def get_reasoning_traces_file_path() -> Path | None:
@@ -138,6 +160,7 @@ def log_reasoning_trace(
         trace_entry["output"]["tool_calls"] = response.tool_calls_made
 
     # Use file locking to handle concurrent writes from multiple processes
-    with open(traces_file, "a") as f, _locked(f):
-        f.write(json.dumps(trace_entry) + "\n")
-        f.flush()
+    with open(traces_file, "a") as f, _locked(f) as acquired:
+        if acquired:
+            f.write(json.dumps(trace_entry) + "\n")
+            f.flush()

--- a/src/telemetry/reasoning_traces.py
+++ b/src/telemetry/reasoning_traces.py
@@ -7,21 +7,23 @@ This module provides structured JSONL logging of LLM inputs/outputs.
 import contextlib
 import json
 import os
+import sys
 import time
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import IO, Any
 
-try:  # POSIX
-    import fcntl
-except ImportError:  # pragma: no cover - platform dependent
-    fcntl = None  # type: ignore[assignment]
+fcntl: Any = None
+msvcrt: Any = None
+if sys.platform == "win32":
+    import msvcrt as _msvcrt
 
-try:  # Windows
-    import msvcrt
-except ImportError:  # pragma: no cover - platform dependent
-    msvcrt = None  # type: ignore[assignment]
+    msvcrt = _msvcrt
+else:
+    import fcntl as _fcntl
+
+    fcntl = _fcntl
 
 
 from pydantic import BaseModel
@@ -34,7 +36,7 @@ from src.config import (
 
 
 @contextmanager
-def _locked(f: IO[str]) -> Iterator[None]:
+def _locked(f: IO[str]) -> Generator[None, None, None]:
     """Exclusively lock an open file for the duration of the block.
 
     Multiple processes (API server and deriver) append to the same traces file, so
@@ -42,13 +44,13 @@ def _locked(f: IO[str]) -> Iterator[None]:
     which locks a byte range from the current offset. If neither is available the
     write still proceeds unlocked rather than losing the trace.
     """
-    if fcntl is not None:
+    if sys.platform != "win32":
         fcntl.flock(f.fileno(), fcntl.LOCK_EX)
         try:
             yield
         finally:
             fcntl.flock(f.fileno(), fcntl.LOCK_UN)
-    elif msvcrt is not None:
+    elif sys.platform == "win32":
         f.seek(0, os.SEEK_END)
         try:
             msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
@@ -144,3 +146,4 @@ def log_reasoning_trace(
     # Use file locking to handle concurrent writes from multiple processes
     with open(traces_file, "a") as f, _locked(f):
         f.write(json.dumps(trace_entry) + "\n")
+        f.flush()

--- a/src/telemetry/reasoning_traces.py
+++ b/src/telemetry/reasoning_traces.py
@@ -81,8 +81,7 @@ def _locked(f: IO[str]) -> Generator[bool, None, None]:
         return
 
     logger.warning(
-        "Could not lock reasoning traces file after %d attempts; dropping trace "
-        "rather than appending without a lock.",
+        "Could not lock reasoning traces file after %d attempts; dropping trace rather than appending without a lock.",
         _LOCK_RETRIES,
     )
     yield False


### PR DESCRIPTION
## Description

Honcho cannot start on a **native Windows** host (no WSL, no Docker) because two Unix-only APIs are called unconditionally: `src/telemetry/reasoning_traces.py` imports `fcntl` at module scope, and `src/deriver/queue_manager.py` calls `loop.add_signal_handler()`, which raises `NotImplementedError` on Windows with an **empty** `str()` — so the deriver dies logging only `Error in main: ` with no message. This guards both, plus adds a Windows shutdown path and cross-platform trace-file locking so the guards don't silently degrade behaviour.

No behaviour change on Unix: every change is behind a `sys.platform` check or an import-availability check.

## Proofs

Verified on Windows 11 / Python 3.11.16 / PostgreSQL 18.6 / pgvector 0.8.6, against an OpenAI-compatible endpoint (Azure AI Foundry model-router).

**Before — API server:**
```
File "src/telemetry/reasoning_traces.py", line 7, in <module>
    import fcntl
ModuleNotFoundError: No module named 'fcntl'
```

**Before — deriver (note the blank error):**
```
2026-08-25 21:07:53,960 - __main__ - INFO - deriver: embedding schema validated, starting queue manager
2026-08-25 21:07:53,960 - src.cache.client - INFO - Cache disabled, using in-memory cache
2026-08-25 21:07:53,960 - src.deriver.queue_manager - ERROR - Error in main:
```

**After — deriver runs and processes work:**
```
2026-08-25 21:14:01 - src.reconciler.scheduler - INFO - ReconcilerScheduler started with 2 tasks: ['sync_vectors', 'cleanup_queue']
2026-08-25 21:15:05 - PERFORMANCE minimal_deriver_5_sergio | llm_call_duration=2552ms | total_processing_time=3485ms | observation_count=8
2026-08-25 21:19:40 - PERFORMANCE minimal_deriver_7_sergio | llm_call_duration=6061ms | total_processing_time=10361ms | observation_count=31
```

**After — API serves and dialectic returns:**
```
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000
INFO:     127.0.0.1:53004 - "POST /v3/workspaces/hermes/peers/hermes/chat HTTP/1.1" 200 OK
PERFORMANCE dialectic_chat | tool_calls=4 | input_tokens=18096 | output_tokens=1013 | total_duration=15267ms
```

**Queue drained cleanly, conclusions generated (SQL against the live DB):**
```
queue processed   : t | 7
documents         : 17
errors            : (none)
```

**Lint / format — commands actually executed:**
```
$ uv run ruff check src/telemetry/reasoning_traces.py src/main.py src/deriver/queue_manager.py
All checks passed!

$ uv run ruff format --check src/telemetry/reasoning_traces.py src/main.py src/deriver/queue_manager.py
3 files already formatted
```

I did **not** run `uv run pytest tests/` — the suite orchestrates Docker-backed services that were not available on this host. Flagging that explicitly rather than implying a green run.

## Checklist

- [x] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.

Fixes #1075

---

### Scope note

Two further Windows blockers are **not** fixed here, because they are launcher/packaging concerns rather than source bugs, and fixing them in-tree implies opinionated decisions you may want to make differently:

- uvicorn hardcodes `ProactorEventLoop` on win32 (`uvicorn/loops/asyncio.py`), which psycopg cannot use. Setting an asyncio policy does **not** help — uvicorn builds the loop from its own factory and ignores it, and `uvicorn.Config()` takes no `loop_factory`. Workaround: drive `Server.serve()` on a `SelectorEventLoop` you construct.
- `src/deriver/__main__.py` imports `uvloop`, which has no Windows wheel.

Launchers for both are in the gist linked from #1075. Happy to contribute them or a `docs/` page if wanted.

---

*Disclosure: prepared with an AI agent (Hermes) while self-hosting Honcho on a Windows workstation. The failures are real ones hit during that install, and every log line and command result above was executed on the running stack — not inferred. Reviewed by me before submitting.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown handling on Windows and other platforms.
  * Enhanced telemetry trace writing across operating systems.
  * Prevented concurrent telemetry writes from corrupting trace data.
  * Improved reliability when trace files are accessed simultaneously.
  * Ensured successfully written telemetry records are flushed promptly.
  * Added safer handling when a trace file cannot be locked, preventing incomplete writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->