### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,33 @@
+name: Trustabl Agent Scanner
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Minimal top-level permissions; write grants are scoped to the scan job only.
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: trustabl-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: write
+    # continue-on-error keeps this job advisory — findings are reported but
+    # CI does not go red so unrelated work is never blocked.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: trustabl/trustabl-action@973f666d20b5fbb2e6a4511bd3846e965a08c28b # v0.4.1
+        with:
+          version: v0.1.6


### PR DESCRIPTION
We came across your repo and we like how you're building a memory infrastructure for stateful agents that can understand complex interactions over time. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [CRITICAL] Bundled skill script reads credentials or secrets
   File: examples/zo/SKILL.md
   What it means: A script bundled with this skill reads credentials or secrets (gh auth, $AWS_*, ~/.github-token) directly from the environment. This exposes sensitive information to potential compromise during runtime, increasing the risk of unauthorized access and data breaches. 

2. [CRITICAL] Bundled skill script reads credentials or secrets
   File: skills/honcho-integration/SKILL.md
   What it means: A script bundled with this skill reads credentials or secrets (gh auth, $AWS_*, ~/.github-token) directly from the environment. This exposes sensitive information to potential compromise during runtime, increasing the risk of unauthorized access and data breaches.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated security scanning for pushes, pull requests, and manually triggered runs.
  * Security findings are reported as advisory results without blocking the build.
  * Added automatic cancellation of outdated scans to reduce redundant checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->