### PR TITLE
feat(messages): add DELETE endpoint for a single message

### DIFF
--- a/src/crud/__init__.py
+++ b/src/crud/__init__.py
@@ -23,6 +23,7 @@ from .document import (
 )
 from .message import (
     create_messages,
+    delete_message,
     get_message,
     get_message_seq_in_session,
     get_messages,
@@ -135,6 +136,7 @@ __all__ = [
     "search_messages",
     "search_messages_temporal",
     "update_message",
+    "delete_message",
     # Peer
     "get_or_create_peers",
     "get_peer",

--- a/src/crud/message.py
+++ b/src/crud/message.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from typing import Any
 
 from nanoid import generate as generate_nanoid
-from sqlalchemy import ColumnElement, Select, and_, func, or_, select, text
+from sqlalchemy import ColumnElement, Select, and_, delete, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -12,6 +12,7 @@ from src import models, schemas
 from src.config import settings
 from src.dependencies import tracked_db
 from src.embedding_client import embedding_client
+from src.exceptions import ResourceNotFoundException
 from src.telemetry.events import EmbeddingCallPurpose
 from src.utils.filter import apply_filter
 from src.utils.formatting import ILIKE_ESCAPE_CHAR, escape_ilike_pattern
@@ -730,6 +731,81 @@ async def update_message(
     await db.commit()
     # await db.refresh(honcho_message)
     return honcho_message
+
+
+async def delete_message(
+    db: AsyncSession,
+    workspace_name: str,
+    session_name: str,
+    message_id: str,
+) -> None:
+    """Hard-delete a single message and the state tied to it.
+
+    Removes the message, its embeddings (and their vectors in an external
+    vector store, if configured), and any queue items that reference it.
+    Conclusions already derived from the message are intentionally left in
+    place — a conclusion can draw on several messages, so cascading here would
+    silently prune a peer's representation. Cannot be undone.
+
+    Raises:
+        ResourceNotFoundException: If the message does not exist in the session.
+    """
+    honcho_message = await get_message(
+        db,
+        workspace_name=workspace_name,
+        session_name=session_name,
+        message_id=message_id,
+    )
+    if honcho_message is None:
+        raise ResourceNotFoundException(f"Message with ID {message_id} not found")
+
+    try:
+        # Drop this message's vectors from an external store before its rows go
+        # away (pgvector embeddings cascade with the message; an external store
+        # doesn't, so it's handled here — best effort).
+        embedding_result = await db.execute(
+            select(models.MessageEmbedding).where(
+                models.MessageEmbedding.message_id == honcho_message.public_id,
+                models.MessageEmbedding.workspace_name == workspace_name,
+            )
+        )
+        embeddings = list(embedding_result.scalars().all())
+        external_vector_store = get_external_vector_store()
+        if external_vector_store is not None and embeddings:
+            embeddings.sort(key=lambda e: e.id)
+            vector_ids = [
+                f"{honcho_message.public_id}_{chunk_idx}"
+                for chunk_idx in range(len(embeddings))
+            ]
+            try:
+                namespace = external_vector_store.get_vector_namespace(
+                    "message", workspace_name
+                )
+                await external_vector_store.delete_many(namespace, vector_ids)
+            except Exception as e:
+                logger.warning(
+                    "Failed to delete message vectors for message %s: %s",
+                    message_id,
+                    e,
+                )
+
+        # Queue items reference messages.id with no ON DELETE rule, so clear them
+        # first or the message delete hits a foreign-key violation.
+        await db.execute(
+            delete(models.QueueItem).where(
+                models.QueueItem.message_id == honcho_message.id
+            )
+        )
+
+        # MessageEmbedding rows cascade via ondelete="CASCADE" on the message FK.
+        await db.delete(honcho_message)
+        await db.commit()
+
+        logger.debug("Message %s deleted", message_id)
+    except Exception as e:
+        logger.error("Failed to delete message %s: %s", message_id, e)
+        await db.rollback()
+        raise e
 
 
 async def _search_messages_external(

--- a/src/routers/messages.py
+++ b/src/routers/messages.py
@@ -392,3 +392,31 @@ async def update_message(
     except ValueError as e:
         logger.warning(f"Failed to update message {message_id}: {str(e)}")
         raise ResourceNotFoundException("Message not found") from e
+
+
+@router.delete(
+    "/{message_id}",
+    status_code=204,
+    response_model=None,
+    dependencies=[Depends(require_session_write)],
+)
+async def delete_message(
+    workspace_id: str = Path(...),
+    session_id: str = Path(...),
+    message_id: str = Path(...),
+    db: AsyncSession = db,
+):
+    """
+    Delete a single message from a Session.
+
+    Removes the message along with its embeddings and any pending queue items.
+    Conclusions already derived from the message are left untouched.
+    This action cannot be undone.
+    """
+    await crud.delete_message(
+        db,
+        workspace_name=workspace_id,
+        session_name=session_id,
+        message_id=message_id,
+    )
+    logger.debug("Message %s deleted successfully", message_id)

--- a/tests/routes/test_messages.py
+++ b/tests/routes/test_messages.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 from nanoid import generate as generate_nanoid
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import models
@@ -1372,3 +1373,138 @@ async def test_create_message_with_null_timestamp(
         message["created_at"].replace("Z", "+00:00")
     )
     assert before_request <= message_created_at <= after_request
+
+
+@pytest.mark.asyncio
+async def test_delete_message(
+    client: TestClient, db_session: AsyncSession, sample_data: tuple[Workspace, Peer]
+):
+    """Deleting a single message removes only that message, leaving siblings."""
+    test_workspace, test_peer = sample_data
+
+    test_session = models.Session(
+        workspace_name=test_workspace.name, name=str(generate_nanoid())
+    )
+    db_session.add(test_session)
+    await db_session.commit()
+
+    base = f"/v3/workspaces/{test_workspace.name}/sessions/{test_session.name}/messages"
+    created = client.post(
+        base,
+        json={
+            "messages": [
+                {"content": "keep me", "peer_id": test_peer.name},
+                {"content": "delete me", "peer_id": test_peer.name},
+            ]
+        },
+    ).json()
+    keep_id, target_id = created[0]["id"], created[1]["id"]
+
+    response = client.delete(f"{base}/{target_id}")
+    assert response.status_code == 204
+
+    # The deleted message is gone, the sibling remains.
+    assert client.get(f"{base}/{target_id}").status_code == 404
+    remaining = client.post(f"{base}/list", json={}).json()["items"]
+    assert [m["id"] for m in remaining] == [keep_id]
+
+
+@pytest.mark.asyncio
+async def test_delete_message_not_found(
+    client: TestClient, db_session: AsyncSession, sample_data: tuple[Workspace, Peer]
+):
+    """Deleting a nonexistent message returns 404."""
+    test_workspace, _test_peer = sample_data
+
+    test_session = models.Session(
+        workspace_name=test_workspace.name, name=str(generate_nanoid())
+    )
+    db_session.add(test_session)
+    await db_session.commit()
+
+    response = client.delete(
+        f"/v3/workspaces/{test_workspace.name}"
+        f"/sessions/{test_session.name}/messages/{generate_nanoid()}"
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_message_clears_embeddings_and_queue_items(
+    client: TestClient, db_session: AsyncSession, sample_data: tuple[Workspace, Peer]
+):
+    """A message's embeddings and queue items are removed with it. Queue items
+    FK messages.id with no ON DELETE rule, so they must be cleared first or the
+    delete fails; embeddings cascade but are asserted gone too."""
+    test_workspace, test_peer = sample_data
+
+    test_session = models.Session(
+        workspace_name=test_workspace.name, name=str(generate_nanoid())
+    )
+    db_session.add(test_session)
+    await db_session.commit()
+    await db_session.refresh(test_session)
+
+    message = models.Message(
+        session_name=test_session.name,
+        content="Test message",
+        workspace_name=test_workspace.name,
+        peer_name=test_peer.name,
+        seq_in_session=1,
+    )
+    db_session.add(message)
+    await db_session.commit()
+    await db_session.refresh(message)
+
+    db_session.add(
+        models.MessageEmbedding(
+            content="Test message",
+            message_id=message.public_id,
+            workspace_name=test_workspace.name,
+            session_name=test_session.name,
+            peer_name=test_peer.name,
+        )
+    )
+    db_session.add(
+        models.QueueItem(
+            session_id=test_session.id,
+            work_unit_key="representation:test",
+            task_type="representation",
+            payload={},
+            workspace_name=test_workspace.name,
+            message_id=message.id,
+        )
+    )
+    await db_session.commit()
+
+    response = client.delete(
+        f"/v3/workspaces/{test_workspace.name}"
+        f"/sessions/{test_session.name}/messages/{message.public_id}"
+    )
+    assert response.status_code == 204
+
+    db_session.expire_all()
+    embeddings = (
+        (
+            await db_session.execute(
+                select(models.MessageEmbedding).where(
+                    models.MessageEmbedding.message_id == message.public_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert embeddings == []
+    queue_items = (
+        (
+            await db_session.execute(
+                select(models.QueueItem).where(
+                    models.QueueItem.message_id == message.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert queue_items == []


### PR DESCRIPTION
Closes #956. Messages were the one resource router without a DELETE — `conclusions`, `sessions`, `workspaces` and `webhooks` all have one, so removing a single stored message meant deleting its whole session. That's the wrong tool when the thing you need gone is one line among thousands (a secret captured into a message, an erasure request), and the issue is marked maintainer-approved.

Added `DELETE /v3/workspaces/{workspace_id}/sessions/{session_id}/messages/{message_id}`, mirroring the shape and semantics of the conclusion delete — 204, session-write scope, "cannot be undone".

The crud path is FK-order-aware, matching what `delete_session` already does: queue items reference `messages.id` with no `ON DELETE` rule, so they're cleared before the message or the delete hits a foreign-key violation. Message embeddings cascade with the message (`ondelete="CASCADE"`), and if an external vector store is configured its vectors are dropped first (best effort), same as session delete.

On the open question from the issue about derived state: conclusions already derived from the message are left in place. A conclusion can draw on several source messages, so cascading here would silently prune a peer's representation — I went with the conservative "leave it and say so" behaviour the issue floated, documented in the endpoint. Happy to switch to cascading if you'd prefer.

Tests cover the happy path (message gone, sibling untouched), 404 for a missing id, and that embeddings and queue items are actually cleared — the last one fails without the queue cleanup, which was the FK trap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to permanently delete individual messages from a session.
  * Related embeddings and pending processing items are removed automatically, while derived conclusions are preserved.
  * Deletion is restricted to authorized session writes and returns a successful no-content response.

* **Bug Fixes**
  * Requests to delete nonexistent messages now return a not-found response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->