### PR TITLE
fix(tests): repair unsatisfiable unified-test assertions and record why tests fail

### DIFF
--- a/src/routers/sessions.py
+++ b/src/routers/sessions.py
@@ -248,6 +248,19 @@ def _select_summary_for_context(
             token_limit - short_len,
         )
 
+    if short_summary or long_summary:
+        # A summary exists but none fits. The caller sees `summary: null`, which
+        # is indistinguishable from "this session has no summary", so say so.
+        # `token_limit` here is already net of the representation and peer card,
+        # which is usually why the budget is smaller than the request suggests.
+        logger.info(
+            "Summary dropped: budget %s too small (short=%s, long=%s, limit=%s)",
+            summary_budget,
+            short_len or None,
+            long_len or None,
+            token_limit,
+        )
+
     return None, 0, token_limit
 
 

--- a/src/utils/summarizer.py
+++ b/src/utils/summarizer.py
@@ -886,12 +886,21 @@ async def get_session_context(
             )
             messages_tokens = token_limit - latest_short_summary["token_count"]
             messages_start_id = latest_short_summary["message_id"]
+        elif latest_short_summary or latest_long_summary:
+            # A summary exists but does not fit the 40% allocation. The caller
+            # receives `summary: null`, which is indistinguishable from a session
+            # that has none, so this is reported rather than left at debug.
+            logger.info(
+                "Summary dropped: budget %s too small (short=%s, long=%s, limit=%s)",
+                summary_tokens_limit,
+                short_len or None,
+                long_len or None,
+                token_limit,
+            )
         else:
             logger.debug(
-                "No summary available for get_context call with token limit %s, returning empty string. Normal if brand-new session. long_summary_len: %s, short_summary_len: %s",
+                "No summary for get_context with token limit %s. Normal for a new session.",
                 token_limit,
-                long_len,
-                short_len,
             )
 
     # Get recent messages after summary

--- a/tests/routes/test_session_context_summary.py
+++ b/tests/routes/test_session_context_summary.py
@@ -1,0 +1,139 @@
+"""How `get_context` decides whether to serve a session summary.
+
+The summary budget is 40% of what remains *after* the peer representation and
+card are subtracted, not 40% of the requested `tokens`. With an observer that
+has accumulated observations, a perfectly valid summary can be dropped and the
+caller just sees `summary: null` — which is what made DEV-2580's
+`config_summary_control` fixtures unsatisfiable.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from fastapi.testclient import TestClient
+from nanoid import generate as generate_nanoid
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import schemas
+from src.models import Peer, Workspace
+from src.routers.sessions import (
+    _select_summary_for_context,  # pyright: ignore[reportPrivateUsage]
+)
+from src.utils.summarizer import (
+    Summary,
+    SummaryType,
+    _save_summary,  # pyright: ignore[reportPrivateUsage]
+)
+
+# Measured from CI run 33779689337: the 12-message config_summary fixtures
+# produce 12 explicit observations costing ~1176 tokens.
+_FIXTURE_REPRESENTATION_TOKENS = 1176
+_SHORT_SUMMARY_CAP = 1000  # SUMMARY.MAX_TOKENS_SHORT default
+
+
+def _summary_schema(token_count: int) -> schemas.Summary:
+    return schemas.Summary(
+        content="A summary of the conversation so far.",
+        message_id=1,
+        summary_type="short",
+        created_at=dt.datetime.now(dt.UTC).isoformat(),
+        token_count=token_count,
+        message_public_id="msg_public",
+    )
+
+
+def _stored_summary(token_count: int) -> Summary:
+    return Summary(
+        content="A summary of the conversation so far. " * 5,
+        message_id=1,
+        summary_type=SummaryType.SHORT.value,
+        created_at=dt.datetime.now(dt.UTC).isoformat(),
+        token_count=token_count,
+        message_public_id="msg_public",
+    )
+
+
+def test_representation_can_exhaust_the_budget_entirely() -> None:
+    """`max_tokens: 400` against these fixtures leaves a negative budget.
+
+    No summary of any size could be served, so the original failure was never
+    about the summary being too large.
+    """
+    adjusted = 400 - _FIXTURE_REPRESENTATION_TOKENS
+    assert adjusted < 0
+    chosen, _, _ = _select_summary_for_context(
+        _summary_schema(99), None, adjusted, True
+    )
+    assert chosen is None
+
+
+def test_a_conforming_summary_can_still_be_dropped() -> None:
+    """2500 leaves a 529-token budget — under `SUMMARY.MAX_TOKENS_SHORT`."""
+    adjusted = 2500 - _FIXTURE_REPRESENTATION_TOKENS
+    chosen, _, _ = _select_summary_for_context(
+        _summary_schema(_SHORT_SUMMARY_CAP), None, adjusted, True
+    )
+    assert chosen is None
+
+
+def test_fixture_limit_fits_any_conforming_summary() -> None:
+    """4000 is what the unified fixtures now request; it must leave room."""
+    adjusted = 4000 - _FIXTURE_REPRESENTATION_TOKENS
+    assert int(adjusted * 0.4) >= _SHORT_SUMMARY_CAP
+    chosen, _, _ = _select_summary_for_context(
+        _summary_schema(_SHORT_SUMMARY_CAP), None, adjusted, True
+    )
+    assert chosen is not None
+
+
+def test_zero_token_summary_is_never_served() -> None:
+    chosen, _, _ = _select_summary_for_context(_summary_schema(0), None, 4000, True)
+    assert chosen is None
+
+
+def test_dropped_summary_is_logged_not_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`summary: null` is indistinguishable from 'no summary exists' otherwise."""
+    with caplog.at_level("INFO", logger="src.routers.sessions"):
+        _select_summary_for_context(_summary_schema(900), None, 1000, True)
+    assert "Summary dropped" in caplog.text
+
+
+def test_no_log_when_the_session_simply_has_no_summary(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("INFO", logger="src.routers.sessions"):
+        _select_summary_for_context(None, None, 1000, True)
+    assert "Summary dropped" not in caplog.text
+
+
+@pytest.mark.parametrize("with_observer", [False, True])
+async def test_a_stored_summary_is_served(
+    client: TestClient,
+    sample_data: tuple[Workspace, Peer],
+    db_session: AsyncSession,
+    with_observer: bool,
+) -> None:
+    """Retrieval itself works: a saved summary comes back through the route."""
+    workspace, peer = sample_data
+    session_id = str(generate_nanoid())
+    client.post(
+        f"/v3/workspaces/{workspace.name}/sessions",
+        json={"id": session_id, "peers": {peer.name: {}}},
+    )
+    await _save_summary(db_session, _stored_summary(99), workspace.name, session_id)
+    await db_session.commit()
+
+    url = (
+        f"/v3/workspaces/{workspace.name}/sessions/{session_id}/context"
+        "?summary=true&tokens=4000"
+    )
+    if with_observer:
+        url += f"&peer_target={peer.name}"
+
+    data = client.get(url).json()
+    assert data["summary"] is not None
+    assert data["summary"]["token_count"] == 99

--- a/tests/routes/test_session_context_summary.py
+++ b/tests/routes/test_session_context_summary.py
@@ -1,10 +1,15 @@
 """How `get_context` decides whether to serve a session summary.
 
-The summary budget is 40% of what remains *after* the peer representation and
-card are subtracted, not 40% of the requested `tokens`. With an observer that
-has accumulated observations, a perfectly valid summary can be dropped and the
-caller just sees `summary: null` — which is what made DEV-2580's
-`config_summary_control` fixtures unsatisfiable.
+Two paths, and which one runs depends on `peer_target`:
+
+- Without it, `summarizer.get_session_context` gives the summary 40% of the
+  requested `tokens`.
+- With it, `sessions._select_summary_for_context` gives it 40% of what remains
+  *after* the peer representation and card are subtracted, so an observer with
+  many observations can starve a perfectly valid summary.
+
+Either way the caller just sees `summary: null`, indistinguishable from a
+session that has none, which is why both paths now log when they drop one.
 """
 
 from __future__ import annotations
@@ -27,8 +32,9 @@ from src.utils.summarizer import (
     _save_summary,  # pyright: ignore[reportPrivateUsage]
 )
 
-# Measured from CI run 33779689337: the 12-message config_summary fixtures
-# produce 12 explicit observations costing ~1176 tokens.
+# Measured from CI run 33779689337: 12 messages from one peer produce 12
+# explicit observations costing ~1176 tokens. Only the `peer_target` path pays
+# this, and the unified `config_summary` fixtures do not take that path.
 _FIXTURE_REPRESENTATION_TOKENS = 1176
 _SHORT_SUMMARY_CAP = 1000  # SUMMARY.MAX_TOKENS_SHORT default
 
@@ -56,11 +62,7 @@ def _stored_summary(token_count: int) -> Summary:
 
 
 def test_representation_can_exhaust_the_budget_entirely() -> None:
-    """`max_tokens: 400` against these fixtures leaves a negative budget.
-
-    No summary of any size could be served, so the original failure was never
-    about the summary being too large.
-    """
+    """A large representation can leave a negative budget on the observer path."""
     adjusted = 400 - _FIXTURE_REPRESENTATION_TOKENS
     assert adjusted < 0
     chosen, _, _ = _select_summary_for_context(
@@ -70,7 +72,7 @@ def test_representation_can_exhaust_the_budget_entirely() -> None:
 
 
 def test_a_conforming_summary_can_still_be_dropped() -> None:
-    """2500 leaves a 529-token budget — under `SUMMARY.MAX_TOKENS_SHORT`."""
+    """With that representation, 2500 leaves 529 — under `SUMMARY.MAX_TOKENS_SHORT`."""
     adjusted = 2500 - _FIXTURE_REPRESENTATION_TOKENS
     chosen, _, _ = _select_summary_for_context(
         _summary_schema(_SHORT_SUMMARY_CAP), None, adjusted, True
@@ -79,7 +81,7 @@ def test_a_conforming_summary_can_still_be_dropped() -> None:
 
 
 def test_fixture_limit_fits_any_conforming_summary() -> None:
-    """4000 is what the unified fixtures now request; it must leave room."""
+    """4000 leaves room even when a representation is subtracted."""
     adjusted = 4000 - _FIXTURE_REPRESENTATION_TOKENS
     assert int(adjusted * 0.4) >= _SHORT_SUMMARY_CAP
     chosen, _, _ = _select_summary_for_context(
@@ -137,3 +139,29 @@ async def test_a_stored_summary_is_served(
     data = client.get(url).json()
     assert data["summary"] is not None
     assert data["summary"]["token_count"] == 99
+
+
+async def test_fixture_path_ignores_representation_budget(
+    client: TestClient,
+    sample_data: tuple[Workspace, Peer],
+    db_session: AsyncSession,
+) -> None:
+    """Without `peer_target`, the summary gets 40% of `tokens` outright.
+
+    The unified `config_summary` fixtures set `observer_peer_id`, but the runner
+    does not forward it to `get_context`, so this is the path they exercise.
+    """
+    workspace, peer = sample_data
+    session_id = str(generate_nanoid())
+    client.post(
+        f"/v3/workspaces/{workspace.name}/sessions",
+        json={"id": session_id, "peers": {peer.name: {}}},
+    )
+    await _save_summary(db_session, _stored_summary(99), workspace.name, session_id)
+    await db_session.commit()
+
+    url = f"/v3/workspaces/{workspace.name}/sessions/{session_id}/context"
+    data = client.get(f"{url}?summary=true&tokens=2500").json()
+
+    assert data["summary"] is not None
+    assert data.get("peer_representation") is None

--- a/tests/unified/runner.py
+++ b/tests/unified/runner.py
@@ -5,7 +5,8 @@ import os
 import sys
 import threading
 import time
-from datetime import datetime, timezone
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -87,17 +88,80 @@ async def send_discord_message(webhook_url: str, message: str) -> None:
         logger.exception("Failed to send Discord notification")
 
 
+@dataclass
+class RunArtifact:
+    """One uploaded file: its S3 key, and a presigned URL when one could be made."""
+
+    key: str
+    url: str | None = None
+
+
+@dataclass
+class RunArtifacts:
+    """Artifacts published for a run. Any field is None when its upload failed."""
+
+    results: RunArtifact | None = None
+    traces: RunArtifact | None = None
+
+
+# 3 days. Long enough to survive a weekend before someone reads the report.
+PRESIGN_EXPIRY_SECONDS = 259200
+
+
+def presign(s3_client: Any, bucket: str, key: str) -> RunArtifact:
+    """Wrap an uploaded key with a presigned URL, or just the key if signing fails."""
+    try:
+        url: str = s3_client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=PRESIGN_EXPIRY_SECONDS,
+        )
+        return RunArtifact(key=key, url=url)
+    except Exception as e:
+        logger.warning(f"Could not generate S3 presigned URL for {key}: {e}")
+        return RunArtifact(key=key)
+
+
+def artifact_lines(artifacts: RunArtifacts) -> list[str]:
+    """Render each uploaded artifact as one markdown line: link when presigned, key otherwise.
+
+    Both artifacts are surfaced. The reasoning traces carry the full prompts and
+    model outputs for the run, which is what a failure usually needs to diagnose.
+    """
+    labels = [
+        ("Complete results", artifacts.results),
+        ("Reasoning traces", artifacts.traces),
+    ]
+    lines: list[str] = []
+    for label, artifact in labels:
+        if artifact is None:
+            continue
+        if artifact.url:
+            lines.append(f"[{label}]({artifact.url}) — `{artifact.key}`")
+        else:
+            lines.append(f"{label}: `{artifact.key}`")
+    return lines
+
+
+def write_job_summary(lines: list[str]) -> None:
+    """Append a markdown block to the GitHub Actions job summary; a no-op locally."""
+    summary_path = os.getenv("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    try:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+    except OSError as e:
+        logger.warning(f"Could not write job summary: {e}")
+
+
 async def save_results_to_s3(
     results: dict[str, tuple[str, float]],
     failed_count: int,
     total_count: int,
     execution_time: float,
-) -> tuple[str | None, str | None]:
-    """Save comprehensive test results to S3.
-
-    Returns:
-        Tuple of (presigned_url, s3_key). Either or both may be None if upload/URL generation fails.
-    """
+) -> RunArtifacts:
+    """Save comprehensive test results and reasoning traces to S3."""
     try:
         import boto3
 
@@ -112,13 +176,13 @@ async def save_results_to_s3(
             credentials = session.get_credentials()  # pyright: ignore
             if not credentials:
                 logger.warning("No AWS credentials available, skipping S3 upload")
-                return None, None
+                return RunArtifacts()
         except Exception as e:
             logger.warning(f"Could not verify AWS credentials: {e}, skipping S3 upload")
-            return None, None
+            return RunArtifacts()
 
         # Create comprehensive results object
-        timestamp = datetime.now(timezone.utc).isoformat()
+        timestamp = datetime.now(UTC).isoformat()
         github_run_id = os.getenv("GITHUB_RUN_ID", "local")
         github_run_attempt = os.getenv("GITHUB_RUN_ATTEMPT", "1")
         github_sha = os.getenv("GITHUB_SHA", "unknown")
@@ -150,7 +214,7 @@ async def save_results_to_s3(
 
         # One "folder" per run: <prefix>/<date>/<run>/ holding results.json plus
         # the reasoning-trace file(s), so a run's summary and full LLM I/O live together.
-        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
         sha_short = github_sha[:7] if github_sha != "unknown" else "unknown"
         ref_slug = github_ref.replace("/", "-")  # branch names may contain "/"
         run_slug = f"{ref_slug}-{sha_short}-{github_run_id}-{github_run_attempt}"
@@ -169,6 +233,7 @@ async def save_results_to_s3(
         # Upload the reasoning traces (full LLM/deriver I/O) captured this run. The
         # API and deriver both append to REASONING_TRACES_FILE (file-locked). Use
         # upload_file so large trace files stream via multipart instead of buffering.
+        traces: RunArtifact | None = None
         traces_path_str = os.getenv("REASONING_TRACES_FILE")
         if traces_path_str:
             traces_path = Path(traces_path_str)
@@ -182,6 +247,7 @@ async def save_results_to_s3(
                         ExtraArgs={"ContentType": "application/x-ndjson"},
                     )
                     logger.info(f"Saved reasoning traces to S3 key {traces_key}")
+                    traces = presign(s3_client, s3_bucket, traces_key)
                 except Exception as e:
                     logger.error(
                         f"Failed to upload reasoning traces: {e}", exc_info=True
@@ -191,20 +257,13 @@ async def save_results_to_s3(
                     f"REASONING_TRACES_FILE={traces_path} is missing or empty; no traces uploaded"
                 )
 
-        try:
-            url: str = s3_client.generate_presigned_url(  # pyright: ignore
-                "get_object",
-                Params={"Bucket": s3_bucket, "Key": results_key},
-                ExpiresIn=259200,  # 3 days
-            )
-            return url, results_key  # pyright: ignore
-        except Exception as e:
-            logger.warning(f"Could not generate S3 presigned URL: {e}")
-            return None, results_key
+        return RunArtifacts(
+            results=presign(s3_client, s3_bucket, results_key), traces=traces
+        )
 
     except Exception as e:
         logger.error(f"Failed to save results to S3: {e}", exc_info=True)
-        return None, None
+        return RunArtifacts()
 
 
 class UnifiedTestExecutor:
@@ -357,7 +416,9 @@ class UnifiedTestExecutor:
             if step.duration:
                 await asyncio.sleep(step.duration)
             if step.target == "queue_empty":
-                # Flush mode is enabled by default in the harness (DERIVER_FLUSH_ENABLED=true)
+                # Flush is process-wide, not per-step: the harness starts the
+                # deriver with DERIVER_FLUSH_ENABLED=true so batches never wait
+                # on the token threshold. See tests/bench/harness.py.
                 await self.wait_for_queue(step.timeout)
 
         elif isinstance(step, ScheduleDreamAction):
@@ -771,30 +832,41 @@ class UnifiedTestRunner:
 
             # 5. Save results and send notifications
             # Always attempt S3 upload - save_results_to_s3 will check for credentials
-            url: str | None
-            s3_key: str | None
-            url, s3_key = await save_results_to_s3(
+            artifacts = await save_results_to_s3(
                 results, failed_count, total_count, total_suite_time
             )
 
-            # 6. Send Discord notification
+            # 6. Report the run: GitHub job summary, then Discord.
+            passed_count = total_count - failed_count
+            status_emoji = "✅" if failed_count == 0 else "⚠️"
+            headline = (
+                f"Results: {passed_count}/{total_count} passed, "
+                f"{failed_count}/{total_count} failed"
+            )
+
+            write_job_summary(
+                [
+                    f"## {status_emoji} Unified Test Results",
+                    "",
+                    headline,
+                    "",
+                    f"Execution time: {total_suite_time:.2f}s",
+                    "",
+                    *artifact_lines(artifacts),
+                ]
+            )
+
             discord_webhook_url = os.getenv("TEST_DISCORD_WEBHOOK_URL")
             if discord_webhook_url:
-                passed_count = total_count - failed_count
-                status_emoji = "✅" if failed_count == 0 else "⚠️"
-
                 message_lines = [
                     f"{status_emoji} **Unified Test Results**",
-                    f"Results: {passed_count}/{total_count} passed, {failed_count}/{total_count} failed",
+                    headline,
                     f"Execution time: {total_suite_time:.2f}s",
+                    *artifact_lines(artifacts),
                 ]
-                if s3_key:
-                    message_lines.append(f"File: `{s3_key}`")
-                if url:
-                    message_lines.append(f"[View Complete Results]({url})")
-                message = "\n".join(message_lines)
-
-                await send_discord_message(discord_webhook_url, message)
+                await send_discord_message(
+                    discord_webhook_url, "\n".join(message_lines)
+                )
 
             return failed_count
 

--- a/tests/unified/runner.py
+++ b/tests/unified/runner.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import httpx
 from anthropic import AsyncAnthropic
@@ -81,22 +81,35 @@ class TestExecutionError(Exception):
 DISCORD_MAX_CONTENT = 2000
 
 
-def truncate(text: str, limit: int) -> str:
-    """Clip `text` to `limit` characters, marking that it was clipped."""
-    if len(text) <= limit:
-        return text
-    return text[: limit - 1].rstrip() + "…"
+def clamp_lines(lines: list[str], limit: int) -> str:
+    """Join `lines` within `limit`, dropping the longest ones first if needed.
+
+    Whole lines rather than characters: a presigned URL cut in half is useless
+    and renders as broken markdown. Longest-first rather than last-first because
+    the only lines that can blow the budget are presigned URLs — dropping one of
+    those keeps every short, always-valid link, the Actions run link above all,
+    instead of losing them to a long URL that merely came first.
+    """
+    kept = list(range(len(lines)))
+
+    def size() -> int:
+        return sum(len(lines[i]) for i in kept) + max(0, len(kept) - 1)
+
+    while kept and size() > limit:
+        kept.remove(max(kept, key=lambda i: len(lines[i])))
+    return "\n".join(lines[i] for i in sorted(kept))
 
 
-async def send_discord_message(webhook_url: str, message: str) -> None:
-    """Send a message to Discord via webhook.
+async def send_discord_message(webhook_url: str, lines: list[str]) -> None:
+    """Send a report to Discord via webhook.
 
-    Clamped to Discord's content limit here rather than at the call site, so an
-    over-long report loses its tail instead of the whole notification.
+    Clamped to Discord's content limit here rather than at the call site: a
+    presigned URL carries an OIDC session token and can run past a thousand
+    characters on its own, and a 400 loses the whole notification.
     """
     try:
         async with httpx.AsyncClient() as client:
-            content = truncate(message, DISCORD_MAX_CONTENT)
+            content = clamp_lines(lines, DISCORD_MAX_CONTENT)
             response = await client.post(webhook_url, json={"content": content})
             response.raise_for_status()
             logger.info("Discord notification sent successfully")
@@ -119,6 +132,9 @@ class StepFailure:
 @dataclass
 class TestOutcome:
     """One test's result. `failure` carries the reason whenever status isn't PASS."""
+
+    # Not a pytest case despite the name; keeps collection from warning on it.
+    __test__: ClassVar[bool] = False
 
     status: str
     duration: float
@@ -159,49 +175,47 @@ def presign(s3_client: Any, bucket: str, key: str) -> RunArtifact:
         return RunArtifact(key=key)
 
 
-def artifact_lines(artifacts: RunArtifacts) -> list[str]:
-    """Render each uploaded artifact as one markdown line: link when presigned, key otherwise.
+def artifact_line(label: str, artifact: RunArtifact | None) -> list[str]:
+    """One markdown line for an artifact: a link when presigned, the key otherwise."""
+    if artifact is None:
+        return []
+    if artifact.url:
+        return [f"[{label}]({artifact.url}) — `{artifact.key}`"]
+    return [f"{label}: `{artifact.key}`"]
 
-    Both artifacts are surfaced. The reasoning traces carry the full prompts and
+
+def artifact_lines(artifacts: RunArtifacts) -> list[str]:
+    """Both uploaded artifacts. The reasoning traces carry the full prompts and
     model outputs for the run, which is what a failure usually needs to diagnose.
     """
-    labels = [
-        ("Complete results", artifacts.results),
-        ("Reasoning traces", artifacts.traces),
-    ]
-    lines: list[str] = []
-    for label, artifact in labels:
-        if artifact is None:
-            continue
-        if artifact.url:
-            lines.append(f"[{label}]({artifact.url}) — `{artifact.key}`")
-        else:
-            lines.append(f"{label}: `{artifact.key}`")
-    return lines
+    return artifact_line("View Complete Results", artifacts.results) + artifact_line(
+        "Reasoning traces", artifacts.traces
+    )
 
 
-def failure_lines(
-    results: dict[str, "TestOutcome"],
-    limit: int | None = None,
-    max_reason_chars: int | None = None,
-) -> list[str]:
-    """One markdown bullet per failing test, naming the step and the reason.
+def gha_run_lines() -> list[str]:
+    """Link to this run's Actions page, which hosts the job summary.
 
-    An LLM-judge verdict runs to several hundred characters, so callers with a
-    size budget pass `max_reason_chars`; the job summary and S3 keep them whole.
+    That summary carries the per-test failure reasons in full, so the Discord
+    message can stay short and point at it instead of restating them.
     """
+    run_id = os.getenv("GITHUB_RUN_ID")
+    repository = os.getenv("GITHUB_REPOSITORY")
+    if not run_id or not repository:
+        return []
+    server = os.getenv("GITHUB_SERVER_URL", "https://github.com")
+    return [f"[View GHA]({server}/{repository}/actions/runs/{run_id})"]
+
+
+def failure_lines(results: dict[str, "TestOutcome"]) -> list[str]:
+    """One markdown bullet per failing test, naming the step and the reason."""
     failed = [(name, o) for name, o in results.items() if o.status != "PASS"]
     if not failed:
         return []
-    shown = failed if limit is None else failed[:limit]
     lines = ["", "**Failures**"]
-    for name, outcome in shown:
+    for name, outcome in failed:
         reason = outcome.failure.describe() if outcome.failure else outcome.status
-        if max_reason_chars is not None:
-            reason = truncate(reason, max_reason_chars)
         lines.append(f"- `{name}` — {reason}")
-    if len(shown) < len(failed):
-        lines.append(f"- …and {len(failed) - len(shown)} more")
     return lines
 
 
@@ -948,12 +962,15 @@ class UnifiedTestRunner:
                     f"{status_emoji} **Unified Test Results**",
                     headline,
                     f"Execution time: {total_suite_time:.2f}s",
-                    *failure_lines(results, limit=10, max_reason_chars=160),
-                    *artifact_lines(artifacts),
+                    *artifact_line("View Complete Results", artifacts.results),
+                    *gha_run_lines(),
+                    *(
+                        [f"Reasoning traces: `{artifacts.traces.key}`"]
+                        if artifacts.traces
+                        else []
+                    ),
                 ]
-                await send_discord_message(
-                    discord_webhook_url, "\n".join(message_lines)
-                )
+                await send_discord_message(discord_webhook_url, message_lines)
 
             return failed_count
 

--- a/tests/unified/runner.py
+++ b/tests/unified/runner.py
@@ -77,11 +77,27 @@ class TestExecutionError(Exception):
     pass
 
 
+# Discord rejects a webhook payload whose content exceeds this with a 400.
+DISCORD_MAX_CONTENT = 2000
+
+
+def truncate(text: str, limit: int) -> str:
+    """Clip `text` to `limit` characters, marking that it was clipped."""
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
 async def send_discord_message(webhook_url: str, message: str) -> None:
-    """Send a message to Discord via webhook."""
+    """Send a message to Discord via webhook.
+
+    Clamped to Discord's content limit here rather than at the call site, so an
+    over-long report loses its tail instead of the whole notification.
+    """
     try:
         async with httpx.AsyncClient() as client:
-            response = await client.post(webhook_url, json={"content": message})
+            content = truncate(message, DISCORD_MAX_CONTENT)
+            response = await client.post(webhook_url, json={"content": content})
             response.raise_for_status()
             logger.info("Discord notification sent successfully")
     except Exception:
@@ -165,9 +181,15 @@ def artifact_lines(artifacts: RunArtifacts) -> list[str]:
 
 
 def failure_lines(
-    results: dict[str, "TestOutcome"], limit: int | None = None
+    results: dict[str, "TestOutcome"],
+    limit: int | None = None,
+    max_reason_chars: int | None = None,
 ) -> list[str]:
-    """One markdown bullet per failing test, naming the step and the reason."""
+    """One markdown bullet per failing test, naming the step and the reason.
+
+    An LLM-judge verdict runs to several hundred characters, so callers with a
+    size budget pass `max_reason_chars`; the job summary and S3 keep them whole.
+    """
     failed = [(name, o) for name, o in results.items() if o.status != "PASS"]
     if not failed:
         return []
@@ -175,6 +197,8 @@ def failure_lines(
     lines = ["", "**Failures**"]
     for name, outcome in shown:
         reason = outcome.failure.describe() if outcome.failure else outcome.status
+        if max_reason_chars is not None:
+            reason = truncate(reason, max_reason_chars)
         lines.append(f"- `{name}` — {reason}")
     if len(shown) < len(failed):
         lines.append(f"- …and {len(failed) - len(shown)} more")
@@ -924,7 +948,7 @@ class UnifiedTestRunner:
                     f"{status_emoji} **Unified Test Results**",
                     headline,
                     f"Execution time: {total_suite_time:.2f}s",
-                    *failure_lines(results, limit=10),
+                    *failure_lines(results, limit=10, max_reason_chars=160),
                     *artifact_lines(artifacts),
                 ]
                 await send_discord_message(

--- a/tests/unified/runner.py
+++ b/tests/unified/runner.py
@@ -89,6 +89,27 @@ async def send_discord_message(webhook_url: str, message: str) -> None:
 
 
 @dataclass
+class StepFailure:
+    """Why a test stopped: the step that raised, and what it said."""
+
+    step_index: int
+    step_type: str
+    message: str
+
+    def describe(self) -> str:
+        return f"step {self.step_index} ({self.step_type}): {self.message}"
+
+
+@dataclass
+class TestOutcome:
+    """One test's result. `failure` carries the reason whenever status isn't PASS."""
+
+    status: str
+    duration: float
+    failure: StepFailure | None = None
+
+
+@dataclass
 class RunArtifact:
     """One uploaded file: its S3 key, and a presigned URL when one could be made."""
 
@@ -143,6 +164,23 @@ def artifact_lines(artifacts: RunArtifacts) -> list[str]:
     return lines
 
 
+def failure_lines(
+    results: dict[str, "TestOutcome"], limit: int | None = None
+) -> list[str]:
+    """One markdown bullet per failing test, naming the step and the reason."""
+    failed = [(name, o) for name, o in results.items() if o.status != "PASS"]
+    if not failed:
+        return []
+    shown = failed if limit is None else failed[:limit]
+    lines = ["", "**Failures**"]
+    for name, outcome in shown:
+        reason = outcome.failure.describe() if outcome.failure else outcome.status
+        lines.append(f"- `{name}` — {reason}")
+    if len(shown) < len(failed):
+        lines.append(f"- …and {len(failed) - len(shown)} more")
+    return lines
+
+
 def write_job_summary(lines: list[str]) -> None:
     """Append a markdown block to the GitHub Actions job summary; a no-op locally."""
     summary_path = os.getenv("GITHUB_STEP_SUMMARY")
@@ -156,7 +194,7 @@ def write_job_summary(lines: list[str]) -> None:
 
 
 async def save_results_to_s3(
-    results: dict[str, tuple[str, float]],
+    results: dict[str, TestOutcome],
     failed_count: int,
     total_count: int,
     execution_time: float,
@@ -205,10 +243,21 @@ async def save_results_to_s3(
             "tests": [
                 {
                     "name": name,
-                    "status": status,
-                    "duration": duration,
+                    "status": outcome.status,
+                    "duration": outcome.duration,
+                    # The reason a test failed lives only in the job log otherwise,
+                    # where secret masking can render it unreadable.
+                    "failure": (
+                        {
+                            "step_index": outcome.failure.step_index,
+                            "step_type": outcome.failure.step_type,
+                            "message": outcome.failure.message,
+                        }
+                        if outcome.failure
+                        else None
+                    ),
                 }
-                for name, (status, duration) in results.items()
+                for name, outcome in results.items()
             ],
         }
 
@@ -307,7 +356,10 @@ class UnifiedTestExecutor:
             )
         return response
 
-    async def execute(self, test_def: TestDefinition, test_name: str) -> bool:
+    async def execute(
+        self, test_def: TestDefinition, test_name: str
+    ) -> StepFailure | None:
+        """Run every step. Returns None on success, or the failure that stopped it."""
         logger.info(f"Starting test: {test_name}")
 
         # 1. Apply workspace config if present
@@ -323,10 +375,12 @@ class UnifiedTestExecutor:
                 await self.execute_step(step)
             except Exception as e:
                 logger.error(f"Step {i + 1} failed: {e}", exc_info=False)
-                return False
+                return StepFailure(
+                    step_index=i + 1, step_type=step.step_type, message=str(e)
+                )
 
         logger.info(f"Test {test_name} PASSED")
-        return True
+        return None
 
     async def execute_step(self, step: Any):
         if isinstance(step, SetWorkspaceConfigAction):
@@ -753,7 +807,7 @@ class UnifiedTestRunner:
                     raise ValueError("tests_dir must be set if test_file is not")
                 test_files = sorted(list(self.tests_dir.glob("*.json")))
 
-            results: dict[str, tuple[str, float]] = {}
+            results: dict[str, TestOutcome] = {}
 
             logger.info(f"Found {len(test_files)} test(s)")
 
@@ -782,23 +836,28 @@ class UnifiedTestRunner:
                         workspace_id=f"test_{test_name}_{int(time.time())}",
                     )
 
-                    success = await executor.execute(test_def, test_name)
+                    failure = await executor.execute(test_def, test_name)
                     test_duration = time.time() - test_start_time
-                    results[test_file.name] = (
-                        "PASS" if success else "FAIL",
-                        test_duration,
+                    results[test_file.name] = TestOutcome(
+                        status="PASS" if failure is None else "FAIL",
+                        duration=test_duration,
+                        failure=failure,
                     )
 
                 except ValidationError as e:
                     logger.error(f"Schema validation failed for {test_file}: {e}")
                     test_duration = time.time() - test_start_time
-                    results[test_file.name] = ("INVALID SCHEMA", test_duration)
+                    results[test_file.name] = TestOutcome(
+                        status="INVALID SCHEMA", duration=test_duration
+                    )
                 except Exception as e:
                     logger.error(
                         f"Test {test_file.name} failed with error: {e}", exc_info=True
                     )
                     test_duration = time.time() - test_start_time
-                    results[test_file.name] = (f"ERROR: {str(e)}", test_duration)
+                    results[test_file.name] = TestOutcome(
+                        status=f"ERROR: {str(e)}", duration=test_duration
+                    )
 
             total_suite_time = time.time() - suite_start_time
 
@@ -813,16 +872,18 @@ class UnifiedTestRunner:
             # Calculate max name length for alignment
             max_name_length = max(len(name) for name in results) if results else 0
 
-            for name, (status, duration) in results.items():
-                duration_str = f"({duration:.2f}s)"
-                if status == "PASS":
+            for name, outcome in results.items():
+                duration_str = f"({outcome.duration:.2f}s)"
+                if outcome.status == "PASS":
                     print(
-                        f"{name:<{max_name_length}} {GREEN}{status:<15}{RESET} {duration_str}"
+                        f"{name:<{max_name_length}} {GREEN}{outcome.status:<15}{RESET} {duration_str}"
                     )
                 else:
                     print(
-                        f"{name:<{max_name_length}} {RED}{status:<15}{RESET} {duration_str}"
+                        f"{name:<{max_name_length}} {RED}{outcome.status:<15}{RESET} {duration_str}"
                     )
+                    if outcome.failure:
+                        print(f"{'':<{max_name_length}} {outcome.failure.describe()}")
                     failed_count += 1
 
             print("=" * 60)
@@ -851,6 +912,7 @@ class UnifiedTestRunner:
                     headline,
                     "",
                     f"Execution time: {total_suite_time:.2f}s",
+                    *failure_lines(results),
                     "",
                     *artifact_lines(artifacts),
                 ]
@@ -862,6 +924,7 @@ class UnifiedTestRunner:
                     f"{status_emoji} **Unified Test Results**",
                     headline,
                     f"Execution time: {total_suite_time:.2f}s",
+                    *failure_lines(results, limit=10),
                     *artifact_lines(artifacts),
                 ]
                 await send_discord_message(

--- a/tests/unified/schema.py
+++ b/tests/unified/schema.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from src.config import ReasoningLevel
 from src.schemas import (
@@ -14,6 +14,8 @@ from src.schemas import (
 
 
 class TestStep(BaseModel):
+    model_config = ConfigDict(extra="forbid")  # pyright: ignore
+
     description: str | None = None
 
 
@@ -89,10 +91,6 @@ class WaitAction(TestStep):
     )
     target: Literal["queue_empty"] = "queue_empty"
     timeout: int = 60
-    flush: bool = Field(
-        False,
-        description="Enable flush mode to bypass batch token threshold before waiting",
-    )
 
 
 # --- Dream Actions ---

--- a/tests/unified/test_cases/config_deriver_hierarchy.json
+++ b/tests/unified/test_cases/config_deriver_hierarchy.json
@@ -34,8 +34,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",
@@ -86,8 +85,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/config_message_positive_override.json
+++ b/tests/unified/test_cases/config_message_positive_override.json
@@ -36,8 +36,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/config_peercard_control.json
+++ b/tests/unified/test_cases/config_peercard_control.json
@@ -38,8 +38,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/config_summary_control.json
+++ b/tests/unified/test_cases/config_summary_control.json
@@ -77,15 +77,14 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",
       "target": "get_context",
       "session_id": "session_summary",
       "summary": true,
-      "max_tokens": 400,
+      "max_tokens": 2500,
       "observer_peer_id": "eve",
       "assertions": [
         {

--- a/tests/unified/test_cases/config_summary_control.json
+++ b/tests/unified/test_cases/config_summary_control.json
@@ -84,7 +84,7 @@
       "target": "get_context",
       "session_id": "session_summary",
       "summary": true,
-      "max_tokens": 2500,
+      "max_tokens": 4000,
       "observer_peer_id": "eve",
       "assertions": [
         {

--- a/tests/unified/test_cases/config_summary_control.json
+++ b/tests/unified/test_cases/config_summary_control.json
@@ -85,7 +85,7 @@
       "session_id": "session_summary",
       "summary": true,
       "max_tokens": 4000,
-      "observer_peer_id": "eve",
+      "description": "Unscoped read, so the summary gets 40% of max_tokens. Naming an observer would route through the peer_target path, where the representation and peer card are subtracted from the budget first.",
       "assertions": [
         {
           "assertion_type": "llm_judge",

--- a/tests/unified/test_cases/config_summary_control_deriver_off.json
+++ b/tests/unified/test_cases/config_summary_control_deriver_off.json
@@ -76,15 +76,14 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",
       "target": "get_context",
       "session_id": "session_summary",
       "summary": true,
-      "max_tokens": 400,
+      "max_tokens": 2500,
       "observer_peer_id": "eve",
       "assertions": [
         {

--- a/tests/unified/test_cases/config_summary_control_deriver_off.json
+++ b/tests/unified/test_cases/config_summary_control_deriver_off.json
@@ -84,7 +84,7 @@
       "session_id": "session_summary",
       "summary": true,
       "max_tokens": 4000,
-      "observer_peer_id": "eve",
+      "description": "Unscoped read, so the summary gets 40% of max_tokens. Naming an observer would route through the peer_target path, where the representation and peer card are subtracted from the budget first.",
       "assertions": [
         {
           "assertion_type": "llm_judge",

--- a/tests/unified/test_cases/config_summary_control_deriver_off.json
+++ b/tests/unified/test_cases/config_summary_control_deriver_off.json
@@ -83,7 +83,7 @@
       "target": "get_context",
       "session_id": "session_summary",
       "summary": true,
-      "max_tokens": 2500,
+      "max_tokens": 4000,
       "observer_peer_id": "eve",
       "assertions": [
         {

--- a/tests/unified/test_cases/dialectic_reasoning_levels.json
+++ b/tests/unified/test_cases/dialectic_reasoning_levels.json
@@ -45,8 +45,7 @@
     {
       "step_type": "wait",
       "target": "queue_empty",
-      "timeout": 120,
-      "flush": true
+      "timeout": 120
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/dialectic_structured_output.json
+++ b/tests/unified/test_cases/dialectic_structured_output.json
@@ -80,8 +80,7 @@
     {
       "step_type": "wait",
       "target": "queue_empty",
-      "timeout": 180,
-      "flush": true
+      "timeout": 180
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/dialectic_tool_calls.json
+++ b/tests/unified/test_cases/dialectic_tool_calls.json
@@ -80,8 +80,7 @@
     {
       "step_type": "wait",
       "target": "queue_empty",
-      "timeout": 180,
-      "flush": true
+      "timeout": 180
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/dream_knowledge_updates_and_patterns.json
+++ b/tests/unified/test_cases/dream_knowledge_updates_and_patterns.json
@@ -44,8 +44,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "add_messages",
@@ -75,8 +74,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "add_messages",
@@ -114,8 +112,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "schedule_dream",
@@ -127,8 +124,7 @@
     {
       "step_type": "wait",
       "target": "queue_empty",
-      "timeout": 180,
-      "flush": true
+      "timeout": 180
     },
     {
       "step_type": "query",
@@ -148,7 +144,6 @@
       "target": "get_representation",
       "observer_peer_id": "assistant",
       "observed_peer_id": "maya",
-      "session_id": "maya_life_story",
       "assertions": [
         {
           "assertion_type": "llm_judge",

--- a/tests/unified/test_cases/longmem_ancash.json
+++ b/tests/unified/test_cases/longmem_ancash.json
@@ -75,8 +75,7 @@
     {
       "step_type": "wait",
       "target": "queue_empty",
-      "timeout": 180,
-      "flush": true
+      "timeout": 180
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/longmem_ancash_directional.json
+++ b/tests/unified/test_cases/longmem_ancash_directional.json
@@ -74,8 +74,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/longmem_ancash_no_session.json
+++ b/tests/unified/test_cases/longmem_ancash_no_session.json
@@ -74,8 +74,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/longmem_giftcard.json
+++ b/tests/unified/test_cases/longmem_giftcard.json
@@ -3664,7 +3664,7 @@
     {
       "step_type": "wait",
       "target": "queue_empty",
-      "flush": true
+      "timeout": 600
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/longmem_plank.json
+++ b/tests/unified/test_cases/longmem_plank.json
@@ -154,8 +154,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/longmem_triple_7161e7e2_single-session-assistant.json
+++ b/tests/unified/test_cases/longmem_triple_7161e7e2_single-session-assistant.json
@@ -3719,7 +3719,7 @@
     {
       "step_type": "wait",
       "target": "queue_empty",
-      "flush": true
+      "timeout": 600
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/longmem_triple_e47becba_single-session-user.json
+++ b/tests/unified/test_cases/longmem_triple_e47becba_single-session-user.json
@@ -3833,8 +3833,7 @@
     {
       "step_type": "wait",
       "target": "queue_empty",
-      "timeout": 600,
-      "flush": true
+      "timeout": 600
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/longmem_triple_gpt4_59149c77_temporal-reasoning.json
+++ b/tests/unified/test_cases/longmem_triple_gpt4_59149c77_temporal-reasoning.json
@@ -3431,7 +3431,7 @@
     {
       "step_type": "wait",
       "target": "queue_empty",
-      "flush": true
+      "timeout": 600
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/message_deriver_disabled.json
+++ b/tests/unified/test_cases/message_deriver_disabled.json
@@ -40,8 +40,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_2peer_bidirectional.json
+++ b/tests/unified/test_cases/observation_2peer_bidirectional.json
@@ -40,8 +40,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_2peer_both_observe_me_false.json
+++ b/tests/unified/test_cases/observation_2peer_both_observe_me_false.json
@@ -40,8 +40,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_2peer_default.json
+++ b/tests/unified/test_cases/observation_2peer_default.json
@@ -40,8 +40,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_2peer_observe_me_false_blocks_observation.json
+++ b/tests/unified/test_cases/observation_2peer_observe_me_false_blocks_observation.json
@@ -40,8 +40,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_2peer_observe_me_false_but_can_still_observe_others.json
+++ b/tests/unified/test_cases/observation_2peer_observe_me_false_but_can_still_observe_others.json
@@ -40,8 +40,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_2peer_unidirectional_alice_observes_bob.json
+++ b/tests/unified/test_cases/observation_2peer_unidirectional_alice_observes_bob.json
@@ -40,8 +40,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_2peer_unidirectional_bob_observes_alice.json
+++ b/tests/unified/test_cases/observation_2peer_unidirectional_bob_observes_alice.json
@@ -40,8 +40,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_3peer_all_observe_each_other.json
+++ b/tests/unified/test_cases/observation_3peer_all_observe_each_other.json
@@ -52,8 +52,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_3peer_circular.json
+++ b/tests/unified/test_cases/observation_3peer_circular.json
@@ -52,8 +52,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_3peer_multiple_observers_one_observed.json
+++ b/tests/unified/test_cases/observation_3peer_multiple_observers_one_observed.json
@@ -48,8 +48,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",
@@ -130,8 +129,7 @@
     {
       "step_type": "wait",
       "target": "queue_empty",
-      "timeout": 180,
-      "flush": true
+      "timeout": 180
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_3peer_one_observer_multiple_observed.json
+++ b/tests/unified/test_cases/observation_3peer_one_observer_multiple_observed.json
@@ -48,8 +48,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_3peer_selective_observation.json
+++ b/tests/unified/test_cases/observation_3peer_selective_observation.json
@@ -48,8 +48,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_4peer_complex_matrix.json
+++ b/tests/unified/test_cases/observation_4peer_complex_matrix.json
@@ -52,8 +52,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_asymmetric_visibility.json
+++ b/tests/unified/test_cases/observation_asymmetric_visibility.json
@@ -40,8 +40,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "create_session",
@@ -77,8 +76,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/observation_isolation_between_sessions.json
+++ b/tests/unified/test_cases/observation_isolation_between_sessions.json
@@ -40,8 +40,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "create_session",
@@ -77,8 +76,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/peer_isolation_test.json
+++ b/tests/unified/test_cases/peer_isolation_test.json
@@ -48,8 +48,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "create_session",
@@ -81,8 +80,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/scope_confines_recall.json
+++ b/tests/unified/test_cases/scope_confines_recall.json
@@ -55,8 +55,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/session_deriver_disabled.json
+++ b/tests/unified/test_cases/session_deriver_disabled.json
@@ -30,8 +30,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/workspace_chat_cross_peer.json
+++ b/tests/unified/test_cases/workspace_chat_cross_peer.json
@@ -68,8 +68,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/workspace_chat_from_observations.json
+++ b/tests/unified/test_cases/workspace_chat_from_observations.json
@@ -52,8 +52,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_cases/workspace_deriver_disabled.json
+++ b/tests/unified/test_cases/workspace_deriver_disabled.json
@@ -30,8 +30,7 @@
     },
     {
       "step_type": "wait",
-      "target": "queue_empty",
-      "flush": true
+      "target": "queue_empty"
     },
     {
       "step_type": "query",

--- a/tests/unified/test_reporting.py
+++ b/tests/unified/test_reporting.py
@@ -1,0 +1,143 @@
+"""Tests for how a unified run is reported to Discord and the job summary.
+
+Discord rejects an over-long payload with a 400, which loses the whole
+notification, so the size behavior here is worth pinning down.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unified.runner import (
+    DISCORD_MAX_CONTENT,
+    RunArtifact,
+    RunArtifacts,
+    StepFailure,
+    TestOutcome,
+    artifact_line,
+    artifact_lines,
+    clamp_lines,
+    failure_lines,
+    gha_run_lines,
+)
+
+_PREFIX = "unified-test-results/2026-09-03/1123-merge-abc1234-33779689337-1"
+
+
+def _presigned(name: str, token_len: int) -> RunArtifact:
+    """A presigned URL of realistic shape; OIDC session tokens dominate its length."""
+    url = (
+        f"https://honcho-unified-tests.s3.amazonaws.com/{_PREFIX}/{name}"
+        "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=259200"
+        f"&X-Amz-Security-Token={'t' * token_len}&X-Amz-Signature={'0' * 64}"
+    )
+    return RunArtifact(key=f"{_PREFIX}/{name}", url=url)
+
+
+def _discord_lines(artifacts: RunArtifacts) -> list[str]:
+    """Mirror of the Discord report the runner assembles."""
+    return [
+        "⚠️ **Unified Test Results**",
+        "Results: 35/41 passed, 6/41 failed",
+        "Execution time: 1015.42s",
+        *artifact_line("View Complete Results", artifacts.results),
+        *gha_run_lines(),
+        *([f"Reasoning traces: `{artifacts.traces.key}`"] if artifacts.traces else []),
+    ]
+
+
+@pytest.fixture
+def in_actions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_RUN_ID", "33779689337")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "plastic-labs/honcho")
+
+
+def test_clamp_lines_leaves_a_short_report_alone() -> None:
+    lines = ["one", "two", "three"]
+    assert clamp_lines(lines, DISCORD_MAX_CONTENT) == "one\ntwo\nthree"
+
+
+def test_clamp_lines_drops_the_longest_line_not_the_last() -> None:
+    """The Actions link is short and leads everywhere; a presigned URL is neither."""
+    lines = ["head", "x" * 100, "[View GHA](url)"]
+    assert clamp_lines(lines, 40) == "head\n[View GHA](url)"
+
+
+def test_clamp_lines_preserves_display_order() -> None:
+    lines = ["a", "y" * 50, "b", "c"]
+    assert clamp_lines(lines, 10) == "a\nb\nc"
+
+
+@pytest.mark.usefixtures("in_actions")
+@pytest.mark.parametrize("token_len", [0, 400, 900, 1400, 1800])
+def test_discord_report_never_exceeds_the_webhook_limit(token_len: int) -> None:
+    """Regression: six judge verdicts plus two presigned URLs returned a 400."""
+    artifacts = RunArtifacts(
+        results=_presigned("results.json", token_len),
+        traces=_presigned("unified-reasoning-traces.jsonl", token_len),
+    )
+    sent = clamp_lines(_discord_lines(artifacts), DISCORD_MAX_CONTENT)
+    assert len(sent) <= DISCORD_MAX_CONTENT
+
+
+@pytest.mark.usefixtures("in_actions")
+@pytest.mark.parametrize("token_len", [0, 400, 900, 1400, 1800])
+def test_actions_link_always_survives_clamping(token_len: int) -> None:
+    """However long the presigned URLs get, the run stays reachable."""
+    artifacts = RunArtifacts(
+        results=_presigned("results.json", token_len),
+        traces=_presigned("unified-reasoning-traces.jsonl", token_len),
+    )
+    sent = clamp_lines(_discord_lines(artifacts), DISCORD_MAX_CONTENT)
+    assert (
+        "[View GHA](https://github.com/plastic-labs/honcho/actions/runs/33779689337)"
+        in sent
+    )
+
+
+@pytest.mark.usefixtures("in_actions")
+def test_discord_report_omits_per_test_failures() -> None:
+    """Failure detail belongs in the job summary the Actions link points at."""
+    artifacts = RunArtifacts(results=_presigned("results.json", 400))
+    assert not any("**Failures**" in line for line in _discord_lines(artifacts))
+
+
+def test_gha_lines_are_empty_outside_actions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    assert gha_run_lines() == []
+
+
+def test_artifact_line_falls_back_to_the_key_when_presigning_failed() -> None:
+    assert artifact_line("Traces", RunArtifact(key="k/x.jsonl")) == [
+        "Traces: `k/x.jsonl`"
+    ]
+    assert artifact_line("Traces", None) == []
+
+
+def test_job_summary_keeps_both_signed_links() -> None:
+    artifacts = RunArtifacts(
+        results=_presigned("results.json", 900),
+        traces=_presigned("unified-reasoning-traces.jsonl", 900),
+    )
+    lines = artifact_lines(artifacts)
+    assert len(lines) == 2
+    assert all("https://" in line for line in lines)
+
+
+def test_failure_lines_reports_every_failure_in_full() -> None:
+    reason = "LLM Judge failed: " + "the model did not recall the fact. " * 20
+    results = {
+        "a.json": TestOutcome("FAIL", 1.0, StepFailure(4, "query", reason)),
+        "b.json": TestOutcome("PASS", 1.0),
+        "c.json": TestOutcome("INVALID SCHEMA", 0.1),
+    }
+    lines = failure_lines(results)
+    assert lines[:2] == ["", "**Failures**"]
+    assert len(lines) == 4  # blank, header, and one bullet per non-PASS
+    assert reason in lines[2]  # untruncated
+    assert "INVALID SCHEMA" in lines[3]  # falls back to status when no StepFailure
+
+
+def test_failure_lines_empty_when_everything_passed() -> None:
+    assert failure_lines({"a.json": TestOutcome("PASS", 1.0)}) == []


### PR DESCRIPTION
# Human

This cleans up 3 tests and makes one (apparently) fail for real reasons. I'd like to stop here for now and not go down this rabbit hole. Further cleanup should be other tickets.

# Claude

DEV-2580

Repairs the `unified-tests` failures that DEV-2579 didn't cover. These are not regressions — the fixtures assert things the code cannot produce, and have failed since #1083 un-skipped the suite on 2026-08-26.

Measured at 6 failures, down from 7 ([run 33785048119](https://github.com/plastic-labs/honcho/actions/runs/33785048119)). Three longmem cases and the dream representation assertion are fixed; `config_summary` is not, and the reason is still open — see below.

## Changes

**Fixtures**
- Three longmem cases get `timeout: 600`. They ingest 484–550 messages across ~50 sessions, then hit the 60s `WaitAction` default while the deriver is still working. Matches `longmem_triple_e47becba`, the same-size case that already passes.
- Both `config_summary_control` cases get `max_tokens: 4000` — see below.
- `dream_knowledge_updates_and_patterns` step 10 drops `session_id`. A bare session id becomes a one-element allowlist (`peers.py:534`), and an allowlist narrows levels to `ALLOWLIST_SAFE_LEVELS = ("explicit",)` (`representation.py:584`), so the deductive and inductive observations that step asserts on are excluded by design (DEV-2201). Steps 11–13 keep theirs; `chat` is a different path.

**Schema**
- `WaitAction.flush` deleted. Declared, set in 47 places, never read — and unwireable: `DERIVER_FLUSH_ENABLED` is process-wide, set once at harness startup (`tests/bench/harness.py:522`). `TestStep` now sets `extra="forbid"` so a dead knob can't accumulate silently again.

**Reporting** (`tests/unified/runner.py`)
- `results.json` now records *why* a test failed — step index, step type, and the message, including the LLM judge's reasoning. It previously carried only name/status/duration, so a red run said nothing about the cause. S3 artifacts aren't subject to GHA masking, so this stays readable when the job log doesn't.
- Reasoning traces are presigned alongside `results.json` and both appear in a new job summary. They were already uploaded but never surfaced.
- The Discord message is the headline, the results link, an Actions link, and the traces S3 key. Failure detail lives in the job summary it points at.

**API** (`src/routers/sessions.py`, +13 lines)
- `_select_summary_for_context` logs when summaries exist but none fits the budget. Previously the caller got `summary: null`, indistinguishable from "no summary exists", with only a debug line in another module.

## `config_summary` is still unexplained

Both cases still fail with `summary: null` after raising `max_tokens` to 4000, and the budget is not the reason.

`get_context` has two paths. With a `peer_target` it subtracts the representation and card before the 40% split; without one the summary simply gets 40% of `tokens`. These fixtures set `observer_peer_id`, but the runner does not forward it to `get_context`, so they take the second path — a 99-token summary against a 1600-token budget.

Ruled out so far: the token budget (arithmetic above), the empty-response fallback that skips persistence (`_create_and_save_summary` guards the save with `if not is_fallback`, and neither of its error logs appears), a stale cached session (`_save_summary` invalidates; a test covering write-after-read passes), retrieval itself (a stored summary is served through the route), and a queue race (`summary` is in `_TRACKED_TASK_TYPES`, so `wait_for_queue` waits for it).

The summary is created — `SHORT_summary_size=99` — and is not visible to the reader a moment later. `get_session_context` reported that at debug, in a module the job log doesn't surface; it now logs at info with the budget and sizes, so the next run distinguishes "didn't fit" from "wasn't there". The `4000` is kept because it costs nothing and removes the budget as a variable.

`observer_peer_id` is dropped from both fixtures. The runner never forwarded it on a `get_context` step, so it read as scoping a request that was never scoped; the step description now records that these are unscoped reads. Forwarding it instead would change what the fixtures test, so that is left alone.

## Not included: the secret-masking item

Item 5 is deliberately out, and worth re-specifying rather than carrying as written:

1. **It names the wrong secret.** The testing-override secret holds seven `*_BASE_URL` entries and two token counts — nothing that eats digits. The staging dotenv is fetched with `parse-json-secrets: true` too and holds 1–3 digit values (`DERIVER_WORKERS` defaults to 1). Emptying the override secret would not change the symptom.
2. **No dependency does this.** `aws-actions/aws-secretsmanager-get-secrets` exposes only `secret-ids`, `name-transformation`, `parse-json-secrets` and a DNS timeout; masking is unconditional.
3. **GitHub's guidance is to avoid the situation** — don't encapsulate secrets in a JSON blob, use configuration variables for non-sensitive values. The real fix moves non-secret config to `vars.*`/`config.toml`, which touches a deploy-owned secret.

A value-shape classifier was prototyped and reverted: it guessed, and guessed in the direction where being wrong means an unmasked secret. `.github/` is untouched by this PR.

## Still failing after this

| test | why |
|---|---|
| `workspace_chat_scope` | Outside this ticket. #1120: "was passing vacuously and now fails honestly". |
| `workspace_chat_cross_peer`, `workspace_chat_from_observations` | Passed on `55a0519`, failed on the run above. Flaky on the small CI model; same shape as DEV-2579's unfinished half. |
| `longmem_triple_7161e7e2` | Timeout fixed — now reaches step 98 and fails on recall, not the harness. |
| `dream_knowledge_updates_and_patterns` | The representation assertion this PR fixed now passes. Step 10 (`get_peer_card`) failed on the latest run and passed on the one before — flaky on the CI model. |
| `config_summary_control` ×2 | See above. |

Worth knowing: **workspace chat emits no reasoning trace**, so the traces won't help diagnose the first two. Only 23 of 597 traces in the `55a0519` run were `dialectic_chat`, across 41 tests.

## Testing

- `pytest tests/unified/ tests/routes/ tests/utils/test_summarizer.py` — passing; full local suite green via pre-push
- New: `tests/unified/test_reporting.py` (Discord size behavior, artifact links, failure rendering) and `tests/routes/test_session_context_summary.py` (budget arithmetic at each limit, the new log line, stored-summary retrieval)
- `ruff check` and `basedpyright` clean
- **Needs a `run-unified-tests` label** to confirm the `config_summary` change. Local runs use the `config.py` default dialectic model; CI pins `gpt-5-nano` from the staging secret.

## Reviewer notes

- `extra="forbid"` on `TestStep` goes beyond deleting the field; it's why the field went unnoticed, and is proven non-breaking across all 41 cases. Easy to drop.
- A presigned URL carries an OIDC session token and can exceed 1000 characters, so two of them alone exceed Discord's 2000-char limit. Hence the traces go in as an S3 key, and `clamp_lines` drops whole lines longest-first so a long URL can't evict the short Actions link.
- `TestOutcome` carries `__test__ = False`; without it pytest tries to collect the dataclass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
