### PR TITLE
fix(deriver): prevent cross-subject self-observations

### DIFF
--- a/src/deriver/prompts.py
+++ b/src/deriver/prompts.py
@@ -57,7 +57,8 @@ def minimal_deriver_prompt(
         f"""
 Analyze messages to extract **explicit atomic facts** about the target peer.
 
-[EXPLICIT] DEFINITION: Facts about the target peer that can be derived directly from their messages.
+[EXPLICIT] DEFINITION: Facts about the target peer that are directly supported by \
+the target peer's own messages.
    - Transform statements into one or multiple conclusions
    - Each conclusion must be self-contained with enough context
    - Use absolute dates/times when possible (e.g. "June 26, 2025" not "yesterday")
@@ -65,19 +66,43 @@ Analyze messages to extract **explicit atomic facts** about the target peer.
 RULES:
 - The target peer is the peer identified below under `Target peer:`.
 - A peer can be a human user, AI agent, bot, service, or other actor.
-- Use the exact peer id from `Target peer:` in final observations, not the phrase "the target peer".
-- Properly attribute observations to the correct subject: if it is about the target peer, use the exact peer id as the subject. If the target peer is referencing someone or something else, make that clear.
-- Observations should make sense on their own. Each observation will be used in the future to better understand the target peer.
-- Extract ALL observations from the target peer's messages, using others as context.
-- Contextualize each observation sufficiently (e.g. "Ann is nervous about the job interview at the pharmacy" not just "Ann is nervous")
+- Use the exact peer id from `Target peer:` in final observations, not the \
+phrase "the target peer".
+- Each message is formatted as `<timestamp> <speaker>: <content>`.
+- Only messages whose speaker label exactly matches `Target peer:` may provide \
+facts for the target peer's representation.
+- Messages from other speakers are context only. Never create an observation \
+about the target peer from another speaker's assertion, even when it explicitly \
+names the target peer.
+- Resolve `I`/`me`/`my` from the labeled speaker's perspective.
+- When the target peer talks about another subject, including with `you`/`your`, \
+do not attribute that subject's facts to the target peer. Do not turn the \
+transient act of saying, hearing, knowing, or repeating another subject's fact \
+into a durable fact about the target peer.
+- Omit any observation whose subject is ambiguous.
+- If the target peer's own messages contain no durable identity, capability, \
+preference, relationship, or action about the target peer, return no observations.
+- Observations should make sense on their own. Each observation will be used in \
+the future to better understand the target peer.
+- Extract all supported observations from the target peer's own messages, using \
+other speakers only as context.
+- Contextualize each observation sufficiently (e.g. "Ann is nervous about the \
+job interview at the pharmacy" not just "Ann is nervous")
 
 <examples>
 These examples are fabricated illustrations of the output format. Never emit a conclusion for which content comes from these examples. Every conclusion must be supported by the <messages> block only.
 
-EXAMPLES (using `alice` as the target peer id):
-- EXPLICIT: "I just turned 25" → "alice is 25 years old"
-- EXPLICIT: "I took my dog for a walk in NYC" → "alice has a dog", "alice walked her dog in NYC"
-- EXPLICIT: "I've lived in NYC for six years" → "alice lives in NYC", "alice has lived in NYC for six years"
+EXAMPLES:
+- TARGET `alice`, MESSAGE `alice: I am 25 years old` → \
+"alice is 25 years old"
+- TARGET `alice`, MESSAGE `bob: alice works remotely on Fridays` → \
+no observation about `alice`
+- TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` → \
+no observation about `assistant`
+- TARGET `assistant`, MESSAGE `assistant: I prefer concise responses` → \
+"assistant prefers concise responses"
+- TARGET `user`, MESSAGE `assistant: user plays tennis on Tuesdays` → \
+no observation about `user`
 </examples>
 
 {custom_instructions_section}

--- a/tests/deriver/test_prompts.py
+++ b/tests/deriver/test_prompts.py
@@ -30,6 +30,46 @@ def test_minimal_deriver_prompt_omits_custom_instructions_when_absent() -> None:
     assert "CUSTOM INSTRUCTIONS:" not in prompt
 
 
+def test_minimal_deriver_prompt_limits_evidence_to_target_speaker() -> None:
+    """Keep another peer's assertions out of the target representation."""
+
+    prompt = minimal_deriver_prompt(
+        peer_id="user",
+        messages="assistant: user plays tennis on Tuesdays",
+    )
+
+    assert "the target peer's own messages" in prompt
+    assert "Only messages whose speaker label exactly matches `Target peer:`" in prompt
+    assert "Messages from other speakers are context only" in prompt
+    assert "even when it explicitly names the target peer" in prompt
+    assert "including with `you`/`your`" in prompt
+    assert (
+        "TARGET `user`, MESSAGE `assistant: user plays tennis on Tuesdays` "
+        "→ no observation about `user`"
+    ) in prompt
+    assert (
+        "TARGET `assistant`, MESSAGE `assistant: You play tennis on Tuesdays` "
+        "→ no observation about `assistant`"
+    ) in prompt
+
+
+def test_target_speaker_rules_preserve_static_cache_prefix() -> None:
+    """Keep target-specific values outside the reusable static prompt prefix."""
+
+    alice_prompt = minimal_deriver_prompt(
+        peer_id="alice",
+        messages="alice: I like tea",
+    )
+    bob_prompt = minimal_deriver_prompt(
+        peer_id="bob",
+        messages="bob: I like coffee",
+    )
+
+    alice_prefix = alice_prompt.split("Target peer:", maxsplit=1)[0]
+    bob_prefix = bob_prompt.split("Target peer:", maxsplit=1)[0]
+    assert alice_prefix == bob_prefix
+
+
 def test_estimate_deriver_prompt_tokens_increases_with_custom_instructions() -> None:
     base_tokens = estimate_minimal_deriver_prompt_tokens()
     custom_tokens = estimate_deriver_prompt_tokens(


### PR DESCRIPTION
## Description

Fixes deriver speaker attribution for interleaved multi-peer batches without changing Honcho's observation model. Only the target peer's own messages may provide facts for that peer's representation; other speakers remain context, and statements about another subject cannot be rewritten as facts about the target peer.

## Proofs

- The focused regression failed against unmodified `main`, then passed on this head.
- `uv run pytest tests/deriver/test_prompts.py -q` — 6 passed.
- Focused Ruff, format, basedpyright, and `git diff --check` passed.

## Checklist

- [x] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.

Fixes #817


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved extraction of lasting facts about the relevant person from conversations.
  * Added clearer handling of speaker-based pronouns and ambiguous addressees.
  * Excluded temporary conversational details, unsupported assumptions, and facts about unrelated people.
* **Tests**
  * Added coverage for cross-speaker context, second-person references, ambiguous subjects, and consistent behavior across different conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->