### PR TITLE
fix(deriver): strip NUL bytes from model-generated observations

### DIFF
--- a/src/crud/representation.py
+++ b/src/crud/representation.py
@@ -25,6 +25,7 @@ from src.utils.representation import (
     Representation,
     allowlist_safe_levels,
 )
+from src.utils.sanitization import strip_nul
 from src.utils.types import embedding_call_purpose
 
 logger = logging.getLogger(__name__)
@@ -38,10 +39,21 @@ def _observation_text(obs: ExplicitObservation | DeductiveObservation) -> str:
 def _normalized_observation(
     obs: ExplicitObservation | DeductiveObservation,
 ) -> ExplicitObservation | DeductiveObservation:
-    """Return an observation with its persisted/embed text normalized."""
-    text = _observation_text(obs).strip()
+    """Return an observation with its persisted/embed text normalized.
+
+    NUL bytes are removed here rather than closer to the database so that the
+    text that gets embedded is the same text that gets stored.
+    """
+    text = strip_nul(_observation_text(obs)).strip()
     if isinstance(obs, DeductiveObservation):
-        return obs.model_copy(update={"conclusion": text})
+        return obs.model_copy(
+            update={
+                "conclusion": text,
+                # Premises ride along in internal_metadata, and jsonb rejects
+                # NUL in strings just as text columns do.
+                "premises": strip_nul(obs.premises),
+            }
+        )
     return obs.model_copy(update={"content": text})
 
 
@@ -87,10 +99,15 @@ class RepresentationManager:
             logger.debug("No observations to save")
             return empty_result
 
+        # Normalize before the emptiness check: str.strip() does not remove
+        # NUL, so content that normalizes away has to be dropped afterwards.
         all_observations = [
-            _normalized_observation(obs)
-            for obs in representation.deductive + representation.explicit
-            if _observation_text(obs).strip()
+            normalized
+            for normalized in (
+                _normalized_observation(obs)
+                for obs in representation.deductive + representation.explicit
+            )
+            if _observation_text(normalized)
         ]
         if not all_observations:
             logger.debug("No non-empty observations to save")

--- a/src/schemas/api.py
+++ b/src/schemas/api.py
@@ -31,6 +31,7 @@ from src.schemas.configuration import (
     SessionPeerConfig,
     WorkspaceConfiguration,
 )
+from src.utils.sanitization import NulStripped, strip_nul
 from src.utils.scopes import (
     SCOPE_PEER_PREFIX,
     is_scope_peer_name,
@@ -46,28 +47,6 @@ RESOURCE_NAME_PATTERN = r"^[a-zA-Z0-9_-]+$"
 
 _METADATA_MAX_KEYS = 100
 _METADATA_MAX_DEPTH = 5
-
-
-def _sanitize_value(v: Any) -> Any:
-    """Recursively strip NUL bytes from strings in nested data structures."""
-    if isinstance(v, str):
-        return v.replace("\x00", "")
-    if isinstance(v, dict):
-        d = cast(dict[str, Any], v)
-        return {_sanitize_value(k): _sanitize_value(val) for k, val in d.items()}
-    if isinstance(v, list):
-        lst = cast(list[Any], v)
-        return [_sanitize_value(item) for item in lst]
-    return v
-
-
-def _strip_nul(v: str) -> str:
-    """Strip NUL bytes from a string field (Postgres TEXT rejects \\x00)."""
-    return v.replace("\x00", "")
-
-
-# Reusable annotation for query fields; composes with a per-field Field(...).
-NulStripped = AfterValidator(_strip_nul)
 
 
 def _check_metadata_limits(
@@ -97,7 +76,7 @@ def _validate_metadata(v: Any) -> Any:
         return v
     data = cast(dict[str, Any], v)
     _check_metadata_limits(data)
-    return _sanitize_value(data)
+    return strip_nul(data)
 
 
 _SanitizedMetadata = Annotated[dict[str, Any], BeforeValidator(_validate_metadata)]
@@ -331,7 +310,7 @@ class PeerCardSet(BaseModel):
     def sanitize_peer_card(cls, v: Any) -> Any:
         if isinstance(v, list):
             return [
-                item.replace("\x00", "") if isinstance(item, str) else item
+                strip_nul(item) if isinstance(item, str) else item
                 for item in cast(list[Any], v)
             ]
         return v
@@ -358,7 +337,7 @@ class MessageCreate(MessageBase):
     @field_validator("content", mode="after")
     @classmethod
     def sanitize_content(cls, v: str) -> str:
-        return v.replace("\x00", "")
+        return strip_nul(v)
 
     @property
     def encoded_message(self) -> list[int]:
@@ -691,7 +670,7 @@ class ConclusionCreate(BaseModel):
     @field_validator("content", mode="after")
     @classmethod
     def sanitize_content(cls, v: str) -> str:
-        return v.replace("\x00", "")
+        return strip_nul(v)
 
     @model_validator(mode="after")
     def validate_token_count(self) -> Self:

--- a/src/schemas/internal.py
+++ b/src/schemas/internal.py
@@ -109,10 +109,16 @@ class ObservationInput(BaseModel):
     ) = None
     confidence: Literal["high", "medium", "low"] | None = None
 
-    @field_validator("content", mode="after")
+    @field_validator("content", mode="before")
     @classmethod
-    def sanitize_content(cls, v: str) -> str:
-        return v.replace("\x00", "")
+    def sanitize_content(cls, v: Any) -> Any:
+        """Strip NUL bytes, which Postgres rejects in text columns.
+
+        Runs before the length constraint so all-NUL content fails
+        `min_length` and is reported back to the model as a validation
+        failure, rather than validating into an empty string.
+        """
+        return strip_nul(v) if isinstance(v, str) else v
 
     @model_validator(mode="after")
     def validate_level_fields(self) -> Self:

--- a/src/schemas/internal.py
+++ b/src/schemas/internal.py
@@ -4,12 +4,13 @@ These are not part of the public API contract and may change without notice.
 """
 
 from enum import Enum
-from typing import Annotated, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from src.schemas.api import MessageCreate
 from src.schemas.configuration import SessionPeerConfig
+from src.utils.sanitization import strip_nul
 from src.utils.types import DocumentLevel
 
 
@@ -80,6 +81,18 @@ class DocumentCreate(DocumentBase):
         default=None,
         description="Document IDs of source/premise documents -- for deductive and inductive documents",
     )
+
+    @field_validator("content", mode="before")
+    @classmethod
+    def sanitize_content(cls, v: Any) -> Any:
+        """Strip NUL bytes, which Postgres rejects in text columns.
+
+        Callers are expected to have normalized already so that the embedded
+        text matches the stored text; this is the last line of defence. It runs
+        before the length constraint so all-NUL content fails `min_length`
+        instead of being stored as an empty string.
+        """
+        return strip_nul(v) if isinstance(v, str) else v
 
 
 class ObservationInput(BaseModel):

--- a/src/schemas/internal.py
+++ b/src/schemas/internal.py
@@ -4,13 +4,13 @@ These are not part of the public API contract and may change without notice.
 """
 
 from enum import Enum
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Literal, Self
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from src.schemas.api import MessageCreate
 from src.schemas.configuration import SessionPeerConfig
-from src.utils.sanitization import strip_nul
+from src.utils.sanitization import NulStripped
 from src.utils.types import DocumentLevel
 
 
@@ -60,7 +60,7 @@ class DocumentMetadata(BaseModel):
 
 
 class DocumentCreate(DocumentBase):
-    content: Annotated[str, Field(min_length=1, max_length=100000)]
+    content: Annotated[str, Field(min_length=1, max_length=100000), NulStripped]
     session_name: str | None = Field(
         default=None,
         description="The session from which the document was derived (NULL for global observations)",
@@ -82,23 +82,11 @@ class DocumentCreate(DocumentBase):
         description="Document IDs of source/premise documents -- for deductive and inductive documents",
     )
 
-    @field_validator("content", mode="before")
-    @classmethod
-    def sanitize_content(cls, v: Any) -> Any:
-        """Strip NUL bytes, which Postgres rejects in text columns.
-
-        Callers are expected to have normalized already so that the embedded
-        text matches the stored text; this is the last line of defence. It runs
-        before the length constraint so all-NUL content fails `min_length`
-        instead of being stored as an empty string.
-        """
-        return strip_nul(v) if isinstance(v, str) else v
-
 
 class ObservationInput(BaseModel):
     """Validated observation input from LLM tool calls."""
 
-    content: Annotated[str, Field(min_length=1)]
+    content: Annotated[str, Field(min_length=1), NulStripped]
     level: DocumentLevel = "explicit"
     source_ids: list[str] | None = None
     premises: list[str] | None = None
@@ -108,17 +96,6 @@ class ObservationInput(BaseModel):
         | None
     ) = None
     confidence: Literal["high", "medium", "low"] | None = None
-
-    @field_validator("content", mode="before")
-    @classmethod
-    def sanitize_content(cls, v: Any) -> Any:
-        """Strip NUL bytes, which Postgres rejects in text columns.
-
-        Runs before the length constraint so all-NUL content fails
-        `min_length` and is reported back to the model as a validation
-        failure, rather than validating into an empty string.
-        """
-        return strip_nul(v) if isinstance(v, str) else v
 
     @model_validator(mode="after")
     def validate_level_fields(self) -> Self:

--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -36,6 +36,7 @@ from src.utils.representation import (
     Representation,
     allowlist_safe_levels,
 )
+from src.utils.sanitization import strip_nul
 from src.utils.types import ToolResult, embedding_call_purpose, get_current_iteration
 
 logger = logging.getLogger(__name__)
@@ -77,8 +78,20 @@ def _validate_peer_card_entry(line: str) -> bool:
 def _normalized_observation_input(
     obs: schemas.ObservationInput,
 ) -> schemas.ObservationInput:
-    """Return an observation input with content normalized for persistence/embedding."""
-    return obs.model_copy(update={"content": obs.content.strip()})
+    """Return an observation input with content normalized for persistence/embedding.
+
+    NUL bytes are removed here rather than closer to the database so that the
+    text that gets embedded is the same text that gets stored. `premises` and
+    `sources` ride along in internal_metadata, and jsonb rejects NUL in strings
+    just as text columns do.
+    """
+    return obs.model_copy(
+        update={
+            "content": strip_nul(obs.content).strip(),
+            "premises": strip_nul(obs.premises),
+            "sources": strip_nul(obs.sources),
+        }
+    )
 
 
 def _base_observation_properties() -> dict[str, Any]:
@@ -986,10 +999,12 @@ async def create_observations(
         logger.warning("create_observations called with empty list")
         return ObservationsCreatedResult(created_count=0, created_levels=[], failed=[])
 
+    # Normalize before the emptiness check: str.strip() does not remove NUL,
+    # so content that normalizes away has to be dropped afterwards.
     normalized_observations = [
-        _normalized_observation_input(obs)
-        for obs in observations
-        if obs.content.strip()
+        normalized
+        for normalized in (_normalized_observation_input(obs) for obs in observations)
+        if normalized.content
     ]
     if not normalized_observations:
         logger.info("No non-empty observations to create")

--- a/src/utils/sanitization.py
+++ b/src/utils/sanitization.py
@@ -9,7 +9,7 @@ arguments, which the JSON parser decodes into a real NUL byte.
 
 from typing import Any, cast, overload
 
-from pydantic import AfterValidator
+from pydantic import BeforeValidator
 
 __all__ = ["NulStripped", "strip_nul"]
 
@@ -41,6 +41,6 @@ def strip_nul(value: Any) -> Any:
 
 
 # Reusable annotation for string fields; composes with a per-field Field(...).
-# Only safe on fields without a `min_length` constraint, since the constraint is
-# checked before this runs -- use a `mode="before"` field validator otherwise.
-NulStripped = AfterValidator(strip_nul)
+# Runs *before* the field's own constraints, so `min_length` is checked against
+# the stripped value and all-NUL input is rejected instead of becoming "".
+NulStripped = BeforeValidator(strip_nul)

--- a/src/utils/sanitization.py
+++ b/src/utils/sanitization.py
@@ -1,0 +1,46 @@
+"""Helpers for stripping bytes Postgres cannot store in text columns.
+
+Postgres rejects NUL (0x00) in ``text``/``varchar`` values and in ``jsonb``
+strings, so any string bound into a query or persisted to those columns has to
+have NUL removed first. This applies to model-generated text as much as to
+user-supplied input: an LLM can emit a ``\\u0000`` escape in its tool-call
+arguments, which the JSON parser decodes into a real NUL byte.
+"""
+
+from typing import Any, cast, overload
+
+from pydantic import AfterValidator
+
+__all__ = ["NulStripped", "strip_nul"]
+
+
+@overload
+def strip_nul(value: str) -> str: ...
+
+
+@overload
+def strip_nul(value: Any) -> Any: ...
+
+
+def strip_nul(value: Any) -> Any:
+    """Recursively remove NUL bytes from strings, including nested ones.
+
+    Dict keys are stripped alongside values. Anything that is not a string,
+    dict, or list -- ``None`` included -- is returned unchanged, so this can be
+    applied to an optional field without a guard.
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, dict):
+        d = cast(dict[str, Any], value)
+        return {strip_nul(k): strip_nul(v) for k, v in d.items()}
+    if isinstance(value, list):
+        lst = cast(list[Any], value)
+        return [strip_nul(item) for item in lst]
+    return value
+
+
+# Reusable annotation for string fields; composes with a per-field Field(...).
+# Only safe on fields without a `min_length` constraint, since the constraint is
+# checked before this runs -- use a `mode="before"` field validator otherwise.
+NulStripped = AfterValidator(strip_nul)

--- a/tests/crud/test_representation_manager.py
+++ b/tests/crud/test_representation_manager.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -196,7 +196,7 @@ class TestRepresentationManagerSoftDelete:
             db_session, test_workspace, test_peer
         )
 
-        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        base = datetime(2026, 1, 1, tzinfo=UTC)
         # Three conclusions, all reinforced once, inserted oldest-first.
         for i in range(3):
             db_session.add(
@@ -484,13 +484,13 @@ class TestRepresentationManagerSave:
             explicit=[
                 ExplicitObservation(
                     content="   ",
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                     message_ids=[1],
                     session_name="session",
                 ),
                 ExplicitObservation(
                     content=" useful observation ",
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                     message_ids=[1],
                     session_name="session",
                 ),
@@ -515,7 +515,7 @@ class TestRepresentationManagerSave:
                 representation,
                 message_ids=[1],
                 session_name="session",
-                message_created_at=datetime.now(timezone.utc),
+                message_created_at=datetime.now(UTC),
                 message_level_configuration=_resolved_config(),
             )
 
@@ -540,7 +540,7 @@ class TestRepresentationManagerSave:
                     conclusion="   ",
                     premises=["premise a"],
                     source_ids=["doc-a"],
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                     message_ids=[1],
                     session_name="session",
                 ),
@@ -548,7 +548,7 @@ class TestRepresentationManagerSave:
                     conclusion=" inferred conclusion ",
                     premises=["premise b"],
                     source_ids=["doc-b"],
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                     message_ids=[1],
                     session_name="session",
                 ),
@@ -573,7 +573,7 @@ class TestRepresentationManagerSave:
                 representation,
                 message_ids=[1],
                 session_name="session",
-                message_created_at=datetime.now(timezone.utc),
+                message_created_at=datetime.now(UTC),
                 message_level_configuration=_resolved_config(),
             )
 
@@ -597,13 +597,13 @@ class TestRepresentationManagerSave:
             explicit=[
                 ExplicitObservation(
                     content="",
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                     message_ids=[1],
                     session_name="session",
                 ),
                 ExplicitObservation(
                     content="\n\t ",
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                     message_ids=[1],
                     session_name="session",
                 ),
@@ -626,7 +626,124 @@ class TestRepresentationManagerSave:
                 representation,
                 message_ids=[1],
                 session_name="session",
-                message_created_at=datetime.now(timezone.utc),
+                message_created_at=datetime.now(UTC),
+                message_level_configuration=_resolved_config(),
+            )
+
+        assert len(saved.created_documents) == 0
+        mock_embed.assert_not_awaited()
+        mock_save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_save_representation_strips_nul_bytes(self):
+        """Models emit \\u0000 escapes when transcribing shell output or Windows
+        paths, and Postgres rejects NUL in text columns. The stripped text must
+        be what gets embedded as well as what gets stored."""
+        manager = RepresentationManager(
+            "workspace",
+            observer="observer",
+            observed="observed",
+        )
+        representation = Representation(
+            explicit=[
+                ExplicitObservation(
+                    content="ran 'cat /proc/1/environ | tr '\x00' '\\n''",
+                    created_at=datetime.now(UTC),
+                    message_ids=[1],
+                    session_name="session",
+                ),
+            ],
+            deductive=[
+                DeductiveObservation(
+                    conclusion="the key is at c:\\\x00users\\amal",
+                    premises=["saw c:\\\x00users in the prompt"],
+                    created_at=datetime.now(UTC),
+                    message_ids=[1],
+                    session_name="session",
+                ),
+            ],
+        )
+
+        with (
+            patch("src.crud.representation.tracked_db", _fake_tracked_db),
+            patch(
+                "src.crud.representation.embedding_client.simple_batch_embed",
+                new=AsyncMock(return_value=[[0.1], [0.2]]),
+            ) as mock_embed,
+            patch.object(
+                manager,
+                "_save_representation_internal",
+                new=AsyncMock(
+                    return_value=CreateDocumentsResult(created_documents=[MagicMock()])
+                ),
+            ) as mock_save,
+        ):
+            await manager.save_representation(
+                representation,
+                message_ids=[1],
+                session_name="session",
+                message_created_at=datetime.now(UTC),
+                message_level_configuration=_resolved_config(),
+            )
+
+        # Deductive observations are embedded ahead of explicit ones.
+        mock_embed.assert_awaited_once_with(
+            [
+                "the key is at c:\\users\\amal",
+                "ran 'cat /proc/1/environ | tr '' '\\n''",
+            ],
+            on_oversize="truncate",
+        )
+
+        saved_observations = _saved_observations(mock_save)
+        deductive = next(
+            obs for obs in saved_observations if isinstance(obs, DeductiveObservation)
+        )
+        explicit = next(
+            obs for obs in saved_observations if isinstance(obs, ExplicitObservation)
+        )
+        assert explicit.content == "ran 'cat /proc/1/environ | tr '' '\\n''"
+        assert deductive.conclusion == "the key is at c:\\users\\amal"
+        # premises land in internal_metadata, and jsonb rejects NUL too
+        assert deductive.premises == ["saw c:\\users in the prompt"]
+
+    @pytest.mark.asyncio
+    async def test_save_representation_skips_observations_that_are_only_nul(self):
+        """str.strip() does not remove NUL, so the emptiness check has to run
+        after normalization or an empty document gets written."""
+        manager = RepresentationManager(
+            "workspace",
+            observer="observer",
+            observed="observed",
+        )
+        representation = Representation(
+            explicit=[
+                ExplicitObservation(
+                    content="\x00\x00",
+                    created_at=datetime.now(UTC),
+                    message_ids=[1],
+                    session_name="session",
+                ),
+            ]
+        )
+
+        with (
+            patch("src.crud.representation.tracked_db", _fake_tracked_db),
+            patch(
+                "src.crud.representation.embedding_client.simple_batch_embed",
+                new=AsyncMock(),
+            ) as mock_embed,
+            patch.object(
+                manager,
+                "_save_representation_internal",
+                new=AsyncMock(),
+            ) as mock_save,
+        ):
+            saved = await manager.save_representation(
+                representation,
+                message_ids=[1],
+                session_name="session",
+                message_created_at=datetime.now(UTC),
                 message_level_configuration=_resolved_config(),
             )
 
@@ -646,7 +763,7 @@ class TestRepresentationManagerSave:
             explicit=[
                 ExplicitObservation(
                     content="short fact",
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                     message_ids=[1],
                     session_name="session",
                 )
@@ -656,7 +773,7 @@ class TestRepresentationManagerSave:
                     conclusion="inferred fact",
                     premises=["premise"],
                     source_ids=["doc-a"],
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                     message_ids=[1],
                     session_name="session",
                 )
@@ -681,7 +798,7 @@ class TestRepresentationManagerSave:
                 representation,
                 message_ids=[1],
                 session_name="session",
-                message_created_at=datetime.now(timezone.utc),
+                message_created_at=datetime.now(UTC),
                 message_level_configuration=_resolved_config(),
             )
 

--- a/tests/test_schema_validations.py
+++ b/tests/test_schema_validations.py
@@ -5,9 +5,11 @@ from pydantic import ValidationError
 
 from src.config import settings
 from src.schemas import (
+    DialecticOptions,
     DocumentCreate,
     DocumentMetadata,
     MessageCreate,
+    ObservationInput,
     PeerCreate,
     ReasoningConfiguration,
     ResolvedConfiguration,
@@ -319,3 +321,24 @@ class TestNulByteSanitization:
         )
 
         assert message.metadata == {"ab": {"c": ["de", 1]}}
+
+    def test_observation_content_strips_nul(self):
+        observation = ObservationInput(content="before\x00after")
+
+        assert observation.content == "beforeafter"
+
+    def test_all_nul_observation_content_is_rejected_not_emptied(self):
+        """Sanitization runs before `min_length`, so an all-NUL observation is
+        reported back to the model as a validation failure rather than saved
+        as an empty document."""
+        with pytest.raises(ValidationError):
+            ObservationInput(content="\x00\x00")
+
+    def test_all_nul_query_is_rejected_not_emptied(self):
+        """`NulStripped` runs before the field's own constraints, so a query
+        that is nothing but NUL fails `min_length` instead of reaching the
+        dialectic as an empty prompt."""
+        options = DialecticOptions.model_validate({"query": "before\x00after"})
+        assert options.query == "beforeafter"
+        with pytest.raises(ValidationError):
+            DialecticOptions.model_validate({"query": "\x00"})

--- a/tests/test_schema_validations.py
+++ b/tests/test_schema_validations.py
@@ -275,3 +275,47 @@ class TestReasoningCustomInstructionsValidation:
         configuration = ReasoningConfiguration(custom_instructions=custom_instructions)
 
         assert configuration.custom_instructions == custom_instructions
+
+
+class TestNulByteSanitization:
+    """Postgres rejects NUL (0x00) in text columns and in jsonb strings.
+
+    Models emit these as `\\u0000` escapes in tool-call arguments, which the
+    JSON parser decodes into real NUL bytes, so model-generated text needs the
+    same treatment as user-supplied input.
+    """
+
+    def test_document_content_strips_nul(self):
+        document = DocumentCreate(
+            content="the key is at c:\\\x00users\\amal",
+            metadata=DocumentMetadata(message_ids=[1], message_created_at="2026-08-28"),
+            embedding=[0.1],
+        )
+
+        assert document.content == "the key is at c:\\users\\amal"
+
+    def test_all_nul_document_content_is_rejected_not_emptied(self):
+        """The validator runs before `min_length`, so content that is nothing
+        but NUL fails validation rather than being stored as an empty string."""
+        with pytest.raises(ValidationError):
+            DocumentCreate(
+                content="\x00\x00",
+                metadata=DocumentMetadata(
+                    message_ids=[1], message_created_at="2026-08-28"
+                ),
+                embedding=[0.1],
+            )
+
+    def test_message_content_strips_nul(self):
+        message = MessageCreate(peer_id="peer", content="before\x00after")
+
+        assert message.content == "beforeafter"
+
+    def test_metadata_strips_nul_at_every_depth(self):
+        message = MessageCreate(
+            peer_id="peer",
+            content="hi",
+            metadata={"a\x00b": {"c": ["d\x00e", 1]}},
+        )
+
+        assert message.metadata == {"ab": {"c": ["de", 1]}}

--- a/tests/utils/test_sanitization.py
+++ b/tests/utils/test_sanitization.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+import pytest
+
+from src.utils.sanitization import strip_nul
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("before\x00after", "beforeafter", id="string"),
+        pytest.param("no nul here", "no nul here", id="string-unchanged"),
+        pytest.param("\x00\x00", "", id="string-all-nul"),
+        pytest.param(["a\x00b", "c"], ["ab", "c"], id="list"),
+        pytest.param({"k\x00": "v\x00"}, {"k": "v"}, id="dict-key-and-value"),
+        pytest.param(
+            {"a": [{"b": "c\x00d"}]},
+            {"a": [{"b": "cd"}]},
+            id="nested",
+        ),
+        # Optional fields are passed in without a guard, so None has to survive.
+        pytest.param(None, None, id="none"),
+        pytest.param(7, 7, id="int"),
+        pytest.param(True, True, id="bool"),
+        pytest.param([], [], id="empty-list"),
+    ],
+)
+def test_strip_nul(value: Any, expected: Any) -> None:
+    assert strip_nul(value) == expected
+
+
+def test_strip_nul_does_not_mutate_its_argument() -> None:
+    original = {"a": ["b\x00c"]}
+
+    stripped = strip_nul(original)
+
+    assert stripped == {"a": ["bc"]}
+    assert original == {"a": ["b\x00c"]}


### PR DESCRIPTION
# Human summary

This is just to sanitize rare LLM outputs that contains bytes that can't be saved to the DB.

# Claude summary

## Description

The deriver crashes with `DataError: PostgreSQL text fields cannot contain NUL (0x00) bytes` whenever a model emits a `\u0000` escape in its tool-call arguments — the JSON parser decodes it into a real NUL byte, and Postgres rejects NUL in `text` columns and in `jsonb` strings. API ingress has always stripped NUL from user-supplied content (`MessageCreate.sanitize_content`), but the deriver's *own output* had no equivalent, so model-generated observations went straight to the database untreated.

This strips NUL in `_normalized_observation` and `_normalized_observation_input` — the points that already normalize observation text for persistence *and* embedding — so the text that gets embedded is the text that gets stored. `DocumentCreate.content` gets a backstop validator for callers that bypass those paths.

Fixes [HONCHO-4XZ](https://plastic-labs.sentry.io/issues/HONCHO-4XZ) (Rootly alert `RNne7G`).

### Impact before the fix

The NUL reached the exact-content dedup pre-fetch in `create_documents` (`src/crud/document.py:539`) as a bind parameter, so the query blew up before any row was written. The exception is caught per-observer at `deriver.py:245`, so it never crash-looped — it just silently discarded the whole observation batch for that observer. 8 occurrences over ~10h across two workspaces, both from models transcribing text that legitimately contains NUL notation:

- `... | tr '\x00' '\n' | grep home` — a shell command
- `c:\<NUL>users\amal/.ssh/id_ed25519` — a Windows path

### Notes for review

- **`premises` and `sources` are covered too.** They ride along in `internal_metadata`, and `jsonb` rejects NUL in strings just as text columns do.
- **The emptiness check moved after normalization.** `str.strip()` does not remove NUL, so `"\x00"` passed the old blank filter; once stripping was added it would have been embedded and stored as an empty document.
- **`DocumentCreate.content` uses `mode="before"` deliberately.** It runs ahead of the `min_length=1` constraint, so all-NUL content fails validation instead of quietly becoming `""`.
- **The NUL helpers moved** from `src/schemas/api.py` into a new `src/utils/sanitization.py` as a single recursive `strip_nul`, so ingress and internal paths share one implementation. It is overloaded to keep `str -> str` for callers that chain `.strip()`, and passes `None` through so optional fields need no guard.
- **Unrelated churn:** `tests/crud/test_representation_manager.py` picked up 14 mechanical `timezone.utc` → `UTC` lines. The pre-commit ruff hook (`UP017`) rewrites them whenever that file is staged; 40 files on `main` still use the old spelling.

Not in scope: session summaries (`src/utils/summarizer.py`) and peer cards have the same model-text-into-TEXT-column exposure and are untouched here.

## Proofs

Full suite against `pgvector/pgvector:pg15` matching CI's service config:

```
2281 passed, 51 skipped, 163 warnings in 36.56s
```

`basedpyright` and `ruff check src/` both at their pre-existing baselines (22 / 44), and all pre-commit + pre-push hooks pass.

New coverage:

- `tests/crud/test_representation_manager.py` — NUL stripped from explicit content, deductive conclusions, and `premises`; embedded text asserted to match stored text; all-NUL observations dropped before embedding rather than stored empty.
- `tests/test_schema_validations.py` — `DocumentCreate` backstop, all-NUL content rejected rather than emptied, message content and nested metadata.
- `tests/utils/test_sanitization.py` — direct coverage of `strip_nul` (string / list / nested dict incl. NUL in a key / `None` / non-string passthrough / non-mutation). These helpers previously had none.

## Checklist

- [x] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Removed NUL characters from document, message, metadata, query, and observation content before storage and embedding.
- Excluded observations that become empty after sanitization.
- Prevented content containing only NUL characters from being saved as empty text.
- Applied sanitization consistently to nested metadata, premises, sources, and list values.
- Improved validation for fields containing only NUL characters.

## Tests
- Added coverage for NUL-byte removal, nested data handling, empty-content validation, query validation, and input preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->