### PR TITLE
fix: reconcile documents in pgvector-only reconciliation mode

### DIFF
--- a/src/reconciler/sync_vectors.py
+++ b/src/reconciler/sync_vectors.py
@@ -265,7 +265,7 @@ def build_message_vector_record(
 async def _sync_documents(
     db: AsyncSession,
     documents: list[models.Document],
-    external_vector_store: VectorStore,
+    external_vector_store: VectorStore | None,
 ) -> tuple[int, int]:
     """
     Sync a batch of pending documents to the external vector store.
@@ -274,6 +274,11 @@ async def _sync_documents(
     1. Embedding exists in postgres → use it for external upsert
     2. Embedding missing + need postgres storage → re-embed, write to both stores
     3. Embedding missing + external-only mode → re-embed, write to external only
+
+    When `external_vector_store` is None (pgvector-only mode), re-embeds any
+    pending document missing a vector, writes the vector to postgres, and
+    marks sync_state='synced'. No external upsert is performed -- mirrors
+    `_sync_message_embeddings`'s pgvector-only branch.
 
     Returns (synced_count, failed_count).
     """
@@ -324,6 +329,31 @@ async def _sync_documents(
     if failed_to_embed:
         await _bump_document_sync_attempts(db, failed_to_embed)
         failed_count += len(failed_to_embed)
+
+    # pgvector-only mode: no external store to upsert to. Any document that
+    # now has an embedding (either pre-existing or freshly embedded) is fully
+    # synced -- write via per-row UPDATE so the vector persists alongside
+    # sync_state in a single statement (session has autoflush=False).
+    if external_vector_store is None:
+        docs_done: list[models.Document] = []
+        for doc in documents:
+            new_emb = freshly_embedded.get(doc.id)
+            existing = cast(list[float] | None, doc.embedding)
+            if new_emb is None and existing is None:
+                continue
+            await db.execute(
+                update(models.Document)
+                .where(models.Document.id == doc.id)
+                .values(
+                    sync_state="synced",
+                    last_sync_at=func.now(),
+                    sync_attempts=0,
+                    **({"embedding": new_emb} if new_emb is not None else {}),
+                )
+            )
+            docs_done.append(doc)
+        synced_count += len(docs_done)
+        return synced_count, failed_count
 
     # Step 2: Build vector records and upsert to external store (all cases)
     by_namespace: dict[str, list[models.Document]] = {}
@@ -606,7 +636,7 @@ async def _cleanup_soft_deleted_documents_pgvector(
 
 
 async def _reconcile_documents_batch(
-    external_vector_store: VectorStore,
+    external_vector_store: VectorStore | None,
     metrics: ReconciliationMetrics,
 ) -> bool:
     """
@@ -715,10 +745,17 @@ async def run_vector_reconciliation_cycle() -> ReconciliationMetrics:
     external_vector_store = get_external_vector_store()
     deadline = time.monotonic() + RECONCILIATION_TIME_BUDGET_SECONDS
 
-    # pgvector-only mode: still need to embed pending MessageEmbedding rows
-    # (create_messages defers embedding to the reconciler), then clean up.
+    # pgvector-only mode: still need to embed pending Document and
+    # MessageEmbedding rows (create_messages defers embedding to the
+    # reconciler; a re-embed migration -- e.g. switching embedding providers
+    # -- also lands here via cleared embedding+sync_state), then clean up.
     if external_vector_store is None:
         while time.monotonic() < deadline:
+            docs_work = await _reconcile_documents_batch(None, metrics)
+
+            if time.monotonic() >= deadline:
+                break
+
             embs_work = await _reconcile_message_embeddings_batch(None, metrics)
 
             if time.monotonic() >= deadline:
@@ -726,7 +763,7 @@ async def run_vector_reconciliation_cycle() -> ReconciliationMetrics:
 
             cleanup_work = await _cleanup_pgvector_batch(metrics)
 
-            if not (embs_work or cleanup_work):
+            if not (docs_work or embs_work or cleanup_work):
                 break
         logger.debug("Vector reconciliation cycle completed (pgvector mode)")
         return metrics

--- a/tests/deriver/test_vector_reconciliation.py
+++ b/tests/deriver/test_vector_reconciliation.py
@@ -506,6 +506,59 @@ class TestReEmbedding:
             assert synced == 3
             assert failed == 0
 
+    async def test_pgvector_only_mode_embeds_and_marks_documents_synced(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ) -> None:
+        """In pgvector-only mode (external_vector_store=None), the reconciler
+        must still re-embed and sync pending documents -- this path was
+        previously skipped entirely (documents got permanently stuck at
+        sync_state='pending' whenever the deployment had no external vector
+        store, e.g. after switching embedding providers)."""
+        workspace, peer1 = sample_data
+
+        collection = models.Collection(
+            workspace_name=workspace.name, observer=peer1.name, observed=peer1.name
+        )
+        db_session.add(collection)
+        await db_session.commit()
+
+        session = models.Session(
+            name=str(generate_nanoid()), workspace_name=workspace.name
+        )
+        db_session.add(session)
+        await db_session.commit()
+
+        doc = models.Document(
+            content="pending doc",
+            workspace_name=workspace.name,
+            observer=peer1.name,
+            observed=peer1.name,
+            session_name=session.name,
+            sync_state="pending",
+            embedding=None,
+        )
+        db_session.add(doc)
+        await db_session.commit()
+        await db_session.refresh(doc)
+
+        with patch("src.reconciler.sync_vectors.embedding_client") as mock_embed_client:
+            mock_embed_client.simple_batch_embed = AsyncMock(
+                return_value=[[1.0] * 1536]
+            )
+
+            synced, failed = await _sync_documents(db_session, [doc], None)
+
+        await db_session.commit()
+        await db_session.refresh(doc)
+
+        assert synced == 1
+        assert failed == 0
+        assert doc.sync_state == "synced"
+        assert doc.sync_attempts == 0
+        assert doc.embedding is not None
+
     async def test_large_documents_embedded_in_single_batch(
         self,
         db_session: AsyncSession,
@@ -993,6 +1046,40 @@ class TestEndToEndReconciliation:
         mock_reconcile_docs.assert_awaited_once()
         mock_reconcile_embs.assert_awaited_once()
         mock_cleanup_docs.assert_awaited_once()
+
+    async def test_pgvector_only_cycle_reconciles_documents_too(self) -> None:
+        """pgvector-only mode (no external vector store) must still reconcile
+        documents, not just message embeddings -- regression test for the gap
+        where `run_vector_reconciliation_cycle`'s pgvector branch never called
+        `_reconcile_documents_batch` at all."""
+        with (
+            patch(
+                "src.reconciler.sync_vectors.get_external_vector_store",
+                return_value=None,
+            ),
+            patch(
+                "src.reconciler.sync_vectors._reconcile_documents_batch",
+                new_callable=AsyncMock,
+            ) as mock_reconcile_docs,
+            patch(
+                "src.reconciler.sync_vectors._reconcile_message_embeddings_batch",
+                new_callable=AsyncMock,
+            ) as mock_reconcile_embs,
+            patch(
+                "src.reconciler.sync_vectors._cleanup_pgvector_batch",
+                new_callable=AsyncMock,
+            ) as mock_cleanup,
+        ):
+            mock_reconcile_docs.return_value = False
+            mock_reconcile_embs.return_value = False
+            mock_cleanup.return_value = False
+
+            metrics = await run_vector_reconciliation_cycle()
+
+        assert isinstance(metrics, ReconciliationMetrics)
+        mock_reconcile_docs.assert_awaited_once_with(None, metrics)
+        mock_reconcile_embs.assert_awaited_once_with(None, metrics)
+        mock_cleanup.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `run_vector_reconciliation_cycle`'s pgvector-only branch (`external_vector_store is None`) only ever called `_reconcile_message_embeddings_batch` + the cleanup step — `_reconcile_documents_batch` was never invoked on this path.
- On a pgvector-only deployment, pending `documents` rows (e.g. anything left with a cleared embedding/sync_state after switching embedding providers) never get picked back up by reconciliation. No error, no log — they just stay pending indefinitely.
- Fix mirrors the existing pgvector-only handling already used for `message_embeddings`: `_sync_documents`'s `external_vector_store` param is loosened to `VectorStore | None`, with a new pgvector-only branch that embeds and marks documents synced via a direct SQLAlchemy `update(models.Document)` (same pattern as `_sync_message_embeddings`). `_reconcile_documents_batch` is loosened the same way, and the pgvector-only cycle branch now calls it.

Found this while migrating our self-hosted deployment's embedding provider (which clears embedding + sync_state to force re-embedding) — 26k+ `documents` rows sat pending with reconciliation running cleanly on schedule and reporting no errors.

## Test plan
- [x] Added `test_pgvector_only_mode_embeds_and_marks_documents_synced` (unit-level, `TestReEmbedding`)
- [x] Added `test_pgvector_only_cycle_reconciles_documents_too` (integration-level, `TestEndToEndReconciliation`) asserting `_reconcile_documents_batch` is actually invoked on the pgvector-only cycle path
- [ ] Full `pytest` suite — not run locally; this deployment's `tests/conftest.py` default DB connection doesn't match our actual prod DB setup, so verification was instead done against a live container (re-embedded the real backlog, confirmed `sync_state` clears going forward)

Fixes #1097 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document vector reconciliation in pgvector-only mode.
  * Pending documents without embeddings are now re-embedded and marked as synced.
  * Reconciliation cycles now process documents as well as message embeddings when no external vector store is configured.

* **Tests**
  * Added regression coverage for pgvector-only document syncing and reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->