### PR TITLE
fix(tools): accept singular `search_message` as an alias for `search_messages`

### DIFF
--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -2588,6 +2588,8 @@ _TOOL_HANDLERS: dict[str, Callable[[ToolContext, dict[str, Any]], Any]] = {
     "search_memory": _handle_search_memory,
     "get_observation_context": _handle_get_observation_context,
     "search_messages": _handle_search_messages,
+    # Some models drop the plural and emit "search_message"; accept it as an alias.
+    "search_message": _handle_search_messages,
     "grep_messages": _handle_grep_messages,
     "get_messages_by_date_range": _handle_get_messages_by_date_range,
     "search_messages_temporal": _handle_search_messages_temporal,

--- a/tests/utils/test_agent_tools.py
+++ b/tests/utils/test_agent_tools.py
@@ -1733,6 +1733,22 @@ class TestToolExecutor:
 
         assert "Unknown tool" in result
 
+    async def test_executor_accepts_search_message_alias(self, tool_test_data: Any):
+        """The singular "search_message" resolves to the search handler."""
+        workspace, peer1, peer2, session, _, _ = tool_test_data
+
+        executor = await create_tool_executor(
+            workspace_name=workspace.name,
+            observer=peer1.name,
+            observed=peer2.name,
+            session_name=session.name,
+        )
+
+        result = await executor("search_message", {"query": "coffee"})
+
+        # The alias must dispatch to the search handler, not the unknown-tool path.
+        assert "Unknown tool: search_message" not in result
+
     async def test_executor_handles_exceptions_gracefully(self, tool_test_data: Any):
         """Executor converts exceptions to error strings instead of raising."""
         workspace, peer1, peer2, session, _, _ = tool_test_data


### PR DESCRIPTION
## Description

The Dreamer and Dialectic agents sometimes call a tool named `search_message` (no final "s"). Honcho only registers `search_messages`, so it replies `Unknown tool: search_message`. The agent retries the same name and eventually hits `Tool execution loop reached max iterations`, which makes dreams fail.

This PR adds one alias entry so `search_message` runs the same handler as `search_messages`.

## Proofs

- New unit test `test_executor_accepts_search_message_alias` in `tests/utils/test_agent_tools.py::TestToolExecutor`.
- `uv run pytest tests/utils/test_agent_tools.py::TestToolExecutor -q` → `6 passed`.
- Without the fix, the new test fails with `Unknown tool: search_message` (the test catches the bug).
- `uv run ruff check` and `ruff format --check` → pass; `uv run basedpyright` → 0 errors; `pre-commit run bandit` → pass.

## Checklist

- [x] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.

Fixes #1078


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added support for the singular `search_message` tool name as an alternative to `search_messages`.
  - Requests using the singular name are now correctly routed to message search instead of being rejected as unknown.

- **Tests**
  - Added coverage verifying the singular tool name works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->