### PR TITLE
Rename repository instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# Honcho repository instructions
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to coding agents that work in this repository.
 
 # Honcho Overview
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,14 +188,14 @@ public and internal vocabularies are being reconciled deliberately.
 | A prompt | `src/deriver/prompts.py`, `src/dialectic/prompts.py`, `src/dreamer/specialists.py` |
 | LLM provider behavior | `src/llm/backends/` — `anthropic.py`, `gemini.py`, `openai.py` |
 | Embeddings or vector storage | `src/embedding_client.py`, `src/vector_store/` |
-| Telemetry or metrics | `src/telemetry/` — see the notes in `CLAUDE.md` before adding an event type |
+| Telemetry or metrics | `src/telemetry/` — see the notes in `AGENTS.md` before adding an event type |
 | Authentication and scoping | `src/security.py`, `src/dependencies.py` |
 | The Python or TypeScript SDK | `sdks/python/`, `sdks/typescript/` |
 | The CLI | `honcho-cli/` |
 | The MCP server | `mcp/` |
 | Public documentation | `docs/v3/` — Mintlify; nav lives in `docs/docs.json` |
 
-Tests in `tests/` mirror `src/`. `CLAUDE.md` at the repo root has more detail on house
+Tests in `tests/` mirror `src/`. `AGENTS.md` at the repo root has more detail on house
 conventions, and is worth skimming even if you are not using an agent.
 
 ## Local setup

--- a/docs/v3/contributing/guidelines.mdx
+++ b/docs/v3/contributing/guidelines.mdx
@@ -177,14 +177,14 @@ public and internal vocabularies are being reconciled deliberately.
 | A prompt | `src/deriver/prompts.py`, `src/dialectic/prompts.py`, `src/dreamer/specialists.py` |
 | LLM provider behavior | `src/llm/backends/` — `anthropic.py`, `gemini.py`, `openai.py` |
 | Embeddings or vector storage | `src/embedding_client.py`, `src/vector_store/` |
-| Telemetry or metrics | `src/telemetry/` — see the notes in `CLAUDE.md` before adding an event type |
+| Telemetry or metrics | `src/telemetry/` — see the notes in `AGENTS.md` before adding an event type |
 | Authentication and scoping | `src/security.py`, `src/dependencies.py` |
 | The Python or TypeScript SDK | `sdks/python/`, `sdks/typescript/` |
 | The CLI | `honcho-cli/` |
 | The MCP server | `mcp/` |
 | Public documentation | `docs/v3/` — Mintlify; nav lives in `docs/docs.json` |
 
-Tests in `tests/` mirror `src/`. `CLAUDE.md` at the repo root has more detail on house
+Tests in `tests/` mirror `src/`. `AGENTS.md` at the repo root has more detail on house
 conventions, and is worth skimming even if you are not using an agent.
 
 ## Local setup

--- a/tests/routes/test_auth_route_policy.py
+++ b/tests/routes/test_auth_route_policy.py
@@ -20,7 +20,7 @@ from src.main import app
 
 # (method, path) pairs intentionally granting member peers read access. Adding a
 # route here is a deliberate security decision: it must be read-only. Never add
-# a mutating route. See CLAUDE.md "Auth scoping" for the rule.
+# a mutating route. See AGENTS.md "Auth scoping" for the rule.
 EXPECTED_MEMBER_READ_ROUTES = {
     ("POST", "/v3/workspaces/{workspace_id}/sessions/{session_id}/messages/list"),
     (


### PR DESCRIPTION
## Summary

- rename the repository instruction file from `CLAUDE.md` to `AGENTS.md`
- make the heading agent-neutral while preserving the current instructions

## Validation

- `git diff --check`
- rename is limited to the instruction file; no runtime code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the repository guidance document with an updated version for coding agents.
  * Updated the introductory heading to use broader terminology.
  * Updated contributor documentation to reference the new guidance document.
* **Tests**
  * Updated a route-policy test comment to reflect the new documentation reference; test behavior is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->