### PR TITLE
test(scopes): pin DREAM.ENABLED so scope-route tests don't depend on local config

### DIFF
--- a/tests/routes/test_scope_route_policy.py
+++ b/tests/routes/test_scope_route_policy.py
@@ -58,9 +58,29 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import models
+from src.config import settings
 from src.main import app
 from src.models import Peer, Workspace
 from src.utils.scopes import scope_peer_name
+
+
+@pytest.fixture(autouse=True)
+def _dreams_enabled(monkeypatch: pytest.MonkeyPatch):
+    """Force DREAM.ENABLED on so this file works regardless of local config.
+
+    This module enumerates the scope policy of every peer-carrying route,
+    `schedule_dream` among them. That route short-circuits with a 400
+    ("Dreams are not enabled in the system configuration") before any scope
+    check runs, so an operator `.env` carrying DREAM_ENABLED=false turns the
+    schedule_dream cases into false failures. Note `src/config.py` calls
+    `load_dotenv(override=True)`, so a `.env` beats a real environment
+    variable — pinning the setting here is the only reliable fix.
+
+    Same intent as tests/dreamer/test_dream_scheduler.py and
+    tests/routes/test_workspaces.py, which already pin it per-test.
+    """
+    monkeypatch.setattr(settings.DREAM, "ENABLED", True)
+
 
 # Request parameters and model fields that carry a peer name, in any position.
 _PEER_PARAM_NAMES = {
@@ -744,9 +764,9 @@ def test_policy_entries_are_well_formed():
                     "status is 422 — missing_status is for the permissive cases"
                 )
             else:
-                assert (
-                    len(case.missing_reason.strip()) > 30
-                ), f"{case.key} tolerates a missing reserved name; say why"
+                assert len(case.missing_reason.strip()) > 30, (
+                    f"{case.key} tolerates a missing reserved name; say why"
+                )
                 assert case.missing_status, (
                     f"{case.key} tolerates a missing reserved name; name the exact "
                     "status(es) it should get, so a 5xx cannot satisfy the case"
@@ -757,9 +777,9 @@ def test_policy_entries_are_well_formed():
                 f"{case.key}: an allow case needs a builder and an expected "
                 "allow_status together, or neither"
             )
-            assert (
-                case.refuse_missing is None
-            ), f"{case.key}: refuse_missing applies to REFUSE cases only"
+            assert case.refuse_missing is None, (
+                f"{case.key}: refuse_missing applies to REFUSE cases only"
+            )
 
 
 _REFUSING = tuple(case for case in POLICY if case.refuse)
@@ -823,9 +843,9 @@ def test_refusing_position_rejects_a_real_scope(
     # A 422 alone proves nothing — a malformed body would also produce one.
     detail = result.text
     if case.schema_level:
-        assert (
-            "pattern" in detail
-        ), f"{case.key} expected a schema-level refusal; detail: {detail[:200]}"
+        assert "pattern" in detail, (
+            f"{case.key} expected a schema-level refusal; detail: {detail[:200]}"
+        )
     else:
         assert "scope" in detail.lower() and backing in detail, (
             f"{case.key} returned 422 but not because of the scope; "

--- a/tests/routes/test_scopes.py
+++ b/tests/routes/test_scopes.py
@@ -1054,6 +1054,7 @@ async def test_dream_cannot_be_queued_for_a_future_scope(
     client: TestClient,
     db_session: AsyncSession,
     sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """A refused dream leaves no queue row behind.
 
@@ -1062,6 +1063,11 @@ async def test_dream_cannot_be_queued_for_a_future_scope(
     is not flagged yet — so the check has to sit in the transaction that inserts
     the queue item, and a check placed after the insert would still 422.
     """
+    # The route 400s on `not settings.DREAM.ENABLED` before reaching the
+    # scope check, and src/config.py load_dotenv(override=True) lets an
+    # operator .env beat the environment, so pin it here.
+    monkeypatch.setattr(settings.DREAM, "ENABLED", True)
+
     test_workspace, test_peer = sample_data
     future = scope_peer_name(str(generate_nanoid()))
 


### PR DESCRIPTION
Fixes #1099

### Problem

Five tests fail on a clean checkout of `main` for anyone whose local `.env` carries `DREAM_ENABLED=false`:

```
tests/routes/test_scope_route_policy.py::test_allowing_position_accepts_a_real_scope[POST:observer]
tests/routes/test_scope_route_policy.py::test_refusing_position_rejects_a_real_scope[POST:observed]
tests/routes/test_scope_route_policy.py::test_refusing_position_allows_unflagged_squatter[POST:observed]
tests/routes/test_scope_route_policy.py::test_refusing_position_and_a_missing_reserved_name[POST:observed]
tests/routes/test_scopes.py::test_dream_cannot_be_queued_for_a_future_scope
```

`POST /v3/workspaces/{id}/schedule_dream` short-circuits on `not settings.DREAM.ENABLED` (`src/routers/workspaces.py:249`) and returns

```
400 {"detail":"Dreams are not enabled in the system configuration"}
```

before any scope check runs. Both files assert on the scope behavior behind that guard, so they get a 400 where they expect 204/422.

CI doesn't see this because CI has no `.env` and `DreamSettings.ENABLED` defaults to `True`.

### Why an env var doesn't fix it

`src/config.py:23` calls `load_dotenv(override=True)`, so a `.env` file **beats a real environment variable**. `DREAM_ENABLED=true uv run pytest` changes nothing. That inverts the precedence documented a few hundred lines further down in `settings_customise_sources`:

```python
# Correct precedence: init > env > .env > toml > secrets > defaults
```

Worth a separate look, but pinning the setting in-process is the reliable fix either way.

### Fix

Pin `settings.DREAM.ENABLED` with `monkeypatch` — the convention this suite already uses in `tests/dreamer/test_dream_scheduler.py:26` ("Patch DREAM.ENABLED to True so tests work regardless of local config") and `tests/routes/test_workspaces.py:739,791`.

- `test_scope_route_policy.py` gets a module-level autouse fixture; it enumerates the scope policy of every peer-carrying route, `schedule_dream` among them.
- `test_scopes.py` pins it for the one dream test only.

No test asserts dreams-disabled behavior, so nothing is masked.

### Verification

```
2250 passed, 47 skipped   # full suite, uv run --frozen
111 passed                # the two files, previously 5 failed
```

Also green under default (random) ordering, so the autouse fixture is order-independent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved route-policy test reliability across all peer-carrying routes.
  - Ensured dream scheduling tests run consistently regardless of local configuration.
  - Added coverage confirming invalid future scopes are rejected without creating queue entries.
  - Reformatted existing assertions for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->