### PR TITLE
fix(dialectic): make workspace chat call a tool before it answers

### DIFF
--- a/src/dialectic/core.py
+++ b/src/dialectic/core.py
@@ -14,7 +14,12 @@ from nanoid import generate as generate_nanoid
 from pydantic import BaseModel
 
 from src import crud
-from src.config import ConfiguredModelSettings, ReasoningLevel, settings
+from src.config import (
+    ConfiguredModelSettings,
+    DialecticLevelSettings,
+    ReasoningLevel,
+    settings,
+)
 from src.dependencies import tracked_db
 from src.dialectic import prompts
 from src.embedding_client import embedding_client
@@ -138,6 +143,20 @@ class DialecticAgent:
         if self.session_allowlist is not None:
             tools = [t for t in tools if t.get("name") != "get_reasoning_chain"]
         return tools
+
+    def _tool_choice(
+        self, level_settings: DialecticLevelSettings
+    ) -> str | dict[str, Any] | None:
+        """Pick the tool_choice for this query.
+
+        Defaults to whatever the reasoning level configures. Subclasses override
+        when the agent has no prefetched corpus to fall back on and so must
+        search before it can answer. Forcing "required"/"any" here costs exactly
+        one tool round rather than pinning the loop: `execute_tool_loop` relaxes
+        it to "auto" after the first iteration so the model can still stop and
+        synthesize.
+        """
+        return level_settings.TOOL_CHOICE
 
     async def _initialize_session_history(self) -> None:
         """Fetch and inject session history into the system prompt if configured."""
@@ -505,7 +524,7 @@ class DialecticAgent:
                 prompt="",  # Ignored since we pass messages
                 max_tokens=max_tokens,
                 tools=tools,
-                tool_choice=level_settings.TOOL_CHOICE,
+                tool_choice=self._tool_choice(level_settings),
                 tool_executor=tool_executor,
                 max_tool_iterations=level_settings.MAX_TOOL_ITERATIONS,
                 messages=self.messages,
@@ -581,7 +600,7 @@ class DialecticAgent:
                 stream=True,
                 stream_final_only=True,
                 tools=tools,
-                tool_choice=level_settings.TOOL_CHOICE,
+                tool_choice=self._tool_choice(level_settings),
                 tool_executor=tool_executor,
                 max_tool_iterations=level_settings.MAX_TOOL_ITERATIONS,
                 messages=self.messages,

--- a/src/dialectic/prompts.py
+++ b/src/dialectic/prompts.py
@@ -396,7 +396,11 @@ If this query is restricted to a session or a set of sessions, message tools alr
 
 4. **Attribute**. Every fact you state names the peer it is about. If it is a cross-peer view, also name whose model it came from. Example: "Alice is a violinist." / "From Bob's model of Alice, …"
 
-5. **Synthesize**. Answer the question. Quote exact names, dates, and numbers. For aggregations, list findings per peer. Do not narrate tool use.
+5. **Synthesize**. Answer the question. Quote exact names, dates, and numbers. For aggregations, list findings per peer. Do not narrate tool use, and do not describe a search you did not run.
+
+## NO CLARIFYING QUESTIONS
+
+Your answer goes to a program, not to someone who can reply. No one will answer a question you ask, approve a plan you propose, or pick from options you offer — your response ends the exchange. So never ask which lookup to run, never lay out a plan and stop, never present a menu. Run the searches yourself and answer from what they return. Empty results are a complete answer; an unanswered question is not.
 
 ## NEVER FABRICATE
 

--- a/src/dialectic/workspace.py
+++ b/src/dialectic/workspace.py
@@ -20,7 +20,7 @@ from collections.abc import Callable
 from typing import Any
 
 from src import crud
-from src.config import ReasoningLevel, settings
+from src.config import DialecticLevelSettings, ReasoningLevel, settings
 from src.dependencies import tracked_db
 from src.dialectic import prompts
 from src.dialectic.core import DialecticAgent
@@ -160,6 +160,30 @@ class WorkspaceDialecticAgent(DialecticAgent):
             unscopable = {"get_reasoning_chain", "get_peer_card"}
             tools = [t for t in tools if t.get("name") not in unscopable]
         return tools
+
+    def _tool_choice(
+        self, level_settings: DialecticLevelSettings
+    ) -> str | dict[str, Any] | None:
+        """Require a tool call on the first turn.
+
+        The pair agent prefetches the observations relevant to its query, so it
+        can legitimately answer from context alone. This agent's prefetch is an
+        orientation overview — scale, active peers, their cards — not the corpus.
+        Left free to skip tools, the model treats that overview as everything it
+        has: it answers when the overview happens to carry the fact, and
+        otherwise writes out the search it should have run and asks the caller
+        which option to take. Workspace chat has no caller to answer, so that
+        response is dead on arrival.
+
+        Recall is the job, so make the first search mandatory and let the loop
+        relax to "auto" afterwards. Any other value a level configures is passed
+        through untouched, so this only overrides the two cases that let the
+        model opt out entirely.
+        """
+        choice = level_settings.TOOL_CHOICE
+        if choice is None or choice == "auto":
+            return "required"
+        return choice
 
     async def _create_tool_executor(self) -> Callable[[str, dict[str, Any]], Any]:
         return await create_workspace_tool_executor(

--- a/tests/test_workspace_chat.py
+++ b/tests/test_workspace_chat.py
@@ -9,7 +9,7 @@ import asyncio
 import json
 from collections.abc import Callable
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
 
@@ -82,7 +82,7 @@ async def workspace_test_data(
     await db_session.flush()
 
     # Create messages
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     messages: list[models.Message] = []
     for i in range(6):
         peer_name = [peer1.name, peer2.name, peer3.name][i % 3]
@@ -593,7 +593,7 @@ class TestSearchMemoryWorkspace:
             content="I really like programming in Python",
             seq_in_session=1,
             token_count=10,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         db_session.add(msg)
         await db_session.flush()
@@ -919,7 +919,7 @@ class TestGetObservationContextWorkspace:
             content="LEAKED_FROM_OTHER_SESSION",
             seq_in_session=messages[0].seq_in_session,
             token_count=10,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         db_session.add(leaked_message)
         await db_session.commit()
@@ -1253,3 +1253,63 @@ class TestWorkspaceChatPrompt:
         }
         assert agent.messages[0]["content"] == workspace_agent_system_prompt(offered)
         assert agent._prefetch_heading() == "Workspace overview (prefetched)"  # pyright: ignore[reportPrivateUsage]
+
+    def test_forbids_clarifying_questions(self) -> None:
+        """The endpoint is non-interactive, so the prompt must say so.
+
+        Without this the model answers a recall query with a plan and a menu of
+        lookups for a caller that cannot reply. The pair agent talks to a peer
+        and is deliberately left alone.
+        """
+        from src.dialectic.prompts import (
+            agent_system_prompt,
+            workspace_agent_system_prompt,
+        )
+
+        prompt = workspace_agent_system_prompt()
+        assert "NO CLARIFYING QUESTIONS" in prompt
+        assert "NO CLARIFYING QUESTIONS" not in agent_system_prompt(
+            "alice", "alice", None, None
+        )
+
+
+class TestWorkspaceToolChoice:
+    """The workspace agent must search before it answers.
+
+    Its prefetch is an orientation overview, not the corpus, so a turn with no
+    tool call ends the loop with whatever the overview happened to contain.
+    """
+
+    @pytest.mark.parametrize("level", ["minimal", "low", "medium", "high", "max"])
+    def test_first_turn_requires_a_tool_call(self, level: str) -> None:
+        from src.config import settings
+        from src.dialectic.workspace import WorkspaceDialecticAgent
+
+        agent = WorkspaceDialecticAgent(workspace_name="w", reasoning_level=level)  # pyright: ignore[reportArgumentType]
+        level_settings = settings.DIALECTIC.LEVELS[level]  # pyright: ignore[reportArgumentType]
+        assert agent._tool_choice(level_settings) == "required"  # pyright: ignore[reportPrivateUsage]
+
+    def test_pair_agent_keeps_the_configured_choice(self) -> None:
+        from src.config import settings
+        from src.dialectic.core import DialecticAgent
+
+        agent = DialecticAgent(
+            workspace_name="w", session_name=None, observer="a", observed="a"
+        )
+        level_settings = settings.DIALECTIC.LEVELS["low"]
+        assert (
+            agent._tool_choice(level_settings)  # pyright: ignore[reportPrivateUsage]
+            == level_settings.TOOL_CHOICE
+        )
+
+    def test_a_configured_non_auto_choice_is_passed_through(self) -> None:
+        from src.config import DialecticLevelSettings, settings
+        from src.dialectic.workspace import WorkspaceDialecticAgent
+
+        agent = WorkspaceDialecticAgent(workspace_name="w")
+        pinned = DialecticLevelSettings(
+            MODEL_CONFIG=settings.DIALECTIC.LEVELS["low"].MODEL_CONFIG,
+            MAX_TOOL_ITERATIONS=5,
+            TOOL_CHOICE="none",
+        )
+        assert agent._tool_choice(pinned) == "none"  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
# Human

This tries to fix the CI failures in `unified-tests` specifically due to the dialectic not making any tool calls and instead asking for permission on the first turn.

The fix is to force it to make a tool call on the first turn, and to instruct it in the prompt that there's no human on the line.

This seems to improve things but weak models can still flake out. There are more forceful things we could try to do, but I propose to start with this and move incrementally.

# Claude

DEV-2579

Supersedes #1119, which was closed when its branch was renamed from `eugene/dev-2577` to `eugene/dev-2579`. Same commit (`4736844`), corrected claims — see **Status after CI** below.

## Problem

Every `workspace_chat` call in [CI run 33662772219](https://github.com/plastic-labs/honcho/actions/runs/33662772219/job/100357616524) made **zero tool calls**. The agent answered entirely from its prefetched overview, and when that overview didn't carry the asked-for fact it wrote out the search it should have run and asked the caller to pick an option — at an endpoint with no caller to answer:

> "Please specify which approach you'd prefer: 1) Pull Alice's self-description (search_memory with observer=alice, observed=alice). 2) Search all messages for mentions of Alice and music."

`search_memory` — the recall path — never ran once.

`WorkspaceDialecticAgent`'s prefetch is an *orientation* overview — scale, active peers, their cards — not the corpus. `low` is the only reasoning level that explicitly sets `TOOL_CHOICE="auto"`, so the model was free to skip tools, and did.

This is why `workspace_chat_from_messages` was the one green test in the group: Carol's peer card happened to be in the prefetch and happened to contain the answer. A false positive, not a working path.

## Fix

- **`workspace.py`** — override `_tool_choice` to require a tool call. `execute_tool_loop` already relaxes `"required"`/`"any"` to `"auto"` after iteration 1 (`tool_loop.py:409,654`), so this costs one search round rather than pinning the loop. Any level value other than `None`/`"auto"` passes through untouched.
- **`core.py`** — add the `_tool_choice` seam alongside `_select_tools`; both call sites now route through it. Pair-agent behavior is unchanged: it prefetches the observations for its query and can legitimately answer from context alone.
- **`prompts.py`** — `## NO CLARIFYING QUESTIONS`. The prompt said "Do not narrate tool use" but never that the caller cannot reply; three of five traced responses ended in a menu.

Deliberately fixed at the agent, **not** as a config default: `DIALECTIC_LEVELS__LOW__TOOL_CHOICE` comes from the staging secret, so changing `config.py`'s default would be overridden in CI and staging.

## Status after CI

The branch has now run the full suite — [run 33677917703](https://github.com/plastic-labs/honcho/actions/runs/33677917703/job/100407622382) on merge commit `bb8de33`. **It fixes less than the local subset suggested.** Correcting the earlier claim of 1/5 → 5/5:

| test | `ccdb8ba` | `5d992bc` | `bb8de33` (this PR) | |
|---|---|---|---|---|
| `workspace_chat_from_messages` | PASS | PASS | PASS | was passing vacuously |
| `workspace_chat_cross_peer` | FAIL | FAIL | **PASS** | genuinely fixed |
| `peer_isolation_test` | PASS | FAIL | PASS | flaky, untouched by this PR |
| `workspace_chat_from_observations` | FAIL | FAIL | **FAIL** | still broken |
| `workspace_chat_scope` | FAIL | FAIL | **FAIL** | still broken |

Suite total 10 → 8 failures, but only one of those two is this PR's doing.

**Why local said 5/5 and CI says otherwise: model.** Local runs use the `config.py` default `gpt-5.4-mini` (no `.env` in this repo pins a dialectic model). CI overrides it from the staging secret to `gpt-5-nano-2025-08-07` at `reasoning_effort: "minimal"`. The fix holds on the former and not the latter.

From the run's reasoning traces (`s3://honcho-unified-tests/unified-test-results/2026-09-02/1119-merge-bb8de33-33677917703-1/unified-reasoning-traces.jsonl`), both remaining failures made exactly **one** tool call, and neither was a search:

- *"What do you know about Alice's musical background?"* → `get_peer_card(alice, alice)` → `"No peer card available"` → *"Would you like me to start by querying Alice's memory for anything about music…?"*
- *"What facts do you know about people in this workspace?"* → `get_workspace_stats()`, which returned exactly the overview already in its prompt → *"If you want more detail, I can pull alice's own self-model…"*

`MAX_TOOL_ITERATIONS` was 5 in both cases, so the budget was not the constraint. `TOOL_CHOICE="required"` bought a first tool call; it did not buy a *search*, and the `## NO CLARIFYING QUESTIONS` instruction did not bind the smaller model at all.

So the remaining work under DEV-2579 is to make the contract structural rather than prompt-borne — gate the final answer on an actual search tool having run, treat `get_peer_card`/`get_workspace_stats` as non-searches for that gate, and consider seeding the prefetched overview with the biographical facts it already advertises.

## What this PR does establish

`search_memory` now fires where it never did before, and routing is sensible rather than blunt:

| query | tools called |
|---|---|
| Carol's writing (`from_messages`) | `search_messages` |
| professions (`cross_peer`) | `search_memory`, `search_messages` |
| peer/message counts (`scope`) | `get_workspace_stats` |

**`workspace_chat_scope` was passing vacuously and now fails honestly.** Its two `not_contains` assertions could not fail while nothing was ever retrieved. Scope enforcement through the tool path had no real coverage before this.

Also: `pytest tests/test_workspace_chat.py` 56 passed (8 new in `TestWorkspaceToolChoice` + `test_forbids_clarifying_questions`); `basedpyright` clean; `ruff check` repo-wide 169 → 169, no new debt.

## Reviewer notes

- **Latency tradeoff.** `workspace.py:37-39` notes the prefetch exists so routing-obvious queries skip a tool round, "~1.3s measured". This spends that on every workspace query. A follow-up could force the round only when the prefetch is thin (no cards, or an allowlist set) — a heuristic I didn't want as the first cut.
- **Applies at every level**, including `medium`/`high`/`max` where `TOOL_CHOICE` is `None` (provider default = auto). Intentional — a workspace recall query should always search — but say the word if you'd rather scope it narrower.
- 4 incidental lines in `tests/test_workspace_chat.py` are `timezone.utc` → `UTC`, auto-applied by the repo's ruff pre-commit hook on a file this PR touches.

## Scope

The other 6 unified failures are **not** dialectic bugs and are tracked separately in DEV-2580: three `Deriver queue did not empty` timeouts (60s default vs ~500-message fixtures), the two `config_summary_control` cases (`get_context` allocates 40% of `max_tokens`, so `max_tokens: 400` gives a 160-token budget against ~388-token summaries), and `dream_knowledge_updates_and_patterns` (asserts on deductive levels that `ALLOWLIST_SAFE_LEVELS = ("explicit",)` deliberately withholds under a session allowlist). That ticket also covers the GHA secret-masking that renders these logs unreadable.

Worth noting separately: main has been red on this suite since #1083 un-skipped it on 2026-08-26. Every green before that was a **skip** — the last time the suite actually ran green anywhere was a PR run on 2026-07-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Workspace answers now complete required lookups before responding.
  - Responses no longer describe searches or lookups that were not performed.
  - Workspace interactions avoid unnecessary clarifying questions and provide a direct answer instead of unfinished plans or alternatives.
  - Tool-assisted responses now begin with the required lookup when needed, improving consistency across reasoning levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->