### PR TITLE
feat(llm): send stable x-opencode-session header to OpenCode Zen/Go endpoints

### DIFF
--- a/src/llm/registry.py
+++ b/src/llm/registry.py
@@ -8,6 +8,7 @@ history adapter selection) lives here now.
 
 from __future__ import annotations
 
+import uuid
 from functools import lru_cache
 from typing import TYPE_CHECKING, assert_never
 
@@ -52,6 +53,18 @@ _DEFAULT_HEADERS_BY_BASE_URL: dict[str, dict[str, str]] = {
     },
 }
 
+# OpenCode Zen / Go (https://opencode.ai/docs/go/) asks clients to send a stable
+# ``x-opencode-session`` header so it can optimize prompt caching, and rejects
+# requests that do not identify their session. Honcho has no chat-session
+# concept at the client layer, so a process-lifetime ID is the closest stable
+# scope; cached so every OpenAI-compatible client in the process shares one ID.
+_OPENCODE_ZEN_BASE_URL_PREFIX = "https://opencode.ai/zen"
+
+
+@lru_cache(maxsize=1)
+def _opencode_session_id() -> str:
+    return str(uuid.uuid4())
+
 
 def _default_headers_for(base_url: str | None) -> dict[str, str]:
     """Default headers for ``base_url`` (prefix match); these merge under any
@@ -60,6 +73,8 @@ def _default_headers_for(base_url: str | None) -> dict[str, str]:
         for prefix, headers in _DEFAULT_HEADERS_BY_BASE_URL.items():
             if base_url.startswith(prefix):
                 return headers
+        if base_url.startswith(_OPENCODE_ZEN_BASE_URL_PREFIX):
+            return {"x-opencode-session": _opencode_session_id()}
     return {}
 
 


### PR DESCRIPTION
## What

When an OpenAI-compatible client's `base_url` matches `https://opencode.ai/zen`, Honcho now sends a stable `x-opencode-session` header automatically: a process-lifetime UUID, shared by every OpenAI-compatible client in the process.

## Why

OpenCode Go/Zen asks API clients to include a stable `x-opencode-session` header so it can optimize prompt caching (https://opencode.ai/docs/go/), and has notified users that requests missing the header may start erroring from 6 Sep 2026. Today the only way to send it from Honcho is to hand-set `provider_params.extra_headers` on every module's `model_config.overrides` - verbose and easy to miss.

## How

This PR was directly inspired by, and follows the pattern of, the previously merged provider-specific header PRs:

- #708 / #805 - OpenRouter app-attribution headers via `_DEFAULT_HEADERS_BY_BASE_URL`
- #761 - provider-specific User-Agent for Kimi

The comment above `_DEFAULT_HEADERS_BY_BASE_URL` already invites "add a prefix here to tag another provider". One nuance vs. OpenRouter: the header value must be a *stable session ID*, not a static string, so the OpenCode entry is generated once per process (`_opencode_session_id`, `lru_cache`d) rather than kept in the static map. Honcho has no chat-session concept at the client layer, so process lifetime is the closest stable scope; operators who want their own ID can still override per module via `provider_params.extra_headers`, which wins over client `default_headers` on key collision.

## Scope and testing

- 15 lines, confined to `src/llm/registry.py`; applies to both the default client (`get_openai_client`) and override clients (`get_openai_override_client`).
- Not yet exercised against the live Zen endpoint; the injection path is the same one already used for OpenRouter.
- Anthropic-transport clients (Zen also serves `/messages`) are out of scope; no default-header plumbing exists there today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * OpenCode Zen requests now include a unique session identifier for each process session.
  * Existing request header behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->