### PR TITLE
fix(ci): stop skipping unified tests on merge to main

### DIFF
--- a/.github/workflows/unified-tests.yml
+++ b/.github/workflows/unified-tests.yml
@@ -57,7 +57,10 @@ jobs:
     name: Run Unified Tests
     runs-on: ${{ fromJSON(format('[{0}]', needs.start-runner.outputs.runner-labels)) }}
     needs: start-runner
-    if: needs.start-runner.outputs.runner-ready == 'true'
+    # !cancelled() so this doesn't inherit gate's skip on push events.
+    if: >-
+      !cancelled() &&
+      needs.start-runner.outputs.runner-ready == 'true'
     timeout-minutes: 90
     environment: unified-tests
     permissions:


### PR DESCRIPTION
- The gate job in CI only runs on pull_request: labeled, so it is skipped on push to main. Because it is skipped, the unified-tests job inherits that skip: The implication is that the `unified-tests` job inherits that skip, and does not run. -

- This PR adds !cancelled() to the unified-tests condition, implying we should always run the job on merge to main unless it has been canceled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated test workflow handling for push-triggered runs.
  * Prevented tests from incorrectly being skipped while still stopping execution when a run is cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->