### PR TITLE
fix(ci): install Python via uv on unified-test Fly runner

### DIFF
--- a/.github/workflows/unified-tests.yml
+++ b/.github/workflows/unified-tests.yml
@@ -148,11 +148,16 @@ jobs:
       - name: Verify Docker is available
         run: docker info
 
+      # Self-hosted Fly runner only has system 3.12; fetch .python-version via uv.
+      - name: Install Python
+        run: uv python install
+
       - name: Verify uv and Python
         run: |
           uv --version
-          python3.13 --version
-          which python3.13
+          PYTHON_BIN="$(uv python find)"
+          "$PYTHON_BIN" --version
+          echo "Using $PYTHON_BIN"
 
       - name: Install the project
         run: uv sync --all-extras


### PR DESCRIPTION
## Description

#1090 pinned the project to 3.13 and updated the verify step to call python3.13, but the self-hosted ivysaur image only ships system 3.12. Install the .python-version interpreter with uv before verify/sync so unified tests can run without rebuilding the runner image.

## Proofs

N/A

## Checklist

- [ ] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing to use the Python version specified by the project configuration.
  * Added clearer reporting of the Python interpreter path and version during test runs.
  * Removed reliance on a hardcoded Python version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->