### PR TITLE
refactor(utils): consolidate JSON narrowing helpers into src/utils/json_coerce.py

### DIFF
--- a/src/llm/conversation.py
+++ b/src/llm/conversation.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, cast
+from typing import Any
 
+from src.utils.json_coerce import as_dict, as_list
 from src.utils.tokens import estimate_tokens
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,24 @@ def count_message_tokens(messages: list[dict[str, Any]]) -> int:
     return total
 
 
+def _has_content_block(msg: dict[str, Any], block_type: str) -> bool:
+    """Whether an Anthropic-style ``content`` list carries a block of this type."""
+    for block in as_list(msg.get("content")) or ():
+        entry = as_dict(block)
+        if entry is not None and entry.get("type") == block_type:
+            return True
+    return False
+
+
+def _has_part_key(msg: dict[str, Any], key: str) -> bool:
+    """Whether a Gemini-style ``parts`` list carries an entry with this key."""
+    for part in as_list(msg.get("parts")) or ():
+        entry = as_dict(part)
+        if entry is not None and key in entry:
+            return True
+    return False
+
+
 def _is_tool_use_message(msg: dict[str, Any]) -> bool:
     """Check if a message contains tool calls (any format).
 
@@ -42,17 +61,11 @@ def _is_tool_use_message(msg: dict[str, Any]) -> bool:
     - Gemini: ``parts`` is a list containing a ``{"function_call": …}`` entry.
     - OpenAI: assistant message with a non-empty ``tool_calls`` field.
     """
-    content = msg.get("content")
-    if isinstance(content, list):
-        for block in cast(list[dict[str, Any]], content):
-            if block.get("type") == "tool_use":
-                return True
-    parts = msg.get("parts")
-    if isinstance(parts, list):
-        for part in cast(list[dict[str, Any]], parts):
-            if "function_call" in part:
-                return True
-    return bool(msg.get("tool_calls"))
+    return (
+        _has_content_block(msg, "tool_use")
+        or _has_part_key(msg, "function_call")
+        or bool(msg.get("tool_calls"))
+    )
 
 
 def _is_tool_result_message(msg: dict[str, Any]) -> bool:
@@ -63,17 +76,11 @@ def _is_tool_result_message(msg: dict[str, Any]) -> bool:
     - Gemini: ``parts`` is a list containing a ``{"function_response": …}`` entry.
     - OpenAI: message with ``role == "tool"``.
     """
-    content = msg.get("content")
-    if isinstance(content, list):
-        for block in cast(list[dict[str, Any]], content):
-            if block.get("type") == "tool_result":
-                return True
-    parts = msg.get("parts")
-    if isinstance(parts, list):
-        for part in cast(list[dict[str, Any]], parts):
-            if "function_response" in part:
-                return True
-    return msg.get("role") == "tool"
+    return (
+        _has_content_block(msg, "tool_result")
+        or _has_part_key(msg, "function_response")
+        or msg.get("role") == "tool"
+    )
 
 
 def _group_into_units(

--- a/src/mock_provider/chat.py
+++ b/src/mock_provider/chat.py
@@ -11,9 +11,9 @@ from typing import Any
 from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
-from src.mock_provider.coerce import as_dict, as_str
 from src.mock_provider.schema_gen import generate
 from src.mock_provider.schemas import ChatCompletionRequest, ChatMessage
+from src.utils.json_coerce import as_dict, as_str
 
 router = APIRouter(tags=["mock-provider"])
 

--- a/src/mock_provider/schema_gen.py
+++ b/src/mock_provider/schema_gen.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
-from src.mock_provider.coerce import as_dict, as_int, as_list, as_str
+from src.utils.json_coerce import as_dict, as_int, as_list, as_str
 
 # Depth cap for self-referential schemas. Reasoning-tree models nest premises
 # inside conclusions, so a $ref cycle is normal input, not a malformed schema.

--- a/src/utils/config_helpers.py
+++ b/src/utils/config_helpers.py
@@ -49,9 +49,8 @@ def normalize_configuration_dict(raw: dict[str, Any]) -> dict[str, Any]:
     """
     normalized: dict[str, Any] = dict(raw)
 
-    reasoning_raw = normalized.get("reasoning")
     reasoning_present = "reasoning" in normalized
-    reasoning: dict[str, Any] = dict(as_dict(reasoning_raw) or {})
+    reasoning: dict[str, Any] = dict(as_dict(normalized.get("reasoning")) or {})
     reasoning_enabled_explicit = reasoning.get("enabled") is not None
 
     if not reasoning_enabled_explicit:

--- a/src/utils/config_helpers.py
+++ b/src/utils/config_helpers.py
@@ -1,7 +1,7 @@
 """Configuration resolution utilities for hierarchical settings."""
 
 import logging
-from typing import Any, cast
+from typing import Any
 
 from src import models
 from src.config import settings
@@ -9,6 +9,7 @@ from src.schemas import (
     MessageConfiguration,
     ResolvedConfiguration,
 )
+from src.utils.json_coerce import as_dict
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +23,10 @@ def deep_update(base: dict[str, Any], update: dict[str, Any]) -> None:
         if value is None:
             continue
 
-        if isinstance(value, dict) and key in base and isinstance(base[key], dict):
-            deep_update(cast(dict[str, Any], base[key]), cast(dict[str, Any], value))
+        nested = as_dict(value)
+        existing = as_dict(base.get(key))
+        if nested is not None and existing is not None:
+            deep_update(existing, nested)
         else:
             base[key] = value
 
@@ -48,20 +51,11 @@ def normalize_configuration_dict(raw: dict[str, Any]) -> dict[str, Any]:
 
     reasoning_raw = normalized.get("reasoning")
     reasoning_present = "reasoning" in normalized
-    reasoning: dict[str, Any]
-    if isinstance(reasoning_raw, dict):
-        reasoning = dict(cast(dict[str, Any], reasoning_raw))
-    else:
-        reasoning = {}
+    reasoning: dict[str, Any] = dict(as_dict(reasoning_raw) or {})
     reasoning_enabled_explicit = reasoning.get("enabled") is not None
 
     if not reasoning_enabled_explicit:
-        deriver_raw = normalized.get("deriver")
-        deriver: dict[str, Any]
-        if isinstance(deriver_raw, dict):
-            deriver = dict(cast(dict[str, Any], deriver_raw))
-        else:
-            deriver = {}
+        deriver: dict[str, Any] = dict(as_dict(normalized.get("deriver")) or {})
         if deriver.get("enabled") is not None:
             reasoning["enabled"] = bool(deriver["enabled"])
 

--- a/src/utils/json_coerce.py
+++ b/src/utils/json_coerce.py
@@ -28,7 +28,7 @@ def as_str(value: object) -> str | None:
 def as_int(value: object) -> int | None:
     """The value as a JSON integer, or None if it is not one.
 
-    ``bool`` is excluded: it is an ``int`` subclass, and a JSON ``true`` reaching
-    a size or dimension field is a malformed request, not the number one.
+    ``bool`` is excluded: it is an ``int`` subclass, so without the guard a JSON
+    ``true`` silently arrives at a numeric field as the number one.
     """
     return value if isinstance(value, int) and not isinstance(value, bool) else None

--- a/tests/mock_provider/test_mock_provider.py
+++ b/tests/mock_provider/test_mock_provider.py
@@ -20,10 +20,10 @@ import pytest
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, Field
 
-from src.mock_provider.coerce import as_dict
 from src.mock_provider.embeddings import content_to_embedding
 from src.mock_provider.main import app
 from src.mock_provider.schema_gen import HARD_MAX_DEPTH, MAX_DEPTH, generate
+from src.utils.json_coerce import as_dict
 from src.utils.representation import PromptRepresentation
 
 # A $ref/$defs schema, which is what Pydantic emits for any nested model and the
@@ -101,9 +101,9 @@ def test_deriver_response_model_round_trips() -> None:
     content = json.dumps(generate(schema))
 
     representation = PromptRepresentation.model_validate_json(content)
-    assert representation.explicit, (
-        "an empty explicit list is exactly the silent failure this mock avoids"
-    )
+    assert (
+        representation.explicit
+    ), "an empty explicit list is exactly the silent failure this mock avoids"
 
 
 def test_json_schema_response_is_never_prose(client: TestClient) -> None:

--- a/tests/utils/test_json_coerce.py
+++ b/tests/utils/test_json_coerce.py
@@ -1,0 +1,47 @@
+"""Unit tests for the shared JSON narrowing helpers."""
+
+from typing import Any
+
+import pytest
+
+from src.utils.json_coerce import as_dict, as_int, as_list, as_str
+
+MISMATCHED: list[Any] = [None, "text", 7, 1.5, True, [], {}, object()]
+
+
+@pytest.mark.parametrize(
+    ("coerce", "value"),
+    [
+        (as_dict, {"a": 1}),
+        (as_dict, {}),
+        (as_list, [1, "two"]),
+        (as_list, []),
+        (as_str, "text"),
+        (as_str, ""),
+        (as_int, 7),
+        (as_int, 0),
+        (as_int, -1),
+    ],
+)
+def test_matching_type_passes_the_value_through(coerce: Any, value: Any) -> None:
+    """A match returns the original object, not a copy, so callers can mutate it."""
+    assert coerce(value) is value
+
+
+@pytest.mark.parametrize("coerce", [as_dict, as_list, as_str, as_int])
+def test_mismatched_type_returns_none(coerce: Any) -> None:
+    matches = {as_dict: dict, as_list: list, as_str: str, as_int: int}[coerce]
+    for value in MISMATCHED:
+        if isinstance(value, matches):
+            continue
+        assert coerce(value) is None, f"{coerce.__name__} accepted {value!r}"
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_as_int_rejects_bool(value: bool) -> None:
+    """bool is an int subclass, so a JSON `true` would otherwise become 1.
+
+    Regression: the mock provider's `dimensions` field accepted `true` and
+    generated a one-element vector instead of rejecting the request.
+    """
+    assert as_int(value) is None

--- a/tests/utils/test_json_coerce.py
+++ b/tests/utils/test_json_coerce.py
@@ -1,12 +1,27 @@
 """Unit tests for the shared JSON narrowing helpers."""
 
+from collections.abc import Callable
 from typing import Any
 
 import pytest
 
 from src.utils.json_coerce import as_dict, as_int, as_list, as_str
 
-MISMATCHED: list[Any] = [None, "text", 7, 1.5, True, [], {}, object()]
+Coercer = Callable[[object], Any]
+
+# One representative value per JSON type, reused to build the mismatch matrix.
+SAMPLES: list[Any] = [None, "text", 7, 1.5, True, ["a"], {"a": 1}]
+
+COERCERS: list[tuple[Coercer, type]] = [
+    (as_dict, dict),
+    (as_list, list),
+    (as_str, str),
+    (as_int, int),
+]
+
+
+def _name(arg: object) -> str:
+    return getattr(arg, "__name__", repr(arg))
 
 
 @pytest.mark.parametrize(
@@ -14,7 +29,7 @@ MISMATCHED: list[Any] = [None, "text", 7, 1.5, True, [], {}, object()]
     [
         (as_dict, {"a": 1}),
         (as_dict, {}),
-        (as_list, [1, "two"]),
+        (as_list, ["a"]),
         (as_list, []),
         (as_str, "text"),
         (as_str, ""),
@@ -22,26 +37,39 @@ MISMATCHED: list[Any] = [None, "text", 7, 1.5, True, [], {}, object()]
         (as_int, 0),
         (as_int, -1),
     ],
+    ids=_name,
 )
-def test_matching_type_passes_the_value_through(coerce: Any, value: Any) -> None:
-    """A match returns the original object, not a copy, so callers can mutate it."""
+def test_matching_type_passes_the_value_through(coerce: Coercer, value: Any) -> None:
+    """A match returns the original object, so callers can mutate it in place.
+
+    `deep_update` relies on this: it recurses into the dict `as_dict` hands back
+    and expects the caller's dict to see the writes.
+
+    The empty and zero cases pin narrowing on type rather than truthiness — a
+    `return value if value else None` implementation would pass every other row.
+    """
     assert coerce(value) is value
 
 
-@pytest.mark.parametrize("coerce", [as_dict, as_list, as_str, as_int])
-def test_mismatched_type_returns_none(coerce: Any) -> None:
-    matches = {as_dict: dict, as_list: list, as_str: str, as_int: int}[coerce]
-    for value in MISMATCHED:
-        if isinstance(value, matches):
-            continue
-        assert coerce(value) is None, f"{coerce.__name__} accepted {value!r}"
+@pytest.mark.parametrize(
+    ("coerce", "value"),
+    [
+        (coerce, value)
+        for coerce, accepted in COERCERS
+        for value in SAMPLES
+        if not isinstance(value, accepted)
+    ],
+    ids=_name,
+)
+def test_mismatched_type_returns_none(coerce: Coercer, value: Any) -> None:
+    assert coerce(value) is None
 
 
 @pytest.mark.parametrize("value", [True, False])
 def test_as_int_rejects_bool(value: bool) -> None:
     """bool is an int subclass, so a JSON `true` would otherwise become 1.
 
-    Regression: the mock provider's `dimensions` field accepted `true` and
-    generated a one-element vector instead of rejecting the request.
+    `True` is filtered out of the mismatch matrix above precisely because it
+    passes `isinstance(True, int)`; this is the case that pins the exclusion.
     """
     assert as_int(value) is None


### PR DESCRIPTION
## Description

`isinstance(x, dict)` on an `Any` narrows to `dict[Unknown, Unknown]`, and basedpyright runs at zero warnings, so every site handling decoded JSON pins the element types with an inline `cast`. That idiom was hand-written at 69 sites across 17 files, while the mock provider already had the shared helper for it.

This promotes `src/mock_provider/coerce.py` to `src/utils/json_coerce.py` (`git mv`, so history follows) and converts two callers off hand-written casts. Cast sites: **69 → 62**.

Per DEV-2520, this deliberately does *not* sweep all 69. Some sit next to bespoke error handling — `schema_conversion.py` reports a JSON path via `_fail(...)` — that a blanket conversion would flatten. The rest convert opportunistically.

### The one change worth isolating

`src/llm/conversation.py` had four `cast(list[dict[str, Any]], ...)` sites that claimed the list *elements* were dicts without ever checking one. A content list carrying a non-dict entry would have raised `AttributeError` on `.get`. Narrowing each entry with `as_dict` skips it instead — a behavior change on malformed input, from crash to skip.

The repeated "scan a content/parts list for a block" shape also collapses into `_has_content_block` / `_has_part_key`:

```python
def _is_tool_use_message(msg: dict[str, Any]) -> bool:
    return (
        _has_content_block(msg, "tool_use")
        or _has_part_key(msg, "function_call")
        or bool(msg.get("tool_calls"))
    )
```

`src/utils/config_helpers.py` is the mechanical case. `deep_update` still mutates `base[key]` in place — `as_dict` returns the same object, the cast was always identity — so recursion semantics are unchanged.

### The bool audit came back clean

DEV-2520 flagged `as_int` excluding `bool` (an `int` subclass, so a JSON `true` silently becomes `1`) and asked whether live instances existed elsewhere. They don't. Five `isinstance(..., int)` sites lack a bool guard, but none take raw JSON:

| Site | Source | Verdict |
|---|---|---|
| `deriver/enqueue.py:195,237`, `utils/queue_payload.py:222` | `message_id` from DB row integers | not JSON |
| `llm/backends/gemini.py:437` | SDK attribute via `getattr` | not JSON |
| `mock_provider/embeddings.py:55` | pydantic-validated `list[int]` | already guarded |

`queue_manager.py:1140` does read a JSONB column, but wraps it in `int(raw)` with a `try/except` and it is a retry counter. No changes were manufactured here.

## Proofs

- `basedpyright src` — **0 errors, 0 warnings, 0 notes**
- `ruff check src tests` — findings byte-identical to the `origin/main` baseline (diffed both trees)
- Full pre-commit + pre-push suite — **2502 passed, 51 skipped**
- New `tests/utils/test_json_coerce.py` — the helpers previously had only indirect coverage through the mock provider; the `as_int` bool exclusion is now pinned directly

One hunk in `test_mock_provider.py` beyond the import line is the ruff-format hook reformatting an assert it already disagreed with on `main` — the pinned pre-commit ruff and the venv's 0.15.12 disagree. Pre-existing drift, reproduces on a clean `main`; it rode along because this PR touches that file. The version skew is probably worth its own ticket.

## Checklist

- [x] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.

DEV-2520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved handling of varied JSON-shaped values in configuration and mock provider workflows.

* **Tests**
  * Expanded coverage for JSON type coercion, including mismatched values and Boolean handling.

* **Documentation**
  * Clarified that Boolean JSON values are excluded from numeric conversion because they can otherwise be interpreted as `1` or `0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->