### PR TITLE
feat(sandbox): committed ephemeral Honcho sandbox with one-command reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,7 @@ grafana-data/
 
 # Claude Code addon stuff
 .omc
+
+# Sandbox real-provider credentials (see sandbox/real.env.example)
+sandbox/real.env
+sandbox/.state.env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,10 +29,10 @@ repos:
       # Linter - only on Python directories
       - id: ruff
         args: [--fix]
-        files: ^(src/|tests/|scripts/|migrations/|sdks/python/).*\.py$
+        files: ^(src/|tests/|scripts/|migrations/|sdks/python/|sandbox/).*\.py$
       # Formatter - only on Python directories
       - id: ruff-format
-        files: ^(src/|tests/|scripts/|migrations/|sdks/python/).*\.py$
+        files: ^(src/|tests/|scripts/|migrations/|sdks/python/|sandbox/).*\.py$
 
   # Security checks - only on main src code (not tests/scripts)
   - repo: https://github.com/PyCQA/bandit

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -1,0 +1,165 @@
+# Honcho sandbox
+
+A local Honcho you can wipe and rebuild in seconds, so harness testing stops depending on
+whatever state your laptop happens to be in.
+
+It comes up **already seeded** — a known workspace, peers, session, messages, and conclusions the
+deriver has actually produced — and `reset` returns it to that exact state without re-deriving.
+
+```bash
+sandbox/sandbox.sh up       # start + seed (first run also builds/pulls)
+sandbox/sandbox.sh reset    # back to the seeded state, under a second
+sandbox/sandbox.sh status   # what's running, which templates exist
+sandbox/sandbox.sh down     # stop and delete the volumes
+```
+
+The API lands on <http://127.0.0.1:18000>. Postgres is on 15432 and Redis on 16379 — all
+deliberately off the defaults, so the sandbox coexists with a normal local stack instead of
+fighting it for ports and volumes.
+
+> **Right now you need `--build`.** The mock provider comes from PR #1094, which is not merged, so
+> no published image contains it. `sandbox.sh` checks and tells you. Once #1094 lands and an image
+> is published, bump the digest in `image.env` and plain `up` works.
+
+## Provider modes
+
+The deriver calls a model provider, which is what made a sandbox neither free nor deterministic.
+Both ways of resolving that ship here; `mock` is the default.
+
+|                       | `mock` (default)                                                 | `real`                                               |
+| --------------------- | ---------------------------------------------------------------- | ---------------------------------------------------- |
+| **Determinism**       | Same conclusions every run                                         | Non-deterministic                                     |
+| **Cost**              | Zero, and no network egress                                        | Real spend                                            |
+| **Seed time**         | ~15s                                                               | ~6 min                                                |
+| **Reset time**        | 0.86s                                                              | 1.29s                                                 |
+| **Vector recall**     | **Untestable** — see below                                         | Testable                                              |
+| **What you get**      | 4 conclusions, all `explicit`, synthetic text                      | 22 conclusions — 16 `explicit`, 4 `deductive`, 2 `inductive` |
+| **Use it for**        | CI, harness smoke tests, anything that needs a repeatable answer   | Recall quality, validating against real model output  |
+
+Those counts are from the committed fixture, measured on both paths. They are the sharpest
+illustration of the difference: mock gives you four copies of `[mock] mock dummy placeholder …`,
+while real mode reasons its way from "my cat Marzipan is named after the pylon's colour" to the
+deductive conclusion *"alice's cat is named after a feature of alice's pedestrian bridge project."*
+Anything asserting on that kind of inference needs real mode.
+
+```bash
+sandbox/sandbox.sh up                    # mock
+sandbox/sandbox.sh up --provider real    # real
+```
+
+Each mode keeps its own seeded template, so both can exist at once and switching between them
+costs nothing — about 10 seconds, and no re-derivation, because `up` restores that mode's existing
+template instead of reseeding.
+
+### Two things that will otherwise cost you a day
+
+**Mock embeddings carry no semantic similarity.** They are hash-derived, so two paraphrases are
+exactly as far apart as two unrelated strings. Any recall assertion built on mock mode must use
+lexical or full-text search. A vector-ranking assertion will fail there for reasons that have
+nothing to do with the code you are testing — that is what `real` mode is for.
+
+**Mock conclusions are synthetic.** The text is derived from the request, not from the meaning of
+your messages, and the level is always `explicit` (the Dreamer's specialists write via tool calls,
+which the mock deliberately never emits). Assert that conclusions *exist*; do not assert on what
+they say or on the level mix, or your test will pass in one mode and fail in the other.
+
+### Real mode
+
+```bash
+cp sandbox/real.env.example sandbox/real.env   # then add a key
+sandbox/sandbox.sh up --provider real
+```
+
+Credentials come from that one gitignored file, never from your ambient shell environment, so a
+real-mode run has a single auditable input and the sandbox still doesn't inherit machine state.
+`sandbox.sh` refuses to start if the file is missing or still carries the placeholder key — a
+real-mode stack with no key boots perfectly well and then derives nothing, which is indistinguishable
+from "the deriver found nothing".
+
+Real mode gets an unexpected benefit from the reset design: derivation is slow and costs money, and
+the snapshot means you pay for it **once per seed** and reset for free after that. Measured: 361s to
+seed, 1.29s to reset back to that exact state with no provider calls at all.
+
+## How reset is fast
+
+Seeding runs the deriver, and a naive reset would have to run it again. Instead, `seed` snapshots
+the finished database as a Postgres template:
+
+```
+CREATE DATABASE honcho_sandbox_seeded_mock TEMPLATE honcho_sandbox
+```
+
+and `reset` drops the live database and re-creates it from that template, then flushes Redis. No
+migrations, no re-derivation, no LLM calls — **measured at 0.86s**, and byte-identical every time.
+
+Nothing is stopped or restarted. `DROP DATABASE ... WITH (FORCE)` evicts the api and deriver
+connection pools, and both reconnect by themselves — the api on its next request, the deriver on its
+next poll a quarter-second later. Each logs one `OperationalError` as its in-flight connection dies;
+that is expected, and it is the price of not paying ~9 seconds of container restart on every reset.
+
+The cost of a snapshot is that it can go stale. Two guards:
+
+- **Per-mode template names**, so a mock-seeded template can never be restored into a real-mode run.
+- **A fingerprint recorded inside each template** — the Alembic revision it was seeded at, a hash of
+  `fixture.json` + `seed.py`, and the provider mode. `reset` compares and refuses with a "reseed"
+  message rather than silently restoring a state that predates a migration.
+
+If you hit that refusal: `sandbox/sandbox.sh seed`.
+
+## What's in the fixture
+
+`fixture.json` — two peers with **explicitly stated** observation topology (`alice` is observed and
+does not observe; `assistant` observes and is not observed), one session, six messages carrying
+distinctive lexically-searchable facts, and one scheduled cross-peer dream.
+
+Topology is written down rather than defaulted because it is the thing that silently breaks, and
+`seed.py` re-reads it back from the server to confirm it took.
+
+Edit `fixture.json`, then `sandbox/sandbox.sh seed` to rebuild the template. `seed` always starts
+from an empty, freshly migrated database, so it means the same thing whatever state you run it
+from — running it twice gives the same result as running it once.
+
+Dreams never fire on their own here — the document threshold is 50 and the minimum gap between
+dreams is 8 hours — so the seed schedules one directly.
+
+## Layout
+
+| File                | Purpose                                                                |
+| ------------------- | ---------------------------------------------------------------------- |
+| `sandbox.sh`        | The entry point. Owns Docker and Postgres.                              |
+| `compose.yml`       | Provider-agnostic base. **Not a working stack alone.**                  |
+| `compose.mock.yml`  | Provider overlay: adds the mock-provider service and wiring.            |
+| `compose.real.yml`  | Provider overlay: reads `real.env`, no mock service.                    |
+| `image.env`         | The pinned image digest. One line, bump deliberately.                   |
+| `init.sql`          | Creates the `honcho_sandbox` database.                                  |
+| `fixture.json`      | The seeded conversation.                                                |
+| `seed.py`           | Populates and verifies. Talks only to the API.                          |
+| `real.env.example`  | Template for real-mode credentials.                                     |
+
+Exactly one provider overlay is always composed on top of the base, so the choice is visible in the
+`-f` list rather than buried in a default. That is also why `compose.yml` alone does not run: the
+`depends_on` edge to `mock-provider` lives in the mock overlay, because Compose merges `depends_on`
+additively and an override file cannot remove one.
+
+## Configuration
+
+The sandbox is configured **only** by what Compose injects. `PYTHON_DOTENV_DISABLED` and
+`HONCHO_CONFIG_TOML_DISABLED` are both set, because `src/config.py` calls `load_dotenv(override=True)`
+at import and the Dockerfile's `COPY config.toml* /app/` bakes a local `config.toml` into any
+locally built image. Without those two flags your machine's leftovers would quietly win.
+
+`compose.yml` also pins the deriver's scheduling so derivation happens *now*. On stock settings a
+sandbox seeded with a handful of messages produces zero conclusions and fails silently: work units
+aren't claimed until a batch reaches 512 tokens or 30 minutes pass, and startup jitter delays the
+first poll by up to 30 seconds. Those are turned off here — see the comments in `compose.yml`.
+
+## Building from the working tree
+
+```bash
+sandbox/sandbox.sh up --build
+```
+
+Builds the repo instead of pulling the pinned digest, and points every service at the result so
+they stay in sync. Use it when testing a change to Honcho itself. It trades reproducibility for
+currency — you are running your tree, not the pinned bytes, which is right while iterating and
+wrong when reproducing someone else's result.

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -93,14 +93,21 @@ connection pools, and both reconnect by themselves — the api on its next reque
 next poll a quarter-second later. Each logs one `OperationalError` as its in-flight connection dies;
 that is expected, and it is the price of not paying ~9 seconds of container restart on every reset.
 
-The cost of a snapshot is that it can go stale. Two guards:
+The cost of a snapshot is that it can go stale. Three guards:
 
 - **Per-mode template names**, so a mock-seeded template can never be restored into a real-mode run.
 - **A fingerprint recorded inside each template** — the Alembic revision it was seeded at, a hash of
   `fixture.json` + `seed.py`, and the provider mode. `reset` compares and refuses with a "reseed"
   message rather than silently restoring a state that predates a migration.
+- **A provider check against the running stack.** Neither `seed` nor `reset` recreates containers, so
+  `--provider` on either cannot change what the stack actually talks to — only what gets recorded.
+  `up` writes the provider it created the stack with to `sandbox/.state.env`, and `seed`/`reset`
+  refuse a mismatch and tell you to run `up --provider ...` first. Without it,
+  `seed --provider mock` against a running real stack would spend money on non-deterministic
+  conclusions and label them `mock`, and every later `reset` would restore those as the
+  deterministic baseline.
 
-If you hit that refusal: `sandbox/sandbox.sh seed`.
+If you hit the staleness refusal: `sandbox/sandbox.sh seed`.
 
 ## What's in the fixture
 

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -3,8 +3,9 @@
 A local Honcho you can wipe and rebuild in seconds, so harness testing stops depending on
 whatever state your laptop happens to be in.
 
-It comes up **already seeded** — a known workspace, peers, session, messages, and conclusions the
-deriver has actually produced — and `reset` returns it to that exact state without re-deriving.
+It comes up **already seeded** — a known workspace, peers, session, messages, conclusions the
+deriver has actually produced, and committed conclusions at every reasoning level — and `reset`
+returns it to that exact state without re-deriving.
 
 ```bash
 sandbox/sandbox.sh up       # start + seed (first run also builds/pulls)
@@ -29,14 +30,19 @@ Both ways of resolving that ship here; `mock` is the default.
 | **Seed time**         | ~15s                                                               | ~6 min                                                |
 | **Reset time**        | 0.86s                                                              | 1.29s                                                 |
 | **Vector recall**     | **Untestable** — see below                                         | Testable                                              |
-| **What you get**      | 4 conclusions, all `explicit`, synthetic text                      | 22 conclusions — 16 `explicit`, 4 `deductive`, 2 `inductive` |
+| **Derived**           | 4 conclusions, all `explicit`, synthetic text                      | 22 conclusions — 16 `explicit`, 4 `deductive`, 2 `inductive` |
+| **Seeded**            | 7 — 4 `explicit`, 2 `deductive`, 1 `inductive`, committed text      | the same 7, identical bytes                          |
 | **Use it for**        | CI, harness smoke tests, anything that needs a repeatable answer   | Recall quality, validating against real model output  |
 
-Those counts are from the committed fixture, measured on both paths. They are the sharpest
+The derived counts are from the committed fixture, measured on both paths. They are the sharpest
 illustration of the difference: mock gives you four copies of `[mock] mock dummy placeholder …`,
 while real mode reasons its way from "my cat Marzipan is named after the pylon's colour" to the
 deductive conclusion *"alice's cat is named after a feature of alice's pedestrian bridge project."*
-Anything asserting on that kind of inference needs real mode.
+Anything asserting on a model's *own* inference needs real mode.
+
+The seeded row is why you may not need to. Seeded conclusions are written straight into the
+collection rather than derived, so their text and level are identical in both modes — see
+[Seeded conclusions](#seeded-conclusions).
 
 ```bash
 sandbox/sandbox.sh up                    # mock
@@ -54,10 +60,11 @@ exactly as far apart as two unrelated strings. Any recall assertion built on moc
 lexical or full-text search. A vector-ranking assertion will fail there for reasons that have
 nothing to do with the code you are testing — that is what `real` mode is for.
 
-**Mock conclusions are synthetic.** The text is derived from the request, not from the meaning of
-your messages, and the level is always `explicit` (the Dreamer's specialists write via tool calls,
-which the mock deliberately never emits). Assert that conclusions *exist*; do not assert on what
-they say or on the level mix, or your test will pass in one mode and fail in the other.
+**Mock *derived* conclusions are synthetic.** The text comes from the request, not from the meaning
+of your messages, and the level is always `explicit` (the Dreamer's specialists write via tool
+calls, which the mock deliberately never emits). Assert that derived conclusions *exist*; do not
+assert on what they say or on the level mix, or your test will pass in one mode and fail in the
+other. Assert against the seeded conclusions instead — that is what they are for.
 
 ### Real mode
 
@@ -109,6 +116,77 @@ The cost of a snapshot is that it can go stale. Three guards:
 
 If you hit the staleness refusal: `sandbox/sandbox.sh seed`.
 
+## Seeded conclusions
+
+`fixture.json` can carry pre-made conclusions per peer, at any of the three reasoning levels.
+All three keys are optional; with none of them the sandbox behaves exactly as it would without
+this feature.
+
+```json
+{
+  "id": "alice",
+  "observe_me": true,
+  "observe_others": false,
+
+  "explicit": [
+    "alice is a structural engineer based in Rotterdam",
+    "alice has a cat called Marzipan, named after the colour of the bridge's pylon"
+  ],
+  "deductive": [
+    { "content": "alice named her cat after a feature of the bridge she is designing",
+      "premises": [0, 1] }
+  ],
+  "inductive": ["alice optimises for low lifetime maintenance cost"]
+}
+```
+
+**The peer carrying the keys is the one being observed.** Conclusions are keyed by an
+`(observer, observed)` pair, and the observer is inferred: every fixture peer with
+`observe_others` set, excluding the observed itself. For the standard harness shape that is
+exactly `assistant -> alice` — the same pair the dream uses and the one a harness reads from. A
+peer nobody else observes is an **error**, not a silent no-op; add an explicit `"observer"` to
+that peer to override the inference, which is also how you reach self-representation
+(`alice -> alice`).
+
+**Items are a bare string, or `{content, premises}`.** Each premise is an index into the same
+peer's `explicit` list. Premises are optional, but a derived conclusion without them is not
+something the Dreamer would ever write, so the committed fixture always supplies them.
+
+**Contents must be unique.** Honcho collapses a conclusion whose content matches something
+already stored — case- and whitespace-insensitively — and that cannot be switched off. The
+seeder asserts exact counts, so a near-duplicate fails the seed rather than quietly vanishing.
+
+### What premises buy you, and what they don't
+
+The premise indices become real `Document.source_ids` pointing at the actual rows from the
+`explicit` pass, so the reasoning tree genuinely traverses in both directions. Two caveats on
+where that is visible:
+
+- **Premise text renders in the representation.** `peer.representation(target=…)` prints each
+  premise indented under its conclusion, which is the practical payoff and what `seed.py verify`
+  asserts.
+- **Premise *links* are not on the API.** The conclusion response carries `level` but not
+  `source_ids`, and `get_reasoning_chain` is a Dialectic tool rather than a route. So a test can
+  only reach the links through the Dialectic, or through SQL. Because of that, a broken
+  reasoning tree is invisible from outside — so the seeder checks its own links before the
+  snapshot is taken, resolving every premise id and confirming each is reachable from its
+  children. A dangling or mis-filed premise fails the seed.
+
+### Why this is not done over the API
+
+The public create-conclusions endpoint always writes `level="explicit"` with no premises, and
+neither the schema nor the SDKs have a field for either. The columns exist; only an in-process
+caller can set them. So `sandbox.sh` runs `inject_conclusions.py` **inside the api container**,
+which already is Honcho's venv with the api's settings and a live embedding client — the script
+goes in on stdin and the fixture through the environment, so nothing is mounted and nothing is
+left behind.
+
+The cost is that the injector calls Honcho *internals*, which carry no stability contract, out
+of the image pinned in `image.env`. It checks the signatures it depends on before writing and
+fails with a "bump `image.env` and update this script together" message, rather than half-seeding
+a database. Widening the public API to accept a level was the alternative and was deliberately
+rejected: it would let any client assert a conclusion is `deductive` with premises it invented.
+
 ## What's in the fixture
 
 `fixture.json` — two peers with **explicitly stated** observation topology (`alice` is observed and
@@ -137,6 +215,7 @@ dreams is 8 hours — so the seed schedules one directly.
 | `init.sql`          | Creates the `honcho_sandbox` database.                                  |
 | `fixture.json`      | The seeded conversation.                                                |
 | `seed.py`           | Populates and verifies. Talks only to the API.                          |
+| `inject_conclusions.py` | Writes the seeded conclusions. Runs inside the api container.       |
 | `real.env.example`  | Template for real-mode credentials.                                     |
 
 Exactly one provider overlay is always composed on top of the base, so the choice is visible in the

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -17,10 +17,6 @@ The API lands on <http://127.0.0.1:18000>. Postgres is on 15432 and Redis on 163
 deliberately off the defaults, so the sandbox coexists with a normal local stack instead of
 fighting it for ports and volumes.
 
-> **Right now you need `--build`.** The mock provider comes from PR #1094, which is not merged, so
-> no published image contains it. `sandbox.sh` checks and tells you. Once #1094 lands and an image
-> is published, bump the digest in `image.env` and plain `up` works.
-
 ## Provider modes
 
 The deriver calls a model provider, which is what made a sandbox neither free nor deterministic.

--- a/sandbox/compose.mock.yml
+++ b/sandbox/compose.mock.yml
@@ -1,0 +1,50 @@
+# Provider overlay: deterministic, free, no network egress. The sandbox default.
+#
+# Adds src/mock_provider (PR #1094) as its own service. It runs from the standard
+# Honcho image under a different entrypoint, the way api and deriver already differ,
+# so there is no second image to build or keep in digest-sync.
+
+services:
+  mock-provider:
+    image: ${HONCHO_SANDBOX_IMAGE:?set by sandbox.sh from sandbox/image.env}
+    entrypoint:
+      ["/app/.venv/bin/fastapi", "run", "--host", "0.0.0.0", "src/mock_provider/main.py"]
+    healthcheck:
+      # The app exposes only POST /chat/completions and POST /embeddings — no health
+      # or models route — so liveness is checked against the schema FastAPI always
+      # serves. A GET keeps the check side-effect free.
+      test:
+        [
+          "CMD",
+          "/app/.venv/bin/python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/openapi.json', timeout=2).read()",
+        ]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
+    restart: "no"
+
+  api: &provider-wiring
+    depends_on:
+      mock-provider:
+        condition: service_healthy
+    environment:
+      # All three are required (src/mock_provider/main.py).
+      #
+      # The key's value is never checked — the mock reads no Authorization header,
+      # and Honcho only tests it for truthiness before building the client
+      # (src/llm/registry.py). Set the base URL without it and the client is never
+      # constructed, so the base URL is silently ignored. Keep the value obviously
+      # fake: a module that ever escapes the override then 401s rather than spends.
+      LLM_OPENAI_API_KEY: sandbox-not-a-real-key
+      LLM_OPENAI_BASE_URL: http://mock-provider:8000/v1
+      # Embeddings resolve through a separate client that reads the base URL only
+      # from this per-module override. Without it, embedding calls go to
+      # api.openai.com for real. Do not add a per-module credential override
+      # (..._OVERRIDES__API_KEY / API_KEY_ENV) — that makes the module ignore the
+      # global base URL above.
+      EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL: http://mock-provider:8000/v1
+
+  deriver: *provider-wiring

--- a/sandbox/compose.mock.yml
+++ b/sandbox/compose.mock.yml
@@ -1,6 +1,6 @@
 # Provider overlay: deterministic, free, no network egress. The sandbox default.
 #
-# Adds src/mock_provider (PR #1094) as its own service. It runs from the standard
+# Adds src/mock_provider as its own service. It runs from the standard
 # Honcho image under a different entrypoint, the way api and deriver already differ,
 # so there is no second image to build or keep in digest-sync.
 

--- a/sandbox/compose.real.yml
+++ b/sandbox/compose.real.yml
@@ -1,0 +1,22 @@
+# Provider overlay: a real, configured model provider.
+#
+# Non-deterministic and it costs money. Use it when you need something the mock
+# cannot give you — chiefly vector recall, since mock embeddings are hash-derived
+# and carry no semantic similarity, and the full conclusion level mix.
+#
+# Credentials come from sandbox/real.env (gitignored), never from ambient host
+# environment, so a real-mode run has one auditable input and the sandbox still does
+# not depend on whatever happens to be exported in your shell.
+#
+# Copy sandbox/real.env.example to sandbox/real.env to get started. sandbox.sh
+# refuses to start real mode if that file is missing or carries no key.
+#
+# No mock-provider service is defined here, so nothing depends on one.
+
+services:
+  api: &provider-wiring
+    env_file:
+      - path: real.env
+        required: true
+
+  deriver: *provider-wiring

--- a/sandbox/compose.yml
+++ b/sandbox/compose.yml
@@ -1,0 +1,133 @@
+# Honcho sandbox — an ephemeral, seeded stack for harness integration testing.
+#
+# This file is provider-agnostic and is NOT a working stack on its own. Exactly one
+# provider overlay must be composed on top of it:
+#
+#   docker compose -f sandbox/compose.yml -f sandbox/compose.mock.yml up -d   # default
+#   docker compose -f sandbox/compose.yml -f sandbox/compose.real.yml up -d
+#
+# Use sandbox/sandbox.sh rather than driving compose directly.
+
+name: honcho-sandbox
+
+# Everything the api and deriver need in order to behave identically and promptly.
+# Provider wiring lives in the overlays; this block is provider-independent.
+x-honcho-env: &honcho-env
+  DB_CONNECTION_URI: postgresql+psycopg://postgres:postgres@database:5432/honcho_sandbox
+  CACHE_URL: redis://redis:6379/0?suppress=true
+  CACHE_ENABLED: "true"
+  AUTH_USE_AUTH: "false"
+  LOG_LEVEL: INFO
+
+  # The sandbox is configured only by what Compose injects here.
+  #
+  # src/config.py calls load_dotenv(override=True) at import, so a stray .env inside
+  # the image would beat this block. Dockerfile's `COPY config.toml* /app/` means a
+  # developer's local config.toml gets baked into any locally built image. Both are
+  # switched off so the stack cannot inherit machine state.
+  PYTHON_DOTENV_DISABLED: "1"
+  HONCHO_CONFIG_TOML_DISABLED: "1"
+
+  # Derivation has to happen now, not eventually. On stock settings a sandbox seeded
+  # with a handful of messages produces zero conclusions, and it fails silently — it
+  # reads as "the deriver found nothing" rather than "the deriver never ran".
+  #
+  # Three separate gates have to come off (src/config.py, DeriverSettings):
+  #   - work units are not claimed until the batch reaches 512 tokens...
+  #   - ...or REPRESENTATION_BATCH_MAX_AGE_SECONDS (30 min) elapses
+  #   - startup jitter delays the first poll by up to 30s, then backoff stretches
+  #     the interval out to 30s
+  DERIVER_FLUSH_ENABLED: "true"
+  DERIVER_REPRESENTATION_BATCH_WORK_UNIT_TARGET_TOKENS: "0"
+  DERIVER_REPRESENTATION_BATCH_MAX_AGE_SECONDS: "1"
+  DERIVER_POLLING_STARTUP_JITTER_SECONDS: "0"
+  DERIVER_POLLING_JITTER_RATIO: "0"
+  DERIVER_POLLING_BACKOFF_ENABLED: "false"
+  DERIVER_POLLING_SLEEP_INTERVAL_SECONDS: "0.25"
+  DERIVER_STALE_WORK_UNIT_CLEANUP_INTERVAL_SECONDS: "5"
+
+  # Dreams never fire on their own here: the document threshold is 50 and the
+  # minimum gap between dreams is 8 hours. seed.py calls schedule_dream directly,
+  # which bypasses both — but the subsystem still has to be enabled.
+  DREAM_ENABLED: "true"
+
+services:
+  api:
+    image: ${HONCHO_SANDBOX_IMAGE:?set by sandbox.sh from sandbox/image.env}
+    entrypoint: ["sh", "docker/entrypoint.sh"]
+    depends_on:
+      database:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:${SANDBOX_API_PORT:-18000}:8000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "/app/.venv/bin/python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2).read()",
+        ]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+    environment: *honcho-env
+    restart: "no"
+
+  deriver:
+    image: ${HONCHO_SANDBOX_IMAGE:?set by sandbox.sh from sandbox/image.env}
+    entrypoint: ["/app/.venv/bin/python", "-m", "src.deriver"]
+    depends_on:
+      api:
+        condition: service_healthy
+      database:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment: *honcho-env
+    restart: "no"
+
+  database:
+    image: pgvector/pgvector:pg15
+    ports:
+      - "127.0.0.1:${SANDBOX_DB_PORT:-15432}:5432"
+    command: ["postgres", "-c", "max_connections=200"]
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      # The port is bound to 127.0.0.1 and the whole database is disposable.
+      POSTGRES_HOST_AUTH_METHOD: trust
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      # Creates the honcho_sandbox database. database/init.sql only adds the vector
+      # extension to `postgres`, and the sandbox needs its own database so that
+      # reset can DROP and re-CREATE it from a template.
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+      - pgdata:/var/lib/postgresql/data/
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d honcho_sandbox"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+    restart: "no"
+
+  redis:
+    image: redis:8.2
+    ports:
+      - "127.0.0.1:${SANDBOX_REDIS_PORT:-16379}:6379"
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+    restart: "no"
+
+# Named volumes are prefixed with the project name (honcho-sandbox_*), so they
+# never collide with a developer's existing local stack. `sandbox.sh down` removes
+# them. Redis is deliberately unbacked — its state is rebuilt by reset.
+volumes:
+  pgdata:

--- a/sandbox/fixture.json
+++ b/sandbox/fixture.json
@@ -3,8 +3,37 @@
   "session": "sandbox-session",
 
   "_comment": "Peer topology is stated explicitly because it is the thing that silently breaks (DEV-2462 asserts on it). alice is observed and does not observe; the assistant observes and is not observed - the standard harness shape.",
+
+  "_conclusions_comment": "The explicit/deductive/inductive keys are optional seeded memory, written straight into the (observer, observed) collection rather than derived. They exist because derived conclusions are only assertable in real mode: the mock provider's conclusion text is synthetic and its level is always explicit. Seeded text is identical in both modes, so a harness test can assert on content and level for free. Premise indices point into the same peer's explicit list, and they are what make the conclusion's reasoning chain resolve - excadrill's equivalent fixtures use synthetic source ids that never resolve to a real document. A premise-less derived conclusion is allowed by the format but is not something the Dreamer would ever write, so the committed fixture does not use one.",
   "peers": [
-    { "id": "alice", "observe_me": true, "observe_others": false },
+    {
+      "id": "alice",
+      "observe_me": true,
+      "observe_others": false,
+
+      "explicit": [
+        "alice is a structural engineer based in Rotterdam",
+        "alice is designing a pedestrian bridge over the Nieuwe Maas spanning 240 metres on a single cable-stayed pylon",
+        "alice specified weathering steel for the bridge because its maintenance budget is close to zero",
+        "alice has a cat called Marzipan, named after the colour of the bridge's pylon"
+      ],
+      "deductive": [
+        {
+          "content": "alice named her cat after a feature of the bridge she is designing",
+          "premises": [1, 3]
+        },
+        {
+          "content": "alice selects materials on lifetime maintenance cost rather than capital cost",
+          "premises": [2]
+        }
+      ],
+      "inductive": [
+        {
+          "content": "alice lets the Nieuwe Maas bridge project shape decisions well outside her working hours",
+          "premises": [1, 3]
+        }
+      ]
+    },
     { "id": "assistant", "observe_me": false, "observe_others": true }
   ],
 

--- a/sandbox/fixture.json
+++ b/sandbox/fixture.json
@@ -1,0 +1,41 @@
+{
+  "workspace": "sandbox",
+  "session": "sandbox-session",
+
+  "_comment": "Peer topology is stated explicitly because it is the thing that silently breaks (DEV-2462 asserts on it). alice is observed and does not observe; the assistant observes and is not observed - the standard harness shape.",
+  "peers": [
+    { "id": "alice", "observe_me": true, "observe_others": false },
+    { "id": "assistant", "observe_me": false, "observe_others": true }
+  ],
+
+  "_messages_comment": "Facts are deliberately distinctive and lexically searchable, so a recall assertion can look for an exact token. Under the mock provider, embeddings carry no semantic similarity, so full-text is the only thing that can work.",
+  "messages": [
+    {
+      "peer": "alice",
+      "content": "I'm Alice Nakamura, I work as a structural engineer in Rotterdam."
+    },
+    {
+      "peer": "assistant",
+      "content": "Good to meet you, Alice. What are you working on in Rotterdam?"
+    },
+    {
+      "peer": "alice",
+      "content": "A pedestrian bridge over the Nieuwe Maas. We're using weathering steel because the maintenance budget is basically zero."
+    },
+    {
+      "peer": "assistant",
+      "content": "Weathering steel is a reasonable call for a low-maintenance span. How long is the crossing?"
+    },
+    {
+      "peer": "alice",
+      "content": "About 240 metres, with a single cable-stayed pylon. My cat Marzipan is named after the pylon's colour, which tells you how much I think about this bridge."
+    },
+    {
+      "peer": "assistant",
+      "content": "240 metres on a single pylon is ambitious. And Marzipan is a good name for a cat."
+    }
+  ],
+
+  "_dreams_comment": "Dreams never fire on their own here - the document threshold is 50 and the minimum gap is 8 hours - so the seed schedules one directly.",
+  "dreams": [{ "observer": "assistant", "observed": "alice" }]
+}

--- a/sandbox/fixture.json
+++ b/sandbox/fixture.json
@@ -2,9 +2,9 @@
   "workspace": "sandbox",
   "session": "sandbox-session",
 
-  "_comment": "Peer topology is stated explicitly because it is the thing that silently breaks (DEV-2462 asserts on it). alice is observed and does not observe; the assistant observes and is not observed - the standard harness shape.",
+  "_comment": "Peer topology is stated explicitly because it is the thing that silently breaks, and harness tests assert on it. alice is observed and does not observe; the assistant observes and is not observed - the standard harness shape.",
 
-  "_conclusions_comment": "The explicit/deductive/inductive keys are optional seeded memory, written straight into the (observer, observed) collection rather than derived. They exist because derived conclusions are only assertable in real mode: the mock provider's conclusion text is synthetic and its level is always explicit. Seeded text is identical in both modes, so a harness test can assert on content and level for free. Premise indices point into the same peer's explicit list, and they are what make the conclusion's reasoning chain resolve - excadrill's equivalent fixtures use synthetic source ids that never resolve to a real document. A premise-less derived conclusion is allowed by the format but is not something the Dreamer would ever write, so the committed fixture does not use one.",
+  "_conclusions_comment": "The explicit/deductive/inductive keys are optional seeded memory, written straight into the (observer, observed) collection rather than derived. They exist because derived conclusions are only assertable in real mode: the mock provider's conclusion text is synthetic and its level is always explicit. Seeded text is identical in both modes, so a harness test can assert on content and level for free. Premise indices point into the same peer's explicit list, and they are what make the conclusion's reasoning chain resolve: they become source_ids pointing at the real rows written by the explicit pass, so the tree traverses in both directions. Synthetic ids would satisfy the schema and resolve to nothing. A premise-less derived conclusion is allowed by the format but is not something the Dreamer would ever write, so the committed fixture does not use one.",
   "peers": [
     {
       "id": "alice",

--- a/sandbox/image.env
+++ b/sandbox/image.env
@@ -1,0 +1,16 @@
+# The image the sandbox runs, pinned by digest so a run is reproducible.
+#
+# Bump this deliberately. The whole point of the sandbox is that two people on two
+# machines exercise the same bytes, which a floating tag does not give you.
+#
+# This is the multi-arch index digest (linux/amd64 + linux/arm64), so it resolves on
+# both Apple Silicon and CI.
+#
+# NOTE: this digest predates PR #1094, so it does NOT contain src/mock_provider.
+# Until #1094 lands and a new image is published, mock mode needs --build:
+#
+#     sandbox/sandbox.sh up --build
+#
+# sandbox.sh checks for the module and tells you this rather than failing obscurely.
+# When #1094 is merged and published, bump the digest here and drop this note.
+HONCHO_SANDBOX_IMAGE=ghcr.io/plastic-labs/honcho@sha256:3e62ce949cd020155e59d58302e11a20465c79815d80e2d4eecd106e9c8f9ab4

--- a/sandbox/image.env
+++ b/sandbox/image.env
@@ -4,13 +4,10 @@
 # machines exercise the same bytes, which a floating tag does not give you.
 #
 # This is the multi-arch index digest (linux/amd64 + linux/arm64), so it resolves on
-# both Apple Silicon and CI.
+# both Apple Silicon and CI. Take it from the index, not a per-platform manifest:
 #
-# NOTE: this digest predates PR #1094, so it does NOT contain src/mock_provider.
-# Until #1094 lands and a new image is published, mock mode needs --build:
+#     docker buildx imagetools inspect ghcr.io/plastic-labs/honcho:latest
 #
-#     sandbox/sandbox.sh up --build
-#
-# sandbox.sh checks for the module and tells you this rather than failing obscurely.
-# When #1094 is merged and published, bump the digest here and drop this note.
-HONCHO_SANDBOX_IMAGE=ghcr.io/plastic-labs/honcho@sha256:3e62ce949cd020155e59d58302e11a20465c79815d80e2d4eecd106e9c8f9ab4
+# The image must contain src/mock_provider, which mock mode runs as its own service.
+# sandbox.sh checks that before starting rather than letting the service crash-loop.
+HONCHO_SANDBOX_IMAGE=ghcr.io/plastic-labs/honcho@sha256:a741e601e2c2fda5af4b6c207946aad45db2a11db05f04c1dc094f998794eae1

--- a/sandbox/init.sql
+++ b/sandbox/init.sql
@@ -1,0 +1,9 @@
+-- Runs once, on first initialisation of an empty PGDATA.
+--
+-- The sandbox uses its own database rather than `postgres` so that reset can DROP
+-- and re-CREATE it from a seeded template. You cannot drop the database you are
+-- connected to, and `postgres` is the default connection target for maintenance.
+CREATE DATABASE honcho_sandbox;
+
+\connect honcho_sandbox
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/sandbox/inject_conclusions.py
+++ b/sandbox/inject_conclusions.py
@@ -1,0 +1,502 @@
+"""Seed conclusions at every reasoning level, from inside the api container.
+
+Run by sandbox.sh, never from the host:
+
+    compose exec -T -e SANDBOX_FIXTURE_JSON="$(cat fixture.json)" api \
+        /app/.venv/bin/python - < sandbox/inject_conclusions.py
+
+Level and premise links are not reachable from the public API. `crud.create_observations`
+hardcodes `level="explicit"`, `source_ids=NULL`, `internal_metadata={}`, and `ConclusionCreate`
+has no field for any of them. The columns exist on Document; only an in-process caller can set
+them. So this script imports Honcho's own write helpers, which is why it runs in the container
+rather than beside seed.py: the container already *is* Honcho's venv, with the api's settings
+and a correctly wired embedding client.
+
+That comes at a price worth stating. These are internal APIs with no stability contract, and
+they are imported out of the *pinned* image, not the working tree — so a digest bump can move
+them underneath us. `check_signatures` fails loudly on that rather than letting a broken seed
+look like a working one.
+
+Two passes, not three: premise indices point into the same peer's `explicit` list, so both
+derived levels reference pass-1 ids and nothing has to reference a derived id.
+
+Everything here is asserted exactly, because every silent-failure mode in this path reduces a
+count without raising: exact-content dedup is always on and cannot be switched off, semantic
+dedup replaces rows, per-item embedding failures drop rows, and the session-purity invariant
+skips explicit rows with no session. A seed that quietly wrote nothing is the failure this
+whole sandbox exists to prevent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import os
+import sys
+from typing import Any
+
+LEVELS = ("explicit", "deductive", "inductive")
+
+# Levels whose premise text renders under a different metadata key. The working representation
+# prints DocumentMetadata.premises for deductive and .sources for inductive, and each is read
+# only for its own level, so putting the text under the wrong one renders nothing.
+PREMISE_FIELD = {"deductive": "premises", "inductive": "sources"}
+
+
+class InjectError(RuntimeError):
+    """Seeding conclusions did not reach a usable state."""
+
+
+def log(message: str) -> None:
+    print(f"[conclusions] {message}", flush=True)
+
+
+def check_signatures(crud: Any, schemas: Any) -> None:
+    """Fail loudly if the image's internals moved.
+
+    Cheap insurance against the real hazard of importing unversioned internals out of a pinned
+    image: without this, a renamed keyword surfaces as a TypeError mid-seed, or worse, as a
+    seed that silently wrote fewer rows.
+    """
+    expected = {
+        "create_documents": (
+            "documents",
+            "workspace_name",
+            "observer",
+            "observed",
+            "deduplicate",
+        ),
+        "create_observations": ("observations", "workspace_name"),
+        "get_or_create_collection": ("workspace_name", "observer", "observed"),
+        "get_documents_by_ids": ("workspace_name", "document_ids"),
+        "get_child_observations": (
+            "workspace_name",
+            "parent_id",
+            "observer",
+            "observed",
+        ),
+    }
+    for name, params in expected.items():
+        signature = inspect.signature(getattr(crud, name))
+        missing = [p for p in params if p not in signature.parameters]
+        if missing:
+            raise InjectError(
+                f"crud.{name} is missing expected parameters {missing} in this image. "
+                "The sandbox seeds conclusions through Honcho internals, which carry no "
+                "stability contract; bump sandbox/image.env and update this script together."
+            )
+
+    for model, fields in (
+        (
+            schemas.DocumentCreate,
+            ("content", "level", "metadata", "embedding", "source_ids"),
+        ),
+        (
+            schemas.DocumentMetadata,
+            ("message_ids", "message_created_at", "premises", "sources"),
+        ),
+    ):
+        missing = [f for f in fields if f not in model.model_fields]
+        if missing:
+            raise InjectError(
+                f"{model.__name__} is missing expected fields {missing} in this image. "
+                "Bump sandbox/image.env and update this script together."
+            )
+
+
+def normalize(
+    items: list[Any], level: str, peer_id: str, explicit_count: int
+) -> list[dict[str, Any]]:
+    """Accept either a bare string or {content, premises}, and validate premise indices.
+
+    An out-of-range index is rejected here rather than written as a dangling source id. Nothing
+    downstream validates source_ids -- a bad one resolves to "referenced N premise IDs but none
+    found in database" at read time, which is precisely the quiet wrongness to avoid.
+    """
+    normalized: list[dict[str, Any]] = []
+    for position, item in enumerate(items):
+        if isinstance(item, str):
+            content, premises = item, []
+        elif isinstance(item, dict):
+            content = item.get("content")
+            premises = item.get("premises", [])
+            unknown = set(item) - {"content", "premises"}
+            if unknown:
+                raise InjectError(
+                    f"{peer_id}.{level}[{position}] has unknown keys {sorted(unknown)}"
+                )
+        else:
+            raise InjectError(
+                f"{peer_id}.{level}[{position}] must be a string or an object, got {type(item).__name__}"
+            )
+
+        if not content or not content.strip():
+            raise InjectError(f"{peer_id}.{level}[{position}] has empty content")
+        if premises and level == "explicit":
+            raise InjectError(
+                f"{peer_id}.explicit[{position}] declares premises. Explicit conclusions come "
+                "straight from messages and are the premises other levels point at."
+            )
+        for index in premises:
+            if not isinstance(index, int) or not 0 <= index < explicit_count:
+                raise InjectError(
+                    f"{peer_id}.{level}[{position}] premise {index!r} is not a valid index into "
+                    f"{peer_id}.explicit (which has {explicit_count} entries)"
+                )
+
+        normalized.append({"content": content, "premises": premises})
+    return normalized
+
+
+def resolve_observers(spec: dict[str, Any], peers: list[dict[str, Any]]) -> list[str]:
+    """Who holds conclusions about this peer.
+
+    The peer carrying the keys is the observed. Absent an explicit override, the observers are
+    every peer configured to observe others -- which for the standard harness shape is exactly
+    the assistant. Resolving to nobody is an error: the conclusions would be written into no
+    collection at all and the seed would report success having stored nothing.
+    """
+    observed = spec["id"]
+    override = spec.get("observer")
+    if override:
+        return [override]
+
+    observers = [
+        peer["id"]
+        for peer in peers
+        if peer.get("observe_others") and peer["id"] != observed
+    ]
+    if not observers:
+        raise InjectError(
+            f"peer {observed!r} has seeded conclusions but no other peer observes it: "
+            "no fixture peer besides itself sets observe_others, and it declares no "
+            f'explicit "observer". The conclusions would be written nowhere. Either give '
+            f'{observed!r} an "observer", or set observe_others on the peer that should '
+            "hold them."
+        )
+    return observers
+
+
+async def latest_message_timestamp(
+    db: Any, models: Any, workspace: str, session: str
+) -> str | None:
+    """The conversation's own clock, for the representation to render.
+
+    Derived conclusions are stamped with the last ingested message time rather than the seed's
+    wall-clock, so the representation shows when the conversation happened. Honcho's own dream
+    path back-dates the same way.
+    """
+    from sqlalchemy import func, select
+
+    result = await db.execute(
+        select(func.max(models.Message.created_at)).where(
+            models.Message.workspace_name == workspace,
+            models.Message.session_name == session,
+        )
+    )
+    newest = result.scalar_one_or_none()
+    return newest.strftime("%Y-%m-%dT%H:%M:%SZ") if newest else None
+
+
+def assert_clean(result: Any, requested: int, label: str) -> None:
+    """No row may be dropped, deduped, or replaced.
+
+    create_documents reports these as counters rather than raising, so without this the seed
+    reports success while having written fewer conclusions than the fixture declares. Exact
+    content dedup cannot be disabled, so this fires on a reseed over existing content too --
+    which is correct: seed.py always starts from an empty database.
+    """
+    created = len(result.created_documents)
+    counters = {
+        "exact duplicates within the batch": result.exact_dup_in_batch_count,
+        "exact duplicates already stored": result.exact_dup_existing_count,
+        "semantically rejected": result.semantic_dup_rejected_count,
+        "semantically replaced": result.semantic_dup_replaced_count,
+    }
+    dropped = {name: count for name, count in counters.items() if count}
+    if created != requested or dropped:
+        raise InjectError(
+            f"{label}: asked for {requested} conclusions, stored {created}"
+            + (
+                f" ({', '.join(f'{n}: {c}' for n, c in dropped.items())})"
+                if dropped
+                else ""
+            )
+            + ". Conclusion contents must be unique; near-identical text is collapsed by "
+            "Honcho's dedup before it reaches the database."
+        )
+
+
+async def inject_pair(
+    modules: dict[str, Any],
+    workspace: str,
+    session: str,
+    observer: str,
+    observed: str,
+    conclusions: dict[str, list[dict[str, Any]]],
+) -> dict[str, int]:
+    """Seed one (observer, observed) collection. Returns per-level counts actually stored."""
+    crud = modules["crud"]
+    schemas = modules["schemas"]
+    models = modules["models"]
+    embedding_client = modules["embedding_client"]
+    tracked_db = modules["tracked_db"]
+
+    stored: dict[str, int] = {}
+
+    # Pass 1. The public write path is the only one that hands back rows, so it is how the
+    # premise ids are obtained -- and it does no dedup, so nothing is silently collapsed.
+    explicit = conclusions["explicit"]
+    premise_ids: list[str] = []
+    async with tracked_db("sandbox.seed_explicit") as db:
+        await crud.get_or_create_collection(
+            db, workspace, observer=observer, observed=observed
+        )
+        if explicit:
+            documents = await crud.create_observations(
+                db,
+                [
+                    schemas.ConclusionCreate(
+                        content=item["content"],
+                        observer_id=observer,
+                        observed_id=observed,
+                        # Explicit rows must carry a session: create_documents refuses
+                        # session-less explicit rows on a session-purity invariant, and an
+                        # explicit conclusion genuinely does come from a conversation.
+                        session_id=session,
+                    )
+                    for item in explicit
+                ],
+                workspace,
+            )
+            if len(documents) != len(explicit):
+                raise InjectError(
+                    f"{observer} -> {observed}: asked for {len(explicit)} explicit "
+                    f"conclusions, stored {len(documents)}"
+                )
+            premise_ids = [document.id for document in documents]
+            stored["explicit"] = len(documents)
+
+    # Pass 2. Both derived levels cite pass-1 ids, so neither needs the other's ids back.
+    derived = {
+        level: conclusions[level]
+        for level in ("deductive", "inductive")
+        if conclusions[level]
+    }
+    if derived:
+        async with tracked_db("sandbox.seed_derived") as db:
+            message_created_at = await latest_message_timestamp(
+                db, models, workspace, session
+            )
+            if message_created_at is None:
+                raise InjectError(
+                    f"session {session!r} has no messages, so derived conclusions have no "
+                    "conversation timestamp to carry. Seed messages before conclusions."
+                )
+
+            for level, items in derived.items():
+                contents = [item["content"] for item in items]
+                embeddings = await embedding_client.simple_batch_embed(
+                    contents, on_oversize="truncate"
+                )
+                if len(embeddings) != len(contents):
+                    raise InjectError(
+                        f"{observer} -> {observed}: embedded {len(embeddings)} of "
+                        f"{len(contents)} {level} conclusions"
+                    )
+
+                payload: list[Any] = []
+                for item, embedding in zip(items, embeddings, strict=True):
+                    source_ids = [premise_ids[index] for index in item["premises"]]
+                    metadata: dict[str, Any] = {
+                        # Not derived from messages, but the representation reads this to
+                        # render the conclusion's timestamp.
+                        "message_ids": [],
+                        "message_created_at": message_created_at,
+                        "source_ids": source_ids,
+                        PREMISE_FIELD[level]: [
+                            explicit[index]["content"] for index in item["premises"]
+                        ],
+                    }
+                    if level == "inductive":
+                        metadata["pattern_type"] = "tendency"
+                        metadata["confidence"] = (
+                            "high" if len(source_ids) > 1 else "low"
+                        )
+                    payload.append(
+                        schemas.DocumentCreate(
+                            content=item["content"],
+                            # Derived conclusions belong to the dream, not to one session,
+                            # which is how the Dreamer writes them.
+                            session_name=None,
+                            level=level,
+                            times_derived=1,
+                            metadata=schemas.DocumentMetadata(**metadata),
+                            embedding=embedding,
+                            source_ids=source_ids,
+                        )
+                    )
+
+                result = await crud.create_documents(
+                    db,
+                    payload,
+                    workspace,
+                    observer=observer,
+                    observed=observed,
+                    # Semantic dedup would replace or reject a seeded row against whatever the
+                    # deriver already wrote, making the fixture's counts depend on the provider.
+                    deduplicate=False,
+                )
+                assert_clean(result, len(items), f"{observer} -> {observed} {level}")
+                stored[level] = len(result.created_documents)
+
+        # Outside the write session on purpose: create_documents commits as it goes, and the
+        # check should read the committed rows back on its own connection rather than through
+        # the identity map of the session that wrote them.
+        await verify_links(modules, workspace, observer, observed, premise_ids, derived)
+
+    return stored
+
+
+async def verify_links(
+    modules: dict[str, Any],
+    workspace: str,
+    observer: str,
+    observed: str,
+    premise_ids: list[str],
+    derived: dict[str, list[dict[str, Any]]],
+) -> None:
+    """Confirm the premise links actually traverse, through Honcho's own read helpers.
+
+    Nothing in the write path validates source_ids: a dangling id is stored happily and then
+    degrades quietly at read time to "referenced N premise IDs but none found in database",
+    while the conclusions endpoint does not expose source_ids at all. So a completely broken
+    reasoning tree looks exactly like a working one from outside.
+
+    Both directions are read back from the stored rows rather than from what this script
+    intended, which is the only version of the check that can fail. Downward: every cited
+    premise must be reachable from its children, which is what catches a child written into a
+    different (observer, observed) collection. Upward: the source_ids those children actually
+    carry must all resolve to live rows.
+    """
+    crud = modules["crud"]
+    tracked_db = modules["tracked_db"]
+
+    cited = sorted(
+        {
+            premise_ids[index]
+            for items in derived.values()
+            for item in items
+            for index in item["premises"]
+        }
+    )
+    if not cited:
+        return
+
+    async with tracked_db("sandbox.verify_links") as db:
+        declared: set[str] = set()
+        for premise_id in cited:
+            children = await crud.get_child_observations(
+                db, workspace, premise_id, observer=observer, observed=observed
+            )
+            if not children:
+                raise InjectError(
+                    f"{observer} -> {observed}: premise {premise_id} has no reachable "
+                    "children, so the reasoning tree does not traverse downward. Premise and "
+                    "conclusion must share one (observer, observed) pair."
+                )
+            for child in children:
+                declared.update(child.source_ids or [])
+
+        resolved = await crud.get_documents_by_ids(db, workspace, sorted(declared))
+        missing = declared - {document.id for document in resolved}
+        if missing:
+            raise InjectError(
+                f"{observer} -> {observed}: {len(missing)} stored premise id(s) resolve to "
+                "nothing, so the reasoning chain would read as empty. First: "
+                f"{sorted(missing)[0]}"
+            )
+
+    log(f"{observer} -> {observed}: {len(cited)} premise link(s) traverse both ways")
+
+
+async def run(fixture: dict[str, Any]) -> int:
+    from src import crud, models, schemas
+    from src.cache.client import close_cache, init_cache
+    from src.db import engine
+    from src.dependencies import tracked_db
+    from src.embedding_client import embedding_client
+
+    check_signatures(crud, schemas)
+
+    workspace = fixture["workspace"]
+    session = fixture["session"]
+    peers = fixture["peers"]
+
+    planned: list[tuple[str, str, dict[str, list[dict[str, Any]]]]] = []
+    for spec in peers:
+        if not any(spec.get(level) for level in LEVELS):
+            continue
+        explicit_count = len(spec.get("explicit", []))
+        conclusions = {
+            level: normalize(spec.get(level, []), level, spec["id"], explicit_count)
+            for level in LEVELS
+        }
+        if (
+            any(conclusions[level] for level in ("deductive", "inductive"))
+            and not explicit_count
+        ):
+            raise InjectError(
+                f"peer {spec['id']!r} has derived conclusions but no explicit ones for their "
+                "premises to point at."
+            )
+        for observer in resolve_observers(spec, peers):
+            planned.append((observer, spec["id"], conclusions))
+
+    if not planned:
+        log("fixture declares no conclusions - nothing to seed")
+        return 0
+
+    # cashews decorates the collection lookups, and an unconfigured backend raises rather than
+    # degrading, so the cache has to be up before the first crud call.
+    await init_cache()
+    try:
+        modules = {
+            "crud": crud,
+            "schemas": schemas,
+            "models": models,
+            "embedding_client": embedding_client,
+            "tracked_db": tracked_db,
+        }
+        for observer, observed, conclusions in planned:
+            stored = await inject_pair(
+                modules, workspace, session, observer, observed, conclusions
+            )
+            summary = " ".join(f"{level}={stored.get(level, 0)}" for level in LEVELS)
+            log(f"{observer} -> {observed}: {summary}")
+    finally:
+        await close_cache()
+        # Without this the process can hang on exit holding pool connections, which inside
+        # `compose exec` looks like the seed itself wedging.
+        await engine.dispose()
+
+    return 0
+
+
+def main() -> int:
+    raw = os.environ.get("SANDBOX_FIXTURE_JSON")
+    if not raw:
+        raise InjectError(
+            "SANDBOX_FIXTURE_JSON is unset. This script is run by sandbox.sh, which passes the "
+            "fixture in through the environment; it is not meant to be run by hand."
+        )
+    return asyncio.run(run(json.loads(raw)))
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except InjectError as exc:
+        print(f"[conclusions] FAILED: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/sandbox/inject_conclusions.py
+++ b/sandbox/inject_conclusions.py
@@ -34,9 +34,11 @@ import inspect
 import json
 import os
 import sys
+from dataclasses import dataclass
 from typing import Any
 
 LEVELS = ("explicit", "deductive", "inductive")
+DERIVED_LEVELS = ("deductive", "inductive")
 
 # Levels whose premise text renders under a different metadata key. The working representation
 # prints DocumentMetadata.premises for deductive and .sources for inductive, and each is read
@@ -46,6 +48,50 @@ PREMISE_FIELD = {"deductive": "premises", "inductive": "sources"}
 
 class InjectError(RuntimeError):
     """Seeding conclusions did not reach a usable state."""
+
+
+@dataclass(frozen=True)
+class SeededConclusion:
+    """One conclusion from the fixture, with its premises resolved to explicit indices."""
+
+    content: str
+    premises: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class PairPlan:
+    """One (observer, observed) collection's worth of seeding, keyed by level."""
+
+    observer: str
+    observed: str
+    by_level: dict[str, list[SeededConclusion]]
+
+    def derived(self) -> dict[str, list[SeededConclusion]]:
+        """The levels that carry premises, skipping any the fixture left empty."""
+        return {
+            level: self.by_level[level]
+            for level in DERIVED_LEVELS
+            if self.by_level[level]
+        }
+
+    def __str__(self) -> str:
+        return f"{self.observer} -> {self.observed}"
+
+
+@dataclass(frozen=True)
+class Internals:
+    """The Honcho internals this script writes through.
+
+    Resolved once inside run() rather than imported at module scope, because importing
+    src.* binds the engine and embedding client from the environment and that must happen
+    with the api's settings in place.
+    """
+
+    crud: Any
+    schemas: Any
+    models: Any
+    embedding_client: Any
+    tracked_db: Any
 
 
 def log(message: str) -> None:
@@ -79,7 +125,7 @@ def check_signatures(crud: Any, schemas: Any) -> None:
     }
     for name, params in expected.items():
         signature = inspect.signature(getattr(crud, name))
-        missing = [p for p in params if p not in signature.parameters]
+        missing = [param for param in params if param not in signature.parameters]
         if missing:
             raise InjectError(
                 f"crud.{name} is missing expected parameters {missing} in this image. "
@@ -97,7 +143,7 @@ def check_signatures(crud: Any, schemas: Any) -> None:
             ("message_ids", "message_created_at", "premises", "sources"),
         ),
     ):
-        missing = [f for f in fields if f not in model.model_fields]
+        missing = [name for name in fields if name not in model.model_fields]
         if missing:
             raise InjectError(
                 f"{model.__name__} is missing expected fields {missing} in this image. "
@@ -107,14 +153,14 @@ def check_signatures(crud: Any, schemas: Any) -> None:
 
 def normalize(
     items: list[Any], level: str, peer_id: str, explicit_count: int
-) -> list[dict[str, Any]]:
+) -> list[SeededConclusion]:
     """Accept either a bare string or {content, premises}, and validate premise indices.
 
     An out-of-range index is rejected here rather than written as a dangling source id. Nothing
     downstream validates source_ids -- a bad one resolves to "referenced N premise IDs but none
     found in database" at read time, which is precisely the quiet wrongness to avoid.
     """
-    normalized: list[dict[str, Any]] = []
+    normalized: list[SeededConclusion] = []
     for position, item in enumerate(items):
         if isinstance(item, str):
             content, premises = item, []
@@ -128,7 +174,8 @@ def normalize(
                 )
         else:
             raise InjectError(
-                f"{peer_id}.{level}[{position}] must be a string or an object, got {type(item).__name__}"
+                f"{peer_id}.{level}[{position}] must be a string or an object, "
+                f"got {type(item).__name__}"
             )
 
         if not content or not content.strip():
@@ -145,7 +192,7 @@ def normalize(
                     f"{peer_id}.explicit (which has {explicit_count} entries)"
                 )
 
-        normalized.append({"content": content, "premises": premises})
+        normalized.append(SeededConclusion(content=content, premises=tuple(premises)))
     return normalized
 
 
@@ -179,7 +226,7 @@ def resolve_observers(spec: dict[str, Any], peers: list[dict[str, Any]]) -> list
 
 
 async def latest_message_timestamp(
-    db: Any, models: Any, workspace: str, session: str
+    internals: Internals, db: Any, workspace: str, session: str
 ) -> str | None:
     """The conversation's own clock, for the representation to render.
 
@@ -189,10 +236,11 @@ async def latest_message_timestamp(
     """
     from sqlalchemy import func, select
 
+    messages = internals.models.Message
     result = await db.execute(
-        select(func.max(models.Message.created_at)).where(
-            models.Message.workspace_name == workspace,
-            models.Message.session_name == session,
+        select(func.max(messages.created_at)).where(
+            messages.workspace_name == workspace,
+            messages.session_name == session,
         )
     )
     newest = result.scalar_one_or_none()
@@ -214,169 +262,187 @@ def assert_clean(result: Any, requested: int, label: str) -> None:
         "semantically rejected": result.semantic_dup_rejected_count,
         "semantically replaced": result.semantic_dup_replaced_count,
     }
-    dropped = {name: count for name, count in counters.items() if count}
+    dropped = {reason: count for reason, count in counters.items() if count}
     if created != requested or dropped:
+        detail = ", ".join(f"{reason}: {count}" for reason, count in dropped.items())
         raise InjectError(
             f"{label}: asked for {requested} conclusions, stored {created}"
-            + (
-                f" ({', '.join(f'{n}: {c}' for n, c in dropped.items())})"
-                if dropped
-                else ""
-            )
+            + (f" ({detail})" if dropped else "")
             + ". Conclusion contents must be unique; near-identical text is collapsed by "
             "Honcho's dedup before it reaches the database."
         )
 
 
-async def inject_pair(
-    modules: dict[str, Any],
+async def seed_explicit(
+    internals: Internals, workspace: str, session: str, plan: PairPlan
+) -> list[str]:
+    """Pass 1. Returns the stored ids, in fixture order, for premises to point at.
+
+    The public write path is the only one that hands back rows, so it is how the premise ids
+    are obtained -- and it does no dedup, so nothing is silently collapsed.
+    """
+    crud = internals.crud
+    explicit = plan.by_level["explicit"]
+
+    async with internals.tracked_db("sandbox.seed_explicit") as db:
+        await crud.get_or_create_collection(
+            db, workspace, observer=plan.observer, observed=plan.observed
+        )
+        if not explicit:
+            return []
+
+        documents = await crud.create_observations(
+            db,
+            [
+                internals.schemas.ConclusionCreate(
+                    content=conclusion.content,
+                    observer_id=plan.observer,
+                    observed_id=plan.observed,
+                    # Explicit rows must carry a session: create_documents refuses
+                    # session-less explicit rows on a session-purity invariant, and an
+                    # explicit conclusion genuinely does come from a conversation.
+                    session_id=session,
+                )
+                for conclusion in explicit
+            ],
+            workspace,
+        )
+        if len(documents) != len(explicit):
+            raise InjectError(
+                f"{plan}: asked for {len(explicit)} explicit conclusions, "
+                f"stored {len(documents)}"
+            )
+        return [document.id for document in documents]
+
+
+def build_derived_document(
+    internals: Internals,
+    session: str,
+    level: str,
+    conclusion: SeededConclusion,
+    explicit: list[SeededConclusion],
+    premise_ids: list[str],
+    embedding: list[float],
+    message_created_at: str,
+) -> Any:
+    """One DocumentCreate for a derived conclusion, with its premise links and display text."""
+    source_ids = [premise_ids[index] for index in conclusion.premises]
+    metadata: dict[str, Any] = {
+        # Not derived from messages, but the representation reads this to render the
+        # conclusion's timestamp.
+        "message_ids": [],
+        "message_created_at": message_created_at,
+        "source_ids": source_ids,
+        PREMISE_FIELD[level]: [
+            explicit[index].content for index in conclusion.premises
+        ],
+    }
+    if level == "inductive":
+        metadata["pattern_type"] = "tendency"
+        metadata["confidence"] = "high" if len(source_ids) > 1 else "low"
+
+    return internals.schemas.DocumentCreate(
+        content=conclusion.content,
+        # The session, not None: the dreamer stamps its output with one session
+        # (dream_scheduler picks whichever holds the most recent explicit conclusion) and
+        # threads it through create_tool_executor, so a session-less derived row is not
+        # what real mode would produce.
+        #
+        # This does not make them visible to a session-scoped read. ALLOWLIST_SAFE_LEVELS
+        # in src/utils/representation.py serves only explicit under a session allowlist,
+        # whatever the stamp says, because the dreamer reads across all sessions and
+        # scoping its output would leak. So representation(session=...) is explicit-only
+        # by construction; drop the session argument to see these.
+        session_name=session,
+        level=level,
+        times_derived=1,
+        metadata=internals.schemas.DocumentMetadata(**metadata),
+        embedding=embedding,
+        source_ids=source_ids,
+    )
+
+
+async def seed_derived(
+    internals: Internals,
     workspace: str,
     session: str,
-    observer: str,
-    observed: str,
-    conclusions: dict[str, list[dict[str, Any]]],
+    plan: PairPlan,
+    premise_ids: list[str],
 ) -> dict[str, int]:
-    """Seed one (observer, observed) collection. Returns per-level counts actually stored."""
-    crud = modules["crud"]
-    schemas = modules["schemas"]
-    models = modules["models"]
-    embedding_client = modules["embedding_client"]
-    tracked_db = modules["tracked_db"]
-
+    """Pass 2. Both derived levels cite pass-1 ids, so neither needs the other's ids back."""
+    crud = internals.crud
+    explicit = plan.by_level["explicit"]
     stored: dict[str, int] = {}
 
-    # Pass 1. The public write path is the only one that hands back rows, so it is how the
-    # premise ids are obtained -- and it does no dedup, so nothing is silently collapsed.
-    explicit = conclusions["explicit"]
-    premise_ids: list[str] = []
-    async with tracked_db("sandbox.seed_explicit") as db:
-        await crud.get_or_create_collection(
-            db, workspace, observer=observer, observed=observed
+    async with internals.tracked_db("sandbox.seed_derived") as db:
+        message_created_at = await latest_message_timestamp(
+            internals, db, workspace, session
         )
-        if explicit:
-            documents = await crud.create_observations(
+        if message_created_at is None:
+            raise InjectError(
+                f"session {session!r} has no messages, so derived conclusions have no "
+                "conversation timestamp to carry. Seed messages before conclusions."
+            )
+
+        for level, conclusions in plan.derived().items():
+            contents = [conclusion.content for conclusion in conclusions]
+            embeddings = await internals.embedding_client.simple_batch_embed(
+                contents, on_oversize="truncate"
+            )
+            if len(embeddings) != len(contents):
+                raise InjectError(
+                    f"{plan}: embedded {len(embeddings)} of {len(contents)} "
+                    f"{level} conclusions"
+                )
+
+            documents = [
+                build_derived_document(
+                    internals,
+                    session,
+                    level,
+                    conclusion,
+                    explicit,
+                    premise_ids,
+                    embedding,
+                    message_created_at,
+                )
+                for conclusion, embedding in zip(conclusions, embeddings, strict=True)
+            ]
+            result = await crud.create_documents(
                 db,
-                [
-                    schemas.ConclusionCreate(
-                        content=item["content"],
-                        observer_id=observer,
-                        observed_id=observed,
-                        # Explicit rows must carry a session: create_documents refuses
-                        # session-less explicit rows on a session-purity invariant, and an
-                        # explicit conclusion genuinely does come from a conversation.
-                        session_id=session,
-                    )
-                    for item in explicit
-                ],
+                documents,
                 workspace,
+                observer=plan.observer,
+                observed=plan.observed,
+                # Semantic dedup would replace or reject a seeded row against whatever the
+                # deriver already wrote, making the fixture's counts depend on the provider.
+                deduplicate=False,
             )
-            if len(documents) != len(explicit):
-                raise InjectError(
-                    f"{observer} -> {observed}: asked for {len(explicit)} explicit "
-                    f"conclusions, stored {len(documents)}"
-                )
-            premise_ids = [document.id for document in documents]
-            stored["explicit"] = len(documents)
+            assert_clean(result, len(conclusions), f"{plan} {level}")
+            stored[level] = len(result.created_documents)
 
-    # Pass 2. Both derived levels cite pass-1 ids, so neither needs the other's ids back.
-    derived = {
-        level: conclusions[level]
-        for level in ("deductive", "inductive")
-        if conclusions[level]
-    }
-    if derived:
-        async with tracked_db("sandbox.seed_derived") as db:
-            message_created_at = await latest_message_timestamp(
-                db, models, workspace, session
-            )
-            if message_created_at is None:
-                raise InjectError(
-                    f"session {session!r} has no messages, so derived conclusions have no "
-                    "conversation timestamp to carry. Seed messages before conclusions."
-                )
+    return stored
 
-            for level, items in derived.items():
-                contents = [item["content"] for item in items]
-                embeddings = await embedding_client.simple_batch_embed(
-                    contents, on_oversize="truncate"
-                )
-                if len(embeddings) != len(contents):
-                    raise InjectError(
-                        f"{observer} -> {observed}: embedded {len(embeddings)} of "
-                        f"{len(contents)} {level} conclusions"
-                    )
 
-                payload: list[Any] = []
-                for item, embedding in zip(items, embeddings, strict=True):
-                    source_ids = [premise_ids[index] for index in item["premises"]]
-                    metadata: dict[str, Any] = {
-                        # Not derived from messages, but the representation reads this to
-                        # render the conclusion's timestamp.
-                        "message_ids": [],
-                        "message_created_at": message_created_at,
-                        "source_ids": source_ids,
-                        PREMISE_FIELD[level]: [
-                            explicit[index]["content"] for index in item["premises"]
-                        ],
-                    }
-                    if level == "inductive":
-                        metadata["pattern_type"] = "tendency"
-                        metadata["confidence"] = (
-                            "high" if len(source_ids) > 1 else "low"
-                        )
-                    payload.append(
-                        schemas.DocumentCreate(
-                            content=item["content"],
-                            # The session, not None: the dreamer stamps its output with
-                            # one session (dream_scheduler picks whichever holds the most
-                            # recent explicit conclusion) and threads it through
-                            # create_tool_executor, so a session-less derived row is not
-                            # what real mode would produce.
-                            #
-                            # This does not make them visible to a session-scoped read.
-                            # ALLOWLIST_SAFE_LEVELS in src/utils/representation.py serves
-                            # only explicit under a session allowlist, whatever the stamp
-                            # says, because the dreamer reads across all sessions and
-                            # scoping its output would leak. So representation(session=...)
-                            # is explicit-only by construction; drop the session argument
-                            # to see these.
-                            session_name=session,
-                            level=level,
-                            times_derived=1,
-                            metadata=schemas.DocumentMetadata(**metadata),
-                            embedding=embedding,
-                            source_ids=source_ids,
-                        )
-                    )
+async def inject_pair(
+    internals: Internals, workspace: str, session: str, plan: PairPlan
+) -> dict[str, int]:
+    """Seed one (observer, observed) collection. Returns per-level counts actually stored."""
+    premise_ids = await seed_explicit(internals, workspace, session, plan)
+    stored = {"explicit": len(premise_ids)} if premise_ids else {}
 
-                result = await crud.create_documents(
-                    db,
-                    payload,
-                    workspace,
-                    observer=observer,
-                    observed=observed,
-                    # Semantic dedup would replace or reject a seeded row against whatever the
-                    # deriver already wrote, making the fixture's counts depend on the provider.
-                    deduplicate=False,
-                )
-                assert_clean(result, len(items), f"{observer} -> {observed} {level}")
-                stored[level] = len(result.created_documents)
-
+    if plan.derived():
+        stored |= await seed_derived(internals, workspace, session, plan, premise_ids)
         # Outside the write session on purpose: create_documents commits as it goes, and the
         # check should read the committed rows back on its own connection rather than through
         # the identity map of the session that wrote them.
-        await verify_links(modules, workspace, observer, observed, premise_ids, derived)
+        await verify_links(internals, workspace, plan, premise_ids)
 
     return stored
 
 
 async def verify_links(
-    modules: dict[str, Any],
-    workspace: str,
-    observer: str,
-    observed: str,
-    premise_ids: list[str],
-    derived: dict[str, list[dict[str, Any]]],
+    internals: Internals, workspace: str, plan: PairPlan, premise_ids: list[str]
 ) -> None:
     """Confirm the premise links actually traverse, through Honcho's own read helpers.
 
@@ -391,31 +457,33 @@ async def verify_links(
     different (observer, observed) collection. Upward: the source_ids those children actually
     carry must all resolve to live rows.
     """
-    crud = modules["crud"]
-    tracked_db = modules["tracked_db"]
-
+    crud = internals.crud
     cited = sorted(
         {
             premise_ids[index]
-            for items in derived.values()
-            for item in items
-            for index in item["premises"]
+            for conclusions in plan.derived().values()
+            for conclusion in conclusions
+            for index in conclusion.premises
         }
     )
     if not cited:
         return
 
-    async with tracked_db("sandbox.verify_links") as db:
+    async with internals.tracked_db("sandbox.verify_links") as db:
         declared: set[str] = set()
         for premise_id in cited:
             children = await crud.get_child_observations(
-                db, workspace, premise_id, observer=observer, observed=observed
+                db,
+                workspace,
+                premise_id,
+                observer=plan.observer,
+                observed=plan.observed,
             )
             if not children:
                 raise InjectError(
-                    f"{observer} -> {observed}: premise {premise_id} has no reachable "
-                    "children, so the reasoning tree does not traverse downward. Premise and "
-                    "conclusion must share one (observer, observed) pair."
+                    f"{plan}: premise {premise_id} has no reachable children, so the "
+                    "reasoning tree does not traverse downward. Premise and conclusion "
+                    "must share one (observer, observed) pair."
                 )
             for child in children:
                 declared.update(child.source_ids or [])
@@ -424,12 +492,33 @@ async def verify_links(
         missing = declared - {document.id for document in resolved}
         if missing:
             raise InjectError(
-                f"{observer} -> {observed}: {len(missing)} stored premise id(s) resolve to "
-                "nothing, so the reasoning chain would read as empty. First: "
-                f"{sorted(missing)[0]}"
+                f"{plan}: {len(missing)} stored premise id(s) resolve to nothing, so the "
+                f"reasoning chain would read as empty. First: {sorted(missing)[0]}"
             )
 
-    log(f"{observer} -> {observed}: {len(cited)} premise link(s) traverse both ways")
+    log(f"{plan}: {len(cited)} premise link(s) traverse both ways")
+
+
+def plan_pairs(fixture: dict[str, Any]) -> list[PairPlan]:
+    """Turn the fixture's per-peer conclusion keys into one plan per collection."""
+    peers = fixture["peers"]
+    planned: list[PairPlan] = []
+    for spec in peers:
+        if not any(spec.get(level) for level in LEVELS):
+            continue
+        explicit_count = len(spec.get("explicit", []))
+        by_level = {
+            level: normalize(spec.get(level, []), level, spec["id"], explicit_count)
+            for level in LEVELS
+        }
+        if any(by_level[level] for level in DERIVED_LEVELS) and not explicit_count:
+            raise InjectError(
+                f"peer {spec['id']!r} has derived conclusions but no explicit ones for their "
+                "premises to point at."
+            )
+        for observer in resolve_observers(spec, peers):
+            planned.append(PairPlan(observer, spec["id"], by_level))
+    return planned
 
 
 async def run(fixture: dict[str, Any]) -> int:
@@ -441,51 +530,29 @@ async def run(fixture: dict[str, Any]) -> int:
 
     check_signatures(crud, schemas)
 
-    workspace = fixture["workspace"]
-    session = fixture["session"]
-    peers = fixture["peers"]
-
-    planned: list[tuple[str, str, dict[str, list[dict[str, Any]]]]] = []
-    for spec in peers:
-        if not any(spec.get(level) for level in LEVELS):
-            continue
-        explicit_count = len(spec.get("explicit", []))
-        conclusions = {
-            level: normalize(spec.get(level, []), level, spec["id"], explicit_count)
-            for level in LEVELS
-        }
-        if (
-            any(conclusions[level] for level in ("deductive", "inductive"))
-            and not explicit_count
-        ):
-            raise InjectError(
-                f"peer {spec['id']!r} has derived conclusions but no explicit ones for their "
-                "premises to point at."
-            )
-        for observer in resolve_observers(spec, peers):
-            planned.append((observer, spec["id"], conclusions))
-
+    planned = plan_pairs(fixture)
     if not planned:
         log("fixture declares no conclusions - nothing to seed")
         return 0
+
+    internals = Internals(
+        crud=crud,
+        schemas=schemas,
+        models=models,
+        embedding_client=embedding_client,
+        tracked_db=tracked_db,
+    )
 
     # cashews decorates the collection lookups, and an unconfigured backend raises rather than
     # degrading, so the cache has to be up before the first crud call.
     await init_cache()
     try:
-        modules = {
-            "crud": crud,
-            "schemas": schemas,
-            "models": models,
-            "embedding_client": embedding_client,
-            "tracked_db": tracked_db,
-        }
-        for observer, observed, conclusions in planned:
+        for plan in planned:
             stored = await inject_pair(
-                modules, workspace, session, observer, observed, conclusions
+                internals, fixture["workspace"], fixture["session"], plan
             )
             summary = " ".join(f"{level}={stored.get(level, 0)}" for level in LEVELS)
-            log(f"{observer} -> {observed}: {summary}")
+            log(f"{plan}: {summary}")
     finally:
         await close_cache()
         # Without this the process can hang on exit holding pool connections, which inside

--- a/sandbox/inject_conclusions.py
+++ b/sandbox/inject_conclusions.py
@@ -327,9 +327,20 @@ async def inject_pair(
                     payload.append(
                         schemas.DocumentCreate(
                             content=item["content"],
-                            # Derived conclusions belong to the dream, not to one session,
-                            # which is how the Dreamer writes them.
-                            session_name=None,
+                            # The session, not None: the dreamer stamps its output with
+                            # one session (dream_scheduler picks whichever holds the most
+                            # recent explicit conclusion) and threads it through
+                            # create_tool_executor, so a session-less derived row is not
+                            # what real mode would produce.
+                            #
+                            # This does not make them visible to a session-scoped read.
+                            # ALLOWLIST_SAFE_LEVELS in src/utils/representation.py serves
+                            # only explicit under a session allowlist, whatever the stamp
+                            # says, because the dreamer reads across all sessions and
+                            # scoping its output would leak. So representation(session=...)
+                            # is explicit-only by construction; drop the session argument
+                            # to see these.
+                            session_name=session,
                             level=level,
                             times_derived=1,
                             metadata=schemas.DocumentMetadata(**metadata),

--- a/sandbox/real.env.example
+++ b/sandbox/real.env.example
@@ -1,0 +1,21 @@
+# Copy to sandbox/real.env and fill in. real.env is gitignored; this file is not.
+#
+#     cp sandbox/real.env.example sandbox/real.env
+#     sandbox/sandbox.sh up --provider real
+#
+# Only needed for real mode. Mock mode needs nothing here.
+
+# One provider key. Honcho tests it for truthiness before building the client.
+LLM_OPENAI_API_KEY=sk-replace-me
+# LLM_ANTHROPIC_API_KEY=
+# LLM_GEMINI_API_KEY=
+
+# Optional: a cheaper model than the gpt-5.4-mini default. The sandbox derives on
+# every seed, so this is the knob that decides what a seed costs.
+# DERIVER_MODEL_CONFIG__TRANSPORT=openai
+# DERIVER_MODEL_CONFIG__MODEL=gpt-5.4-mini
+
+# Deliberately absent: EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL.
+# Leaving it unset is what sends embeddings to the real provider — which is the
+# entire reason to run real mode, since mock embeddings carry no semantic
+# similarity and cannot support a vector-recall assertion.

--- a/sandbox/sandbox.sh
+++ b/sandbox/sandbox.sh
@@ -74,6 +74,22 @@ elif [ -f "$STATE" ]; then
 fi
 export HONCHO_SANDBOX_IMAGE
 
+# The provider the running stack was actually created with, read on its own because
+# the source above is skipped under --build. Empty means nothing has been started
+# through `up` since the last `down`.
+RUNNING_PROVIDER=""
+if [ -f "$STATE" ]; then
+  RUNNING_PROVIDER="$(sed -n 's/^SANDBOX_RUNNING_PROVIDER=//p' "$STATE")"
+fi
+
+write_state() {
+  cat > "$STATE" <<EOF
+HONCHO_SANDBOX_IMAGE=$HONCHO_SANDBOX_IMAGE
+SANDBOX_RUNNING_PROVIDER=$PROVIDER
+EOF
+  RUNNING_PROVIDER="$PROVIDER"
+}
+
 compose() {
   docker compose \
     -f "$HERE/compose.yml" \
@@ -134,6 +150,31 @@ MSG
   fi
 }
 
+# Containers carry the provider wiring they were created with, and neither seed nor
+# reset recreates them: seed uses `start` plus `--no-recreate` to avoid paying a
+# container rebuild, and reset touches no container at all. So a --provider that
+# disagrees with the running stack does not change what the stack talks to. It only
+# changes what gets recorded — seed would derive through the running provider and
+# then stamp the requested one into the template, defeating the fingerprint guard,
+# which compares the flag rather than reality.
+#
+# The real-stack-seeding-a-mock-template case is the damaging one: it spends money,
+# produces non-deterministic conclusions, and labels them `mock`, so every later
+# reset restores that as the deterministic baseline. Refuse rather than mislead.
+require_running_provider() {
+  [ -n "$RUNNING_PROVIDER" ] || return 0
+  [ "$RUNNING_PROVIDER" != "$PROVIDER" ] || return 0
+  die "$(cat <<MSG
+the stack is running the $RUNNING_PROVIDER provider, but this is a $PROVIDER-mode command.
+
+seed and reset do not recreate containers, so this would act through the
+$RUNNING_PROVIDER provider while recording $PROVIDER. Switch the stack first:
+
+    sandbox/sandbox.sh up --provider $PROVIDER
+MSG
+)"
+}
+
 # --------------------------------------------------------------------------
 # Commands
 # --------------------------------------------------------------------------
@@ -162,7 +203,9 @@ cmd_up() {
   # mock to real leaves mock-provider running and otherwise unreferenced, where it
   # would sit idle and make `status` misleading about what the stack is using.
   compose up -d --wait --remove-orphans
-  echo "HONCHO_SANDBOX_IMAGE=$HONCHO_SANDBOX_IMAGE" > "$STATE"
+  # Recorded before the seed/reset below, so their provider guard sees the stack
+  # that was just created rather than the one it replaced.
+  write_state
 
   if db_exists "$TEMPLATE"; then
     say "template $TEMPLATE already present — resetting to it"
@@ -177,6 +220,7 @@ cmd_up() {
 
 cmd_seed() {
   preflight
+  require_running_provider
   # Seeding an already-seeded database appends to it — the fixture would land a
   # second time and the "expected 6 messages, found 12" check in seed.py would
   # (correctly) fail. Start from an empty, freshly migrated database every time so
@@ -215,6 +259,7 @@ cmd_seed() {
 
 cmd_reset() {
   preflight
+  require_running_provider
   db_exists "$TEMPLATE" || die \
     "no template for $PROVIDER mode. Run: sandbox/sandbox.sh seed --provider $PROVIDER"
 
@@ -242,7 +287,11 @@ cmd_reset() {
 cmd_status() {
   compose ps
   echo
-  echo "provider:  $PROVIDER"
+  if [ -n "$RUNNING_PROVIDER" ] && [ "$RUNNING_PROVIDER" != "$PROVIDER" ]; then
+    echo "provider:  $RUNNING_PROVIDER (running) — this command asked for $PROVIDER"
+  else
+    echo "provider:  $PROVIDER"
+  fi
   echo "image:     $HONCHO_SANDBOX_IMAGE"
   echo "api:       http://127.0.0.1:${SANDBOX_API_PORT:-18000}"
   for mode in mock real; do

--- a/sandbox/sandbox.sh
+++ b/sandbox/sandbox.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+#
+# Honcho sandbox — an ephemeral, seeded stack that resets to a known state in
+# seconds, so harness testing stops depending on machine state.
+#
+#   sandbox.sh up [--provider mock|real] [--build]
+#   sandbox.sh seed [--provider ...]
+#   sandbox.sh reset [--provider ...]
+#   sandbox.sh status [--provider ...]
+#   sandbox.sh down [--provider ...]
+#
+# See README.md.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+
+DB=honcho_sandbox
+BUILT_IMAGE=honcho-sandbox/honcho:built
+
+PROVIDER="${HONCHO_SANDBOX_PROVIDER:-mock}"
+BUILD=0
+
+die() { echo "error: $*" >&2; exit 1; }
+say() { echo "==> $*"; }
+
+# --------------------------------------------------------------------------
+# Argument parsing
+# --------------------------------------------------------------------------
+
+COMMAND="${1:-}"
+[ -n "$COMMAND" ] || die "usage: sandbox.sh {up|seed|reset|status|down} [--provider mock|real] [--build]"
+shift
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --provider) PROVIDER="${2:-}"; shift 2 ;;
+    --provider=*) PROVIDER="${1#*=}"; shift ;;
+    --build) BUILD=1; shift ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+case "$PROVIDER" in
+  mock|real) ;;
+  *) die "unknown provider '$PROVIDER' (expected 'mock' or 'real')" ;;
+esac
+
+# Each mode keeps its own template, so both can coexist and switching modes is
+# free rather than forcing a reseed.
+TEMPLATE="${DB}_seeded_${PROVIDER}"
+
+# --------------------------------------------------------------------------
+# Compose invocation
+#
+# The base file is provider-agnostic and is not a working stack on its own;
+# exactly one provider overlay is always composed on top.
+# --------------------------------------------------------------------------
+
+# The pinned default...
+# shellcheck disable=SC1091
+set -a; . "$HERE/image.env"; set +a
+
+# ...then whatever the running stack was actually started with. Without this,
+# `up --build` followed by a plain `reset` would flip the image back to the pinned
+# digest, and Compose would helpfully recreate every container from it mid-reset.
+STATE="$HERE/.state.env"
+if [ "$BUILD" = 1 ]; then
+  HONCHO_SANDBOX_IMAGE="$BUILT_IMAGE"
+elif [ -f "$STATE" ]; then
+  # shellcheck disable=SC1090
+  set -a; . "$STATE"; set +a
+fi
+export HONCHO_SANDBOX_IMAGE
+
+compose() {
+  docker compose \
+    -f "$HERE/compose.yml" \
+    -f "$HERE/compose.$PROVIDER.yml" \
+    --project-directory "$HERE" \
+    "$@"
+}
+
+psql_db() {
+  # Maintenance connections go to `postgres`, never to $DB — you cannot drop a
+  # database you are connected to.
+  compose exec -T database psql -v ON_ERROR_STOP=1 -U postgres -d postgres "$@"
+}
+
+db_exists() {
+  [ "$(psql_db -tAc "SELECT 1 FROM pg_database WHERE datname='$1'" 2>/dev/null)" = "1" ]
+}
+
+# --------------------------------------------------------------------------
+# Preconditions
+# --------------------------------------------------------------------------
+
+preflight() {
+  docker info >/dev/null 2>&1 || die "the Docker daemon is not running"
+
+  if [ "$PROVIDER" = real ]; then
+    # Fail before starting anything. A real-mode stack with no key boots fine and
+    # then derives nothing, which reads as "the deriver found nothing".
+    [ -f "$HERE/real.env" ] || die \
+      "real mode needs $HERE/real.env. Copy real.env.example and add a provider key."
+    grep -Eq '^\s*LLM_[A-Z]+_API_KEY=.+' "$HERE/real.env" || die \
+      "no LLM_*_API_KEY with a value in real.env."
+    if grep -Eq '^\s*LLM_[A-Z]+_API_KEY=(sk-replace-me|your-api-key-here)\s*$' "$HERE/real.env"; then
+      die "real.env still has the placeholder key from real.env.example."
+    fi
+  fi
+  # Must not end on a failed test. Under `set -e`, a non-zero return from the last
+  # command in this function aborts the script with no output at all — which is
+  # exactly how the first real-mode `up` "failed": silently, before doing anything.
+  return 0
+}
+
+# The pinned digest predates PR #1094, so it carries no src/mock_provider. Say so
+# precisely instead of letting the service crash-loop on a missing module.
+check_mock_provider_present() {
+  [ "$PROVIDER" = mock ] || return 0
+  if ! docker run --rm --entrypoint test "$HONCHO_SANDBOX_IMAGE" -d /app/src/mock_provider; then
+    die "$(cat <<MSG
+the image $HONCHO_SANDBOX_IMAGE does not contain src/mock_provider.
+
+PR #1094 adds it and is not merged yet, so no published image has it. Build from
+the working tree instead:
+
+    sandbox/sandbox.sh up --build
+
+Once #1094 is merged and published, bump the digest in sandbox/image.env.
+MSG
+)"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Commands
+# --------------------------------------------------------------------------
+
+cmd_up() {
+  preflight
+
+  compose pull --quiet database redis
+  if [ "$BUILD" = 1 ]; then
+    say "building $BUILT_IMAGE from the working tree"
+    docker build -t "$BUILT_IMAGE" "$REPO"
+  elif docker image inspect "$HONCHO_SANDBOX_IMAGE" >/dev/null 2>&1; then
+    # Already here — either pulled on an earlier run, or built locally by --build
+    # and recorded in .state.env, in which case pulling it would fail outright
+    # because the tag exists in no registry.
+    say "using local image $HONCHO_SANDBOX_IMAGE"
+  else
+    say "pulling $HONCHO_SANDBOX_IMAGE"
+    docker pull --quiet "$HONCHO_SANDBOX_IMAGE" >/dev/null
+  fi
+
+  check_mock_provider_present
+
+  say "starting the $PROVIDER stack"
+  # --remove-orphans because both modes share one Compose project: switching from
+  # mock to real leaves mock-provider running and otherwise unreferenced, where it
+  # would sit idle and make `status` misleading about what the stack is using.
+  compose up -d --wait --remove-orphans
+  echo "HONCHO_SANDBOX_IMAGE=$HONCHO_SANDBOX_IMAGE" > "$STATE"
+
+  if db_exists "$TEMPLATE"; then
+    say "template $TEMPLATE already present — resetting to it"
+    cmd_reset
+  else
+    cmd_seed
+  fi
+
+  echo
+  say "sandbox ready at http://127.0.0.1:${SANDBOX_API_PORT:-18000} (provider: $PROVIDER)"
+}
+
+cmd_seed() {
+  preflight
+  # Seeding an already-seeded database appends to it — the fixture would land a
+  # second time and the "expected 6 messages, found 12" check in seed.py would
+  # (correctly) fail. Start from an empty, freshly migrated database every time so
+  # `seed` means the same thing regardless of what was there before.
+  say "clearing the database before seeding"
+  compose stop api deriver >/dev/null
+  psql_db -c "DROP DATABASE IF EXISTS $DB WITH (FORCE)" >/dev/null
+  psql_db -c "CREATE DATABASE $DB" >/dev/null
+  compose exec -T database psql -q -v ON_ERROR_STOP=1 -U postgres -d "$DB" \
+    -c "CREATE EXTENSION IF NOT EXISTS vector" >/dev/null
+  # Redis still holds entries keyed to the database that was just dropped; without
+  # this the api serves cached peers that no longer exist and seeding conflicts.
+  compose exec -T redis redis-cli FLUSHALL >/dev/null
+  # The api entrypoint runs scripts/provision_db.py, so starting it is what applies
+  # the Alembic migrations to the new database.
+  compose start api deriver >/dev/null
+  compose up -d --wait --no-recreate >/dev/null
+
+  say "seeding ($PROVIDER)"
+  SANDBOX_BASE_URL="http://127.0.0.1:${SANDBOX_API_PORT:-18000}" \
+    uv run --no-project --with-editable "$REPO/sdks/python" \
+      python "$HERE/seed.py"
+
+  say "snapshotting to $TEMPLATE"
+  stamp_fingerprint
+  # api and deriver hold pooled connections; CREATE DATABASE ... TEMPLATE needs
+  # the source to have none.
+  compose stop api deriver >/dev/null
+  disconnect_db "$DB"
+  psql_db -c "DROP DATABASE IF EXISTS $TEMPLATE" >/dev/null
+  psql_db -c "CREATE DATABASE $TEMPLATE TEMPLATE $DB" >/dev/null
+  compose start api deriver >/dev/null
+  compose up -d --wait --no-recreate >/dev/null
+  say "snapshot ready — reset restores this state without re-deriving"
+}
+
+cmd_reset() {
+  preflight
+  db_exists "$TEMPLATE" || die \
+    "no template for $PROVIDER mode. Run: sandbox/sandbox.sh seed --provider $PROVIDER"
+
+  check_fingerprint
+
+  # Nothing is stopped or restarted. DROP ... WITH (FORCE) evicts the api and
+  # deriver connection pools itself, and both reconnect on their next use
+  # (db.POOL_PRE_PING is on) — the api on its next request, the deriver on its
+  # next poll a quarter-second later.
+  #
+  # Both log one OperationalError as their in-flight connection dies. That noise
+  # is the cost of not paying ~9s of container stop/start on every reset, which
+  # would defeat the point. Restarting them instead is the fallback if this ever
+  # stops being true.
+  #
+  # CREATE DATABASE ... TEMPLATE additionally needs the *source* to be
+  # connectionless, and check_fingerprint just read from it.
+  disconnect_db "$TEMPLATE"
+  psql_db -c "DROP DATABASE $DB WITH (FORCE)" >/dev/null
+  psql_db -c "CREATE DATABASE $DB TEMPLATE $TEMPLATE" >/dev/null
+  compose exec -T redis redis-cli FLUSHALL >/dev/null
+  say "reset to $TEMPLATE"
+}
+
+cmd_status() {
+  compose ps
+  echo
+  echo "provider:  $PROVIDER"
+  echo "image:     $HONCHO_SANDBOX_IMAGE"
+  echo "api:       http://127.0.0.1:${SANDBOX_API_PORT:-18000}"
+  for mode in mock real; do
+    if db_exists "${DB}_seeded_${mode}"; then
+      echo "template:  ${DB}_seeded_${mode}  present"
+    else
+      echo "template:  ${DB}_seeded_${mode}  absent"
+    fi
+  done
+}
+
+cmd_down() {
+  say "tearing down the $PROVIDER stack and its volumes"
+  compose down -v
+  rm -f "$STATE"
+}
+
+# --------------------------------------------------------------------------
+# Snapshot staleness
+#
+# A template that predates a migration, or was built against a different
+# provider, restores silently and wrongly. Both are recorded inside the template
+# itself so reset can refuse rather than mislead.
+# --------------------------------------------------------------------------
+
+fingerprint() {
+  local alembic
+  alembic="$(compose exec -T database psql -tAX -U postgres -d "$DB" \
+    -c "SELECT version_num FROM alembic_version" 2>/dev/null | tr -d '[:space:]')"
+  local files
+  files="$(cat "$HERE/fixture.json" "$HERE/seed.py" | shasum -a 256 | cut -c1-16)"
+  echo "alembic=$alembic fixture=$files provider=$PROVIDER"
+}
+
+stamp_fingerprint() {
+  compose exec -T database psql -v ON_ERROR_STOP=1 -U postgres -d "$DB" >/dev/null <<SQL
+CREATE TABLE IF NOT EXISTS sandbox_fingerprint (value text PRIMARY KEY);
+TRUNCATE sandbox_fingerprint;
+INSERT INTO sandbox_fingerprint VALUES ('$(fingerprint)');
+SQL
+}
+
+check_fingerprint() {
+  local want have
+  want="$(fingerprint)"
+  have="$(compose exec -T database psql -tAX -U postgres -d "$TEMPLATE" \
+    -c "SELECT value FROM sandbox_fingerprint" 2>/dev/null | tr -d '\r')"
+
+  # The live database carries whatever revision the api container migrated it to
+  # on boot; the template carries the revision it was seeded at. A difference is
+  # exactly the migration drift this guard exists to catch, so it is compared,
+  # not normalised away.
+  [ "$want" = "$have" ] || die "$(cat <<MSG
+$TEMPLATE is stale and would restore the wrong state.
+
+  template: ${have:-<no fingerprint>}
+  current:  $want
+
+Reseed:  sandbox/sandbox.sh seed --provider $PROVIDER
+MSG
+)"
+}
+
+disconnect_db() {
+  # Defaults to the live database. CREATE DATABASE ... TEMPLATE also requires the
+  # *source* to have no connections, and reading the fingerprint just opened one.
+  local target="${1:-$DB}"
+  psql_db -c \
+    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='$target' AND pid <> pg_backend_pid()" \
+    >/dev/null
+}
+
+case "$COMMAND" in
+  up) cmd_up ;;
+  seed) cmd_seed ;;
+  reset) cmd_reset ;;
+  status) cmd_status ;;
+  down) cmd_down ;;
+  *) die "unknown command '$COMMAND' (expected up, seed, reset, status, or down)" ;;
+esac

--- a/sandbox/sandbox.sh
+++ b/sandbox/sandbox.sh
@@ -175,6 +175,26 @@ MSG
 )"
 }
 
+seed_py() {
+  SANDBOX_BASE_URL="http://127.0.0.1:${SANDBOX_API_PORT:-18000}" \
+    uv run --no-project --with-editable "$REPO/sdks/python" \
+      python "$HERE/seed.py" "$1"
+}
+
+# Conclusion levels and premise links are not reachable from the public API, so this
+# part of the fixture is written by a script running inside the api container, which
+# already is Honcho's venv with the api's settings and embedding client. The script
+# arrives on stdin and the fixture in the environment, so nothing has to be mounted
+# and nothing is left behind in the container.
+#
+# It decides for itself whether the fixture declares any conclusions, rather than
+# being gated by a grep here that a comment mentioning a level name would fool.
+inject_conclusions() {
+  compose exec -T \
+    -e SANDBOX_FIXTURE_JSON="$(cat "$HERE/fixture.json")" \
+    api /app/.venv/bin/python - < "$HERE/inject_conclusions.py"
+}
+
 # --------------------------------------------------------------------------
 # Commands
 # --------------------------------------------------------------------------
@@ -240,9 +260,9 @@ cmd_seed() {
   compose up -d --wait --no-recreate >/dev/null
 
   say "seeding ($PROVIDER)"
-  SANDBOX_BASE_URL="http://127.0.0.1:${SANDBOX_API_PORT:-18000}" \
-    uv run --no-project --with-editable "$REPO/sdks/python" \
-      python "$HERE/seed.py"
+  seed_py seed
+  inject_conclusions
+  seed_py verify
 
   say "snapshotting to $TEMPLATE"
   stamp_fingerprint
@@ -322,7 +342,8 @@ fingerprint() {
   alembic="$(compose exec -T database psql -tAX -U postgres -d "$DB" \
     -c "SELECT version_num FROM alembic_version" 2>/dev/null | tr -d '[:space:]')"
   local files
-  files="$(cat "$HERE/fixture.json" "$HERE/seed.py" | shasum -a 256 | cut -c1-16)"
+  files="$(cat "$HERE/fixture.json" "$HERE/seed.py" "$HERE/inject_conclusions.py" \
+    | shasum -a 256 | cut -c1-16)"
   echo "alembic=$alembic fixture=$files provider=$PROVIDER"
 }
 

--- a/sandbox/sandbox.sh
+++ b/sandbox/sandbox.sh
@@ -3,13 +3,8 @@
 # Honcho sandbox — an ephemeral, seeded stack that resets to a known state in
 # seconds, so harness testing stops depending on machine state.
 #
-#   sandbox.sh up [--provider mock|real] [--build]
-#   sandbox.sh seed [--provider ...]
-#   sandbox.sh reset [--provider ...]
-#   sandbox.sh status [--provider ...]
-#   sandbox.sh down [--provider ...]
-#
-# See README.md.
+# `sandbox.sh --help` for commands and options; README.md for the fixture format
+# and the provider modes.
 
 set -euo pipefail
 
@@ -25,20 +20,75 @@ BUILD=0
 die() { echo "error: $*" >&2; exit 1; }
 say() { echo "==> $*"; }
 
+usage() {
+  cat <<'USAGE'
+Honcho sandbox — an ephemeral, seeded stack that resets to a known state in
+seconds, so harness testing stops depending on machine state.
+
+usage: sandbox.sh <command> [--provider mock|real] [--build]
+
+Commands:
+  up        Start the stack and seed it. Restores this provider's existing
+            snapshot if there is one, otherwise seeds from scratch.
+  seed      Clear the database, seed it again, and snapshot the result.
+            Run this after editing fixture.json.
+  reset     Restore the snapshot. Under a second, no derivation, no LLM calls.
+  status    What is running, on which image, and which snapshots exist.
+  down      Stop the stack and delete its volumes.
+
+Options:
+  --provider mock|real  Which model provider to run against (default: mock).
+                        mock is deterministic, free, and makes no network
+                        calls. real needs sandbox/real.env and spends money.
+  --build               Build the image from the working tree instead of
+                        pulling the digest pinned in image.env. Use it when
+                        testing a change to Honcho itself.
+  -h, --help            Show this help.
+
+Environment:
+  HONCHO_SANDBOX_PROVIDER  Default provider, overridden by --provider.
+  SANDBOX_API_PORT         Host port for the api      (default 18000).
+  SANDBOX_DB_PORT          Host port for Postgres     (default 15432).
+  SANDBOX_REDIS_PORT       Host port for Redis        (default 16379).
+  SANDBOX_DRAIN_TIMEOUT    Seconds to wait for the deriver queue to drain
+                           while seeding (default 300).
+
+Examples:
+  sandbox.sh up                    # mock stack, seeded and ready
+  sandbox.sh up --provider real    # needs sandbox/real.env with a key
+  sandbox.sh up --build            # run the working tree, not the pinned image
+  sandbox.sh reset                 # back to the seeded state
+  sandbox.sh seed                  # rebuild the snapshot after editing the fixture
+
+seed and reset act through the containers that are already running, so they
+refuse a --provider that disagrees with the running stack. Switch it with
+`up --provider ...` instead.
+
+See sandbox/README.md for the fixture format and what each provider mode can
+and cannot test.
+USAGE
+}
+
 # --------------------------------------------------------------------------
 # Argument parsing
 # --------------------------------------------------------------------------
 
 COMMAND="${1:-}"
-[ -n "$COMMAND" ] || die "usage: sandbox.sh {up|seed|reset|status|down} [--provider mock|real] [--build]"
+case "$COMMAND" in
+  -h|--help|help) usage; exit 0 ;;
+  # No command at all is a mistake rather than a request for help, so the help
+  # goes to stderr and the exit code says so.
+  "") usage >&2; exit 1 ;;
+esac
 shift
 
 while [ $# -gt 0 ]; do
   case "$1" in
+    -h|--help) usage; exit 0 ;;
     --provider) PROVIDER="${2:-}"; shift 2 ;;
     --provider=*) PROVIDER="${1#*=}"; shift ;;
     --build) BUILD=1; shift ;;
-    *) die "unknown argument: $1" ;;
+    *) die "unknown argument: $1 (try: sandbox.sh --help)" ;;
   esac
 done
 
@@ -391,5 +441,5 @@ case "$COMMAND" in
   reset) cmd_reset ;;
   status) cmd_status ;;
   down) cmd_down ;;
-  *) die "unknown command '$COMMAND' (expected up, seed, reset, status, or down)" ;;
+  *) die "unknown command '$COMMAND' (try: sandbox.sh --help)" ;;
 esac

--- a/sandbox/sandbox.sh
+++ b/sandbox/sandbox.sh
@@ -116,20 +116,19 @@ preflight() {
   return 0
 }
 
-# The pinned digest predates PR #1094, so it carries no src/mock_provider. Say so
-# precisely instead of letting the service crash-loop on a missing module.
+# Mock mode runs src/mock_provider out of the same image. A digest that predates the
+# module resolves and pulls fine, then crash-loops one service on a missing module —
+# so check for it up front and name the two ways out.
 check_mock_provider_present() {
   [ "$PROVIDER" = mock ] || return 0
   if ! docker run --rm --entrypoint test "$HONCHO_SANDBOX_IMAGE" -d /app/src/mock_provider; then
     die "$(cat <<MSG
 the image $HONCHO_SANDBOX_IMAGE does not contain src/mock_provider.
 
-PR #1094 adds it and is not merged yet, so no published image has it. Build from
-the working tree instead:
+It predates the mock provider. Either bump the digest in sandbox/image.env to an
+image that has it, or build from the working tree:
 
     sandbox/sandbox.sh up --build
-
-Once #1094 is merged and published, bump the digest in sandbox/image.env.
 MSG
 )"
   fi

--- a/sandbox/seed.py
+++ b/sandbox/seed.py
@@ -1,0 +1,184 @@
+"""Populate the sandbox with a known fixture and verify it actually landed.
+
+Run through sandbox.sh, which supplies the base URL and owns the Docker and
+Postgres side. This script only talks to the API:
+
+    uv run --no-project --with-editable ./sdks/python python sandbox/seed.py
+
+It is provider-agnostic. Under the mock provider the *text* of a conclusion is
+synthetic and unrelated to the messages, so nothing here asserts on conclusion
+content - only that derivation ran and produced something. What it does assert
+strictly is the round trip that harness integrations actually get wrong: which
+messages landed, on which peers, with which observation topology.
+
+Exits non-zero on any failure. An empty sandbox that reports success is the exact
+failure mode this whole thing exists to prevent.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from honcho import Honcho
+from honcho.api_types import MessageCreateParams, SessionPeerConfig
+
+FIXTURE = Path(__file__).with_name("fixture.json")
+
+# Generous: a cold deriver on a real provider is slow, and the failure we care
+# about (nothing is processing at all) shows up as a timeout either way.
+DRAIN_TIMEOUT_SECONDS = float(os.environ.get("SANDBOX_DRAIN_TIMEOUT", "300"))
+DRAIN_POLL_SECONDS = 0.5
+
+
+class SeedError(RuntimeError):
+    """Seeding did not reach a usable state."""
+
+
+def log(message: str) -> None:
+    print(f"[seed] {message}", flush=True)
+
+
+def drain(honcho: Honcho, what: str) -> None:
+    """Block until the deriver queue is empty, or fail loudly.
+
+    Silence is the dangerous outcome here. A queue that never drains and a queue
+    that never had anything queued look identical from the outside, so the timeout
+    reports the last status it saw rather than just giving up.
+    """
+    deadline = time.monotonic() + DRAIN_TIMEOUT_SECONDS
+    last: Any = None
+    while time.monotonic() < deadline:
+        last = honcho.queue_status()
+        outstanding = last.pending_work_units + last.in_progress_work_units
+        if outstanding == 0 and last.completed_work_units > 0:
+            log(f"drained after {what} ({last.completed_work_units} work units)")
+            return
+        time.sleep(DRAIN_POLL_SECONDS)
+
+    raise SeedError(
+        f"queue did not drain after {what} within {DRAIN_TIMEOUT_SECONDS:.0f}s. "
+        f"Last status: {last}. "
+        "If completed_work_units is 0, nothing was ever enqueued - check that the "
+        "deriver is running and that the provider base URL resolves."
+    )
+
+
+def main() -> int:
+    fixture = json.loads(FIXTURE.read_text())
+    base_url = os.environ.get("SANDBOX_BASE_URL", "http://127.0.0.1:18000")
+    workspace_id = fixture["workspace"]
+
+    log(f"seeding workspace {workspace_id!r} at {base_url}")
+    honcho = Honcho(base_url=base_url, workspace_id=workspace_id, api_key="sandbox")
+
+    peers = {spec["id"]: honcho.peer(spec["id"]) for spec in fixture["peers"]}
+    session = honcho.session(fixture["session"])
+
+    session.add_peers(
+        [
+            (
+                peers[spec["id"]],
+                SessionPeerConfig(
+                    observe_me=spec["observe_me"],
+                    observe_others=spec["observe_others"],
+                ),
+            )
+            for spec in fixture["peers"]
+        ]
+    )
+    log(f"created {len(peers)} peers with explicit observation topology")
+
+    session.add_messages(
+        [
+            MessageCreateParams(peer_id=msg["peer"], content=msg["content"])
+            for msg in fixture["messages"]
+        ]
+    )
+    log(f"posted {len(fixture['messages'])} messages")
+    drain(honcho, "messages")
+
+    for dream in fixture.get("dreams", []):
+        honcho.schedule_dream(
+            observer=dream["observer"],
+            observed=dream["observed"],
+            session=session,
+        )
+        log(f"scheduled dream: {dream['observer']} -> {dream['observed']}")
+    if fixture.get("dreams"):
+        drain(honcho, "dream")
+
+    verify(honcho, session, peers, fixture)
+    log("seed complete")
+    return 0
+
+
+def verify(
+    honcho: Honcho,
+    session: Any,
+    peers: dict[str, Any],
+    fixture: dict[str, Any],
+) -> None:
+    """Assert the fixture round-tripped. Raises SeedError on any mismatch."""
+    stored = list(session.messages(size=100))
+    if len(stored) != len(fixture["messages"]):
+        raise SeedError(
+            f"expected {len(fixture['messages'])} messages, found {len(stored)}"
+        )
+
+    expected_authors = sorted(msg["peer"] for msg in fixture["messages"])
+    actual_authors = sorted(msg.peer_id for msg in stored)
+    if actual_authors != expected_authors:
+        raise SeedError(
+            f"messages landed on the wrong peers: expected {expected_authors}, "
+            f"got {actual_authors}"
+        )
+    log(f"verified {len(stored)} messages on the expected peers")
+
+    # Topology is the thing that silently breaks, so it is checked against the
+    # server's view rather than assumed from the create call.
+    for spec in fixture["peers"]:
+        config = session.get_peer_configuration(spec["id"])
+        if (config.observe_me, config.observe_others) != (
+            spec["observe_me"],
+            spec["observe_others"],
+        ):
+            raise SeedError(
+                f"peer {spec['id']!r} topology mismatch: expected "
+                f"observe_me={spec['observe_me']} "
+                f"observe_others={spec['observe_others']}, got {config}"
+            )
+    log("verified observation topology")
+
+    # Presence only. Under the mock provider, conclusion text is synthetic and
+    # says nothing about the messages, and the level mix is explicit-only because
+    # the Dreamer specialists write via tool calls the mock never emits. Asserting
+    # on either would pass in real mode and fail in mock mode.
+    total = 0
+    for observer_id, observer in peers.items():
+        for observed_id in peers:
+            found = len(list(observer.conclusions_of(observed_id).list(size=100)))
+            if found:
+                log(f"  {observer_id} -> {observed_id}: {found} conclusions")
+            total += found
+
+    if total == 0:
+        raise SeedError(
+            "no conclusions were derived. The queue drained, so the deriver ran and "
+            "produced nothing - check the provider wiring "
+            "(LLM_OPENAI_BASE_URL / EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL) "
+            "and the deriver logs."
+        )
+    log(f"verified {total} conclusions present")
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except SeedError as exc:
+        print(f"[seed] FAILED: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/sandbox/seed.py
+++ b/sandbox/seed.py
@@ -152,9 +152,9 @@ def main() -> int:
         api_key="sandbox",
         # No retries. Creating messages is not idempotent, and the SDK retries on
         # 429/500/502/503/504 as well as timeouts, so a write that commits and then
-        # errors on the way back gets replayed -- seeding the fixture twice. That
-        # was observed as "expected 6 messages, found 12" on a cold api, right
-        # after cmd_seed restarts it.
+        # errors on the way back is replayed and the fixture is seeded twice -- the
+        # message-count assertion below then reports finding double what it posted.
+        # The window is the cold api that cmd_seed has just restarted.
         #
         # The sandbox is local and `up` always seeds from a cleared database, so a
         # transient failure here should stop and be re-run, not be papered over
@@ -165,7 +165,7 @@ def main() -> int:
     session = honcho.session(fixture["session"])
 
     if phase == "verify":
-        verify(honcho, session, peers, fixture)
+        verify(session, peers, fixture)
         log("verify complete")
         return 0
 
@@ -220,7 +220,6 @@ def main() -> int:
 
 
 def verify(
-    honcho: Honcho,
     session: Any,
     peers: dict[str, Any],
     fixture: dict[str, Any],
@@ -301,7 +300,9 @@ def verify_seeded(
         for level, expected in by_level.items():
             if not expected:
                 continue
-            actual = {c.content for c in stored if c.level == level}
+            actual = {
+                conclusion.content for conclusion in stored if conclusion.level == level
+            }
             missing = [content for content in expected if content not in actual]
             if missing:
                 raise SeedError(

--- a/sandbox/seed.py
+++ b/sandbox/seed.py
@@ -146,7 +146,21 @@ def main() -> int:
     base_url = os.environ.get("SANDBOX_BASE_URL", "http://127.0.0.1:18000")
     workspace_id = fixture["workspace"]
 
-    honcho = Honcho(base_url=base_url, workspace_id=workspace_id, api_key="sandbox")
+    honcho = Honcho(
+        base_url=base_url,
+        workspace_id=workspace_id,
+        api_key="sandbox",
+        # No retries. Creating messages is not idempotent, and the SDK retries on
+        # 429/500/502/503/504 as well as timeouts, so a write that commits and then
+        # errors on the way back gets replayed -- seeding the fixture twice. That
+        # was observed as "expected 6 messages, found 12" on a cold api, right
+        # after cmd_seed restarts it.
+        #
+        # The sandbox is local and `up` always seeds from a cleared database, so a
+        # transient failure here should stop and be re-run, not be papered over
+        # into a silently doubled fixture.
+        max_retries=0,
+    )
     peers = {spec["id"]: honcho.peer(spec["id"]) for spec in fixture["peers"]}
     session = honcho.session(fixture["session"])
 

--- a/sandbox/seed.py
+++ b/sandbox/seed.py
@@ -3,13 +3,25 @@
 Run through sandbox.sh, which supplies the base URL and owns the Docker and
 Postgres side. This script only talks to the API:
 
-    uv run --no-project --with-editable ./sdks/python python sandbox/seed.py
+    uv run --no-project --with-editable ./sdks/python python sandbox/seed.py verify
 
-It is provider-agnostic. Under the mock provider the *text* of a conclusion is
-synthetic and unrelated to the messages, so nothing here asserts on conclusion
-content - only that derivation ran and produced something. What it does assert
-strictly is the round trip that harness integrations actually get wrong: which
-messages landed, on which peers, with which observation topology.
+Two phases, because seeded conclusions are written between them by
+inject_conclusions.py, which sandbox.sh runs inside the api container:
+
+    seed.py seed      peers, messages, derivation
+    seed.py verify    the whole round trip, seeded conclusions included
+
+The split is what keeps the deriver honest. The check that proves derivation ran
+at all is "some conclusion exists", and once conclusions are seeded that would
+pass against a completely dead deriver - so it runs in the seed phase, before
+anything is injected.
+
+It is provider-agnostic. Under the mock provider the *text* of a derived
+conclusion is synthetic and unrelated to the messages, so nothing here asserts on
+derived content. Seeded conclusions are the opposite: their text is committed, so
+they are asserted exactly, in both modes. What is asserted strictly either way is
+the round trip that harness integrations actually get wrong: which messages
+landed, on which peers, with which observation topology.
 
 Exits non-zero on any failure. An empty sandbox that reports success is the exact
 failure mode this whole thing exists to prevent.
@@ -43,6 +55,63 @@ def log(message: str) -> None:
     print(f"[seed] {message}", flush=True)
 
 
+LEVELS = ("explicit", "deductive", "inductive")
+
+
+def seeded_conclusions(
+    fixture: dict[str, Any],
+) -> dict[tuple[str, str], dict[str, list[str]]]:
+    """What inject_conclusions.py should have written, keyed by (observer, observed).
+
+    Mirrors the injector's resolution rules so verification is stated in terms of the
+    fixture rather than of whatever happens to be in the database.
+    """
+    peers = fixture["peers"]
+    planned: dict[tuple[str, str], dict[str, list[str]]] = {}
+    for spec in peers:
+        by_level = {
+            level: [
+                item if isinstance(item, str) else item["content"]
+                for item in spec.get(level, [])
+            ]
+            for level in LEVELS
+        }
+        if not any(by_level.values()):
+            continue
+        override = spec.get("observer")
+        observers = (
+            [override]
+            if override
+            else [
+                peer["id"]
+                for peer in peers
+                if peer.get("observe_others") and peer["id"] != spec["id"]
+            ]
+        )
+        for observer in observers:
+            planned[(observer, spec["id"])] = by_level
+    return planned
+
+
+def cited_premise_texts(spec: dict[str, Any], explicit: list[str]) -> set[str]:
+    """The explicit conclusions this peer's derived conclusions name as premises."""
+    return {
+        explicit[index]
+        for level in ("deductive", "inductive")
+        for item in spec.get(level, [])
+        if isinstance(item, dict)
+        for index in item.get("premises", [])
+    }
+
+
+def count_conclusions(peers: dict[str, Any]) -> int:
+    total = 0
+    for observer in peers.values():
+        for observed_id in peers:
+            total += len(list(observer.conclusions_of(observed_id).list(size=100)))
+    return total
+
+
 def drain(honcho: Honcho, what: str) -> None:
     """Block until the deriver queue is empty, or fail loudly.
 
@@ -69,15 +138,24 @@ def drain(honcho: Honcho, what: str) -> None:
 
 
 def main() -> int:
+    phase = sys.argv[1] if len(sys.argv) > 1 else "seed"
+    if phase not in ("seed", "verify"):
+        raise SeedError(f"unknown phase {phase!r} (expected 'seed' or 'verify')")
+
     fixture = json.loads(FIXTURE.read_text())
     base_url = os.environ.get("SANDBOX_BASE_URL", "http://127.0.0.1:18000")
     workspace_id = fixture["workspace"]
 
-    log(f"seeding workspace {workspace_id!r} at {base_url}")
     honcho = Honcho(base_url=base_url, workspace_id=workspace_id, api_key="sandbox")
-
     peers = {spec["id"]: honcho.peer(spec["id"]) for spec in fixture["peers"]}
     session = honcho.session(fixture["session"])
+
+    if phase == "verify":
+        verify(honcho, session, peers, fixture)
+        log("verify complete")
+        return 0
+
+    log(f"seeding workspace {workspace_id!r} at {base_url}")
 
     session.add_peers(
         [
@@ -112,7 +190,17 @@ def main() -> int:
     if fixture.get("dreams"):
         drain(honcho, "dream")
 
-    verify(honcho, session, peers, fixture)
+    # The one check that proves derivation happened, made here rather than in verify
+    # because seeded conclusions land afterwards and would satisfy it on their own.
+    derived = count_conclusions(peers)
+    if derived == 0:
+        raise SeedError(
+            "no conclusions were derived. The queue drained, so the deriver ran and "
+            "produced nothing - check the provider wiring "
+            "(LLM_OPENAI_BASE_URL / EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL) "
+            "and the deriver logs."
+        )
+    log(f"verified {derived} derived conclusions present")
     log("seed complete")
     return 0
 
@@ -154,10 +242,10 @@ def verify(
             )
     log("verified observation topology")
 
-    # Presence only. Under the mock provider, conclusion text is synthetic and
-    # says nothing about the messages, and the level mix is explicit-only because
-    # the Dreamer specialists write via tool calls the mock never emits. Asserting
-    # on either would pass in real mode and fail in mock mode.
+    # Derived conclusions get presence only. Under the mock provider their text is
+    # synthetic and says nothing about the messages, and the level mix is
+    # explicit-only because the Dreamer specialists write via tool calls the mock
+    # never emits. Asserting on either would pass in real mode and fail in mock mode.
     total = 0
     for observer_id, observer in peers.items():
         for observed_id in peers:
@@ -168,12 +256,84 @@ def verify(
 
     if total == 0:
         raise SeedError(
-            "no conclusions were derived. The queue drained, so the deriver ran and "
-            "produced nothing - check the provider wiring "
+            "no conclusions at all. Both derivation and injection produced nothing - "
+            "check the provider wiring "
             "(LLM_OPENAI_BASE_URL / EMBEDDING_MODEL_CONFIG__OVERRIDES__BASE_URL) "
             "and the deriver logs."
         )
     log(f"verified {total} conclusions present")
+
+    verify_seeded(peers, fixture, total)
+
+
+def verify_seeded(
+    peers: dict[str, Any],
+    fixture: dict[str, Any],
+    total: int,
+) -> None:
+    """Assert the seeded conclusions landed exactly, level by level.
+
+    Seeded text is committed, so unlike derived conclusions it is asserted by content
+    in both modes - which is the whole reason the fixture carries these keys.
+    """
+    planned = seeded_conclusions(fixture)
+    if not planned:
+        log("fixture declares no conclusions to seed")
+        return
+
+    seeded_total = 0
+    for (observer_id, observed_id), by_level in planned.items():
+        stored = list(peers[observer_id].conclusions_of(observed_id).list(size=100))
+        for level, expected in by_level.items():
+            if not expected:
+                continue
+            actual = {c.content for c in stored if c.level == level}
+            missing = [content for content in expected if content not in actual]
+            if missing:
+                raise SeedError(
+                    f"{observer_id} -> {observed_id}: {len(missing)} seeded {level} "
+                    f"conclusion(s) missing, first is {missing[0]!r}. Honcho collapses "
+                    "conclusions whose content matches something already stored, so "
+                    "check for near-duplicate text in the fixture."
+                )
+            seeded_total += len(expected)
+        summary = " ".join(f"{level}={len(by_level[level])}" for level in LEVELS)
+        log(f"verified seeded {observer_id} -> {observed_id}: {summary}")
+
+    # Derived and seeded conclusions must both be present. The seed phase already
+    # proved derivation ran against an un-injected database; this catches the reverse
+    # error of an injection that somehow replaced the derived rows.
+    if total <= seeded_total:
+        raise SeedError(
+            f"found {total} conclusions but {seeded_total} were seeded, leaving none "
+            "derived. Injection should add to the deriver's output, not replace it."
+        )
+    log(
+        f"verified {total - seeded_total} derived conclusions alongside {seeded_total} seeded"
+    )
+
+    # Premise text is what the working representation renders for a derived
+    # conclusion, and it is the only part of the reasoning tree an API client can
+    # see - schemas.Conclusion does not expose source_ids.
+    by_peer = {spec["id"]: spec for spec in fixture["peers"]}
+    for (observer_id, observed_id), by_level in planned.items():
+        premise_texts = cited_premise_texts(by_peer[observed_id], by_level["explicit"])
+        if not premise_texts:
+            continue
+        rendered = peers[observer_id].representation(
+            target=observed_id, max_conclusions=100
+        )
+        absent = [text for text in premise_texts if text not in rendered]
+        if absent:
+            raise SeedError(
+                f"{observer_id} -> {observed_id}: premise text missing from the "
+                f"representation, first is {absent[0]!r}. Premises render only for "
+                "deductive conclusions and sources only for inductive ones, so a "
+                "premise stored under the wrong metadata key renders as nothing."
+            )
+        log(
+            f"verified premise text renders in {observer_id}'s representation of {observed_id}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

A local Honcho that comes up already seeded and resets to that exact state in under a second. Harness integration testing currently gets verified against whatever state a given laptop is in, which is where "works on my machine" keeps coming from.

Everything lives in `sandbox/`. Outside it: two `.gitignore` lines, and `sandbox/` added to the ruff pre-commit scopes so the new Python is linted.

```bash
sandbox/sandbox.sh up       # start + seed
sandbox/sandbox.sh reset    # back to the seeded state, 0.9s
sandbox/sandbox.sh status
sandbox/sandbox.sh down
```

The seeded state is a workspace, two peers with explicit observation topology, a session, six messages, conclusions the deriver actually produced, and committed conclusions at all three reasoning levels.

### Reset is a template-database restore, not a re-derive

`seed` snapshots the finished database as a Postgres template; `reset` drops the live database and recreates it from that snapshot, then flushes Redis. No migrations, no derivation, no LLM calls.

Nothing is stopped or restarted: `DROP DATABASE ... WITH (FORCE)` evicts the api and deriver connection pools and both reconnect unaided (`POOL_PRE_PING` is on) — the api on its next request, the deriver on its next 0.25s poll. Each logs one `OperationalError` as its in-flight connection dies; that is expected and documented. Restarting them instead measures 9.5s, which defeats the point.

Three guards keep a snapshot from restoring the wrong state:

- **Per-mode template names**, so a mock-seeded template cannot be restored into a real-mode run.
- **A fingerprint inside each template** — Alembic revision, fixture hash, provider mode — and `reset` refuses on a mismatch rather than restoring a state that predates a migration.
- **A provider check against the running stack.** Neither `seed` nor `reset` recreates containers, so `--provider` on either cannot change what the stack talks to, only what gets recorded. `up` records the provider it created the stack with, and the other two refuse a mismatch. Without it, `seed --provider mock` against a running real stack spends money on non-deterministic conclusions and labels them `mock`, and every later `reset` restores those as the deterministic baseline.

### Two provider modes, both first class

`mock` is the default.

|  | `mock` | `real` |
|---|---|---|
| Determinism | Same conclusions every run | Non-deterministic |
| Cost | Zero, no egress | Real spend |
| Seed / reset | ~15s / 0.9s | ~6 min / 1.3s |
| Vector recall | **Untestable** | Testable |
| Derived on this fixture | 4 conclusions, all `explicit`, synthetic | 22 — 16 `explicit`, 4 `deductive`, 2 `inductive` |
| Seeded on this fixture | 7 — 4 `explicit`, 2 `deductive`, 1 `inductive` | the same 7, identical bytes |

Two things about mock mode will otherwise cost someone a day, both documented in the README:

- **Mock embeddings are hash-derived and carry no semantic similarity.** Measured on the seeded fixture, the nearest neighbour to a conclusion about a cat named Marzipan is `[mock] mock dummy placeholder…` at cosine distance 0.93, while the semantically closest real conclusion ranks *below* it at 0.98. Recall assertions under mock must be lexical or full-text; a vector-ranking assertion fails there for reasons unrelated to the code under test.
- **Mock *derived* conclusions are synthetic and `explicit`-only** (the Dreamer's specialists write via tool calls the mock never emits). Assert presence, not content or level mix, or a test passes in one mode and fails in the other.

Real mode reads credentials from one gitignored `sandbox/real.env`, never ambient environment, so switching to it is a deliberate act with an auditable input. `sandbox.sh` refuses to start if that file is missing or still holds the placeholder key — a real-mode stack with no key boots fine and then derives nothing, which is indistinguishable from "the deriver found nothing".

The base compose file is provider-agnostic and is not a working stack alone; exactly one provider overlay is always composed on top. That is deliberate: the `depends_on` edge to `mock-provider` lives in the mock overlay, because Compose merges `depends_on` additively and an override file cannot remove one.

### Seeded conclusions

`fixture.json` takes optional `explicit`, `deductive` and `inductive` keys per peer. They exist because derived conclusions are only assertable in real mode — under the mock the text is synthetic and the level is always `explicit`, so a harness test cannot assert on content in the one mode that is free and deterministic. Seeded text is committed, so it is identical in both modes and asserted exactly.

```json
{
  "id": "alice",
  "observe_me": true,
  "observe_others": false,
  "explicit": ["alice is a structural engineer based in Rotterdam", "…"],
  "deductive": [
    { "content": "alice named her cat after a feature of the bridge she is designing",
      "premises": [1, 3] }
  ],
  "inductive": ["…"]
}
```

The peer carrying the keys is the **observed**; observers are inferred from `observe_others`, which for the standard shape resolves to `assistant -> alice`. A peer nobody else observes is an error rather than a silent no-op, overridable with an explicit `"observer"` (which is also how to reach self-representation). Premises index into the same peer's `explicit` list and become real `source_ids` pointing at the rows written by the explicit pass, so the reasoning tree traverses in both directions. With none of the keys present the sandbox behaves exactly as it would without the feature.

**Why this is not done over the API.** The public create-conclusions endpoint always writes `level="explicit"` with no premises, and neither the schema nor the SDKs have a field for either. Widening the API was rejected: it would let any client assert a conclusion is `deductive` with premises it invented. So `inject_conclusions.py` runs **inside the api container**, which already is Honcho's venv with the api's settings and a live embedding client; the script arrives on stdin and the fixture through the environment, so nothing is mounted and nothing is left behind.

That costs one thing worth reviewing: the seeder calls Honcho **internals** out of the image pinned in `image.env`, and internals carry no stability contract. It checks the signatures it depends on before writing and fails with "bump `image.env` and update this script together" rather than half-seeding a database.

**Embeddings are the api's own.** Explicit rows are embedded by `crud.create_observations` internally; derived rows need a precomputed vector, so the seeder calls the same `embedding_client` and passes it in. No synthetic vectors — seeded rows land `sync_state=synced` with nothing left for the reconciler.

### The part that isn't obvious

**On stock settings this sandbox produces zero conclusions, and fails silently doing it** — it reads as "the deriver found nothing". Three gates have to come off (`DeriverSettings`): work units aren't claimed until a batch reaches 512 tokens, or `REPRESENTATION_BATCH_MAX_AGE_SECONDS` (30 min) elapses, and startup jitter delays the first poll by up to 30s with backoff to 30s intervals. Dreams never fire either — threshold 50, minimum gap 8 hours — so the seed calls `schedule_dream` directly.

**The sandbox is configured only by what Compose injects.** `PYTHON_DOTENV_DISABLED` and `HONCHO_CONFIG_TOML_DISABLED` are both set because `src/config.py` calls `load_dotenv(override=True)` at import, and the Dockerfile's `COPY config.toml* /app/` bakes any local `config.toml` into a locally built image. This is not theoretical — see the proofs.

**Every silent-failure mode in this path is asserted against.** An empty sandbox that reports success is the failure this whole thing exists to prevent, so:

- `seed.py` splits into `seed` and `verify` phases. The check that proves derivation ran is "some conclusion exists", which seeded rows would satisfy on their own, so it runs *before* injection.
- Exact-content dedup is always on and cannot be disabled, semantic dedup replaces rows, and per-item embedding failures drop rows — all of which reduce a count without raising. The seeder asserts exact counts and all four dedup counters.
- Nothing validates `source_ids`, and the conclusions endpoint does not expose them, so a broken reasoning tree looks identical to a working one from outside. The seeder reads its own links back before the snapshot: every cited premise must be reachable from its children, and the `source_ids` those children carry must all resolve.
- Creating messages is not idempotent and the SDK retries on 5xx, so the seed runs with `max_retries=0`; a transient failure stops and is re-run rather than silently doubling the fixture.

## Proofs

**Clean-machine bring-up**, from zero volumes: `up` 41.5s, `reset` 0.89s, repeated across three consecutive `down`/`up` cycles with identical results.

**Reset is exact.** Added a junk peer and message, reset, re-read over the raw API: junk gone, messages byte-identical to the pre-pollution baseline, all conclusions restored.

**Determinism.** Two full from-scratch cycles produced identical conclusion sets.

**Seeded conclusions land and traverse.** 4 explicit, 2 deductive, 1 inductive alongside 4 derived. In SQL: every declared premise resolves, explicit rows carry the session and derived rows are 1536-dim and `synced`, and each premise is reachable from its children. Premise text renders in the working representation.

**No developer state leaks in — verified adversarially.** With a real `config.toml` pointing at other providers present in the checkout, that file *is* baked into a locally built image, and `HONCHO_CONFIG_TOML_DISABLED=1` is demonstrably the only thing stopping it winning. A local `.env` is excluded by `.dockerignore`.

**No spend in mock mode.** The mock served the chat and embedding calls; zero references to any real provider host in api/deriver logs. The embedding override is the one that matters — it is the easiest of the three to omit silently.

**Real mode.** Seeded in 361s → 22 derived conclusions across all three levels, then `reset` restored them identically in 1.29s with no provider calls. It reasons from *"my cat Marzipan is named after the pylon's colour"* to the deductive *"alice's cat is named after a feature of alice's pedestrian bridge project."*

**Modes don't cross-contaminate.** With both templates present, switching mock↔real (~10s each way) restored each mode's own data exactly. The fingerprint guard was verified by corrupting a template — `reset` refused with a diff — and the provider guard by pointing `seed` and `reset` at the wrong mode, which both refuse with exit 1.

**Failure paths refuse rather than seed partially:** a peer nobody observes, a premise index out of range, derived conclusions with no explicit to cite, an unknown key in a fixture item, near-duplicate content collapsing under dedup, a dangling premise id, and a premise sought in the wrong collection.

## Reviewer notes

- **The internal-API coupling is the main thing to weigh.** `inject_conclusions.py` imports `crud.create_documents` and `DocumentCreate` from the pinned image. The signature guard turns a drift into a clear message, but every digest bump is a place this can break. The alternative was widening the public API to accept a level, which seemed worse.
- **Premise links are invisible to API clients.** The conclusion response exposes `level` but not `source_ids`, and `get_reasoning_chain` is a Dialectic tool rather than a route. Premise *text* does surface through the representation. So the `premises` key is worth less than the level keys unless a test goes through the Dialectic.
- **Seeded conclusions did not fix vector recall**, only content assertability — mock embeddings are still meaningless. Committing real vectors in the fixture would fix that and is not done here.
- **The fixture's peer topology is a guess** at the harness shape (`alice` observed and not observing, `assistant` observing and not observed). If the real topology differs, `fixture.json` is the one file to change, and changing it invalidates the templates by design.
- `sandbox/` is now in the ruff pre-commit scopes but deliberately not basedpyright's: it reports 0 errors there but 37 warnings, almost all `reportImplicitStringConcatenation` from the multi-line failure messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an ephemeral, seeded sandbox for harness and integration testing.
  - Added mock-provider mode for credential-free local runs and real-provider mode with documented credential setup.
  - Added commands to start, seed, inspect, reset, and stop the sandbox.
  - Added reproducible fixture data covering conversations, observations, memories, conclusions, and dreams.
  - Added safeguards to detect missing credentials, stale state, mismatched providers, and invalid seeded data.

- **Documentation**
  - Added comprehensive sandbox setup, usage, provider, configuration, and troubleshooting documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->