### PR TITLE
feat: API endpoint can run timer logic instead of deriver

### DIFF
--- a/docs/v3/contributing/configuration.mdx
+++ b/docs/v3/contributing/configuration.mdx
@@ -431,6 +431,7 @@ DERIVER_MAX_CUSTOM_INSTRUCTIONS_TOKENS=2000
 
 # Worker settings
 DERIVER_WORKERS=1  # Increase for higher throughput
+DERIVER_SCHEDULER=deriver  # Which process runs the scheduling loops: "deriver" or "api"
 DERIVER_POLLING_SLEEP_INTERVAL_SECONDS=1.0
 # Adaptive polling: when idle/erroring, the sleep interval grows from the base
 # toward DERIVER_POLLING_SLEEP_MAX_INTERVAL_SECONDS by the multiplier each cycle,

--- a/src/backlog.py
+++ b/src/backlog.py
@@ -1,4 +1,4 @@
-"""Read-only polling of the deriver's outstanding work. Schedules nothing."""
+"""Polling of the deriver's outstanding work. Schedules only when it owns scheduling."""
 
 import asyncio
 import contextlib
@@ -11,7 +11,8 @@ import sentry_sdk
 from src import crud, schemas
 from src.config import settings
 from src.dependencies import tracked_db
-from src.dreamer.dream_due import count_due_dreams
+from src.deriver.enqueue import enqueue_dream
+from src.dreamer.dream_due import DueDream, list_due_dreams
 from src.telemetry import prometheus_metrics
 
 logger = getLogger(__name__)
@@ -62,7 +63,8 @@ class DeriverMetricsPoller:
         self._shutdown_event: asyncio.Event = asyncio.Event()
         self._snapshot: DeriverMetricsSnapshot = DeriverMetricsSnapshot()
         self._next_dream_poll: float | None = None
-        self._dreams_due: int = 0
+        self._due_dreams: list[DueDream] = []
+        self._next_stale_cleanup: float | None = None
 
     @property
     def snapshot(self) -> DeriverMetricsSnapshot:
@@ -103,25 +105,37 @@ class DeriverMetricsPoller:
                 logger.error("DeriverMetricsPoller refresh failed: %s", e)
                 if settings.SENTRY.ENABLED:
                     sentry_sdk.capture_exception(e)
+            if settings.DERIVER.SCHEDULER == "api":
+                try:
+                    await self._maybe_cleanup_stale_work_units()
+                except Exception as e:
+                    logger.error("Stale work unit cleanup failed: %s", e)
+                    if settings.SENTRY.ENABLED:
+                        sentry_sdk.capture_exception(e)
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(self._shutdown_event.wait(), timeout=interval)
 
     async def refresh(self) -> None:
-        """One read-only pass. The snapshot only advances on a complete pass."""
+        """One pass. The snapshot only advances on a complete pass."""
+        dreams_refreshed = False
         async with tracked_db("deriver_metrics", read_only=True) as db:
             stats = await crud.get_deriver_metrics(db)
             if self._dream_poll_due():
-                self._dreams_due = await count_due_dreams(db)
+                self._due_dreams = await list_due_dreams(db)
                 self._next_dream_poll = (
                     time.monotonic() + settings.DREAM.DUE_POLL_INTERVAL_SECONDS
                 )
+                dreams_refreshed = True
 
-        signal = outstanding_work_seconds(stats, dreams_due=self._dreams_due)
+        if dreams_refreshed and settings.DERIVER.SCHEDULER == "api":
+            await self._enqueue_due_dreams()
+
+        signal = outstanding_work_seconds(stats, dreams_due=len(self._due_dreams))
         measured_at = time.time()
 
         self._snapshot = DeriverMetricsSnapshot(
             signal_seconds=signal,
-            dreams_due=self._dreams_due,
+            dreams_due=len(self._due_dreams),
             stats=stats,
             measured_at=measured_at,
         )
@@ -135,7 +149,7 @@ class DeriverMetricsPoller:
             embeddings_pending=stats.embeddings_pending,
             embeddings_pending_due=stats.embeddings_pending_due,
         )
-        metrics.set_dreams_due(count=self._dreams_due)
+        metrics.set_dreams_due(count=len(self._due_dreams))
         metrics.set_deriver_outstanding_work(seconds=signal)
         metrics.set_deriver_metrics_last_success(timestamp=measured_at)
 
@@ -144,3 +158,37 @@ class DeriverMetricsPoller:
         return (
             self._next_dream_poll is None or time.monotonic() >= self._next_dream_poll
         )
+
+    async def _enqueue_due_dreams(self) -> None:
+        for due_dream in self._due_dreams:
+            try:
+                await enqueue_dream(
+                    due_dream.workspace_name,
+                    observer=due_dream.observer,
+                    observed=due_dream.observed,
+                    dream_type=due_dream.dream_type,
+                    session_name=due_dream.session_name,
+                    trigger_reason="document_threshold",
+                    delay_reason="api_poll",
+                )
+            except Exception as e:
+                logger.error(
+                    "Failed to enqueue dream for %s/%s/%s: %s",
+                    due_dream.workspace_name,
+                    due_dream.observer,
+                    due_dream.observed,
+                    e,
+                )
+                if settings.SENTRY.ENABLED:
+                    sentry_sdk.capture_exception(e)
+
+    async def _maybe_cleanup_stale_work_units(self) -> None:
+        interval = settings.DERIVER.STALE_WORK_UNIT_CLEANUP_INTERVAL_SECONDS
+        if (
+            self._next_stale_cleanup is not None
+            and time.monotonic() < self._next_stale_cleanup
+        ):
+            return
+        self._next_stale_cleanup = time.monotonic() + interval
+        async with tracked_db("cleanup_stale_work_units") as db:
+            await crud.cleanup_stale_work_units(db)

--- a/src/backlog.py
+++ b/src/backlog.py
@@ -160,7 +160,8 @@ class DeriverMetricsPoller:
         )
 
     async def _enqueue_due_dreams(self) -> None:
-        for due_dream in self._due_dreams:
+        cap = settings.DREAM.MAX_ENQUEUED_PER_POLL
+        for due_dream in self._due_dreams[:cap]:
             try:
                 await enqueue_dream(
                     due_dream.workspace_name,

--- a/src/config.py
+++ b/src/config.py
@@ -974,6 +974,8 @@ class DeriverSettings(HonchoSettings):
 
     BACKLOG_METRICS_POLL_INTERVAL_SECONDS: Annotated[int, Field(default=30, ge=1)] = 30
 
+    SCHEDULER: Literal["api", "deriver"] = "deriver"
+
     @model_validator(mode="before")
     @classmethod
     def _merge_model_config_defaults(cls, data: Any) -> Any:

--- a/src/config.py
+++ b/src/config.py
@@ -1,11 +1,11 @@
 import logging
 import math
 import os
+import tomllib
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, Literal, cast, get_args
 from urllib.parse import urlparse
 
-import tomllib
 from dotenv import load_dotenv
 from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 from pydantic.fields import FieldInfo
@@ -1356,6 +1356,7 @@ class DreamSettings(HonchoSettings):
     IDLE_TIMEOUT_MINUTES: Annotated[int, Field(default=60, gt=0, le=1440)] = 60
     MIN_HOURS_BETWEEN_DREAMS: Annotated[int, Field(default=8, gt=0, le=72)] = 8
     DUE_POLL_INTERVAL_SECONDS: Annotated[int, Field(default=300, ge=1)] = 300
+    MAX_ENQUEUED_PER_POLL: Annotated[int, Field(default=100, gt=0, le=10_000)] = 100
     ENABLED_TYPES: list[str] = ["omni"]
 
     # Agent iteration limit - increased for extended reasoning workflow

--- a/src/crud/__init__.py
+++ b/src/crud/__init__.py
@@ -4,6 +4,7 @@ from .collection import (
     update_collection_internal_metadata,
 )
 from .deriver import (
+    cleanup_stale_work_units,
     get_deriver_metrics,
     get_deriver_status,
     get_queue_status,
@@ -109,6 +110,7 @@ __all__ = [
     "get_or_create_collection",
     "update_collection_internal_metadata",
     # Deriver
+    "cleanup_stale_work_units",
     "get_deriver_metrics",
     "get_deriver_status",
     "get_queue_status",

--- a/src/crud/deriver.py
+++ b/src/crud/deriver.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 from logging import getLogger
 from typing import Any
 
-from sqlalchemy import ColumnElement, Select, case, func, or_, select
+from sqlalchemy import ColumnElement, Select, case, delete, func, or_, select
 from sqlalchemy.engine import Row
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -73,6 +73,30 @@ def not_live_claimed_work_unit_clause(
         )
         .exists()
     )
+
+
+async def cleanup_stale_work_units(db: AsyncSession) -> None:
+    """Delete claim rows whose last update is older than the stale timeout."""
+    stale_ids = (
+        (
+            await db.execute(
+                select(models.ActiveQueueSession.id)
+                .where(models.ActiveQueueSession.last_updated < stale_claim_cutoff())
+                .order_by(models.ActiveQueueSession.last_updated)
+                .with_for_update(skip_locked=True)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    if stale_ids:
+        await db.execute(
+            delete(models.ActiveQueueSession).where(
+                models.ActiveQueueSession.id.in_(stale_ids)
+            )
+        )
+    await db.commit()
 
 
 async def get_deriver_metrics(db: AsyncSession) -> schemas.DeriverMetrics:

--- a/src/deriver/enqueue.py
+++ b/src/deriver/enqueue.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Literal
 
 from sqlalchemy import exists, insert, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, models, schemas
@@ -561,6 +562,14 @@ async def enqueue_dream(
                 dream_type.value,
             )
 
+        except IntegrityError:
+            logger.debug(
+                "Dream already enqueued by another process: %s/%s/%s (type: %s)",
+                workspace_name,
+                observer,
+                observed,
+                dream_type.value,
+            )
         except Exception as e:
             logger.exception("Failed to enqueue dream task!")
             if settings.SENTRY.ENABLED:

--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -6,7 +6,6 @@ import time
 from asyncio import Task
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
 from logging import getLogger
 from typing import Any, NamedTuple, cast
 
@@ -28,6 +27,9 @@ from src.crud.deriver import (
     REPRESENTATION_WORK_UNIT_PREFIX,
     representation_batch_threshold_clause,
     unclaimed_work_unit_clause,
+)
+from src.crud.deriver import (
+    cleanup_stale_work_units as crud_cleanup_stale_work_units,
 )
 from src.dependencies import tracked_db
 from src.deriver.consumer import (
@@ -222,11 +224,11 @@ class QueueManager:
             )
         logger.debug("Signal handlers registered")
 
-        # Start the reconciler scheduler
-        try:
-            await self.reconciler_scheduler.start()
-        except Exception:
-            logger.exception("Failed to start reconciler scheduler")
+        if settings.DERIVER.SCHEDULER == "deriver":
+            try:
+                await self.reconciler_scheduler.start()
+            except Exception:
+                logger.exception("Failed to start reconciler scheduler")
 
         # Run the polling loop directly in this task
         logger.debug("Starting polling loop directly")
@@ -314,31 +316,7 @@ class QueueManager:
     async def cleanup_stale_work_units(self) -> None:
         """Clean up stale work units"""
         async with tracked_db("cleanup_stale_work_units") as db:
-            cutoff = datetime.now(UTC) - timedelta(
-                minutes=settings.DERIVER.STALE_SESSION_TIMEOUT_MINUTES
-            )
-
-            stale_ids = (
-                (
-                    await db.execute(
-                        select(models.ActiveQueueSession.id)
-                        .where(models.ActiveQueueSession.last_updated < cutoff)
-                        .order_by(models.ActiveQueueSession.last_updated)
-                        .with_for_update(skip_locked=True)
-                    )
-                )
-                .scalars()
-                .all()
-            )
-
-            # Delete only the records we successfully got locks for
-            if stale_ids:
-                await db.execute(
-                    delete(models.ActiveQueueSession).where(
-                        models.ActiveQueueSession.id.in_(stale_ids)
-                    )
-                )
-            await db.commit()
+            await crud_cleanup_stale_work_units(db)
 
     async def get_and_claim_work_units(self) -> dict[str, str]:
         """
@@ -543,7 +521,8 @@ class QueueManager:
                     continue
 
                 try:
-                    await self._maybe_cleanup_stale_work_units()
+                    if settings.DERIVER.SCHEDULER == "deriver":
+                        await self._maybe_cleanup_stale_work_units()
                     claimed_work_units = await self.get_and_claim_work_units()
                     if claimed_work_units:
                         if self._is_tenant_work(claimed_work_units):

--- a/src/dreamer/dream_due.py
+++ b/src/dreamer/dream_due.py
@@ -170,9 +170,7 @@ async def list_due_dreams(db: AsyncSession) -> list[DueDream]:
     )
     active_observed = {
         (parsed.workspace_name, parsed.observed)
-        for parsed in (
-            parse_work_unit_key(key) for key in pending_representation_keys
-        )
+        for parsed in (parse_work_unit_key(key) for key in pending_representation_keys)
     }
 
     unattempted = [

--- a/src/dreamer/dream_due.py
+++ b/src/dreamer/dream_due.py
@@ -12,7 +12,7 @@ from src import models
 from src.config import settings
 from src.schemas import DreamType
 from src.utils.config_helpers import get_configuration
-from src.utils.work_unit import construct_work_unit_key
+from src.utils.work_unit import construct_work_unit_key, parse_work_unit_key
 
 logger = getLogger(__name__)
 
@@ -33,7 +33,7 @@ async def count_due_dreams(db: AsyncSession) -> int:
 
 
 async def list_due_dreams(db: AsyncSession) -> list[DueDream]:
-    """List collections past the threshold, the idle timeout, the min-hours gate, any earlier attempt, and the session's dream setting."""
+    """List collections past the threshold, the idle timeout, the min-hours gate, any earlier attempt, pending representation work, and the session's dream setting."""
     dream_types = [
         DreamType(dream_type)
         for dream_type in settings.DREAM.ENABLED_TYPES
@@ -154,11 +154,35 @@ async def list_due_dreams(db: AsyncSession) -> list[DueDream]:
         cast(str, row[0]): cast(datetime, row[1]) for row in attempt_rows
     }
 
+    pending_representation_keys = (
+        (
+            await db.execute(
+                select(models.QueueItem.work_unit_key)
+                .where(
+                    models.QueueItem.task_type == "representation",
+                    models.QueueItem.processed == False,  # noqa: E712
+                )
+                .distinct()
+            )
+        )
+        .scalars()
+        .all()
+    )
+    active_observed = {
+        (parsed.workspace_name, parsed.observed)
+        for parsed in (
+            parse_work_unit_key(key) for key in pending_representation_keys
+        )
+    }
+
     unattempted = [
         due_dream
         for work_unit_key, (due_dream, newest_created_at) in candidates.items()
-        if work_unit_key not in newest_attempts
-        or newest_attempts[work_unit_key] < newest_created_at
+        if (
+            work_unit_key not in newest_attempts
+            or newest_attempts[work_unit_key] < newest_created_at
+        )
+        and (due_dream.workspace_name, due_dream.observed) not in active_observed
     ]
     if not unattempted:
         return []

--- a/src/dreamer/dream_due.py
+++ b/src/dreamer/dream_due.py
@@ -1,8 +1,8 @@
-"""Read-only count of the collections whose next dream is due. Enqueues nothing."""
+"""Read-only listing of the collections whose next dream is due. Enqueues nothing."""
 
 from datetime import UTC, datetime, timedelta
 from logging import getLogger
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import aggregate_order_by
@@ -17,15 +17,30 @@ from src.utils.work_unit import construct_work_unit_key
 logger = getLogger(__name__)
 
 
+class DueDream(NamedTuple):
+    """One collection whose next dream is due, with everything needed to enqueue it."""
+
+    workspace_name: str
+    observer: str
+    observed: str
+    dream_type: DreamType
+    session_name: str
+
+
 async def count_due_dreams(db: AsyncSession) -> int:
-    """Count collections past the threshold, the idle timeout, the min-hours gate, any earlier attempt, and the session's dream setting."""
+    """Count collections whose next dream is due."""
+    return len(await list_due_dreams(db))
+
+
+async def list_due_dreams(db: AsyncSession) -> list[DueDream]:
+    """List collections past the threshold, the idle timeout, the min-hours gate, any earlier attempt, and the session's dream setting."""
     dream_types = [
         DreamType(dream_type)
         for dream_type in settings.DREAM.ENABLED_TYPES
         if dream_type == DreamType.OMNI.value
     ]
     if not settings.DREAM.ENABLED or not dream_types:
-        return 0
+        return []
 
     explicit_counts = (
         select(
@@ -70,7 +85,7 @@ async def count_due_dreams(db: AsyncSession) -> int:
 
     now = datetime.now(UTC)
     idle_cutoff = now - timedelta(minutes=settings.DREAM.IDLE_TIMEOUT_MINUTES)
-    candidates: dict[str, tuple[str, str, datetime]] = {}
+    candidates: dict[str, tuple[DueDream, datetime]] = {}
 
     for row in rows:
         workspace_name = cast(str, row[0])
@@ -109,13 +124,18 @@ async def count_due_dreams(db: AsyncSession) -> int:
                 },
             )
             candidates[work_unit_key] = (
-                workspace_name,
-                newest_session_name,
+                DueDream(
+                    workspace_name=workspace_name,
+                    observer=observer,
+                    observed=observed,
+                    dream_type=dream_type,
+                    session_name=newest_session_name,
+                ),
                 newest_created_at,
             )
 
     if not candidates:
-        return 0
+        return []
 
     attempt_rows = (
         await db.execute(
@@ -135,27 +155,25 @@ async def count_due_dreams(db: AsyncSession) -> int:
     }
 
     unattempted = [
-        (workspace_name, session_name)
-        for work_unit_key, (
-            workspace_name,
-            session_name,
-            newest_created_at,
-        ) in candidates.items()
+        due_dream
+        for work_unit_key, (due_dream, newest_created_at) in candidates.items()
         if work_unit_key not in newest_attempts
         or newest_attempts[work_unit_key] < newest_created_at
     ]
     if not unattempted:
-        return 0
+        return []
 
-    return await _count_with_dreams_enabled(db, unattempted)
+    return await _filter_dreams_enabled(db, unattempted)
 
 
-async def _count_with_dreams_enabled(
-    db: AsyncSession, candidates: list[tuple[str, str]]
-) -> int:
+async def _filter_dreams_enabled(
+    db: AsyncSession, candidates: list[DueDream]
+) -> list[DueDream]:
     """Drop candidates whose resolved configuration has dreams turned off."""
-    workspace_names = {workspace_name for workspace_name, _ in candidates}
-    session_keys = set(candidates)
+    workspace_names = {due_dream.workspace_name for due_dream in candidates}
+    session_keys = {
+        (due_dream.workspace_name, due_dream.session_name) for due_dream in candidates
+    }
 
     workspaces = {
         workspace.name: workspace
@@ -178,7 +196,7 @@ async def _count_with_dreams_enabled(
                     select(models.Session).where(
                         models.Session.workspace_name.in_(workspace_names),
                         models.Session.name.in_(
-                            {session_name for _, session_name in candidates}
+                            {due_dream.session_name for due_dream in candidates}
                         ),
                     )
                 )
@@ -190,15 +208,15 @@ async def _count_with_dreams_enabled(
             (session.workspace_name, session.name): session for session in session_rows
         }
 
-    enabled = 0
-    for workspace_name, session_name in candidates:
+    enabled: list[DueDream] = []
+    for due_dream in candidates:
         configuration = get_configuration(
             None,
-            sessions.get((workspace_name, session_name)),
-            workspaces.get(workspace_name),
+            sessions.get((due_dream.workspace_name, due_dream.session_name)),
+            workspaces.get(due_dream.workspace_name),
         )
         if configuration.dream.enabled:
-            enabled += 1
+            enabled.append(due_dream)
     return enabled
 
 

--- a/src/dreamer/dream_scheduler.py
+++ b/src/dreamer/dream_scheduler.py
@@ -270,7 +270,7 @@ async def check_and_schedule_dream(
     Returns:
         True if a dream timer was scheduled, False otherwise
     """
-    if not settings.DREAM.ENABLED:
+    if not settings.DREAM.ENABLED or settings.DERIVER.SCHEDULER == "api":
         return False
 
     dream_metadata = collection.internal_metadata.get("dream", {})

--- a/src/main.py
+++ b/src/main.py
@@ -25,6 +25,7 @@ from src.db import (
     request_context,
 )
 from src.exceptions import HonchoException
+from src.reconciler import ReconcilerScheduler, set_reconciler_scheduler
 from src.routers import (
     conclusions,
     deriver_metrics,
@@ -144,12 +145,23 @@ async def lifespan(_: FastAPI):
     except Exception as e:
         logger.error("Failed to start backlog metrics poller: %s", e)
 
+    reconciler_scheduler = None
+    if settings.DERIVER.SCHEDULER == "api":
+        reconciler_scheduler = ReconcilerScheduler()
+        set_reconciler_scheduler(reconciler_scheduler)
+        try:
+            await reconciler_scheduler.start()
+        except Exception as e:
+            logger.error("Failed to start reconciler scheduler: %s", e)
+
     try:
         yield
     finally:
         # Import here to avoid circular import at module load time
         from src.vector_store import close_external_vector_store
 
+        if reconciler_scheduler is not None:
+            await reconciler_scheduler.shutdown()
         await deriver_metrics_poller.shutdown()
         deriver_metrics.set_deriver_metrics_poller(None)
         await close_external_vector_store()

--- a/src/telemetry/prometheus/metrics.py
+++ b/src/telemetry/prometheus/metrics.py
@@ -575,6 +575,9 @@ class PrometheusMetrics:
             self.set_deriver_outstanding_work(seconds=0)
             self.set_dreams_due(count=0)
 
+            if settings.DERIVER.SCHEDULER == "api":
+                self.set_message_embeddings_pending(count=0)
+
         elif instance_type == "deriver":
             # deriver tokens: only the valid (token_type, component) tuples per
             # task_type (see _DERIVER_TOKEN_COMBOS_BY_TASK).

--- a/tests/deriver/test_queue_processing.py
+++ b/tests/deriver/test_queue_processing.py
@@ -321,6 +321,58 @@ class TestQueueProcessing:
         # This test ensures the cleanup logic doesn't break, though we don't have stale entries yet
         assert isinstance(work_units, dict)
 
+    async def test_initialize_starts_reconciler_when_deriver_owns_scheduling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "deriver")
+        queue_manager = QueueManager()
+
+        with (
+            patch.object(queue_manager.reconciler_scheduler, "start", AsyncMock()) as start,
+            patch.object(queue_manager, "_sleep_startup_jitter", AsyncMock()),
+            patch.object(queue_manager, "polling_loop", AsyncMock()),
+            patch.object(queue_manager, "cleanup", AsyncMock()),
+        ):
+            await queue_manager.initialize()
+
+        assert start.await_count == 1
+
+    async def test_initialize_skips_reconciler_when_api_owns_scheduling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
+        queue_manager = QueueManager()
+
+        with (
+            patch.object(queue_manager.reconciler_scheduler, "start", AsyncMock()) as start,
+            patch.object(queue_manager, "_sleep_startup_jitter", AsyncMock()),
+            patch.object(queue_manager, "polling_loop", AsyncMock()),
+            patch.object(queue_manager, "cleanup", AsyncMock()),
+        ):
+            await queue_manager.initialize()
+
+        assert start.await_count == 0
+
+    async def test_polling_loop_skips_stale_cleanup_when_api_owns_scheduling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
+        queue_manager = QueueManager()
+
+        with (
+            patch.object(
+                queue_manager, "_maybe_cleanup_stale_work_units", AsyncMock()
+            ) as cleanup,
+            patch.object(
+                queue_manager,
+                "get_and_claim_work_units",
+                AsyncMock(side_effect=lambda: queue_manager.shutdown_event.set() or {}),
+            ),
+        ):
+            await queue_manager.polling_loop()
+
+        assert cleanup.await_count == 0
+
     async def test_work_unit_key_format(
         self, sample_session_with_peers: tuple[models.Session, list[models.Peer]]
     ) -> None:

--- a/tests/deriver/test_queue_processing.py
+++ b/tests/deriver/test_queue_processing.py
@@ -328,7 +328,9 @@ class TestQueueProcessing:
         queue_manager = QueueManager()
 
         with (
-            patch.object(queue_manager.reconciler_scheduler, "start", AsyncMock()) as start,
+            patch.object(
+                queue_manager.reconciler_scheduler, "start", AsyncMock()
+            ) as start,
             patch.object(queue_manager, "_sleep_startup_jitter", AsyncMock()),
             patch.object(queue_manager, "polling_loop", AsyncMock()),
             patch.object(queue_manager, "cleanup", AsyncMock()),
@@ -344,7 +346,9 @@ class TestQueueProcessing:
         queue_manager = QueueManager()
 
         with (
-            patch.object(queue_manager.reconciler_scheduler, "start", AsyncMock()) as start,
+            patch.object(
+                queue_manager.reconciler_scheduler, "start", AsyncMock()
+            ) as start,
             patch.object(queue_manager, "_sleep_startup_jitter", AsyncMock()),
             patch.object(queue_manager, "polling_loop", AsyncMock()),
             patch.object(queue_manager, "cleanup", AsyncMock()),
@@ -359,6 +363,10 @@ class TestQueueProcessing:
         monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
         queue_manager = QueueManager()
 
+        def _claim_nothing_and_stop() -> dict[str, str]:
+            queue_manager.shutdown_event.set()
+            return {}
+
         with (
             patch.object(
                 queue_manager, "_maybe_cleanup_stale_work_units", AsyncMock()
@@ -366,7 +374,7 @@ class TestQueueProcessing:
             patch.object(
                 queue_manager,
                 "get_and_claim_work_units",
-                AsyncMock(side_effect=lambda: queue_manager.shutdown_event.set() or {}),
+                AsyncMock(side_effect=_claim_nothing_and_stop),
             ),
         ):
             await queue_manager.polling_loop()

--- a/tests/dreamer/test_dream_due.py
+++ b/tests/dreamer/test_dream_due.py
@@ -164,6 +164,40 @@ class TestCountDueDreams:
 
         assert await count_due_dreams(db_session) == 1
 
+    async def test_pending_representation_work_blocks_a_due_dream(
+        self,
+        db_session: AsyncSession,
+        sample_data: tuple[models.Workspace, models.Peer],
+    ):
+        collection = await _make_collection(db_session, sample_data)
+        await _insert_docs(db_session, collection, "explicit", 60, age_minutes=90)
+
+        session_name = await _make_session(db_session, collection.workspace_name)
+        representation_key = construct_work_unit_key(
+            collection.workspace_name,
+            {
+                "task_type": "representation",
+                "session_name": session_name,
+                "observed": collection.observed,
+            },
+        )
+        item = models.QueueItem(
+            work_unit_key=representation_key,
+            payload={"task_type": "representation"},
+            task_type="representation",
+            workspace_name=collection.workspace_name,
+            processed=False,
+        )
+        db_session.add(item)
+        await db_session.commit()
+
+        assert await count_due_dreams(db_session) == 0
+
+        item.processed = True
+        await db_session.commit()
+
+        assert await count_due_dreams(db_session) == 1
+
     async def test_documents_since_last_dream_uses_stored_count(
         self,
         db_session: AsyncSession,

--- a/tests/dreamer/test_dreamer_integration.py
+++ b/tests/dreamer/test_dreamer_integration.py
@@ -17,6 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import models
+from src.config import settings
 from src.deriver.enqueue import enqueue_dream
 from src.dreamer.dream_scheduler import (
     DreamScheduler,
@@ -79,6 +80,21 @@ async def _get_dream_metadata(
     refreshed = (await db_session.execute(stmt)).scalar_one()
     dream_meta: dict[str, Any] = refreshed.internal_metadata.get("dream", {})
     return dream_meta
+
+
+class TestSchedulerGate:
+    @pytest.mark.asyncio
+    async def test_check_and_schedule_dream_is_off_when_api_owns_scheduling(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db_session: AsyncSession,
+        seeded_collection: models.Collection,
+    ) -> None:
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
+
+        scheduled = await check_and_schedule_dream(db_session, seeded_collection)
+
+        assert scheduled is False
 
 
 class TestLastDreamAtCompletionWrite:

--- a/tests/test_deriver_metrics.py
+++ b/tests/test_deriver_metrics.py
@@ -320,3 +320,56 @@ class TestDeriverMetricsRoute:
             await deriver_metrics.get_deriver_metrics_response()
 
         assert excinfo.value.status_code == 503
+
+
+@pytest.mark.asyncio
+class TestLifespanScheduler:
+    async def _run_lifespan(self) -> AsyncMock:
+        from src import main as main_module
+
+        scheduler = AsyncMock()
+
+        with (
+            patch.object(main_module, "initialize_telemetry_async", AsyncMock()),
+            patch.object(main_module, "register_db_pool_collector"),
+            patch.object(main_module, "register_db_query_instrumentation"),
+            patch.object(main_module, "register_db_connection_instrumentation"),
+            patch.object(main_module, "validate_embedding_schema", AsyncMock()),
+            patch.object(main_module, "init_cache", AsyncMock()),
+            patch.object(main_module, "close_cache", AsyncMock()),
+            patch.object(main_module, "shutdown_telemetry", AsyncMock()),
+            patch.object(main_module, "engine", AsyncMock()),
+            patch.object(
+                main_module, "DeriverMetricsPoller", return_value=AsyncMock()
+            ),
+            patch.object(main_module, "ReconcilerScheduler", return_value=scheduler),
+            patch.object(main_module, "set_reconciler_scheduler"),
+            patch(
+                "src.vector_store.close_external_vector_store",
+                AsyncMock(),
+            ),
+        ):
+            async with main_module.lifespan(main_module.app):
+                pass
+
+        return scheduler
+
+    async def test_api_scheduler_runs_the_reconciler(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
+
+        scheduler = await self._run_lifespan()
+
+        assert scheduler.start.await_count == 1
+        assert scheduler.shutdown.await_count == 1
+
+    async def test_deriver_scheduler_leaves_the_reconciler_off(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "deriver")
+
+        scheduler = await self._run_lifespan()
+
+        assert scheduler.start.await_count == 0
+        assert scheduler.shutdown.await_count == 0

--- a/tests/test_deriver_metrics.py
+++ b/tests/test_deriver_metrics.py
@@ -7,13 +7,28 @@ import pytest
 from fastapi import HTTPException
 
 from src import schemas
+from src.config import settings
 from src.backlog import (
     DeriverMetricsPoller,
     DeriverMetricsSnapshot,
     active_work_seconds,
     outstanding_work_seconds,
 )
+from src.dreamer.dream_due import DueDream
 from src.routers import deriver_metrics
+
+
+def _due_dreams(count: int) -> list[DueDream]:
+    return [
+        DueDream(
+            workspace_name=f"workspace-{i}",
+            observer=f"peer-{i}",
+            observed=f"peer-{i}",
+            dream_type=schemas.DreamType.OMNI,
+            session_name=f"session-{i}",
+        )
+        for i in range(count)
+    ]
 
 
 class TestScaleSignal:
@@ -73,7 +88,7 @@ class TestPoller:
                 "src.backlog.crud.get_deriver_metrics",
                 AsyncMock(return_value=stats),
             ),
-            patch("src.backlog.count_due_dreams", AsyncMock(return_value=3)),
+            patch("src.backlog.list_due_dreams", AsyncMock(return_value=_due_dreams(3))),
         ):
             await poller.refresh()
 
@@ -87,14 +102,14 @@ class TestPoller:
         """The dream query is the expensive one, so it must not run every pass."""
         stats = schemas.DeriverMetrics()
         poller = DeriverMetricsPoller()
-        dream_count = AsyncMock(return_value=1)
+        dream_count = AsyncMock(return_value=_due_dreams(1))
 
         with (
             patch(
                 "src.backlog.crud.get_deriver_metrics",
                 AsyncMock(return_value=stats),
             ),
-            patch("src.backlog.count_due_dreams", dream_count),
+            patch("src.backlog.list_due_dreams", dream_count),
         ):
             await poller.refresh()
             await poller.refresh()
@@ -106,14 +121,14 @@ class TestPoller:
         """Advancing the deadline first would republish the old count for a whole interval."""
         stats = schemas.DeriverMetrics()
         poller = DeriverMetricsPoller()
-        dream_count = AsyncMock(side_effect=[RuntimeError("db down"), 4])
+        dream_count = AsyncMock(side_effect=[RuntimeError("db down"), _due_dreams(4)])
 
         with (
             patch(
                 "src.backlog.crud.get_deriver_metrics",
                 AsyncMock(return_value=stats),
             ),
-            patch("src.backlog.count_due_dreams", dream_count),
+            patch("src.backlog.list_due_dreams", dream_count),
         ):
             with pytest.raises(RuntimeError):
                 await poller.refresh()
@@ -132,7 +147,7 @@ class TestPoller:
                 "src.backlog.crud.get_deriver_metrics",
                 AsyncMock(return_value=stats),
             ),
-            patch("src.backlog.count_due_dreams", AsyncMock(return_value=0)),
+            patch("src.backlog.list_due_dreams", AsyncMock(return_value=[])),
         ):
             await poller.refresh()
 
@@ -148,6 +163,98 @@ class TestPoller:
             await poller.refresh()
 
         assert poller.snapshot is first
+
+    async def test_api_scheduler_enqueues_due_dreams(self, monkeypatch):
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
+        stats = schemas.DeriverMetrics()
+        poller = DeriverMetricsPoller()
+        due = _due_dreams(2)
+        enqueue = AsyncMock()
+
+        with (
+            patch(
+                "src.backlog.crud.get_deriver_metrics",
+                AsyncMock(return_value=stats),
+            ),
+            patch("src.backlog.list_due_dreams", AsyncMock(return_value=due)),
+            patch("src.backlog.enqueue_dream", enqueue),
+        ):
+            await poller.refresh()
+
+        assert enqueue.await_count == 2
+        first_call = enqueue.await_args_list[0]
+        assert first_call.args == (due[0].workspace_name,)
+        assert first_call.kwargs["observer"] == due[0].observer
+        assert first_call.kwargs["observed"] == due[0].observed
+        assert first_call.kwargs["dream_type"] == due[0].dream_type
+        assert first_call.kwargs["session_name"] == due[0].session_name
+
+    async def test_api_scheduler_does_not_reenqueue_from_the_cached_list(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
+        stats = schemas.DeriverMetrics()
+        poller = DeriverMetricsPoller()
+        enqueue = AsyncMock()
+
+        with (
+            patch(
+                "src.backlog.crud.get_deriver_metrics",
+                AsyncMock(return_value=stats),
+            ),
+            patch(
+                "src.backlog.list_due_dreams",
+                AsyncMock(return_value=_due_dreams(1)),
+            ),
+            patch("src.backlog.enqueue_dream", enqueue),
+        ):
+            await poller.refresh()
+            await poller.refresh()
+
+        assert enqueue.await_count == 1
+
+    async def test_deriver_scheduler_enqueues_nothing(self, monkeypatch):
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "deriver")
+        stats = schemas.DeriverMetrics()
+        poller = DeriverMetricsPoller()
+        enqueue = AsyncMock()
+
+        with (
+            patch(
+                "src.backlog.crud.get_deriver_metrics",
+                AsyncMock(return_value=stats),
+            ),
+            patch(
+                "src.backlog.list_due_dreams",
+                AsyncMock(return_value=_due_dreams(1)),
+            ),
+            patch("src.backlog.enqueue_dream", enqueue),
+        ):
+            await poller.refresh()
+
+        assert enqueue.await_count == 0
+        assert poller.snapshot.dreams_due == 1
+
+    async def test_one_failed_enqueue_does_not_stop_the_rest(self, monkeypatch):
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
+        stats = schemas.DeriverMetrics()
+        poller = DeriverMetricsPoller()
+        enqueue = AsyncMock(side_effect=[RuntimeError("db down"), None])
+
+        with (
+            patch(
+                "src.backlog.crud.get_deriver_metrics",
+                AsyncMock(return_value=stats),
+            ),
+            patch(
+                "src.backlog.list_due_dreams",
+                AsyncMock(return_value=_due_dreams(2)),
+            ),
+            patch("src.backlog.enqueue_dream", enqueue),
+        ):
+            await poller.refresh()
+
+        assert enqueue.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_deriver_metrics.py
+++ b/tests/test_deriver_metrics.py
@@ -7,13 +7,13 @@ import pytest
 from fastapi import HTTPException
 
 from src import schemas
-from src.config import settings
 from src.backlog import (
     DeriverMetricsPoller,
     DeriverMetricsSnapshot,
     active_work_seconds,
     outstanding_work_seconds,
 )
+from src.config import settings
 from src.dreamer.dream_due import DueDream
 from src.routers import deriver_metrics
 
@@ -88,7 +88,9 @@ class TestPoller:
                 "src.backlog.crud.get_deriver_metrics",
                 AsyncMock(return_value=stats),
             ),
-            patch("src.backlog.list_due_dreams", AsyncMock(return_value=_due_dreams(3))),
+            patch(
+                "src.backlog.list_due_dreams", AsyncMock(return_value=_due_dreams(3))
+            ),
         ):
             await poller.refresh()
 
@@ -164,7 +166,9 @@ class TestPoller:
 
         assert poller.snapshot is first
 
-    async def test_api_scheduler_enqueues_due_dreams(self, monkeypatch):
+    async def test_api_scheduler_enqueues_due_dreams(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
         stats = schemas.DeriverMetrics()
         poller = DeriverMetricsPoller()
@@ -190,7 +194,7 @@ class TestPoller:
         assert first_call.kwargs["session_name"] == due[0].session_name
 
     async def test_api_scheduler_does_not_reenqueue_from_the_cached_list(
-        self, monkeypatch
+        self, monkeypatch: pytest.MonkeyPatch
     ):
         monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
         stats = schemas.DeriverMetrics()
@@ -213,7 +217,9 @@ class TestPoller:
 
         assert enqueue.await_count == 1
 
-    async def test_deriver_scheduler_enqueues_nothing(self, monkeypatch):
+    async def test_deriver_scheduler_enqueues_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "deriver")
         stats = schemas.DeriverMetrics()
         poller = DeriverMetricsPoller()
@@ -235,7 +241,9 @@ class TestPoller:
         assert enqueue.await_count == 0
         assert poller.snapshot.dreams_due == 1
 
-    async def test_one_failed_enqueue_does_not_stop_the_rest(self, monkeypatch):
+    async def test_one_failed_enqueue_does_not_stop_the_rest(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
         stats = schemas.DeriverMetrics()
         poller = DeriverMetricsPoller()

--- a/tests/utils/test_retryable_errors.py
+++ b/tests/utils/test_retryable_errors.py
@@ -1,6 +1,5 @@
 """DB-free unit tests for src/utils/retryable_errors.py."""
 
-import asyncio
 from typing import cast
 
 import httpx
@@ -90,7 +89,7 @@ def test_non_db_exceptions_are_not_db_retryable():
         (httpx.ReadTimeout("timed out"), True),
         (httpx.ConnectError("connection refused"), True),
         (ConnectionResetError("reset"), True),
-        (asyncio.TimeoutError(), True),
+        (TimeoutError(), True),
         (TimeoutError(), True),
         (ValueError("bad input"), False),
         (httpx.HTTPStatusError("401", request=None, response=None), False),  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
## Description

This adds a setting `DERIVER.SCHEDULER` that be `api` or `deriver` that determines whether the deriver is responsible for running the timers for the deriver (that's how it works now) or the API endpoint is responsible. This will make it easier to turn the deriver on and off as it's needed to consume events in the queue.

The only difference in how the API endpoint will run the timers vs how the deriver currently does it is: the deriver cancels a scheduled dream if representation events come through the consumer for that particular collection. On the API endpoint, we approximate this by making a database call (`pending_representation_keys`).

This reuses the code that we added in https://github.com/plastic-labs/honcho/pull/1115 to surface these metrics in the API endpoint (`backlog.py`). It pulls out `cleanup_stale_work_units()` and `_maybe_cleanup_stale_work_units()` from existing deriver code.

## Proofs

```bash
uv run pytest tests/ -q --ignore=tests/live_llm --ignore=tests/bench
```

E2E tests with `DERIVER__SCHEDULER=api`:
- 4 representation rows processed, 6 explicit documents written
- 1 summary row processed
- sync_vectors rows enqueued by the API, consumed by the deriver
- Dream enqueued by the API, run by the deriver (5 deductive, 2 inductive docs; collection metadata advanced)
- Stale claim reaped by the API with the deriver stopped
- deriver/metrics JSON and all /metrics gauges served values
- Deriver log shows no ReconcilerScheduler start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable scheduling ownership between the API and deriver processes.
  - API-managed scheduling now queues due dreams during refreshes, with configurable per-poll limits and duplicate prevention.
  - Added automatic cleanup of stale work units.
  - Due-dream tracking includes scheduling details and excludes items with pending representation work.

- **Bug Fixes**
  - Prevented deriver timer scheduling and cleanup when scheduling is API-managed.
  - Prevented dreams from being scheduled while related representation work remains unprocessed.
  - Handled duplicate scheduling attempts without surfacing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->