### PR TITLE
fix(peers): cancel non-streaming dialectic when the client disconnects

### DIFF
--- a/src/routers/peers.py
+++ b/src/routers/peers.py
@@ -1,12 +1,13 @@
 """FastAPI routes for peer resources and peer-scoped operations."""
 
+import asyncio
 import json
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable
 from contextlib import suppress
 from time import perf_counter
 
-from fastapi import APIRouter, Body, Depends, Path, Query, Response
+from fastapi import APIRouter, Body, Depends, Path, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlalchemy import apaginate
@@ -45,6 +46,44 @@ router = APIRouter(
     prefix="/workspaces/{workspace_id}/peers",
     tags=["peers"],
 )
+
+
+class _ClientDisconnected(Exception):
+    """Raised when the client goes away before an awaited operation finishes."""
+
+
+async def _wait_for_disconnect(request: Request) -> None:
+    """Block until the client disconnects, draining the ASGI receive channel."""
+    while True:
+        if (await request.receive())["type"] == "http.disconnect":
+            return
+
+
+async def _run_until_disconnect[T](request: Request, coro: Awaitable[T]) -> T:
+    """Await ``coro``, cancelling it if the client disconnects first.
+
+    Uvicorn surfaces a client disconnect on the ASGI receive channel but does
+    not cancel the running handler, so a non-streaming dialectic would keep the
+    (expensive) LLM call going long after the caller has timed out (#1050).
+    Raises ``_ClientDisconnected`` if the client leaves before ``coro`` returns.
+    """
+    work = asyncio.ensure_future(coro)
+    watcher = asyncio.ensure_future(_wait_for_disconnect(request))
+    try:
+        await asyncio.wait({work, watcher}, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        if not watcher.done():
+            watcher.cancel()
+            with suppress(asyncio.CancelledError):
+                await watcher
+
+    if work.done():
+        return work.result()
+
+    work.cancel()
+    with suppress(asyncio.CancelledError):
+        await work
+    raise _ClientDisconnected
 
 
 async def _resolve_scope_option(
@@ -240,6 +279,7 @@ async def get_sessions_for_peer(
     },
 )
 async def chat(
+    request: Request,
     workspace_id: str = Path(...),
     peer_id: str = Path(...),
     options: schemas.DialecticOptions = Body(...),
@@ -392,19 +432,35 @@ async def chat(
             media_type="text/event-stream",
         )
 
-    response = await agentic_chat(
-        workspace_name=workspace_id,
-        session_name=options.session_id,
-        query=options.query,
-        # a single `scope` swaps the observer to the scope peer
-        observer=observer,
-        # if target is given, that's the observed peer. otherwise, observer==observed
-        # and it's answered from the omniscient Honcho perspective
-        observed=options.target if options.target is not None else peer_id,
-        reasoning_level=options.reasoning_level,
-        session_allowlist=session_allowlist,
-        response_model=response_model,
-    )
+    # Uvicorn detects the client going away but doesn't cancel this handler, so
+    # race the dialectic against the disconnect and drop the LLM work if the
+    # caller leaves first (#1050) — the streaming path already dies with its
+    # generator.
+    try:
+        response = await _run_until_disconnect(
+            request,
+            agentic_chat(
+                workspace_name=workspace_id,
+                session_name=options.session_id,
+                query=options.query,
+                # a single `scope` swaps the observer to the scope peer
+                observer=observer,
+                # if target is given, that's the observed peer. otherwise, observer==observed
+                # and it's answered from the omniscient Honcho perspective
+                observed=options.target if options.target is not None else peer_id,
+                reasoning_level=options.reasoning_level,
+                session_allowlist=session_allowlist,
+                response_model=response_model,
+            ),
+        )
+    except _ClientDisconnected:
+        logger.info(
+            "Client disconnected during dialectic chat; cancelling work "
+            + "(workspace=%s peer=%s)",
+            workspace_id,
+            peer_id,
+        )
+        return Response(status_code=499)
 
     # Prometheus metrics
     if settings.METRICS.ENABLED:

--- a/src/routers/peers.py
+++ b/src/routers/peers.py
@@ -53,10 +53,23 @@ class _ClientDisconnected(Exception):
 
 
 async def _wait_for_disconnect(request: Request) -> None:
-    """Block until the client disconnects, draining the ASGI receive channel."""
+    """Block until the client disconnects, draining the ASGI receive channel.
+
+    Args:
+        request: The request whose receive channel is drained.
+    """
     while True:
         if (await request.receive())["type"] == "http.disconnect":
             return
+
+
+async def _cancel_and_wait[T](task: asyncio.Future[T]) -> None:
+    """Cancel ``task`` if it is still pending and wait for it to unwind."""
+    if task.done():
+        return
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
 
 
 async def _run_until_disconnect[T](request: Request, coro: Awaitable[T]) -> T:
@@ -65,25 +78,26 @@ async def _run_until_disconnect[T](request: Request, coro: Awaitable[T]) -> T:
     Uvicorn surfaces a client disconnect on the ASGI receive channel but does
     not cancel the running handler, so a non-streaming dialectic would keep the
     (expensive) LLM call going long after the caller has timed out (#1050).
-    Raises ``_ClientDisconnected`` if the client leaves before ``coro`` returns.
+
+    Args:
+        request: The in-flight request, whose receive channel is watched.
+        coro: The work to run for as long as the client is still listening.
+
+    Raises:
+        _ClientDisconnected: If the client leaves before ``coro`` returns.
     """
     work = asyncio.ensure_future(coro)
     watcher = asyncio.ensure_future(_wait_for_disconnect(request))
     try:
         await asyncio.wait({work, watcher}, return_when=asyncio.FIRST_COMPLETED)
+        if work.done():
+            return work.result()
+        raise _ClientDisconnected
     finally:
-        if not watcher.done():
-            watcher.cancel()
-            with suppress(asyncio.CancelledError):
-                await watcher
-
-    if work.done():
-        return work.result()
-
-    work.cancel()
-    with suppress(asyncio.CancelledError):
-        await work
-    raise _ClientDisconnected
+        # Also covers the wrapper itself being cancelled: without this the LLM
+        # call would outlive the request it was started for.
+        await _cancel_and_wait(watcher)
+        await _cancel_and_wait(work)
 
 
 async def _resolve_scope_option(

--- a/tests/routes/test_chat_disconnect.py
+++ b/tests/routes/test_chat_disconnect.py
@@ -13,12 +13,47 @@ from collections.abc import Awaitable, Callable
 import pytest
 from starlette.requests import Request
 
-from src.routers.peers import _ClientDisconnected, _run_until_disconnect
+from src.routers.peers import (
+    _ClientDisconnected,  # pyright: ignore[reportPrivateUsage]
+    _run_until_disconnect,  # pyright: ignore[reportPrivateUsage]
+)
 
 
 def _request(receive: Callable[[], Awaitable[dict[str, object]]]) -> Request:
-    """A minimal ASGI request whose receive channel is scripted per test."""
+    """A minimal ASGI request whose receive channel is scripted per test.
+
+    Args:
+        receive: The scripted ASGI receive callable for this test.
+    """
     return Request({"type": "http", "method": "POST", "headers": []}, receive)
+
+
+async def test_cancelling_the_wrapper_cancels_the_work():
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def slow_work() -> str:
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return "should not get here"
+
+    # Never disconnects — the only thing ending this request is the server
+    # tearing the handler down (shutdown, timeout middleware, worker restart).
+    async def receive() -> dict[str, object]:
+        await asyncio.Event().wait()
+        return {"type": "http.disconnect"}
+
+    task = asyncio.ensure_future(_run_until_disconnect(_request(receive), slow_work()))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cancelled.is_set()
 
 
 async def test_disconnect_cancels_inflight_work():

--- a/tests/routes/test_chat_disconnect.py
+++ b/tests/routes/test_chat_disconnect.py
@@ -1,0 +1,92 @@
+"""Disconnect handling for the non-streaming dialectic chat route (#1050).
+
+Uvicorn reports a client disconnect on the ASGI receive channel but does not
+cancel the running handler, so a non-streaming `/chat` request could keep its
+(expensive) LLM call alive for minutes after the caller had already timed out.
+These exercise the race helper directly — no DB, no LLM — so the cancellation
+contract is pinned without standing up the full stack.
+"""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+import pytest
+from starlette.requests import Request
+
+from src.routers.peers import _ClientDisconnected, _run_until_disconnect
+
+
+def _request(receive: Callable[[], Awaitable[dict[str, object]]]) -> Request:
+    """A minimal ASGI request whose receive channel is scripted per test."""
+    return Request({"type": "http", "method": "POST", "headers": []}, receive)
+
+
+async def test_disconnect_cancels_inflight_work():
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def slow_work() -> str:
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return "should not get here"
+
+    async def receive() -> dict[str, object]:
+        # Let the work start, then report the client hanging up.
+        await started.wait()
+        return {"type": "http.disconnect"}
+
+    with pytest.raises(_ClientDisconnected):
+        await asyncio.wait_for(
+            _run_until_disconnect(_request(receive), slow_work()), timeout=1
+        )
+
+    assert cancelled.is_set()
+
+
+async def test_completed_work_returns_and_stops_watching():
+    async def work() -> str:
+        return "answer"
+
+    # A receive that never yields a disconnect — the watcher must be torn down
+    # once the work finishes rather than leaking a pending task.
+    async def receive() -> dict[str, object]:
+        await asyncio.Event().wait()
+        return {"type": "http.disconnect"}
+
+    before = len(asyncio.all_tasks())
+    result = await asyncio.wait_for(
+        _run_until_disconnect(_request(receive), work()), timeout=1
+    )
+
+    assert result == "answer"
+    # give the cancelled watcher a tick to unwind
+    await asyncio.sleep(0)
+    assert len(asyncio.all_tasks()) <= before
+
+
+async def test_non_disconnect_receive_messages_are_ignored():
+    # A stray http.request frame must not be mistaken for a disconnect.
+    frames: list[dict[str, object]] = [
+        {"type": "http.request", "body": b"", "more_body": False}
+    ]
+    messages = iter(frames)
+
+    async def receive() -> dict[str, object]:
+        try:
+            return next(messages)
+        except StopIteration:
+            await asyncio.Event().wait()  # then block
+            raise  # pragma: no cover
+
+    async def work() -> str:
+        await asyncio.sleep(0)
+        return "done"
+
+    result = await asyncio.wait_for(
+        _run_until_disconnect(_request(receive), work()), timeout=1
+    )
+    assert result == "done"


### PR DESCRIPTION
Fixes #1050. A non-streaming dialectic `/chat` request keeps running after the caller has gone away. Uvicorn notices the disconnect and surfaces it on the ASGI receive channel, but it doesn't cancel the handler coroutine, so `await agentic_chat(...)` sails on toward the provider's much longer timeout — the reporter saw abandoned Ollama calls survive ~10 minutes past a 30s client timeout, and with the SDK's retries plus Honcho's outer retry layer those pile up.

The streaming path already dies when its generator is dropped; only the non-streaming branch was affected. I race the dialectic against a small watcher that drains `request.receive()` until it sees `http.disconnect`. Whichever finishes first wins: if the work completes, the watcher is cancelled and the response is returned as before; if the client leaves first, the dialectic task is cancelled (and awaited, so cancellation propagates down to the LLM call) and the route returns 499.

The watcher ignores non-disconnect frames, so a stray `http.request` can't be mistaken for a hangup. Added unit tests over the race helper covering all three cases — no DB or LLM needed. Full route suite (`tests/routes`, `tests/dialectic`, the chat/allowlist tests) stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped processing non-streaming chat requests when the client disconnects.
  * Cancelled in-progress chat generation after disconnection and returned an appropriate HTTP 499 response.
  * Continued to ignore unrelated request messages while monitoring connection status.

* **Tests**
  * Added coverage for disconnect handling, completed requests, task cleanup, cancellation, and non-disconnect messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->