### PR TITLE
docs for programmatically creating api key

### DIFF
--- a/docs/v3/api-reference/endpoint/keys/create-key.mdx
+++ b/docs/v3/api-reference/endpoint/keys/create-key.mdx
@@ -3,11 +3,8 @@ openapi: post /v3/keys
 ---
 
 <Note>
-**Self-hosted only.** This endpoint is not available on Honcho Cloud
-(`api.honcho.dev`) — requests to it return `405 Method Not Allowed`. Create and
-manage keys for a cloud instance from the
-[API Keys page](https://app.honcho.dev/api-keys) in the dashboard.
-
-On a self-hosted instance it requires an admin key, and returns an error when
-`AUTH_USE_AUTH` is disabled.
+Requires an admin key. On Honcho Cloud (`api.honcho.dev`) the returned key is a
+real cloud key on the calling key's instance, attributed to its owner and
+revocable from the [API Keys page](https://app.honcho.dev/api-keys). On a
+self-hosted instance it returns an error when `AUTH_USE_AUTH` is disabled.
 </Note>

--- a/docs/v3/api-reference/endpoint/keys/create-key.mdx
+++ b/docs/v3/api-reference/endpoint/keys/create-key.mdx
@@ -7,4 +7,9 @@ Requires an admin key. On Honcho Cloud (`api.honcho.dev`) the returned key is a
 real cloud key on the calling key's instance, attributed to its owner and
 revocable from the [API Keys page](https://app.honcho.dev/api-keys). On a
 self-hosted instance it returns an error when `AUTH_USE_AUTH` is disabled.
+
+Provide at least one of `workspace_id`, `peer_id`, or `session_id` — a request
+carrying none of them is rejected. A key scoped to a peer or a session must also
+carry its `workspace_id`. On Honcho Cloud, pass either `admin=true` or a
+`workspace_id`.
 </Note>

--- a/docs/v3/documentation/reference/platform.mdx
+++ b/docs/v3/documentation/reference/platform.mdx
@@ -62,7 +62,7 @@ The **Performance** page provides comprehensive monitoring with usage metrics, h
 ## 3. Manage API Keys
 The [API Keys](https://app.honcho.dev/api-keys) page allows you to create and manage authentication tokens for different environments. You can create admin-level keys with full instance access or scope keys to a specific `Workspace`, `Peer`, or `Session`.
 
-Keys for a cloud instance can only be created here, not through the API — `POST /v3/keys` is disabled on `api.honcho.dev` and returns `405`. The same applies to the webhook management endpoints, which live on the [Webhooks](https://app.honcho.dev/webhooks) page.
+Keys can also be created programmatically. `POST /v3/keys` with an admin key returns a real cloud key on that key's instance, attributed to its owner and revocable from the [API Keys](https://app.honcho.dev/api-keys) page.
 
 Scoped keys are authorized by their narrowest claim and never widen to the whole workspace:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that cloud API keys can be created programmatically through the key creation endpoint.
  * Documented required scopes, including `workspace_id` for peer and session scopes.
  * Added cloud request requirements for admin access or workspace context.
  * Noted that created cloud keys are attributable and revocable.
  * Documented the self-hosted error returned when authentication is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->