### PR TITLE
docs: document workspace-level chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ const completion = await openai.chat.completions.create({
 | ---------------------------------- | --------------------------------------------------------------- |
 | Save interaction history           | `session.add_messages(...)`                                     |
 | Ask what Honcho knows about a peer | `peer.chat(...)`                                                |
+| Ask across the whole workspace     | `honcho.chat(...)` / `honcho.chat_stream(...)`                  |
 | Get prompt-ready context           | `session.context(...).to_openai(...)` / `.to_anthropic(...)`    |
 | Hybrid search (BM25 + vector)      | `peer.search(...)`, `session.search(...)`, `honcho.search(...)` |
 | Low-latency static representations | `peer.representation(...)`, `session.representation(...)`       |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -177,6 +177,7 @@
                   "v3/api-reference/endpoint/workspaces/update-workspace",
                   "v3/api-reference/endpoint/workspaces/delete-workspace",
                   "v3/api-reference/endpoint/workspaces/search-workspace",
+                  "v3/api-reference/endpoint/workspaces/chat-workspace",
                   "v3/api-reference/endpoint/workspaces/get-queue-status",
                   "v3/api-reference/endpoint/workspaces/schedule-dream"
                 ]

--- a/docs/v3/api-reference/endpoint/workspaces/chat-workspace.mdx
+++ b/docs/v3/api-reference/endpoint/workspaces/chat-workspace.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v3/workspaces/{workspace_id}/chat
+---

--- a/docs/v3/documentation/core-concepts/architecture.mdx
+++ b/docs/v3/documentation/core-concepts/architecture.mdx
@@ -92,6 +92,8 @@ Honcho runs as two cooperating processes: an **API server** that handles request
 
 **Query path (Dialectic).** A `chat()` call spawns a Dialectic agent that answers your question by exploring memory--searching conclusions semantically, pulling supporting messages, and tracing a conclusion back to the premises it was drawn from--before synthesizing a grounded answer. This all happens inline during the request, since answering well is worth the latency that write-path reasoning is designed to avoid.
 
+The same agent runs in two shapes. `peer.chat()` is anchored to one (observer, observed) pair and prefetches the conclusions relevant to the query, so it can often answer from that context alone. `honcho.chat()` has no anchor peer: it prefetches workspace stats and the most active peers' cards as a routing aid, is required to search before answering, and then reads memory pair by pair with `[observer->observed]` attribution. See [Workspace Chat](/v3/documentation/features/chat#workspace-chat).
+
 ## Configuration & Extensibility
 
 Honcho is designed to be flexible. Settings cascade hierarchically from workspace to peer to session, so you can set defaults at the workspace level and override them for specific peers or sessions. Feature flags let you enable or disable reasoning modes, perspective tracking, and other capabilities. You can bring your own LLM provider--OpenAI, Anthropic, or custom endpoints--and metadata fields let you extend any primitive with custom JSON data. Batch operations let you create up to 100 messages in a single API call for efficient bulk ingestion.

--- a/docs/v3/documentation/core-concepts/design-patterns.mdx
+++ b/docs/v3/documentation/core-concepts/design-patterns.mdx
@@ -24,6 +24,7 @@ Ready to add Honcho to your codebase? The **`/honcho-integration` skill** applie
 | Should I set `observe_me: false`? | Yes, for deterministic peers Honcho does not need to model, like bots or tool agents. Still save their messages so other peers have session context. Keep it enabled for users and evolving agents. |
 | Do I need `observe_others`? | Only when a peer needs its own perspective on another participant, such as in games, multi-agent systems, or parent/subagent workflows. |
 | When do I need a scope? | When one peer's history spans contexts that must not leak into each other's recall — but you still want one workspace and one unified peer. Group the confidential sessions into a [scope](/v3/documentation/features/advanced/scopes) and pass it at query time. |
+| Peer chat or workspace chat? | `peer.chat()` for one peer's perspective (personalization, what one agent knows about another). [`honcho.chat()`](/v3/documentation/features/chat#workspace-chat) when the question spans peers: team digests, cross-agent themes, or you don't know which peer holds the answer. |
 | Perspectives or scopes? | `observe_others` gives a *participant* its own view of another peer. A scope bounds recall to *where things were said*, for a reader that isn't a participant. If the reader is in the session, use perspectives; if you're fencing off a set of sessions, use a scope. |
 
 ## Workspace Design
@@ -117,7 +118,7 @@ Two things scopes are **not**:
     Bound recall to named sets of sessions
   </Card>
   <Card title="Chat Endpoint" icon="comments" href="/v3/documentation/features/chat">
-    Query Honcho about your peers with natural language
+    Query Honcho about one peer, or across the whole workspace
   </Card>
   <Card title="Reasoning Configuration" icon="wrench" href="/v3/documentation/features/advanced/reasoning-configuration">
     Fine-tune what gets reasoned about and how

--- a/docs/v3/documentation/features/advanced/overview.mdx
+++ b/docs/v3/documentation/features/advanced/overview.mdx
@@ -20,6 +20,7 @@ Advanced features give you fine-grained control over Honcho's behavior and imple
 ## Querying & Data
 
 - [Search](/v3/documentation/features/advanced/search) - Search across peers, sessions, and messages
+- [Workspace Chat](/v3/documentation/features/chat#workspace-chat) - Ask a question across every peer in a workspace
 - [Filters](/v3/documentation/features/advanced/using-filters) - Filter queries with advanced parameters
 - [Streaming Responses](/v3/documentation/features/advanced/streaming-response) - Stream dialectic responses in real-time
 - [File Uploads](/v3/documentation/features/advanced/file-uploads) - Ingest files into peer memory

--- a/docs/v3/documentation/features/advanced/scopes.mdx
+++ b/docs/v3/documentation/features/advanced/scopes.mdx
@@ -244,7 +244,7 @@ empty result means none have — not that the scope is empty.
 | `peer.representation()` | one scope or a list | Confines conclusion recall |
 | [`session.context()`](/v3/documentation/features/get-context) | one scope only | Perspective source for `peer_target`'s representation and card. Requires `peer_target`; mutually exclusive with `peer_perspective` |
 | `honcho.search()` | one scope only | Restricts message search to the scope's member sessions |
-| `honcho.chat()` | one scope or a list | Always the allowlist arm — even a single name. There is no observer to swap |
+| [`honcho.chat()`](/v3/documentation/features/chat#workspace-chat) | one scope or a list | Always the allowlist arm — even a single name. There is no observer to swap, and no `target` |
 
 <CodeGroup>
 ```python Python
@@ -295,7 +295,8 @@ curl -X POST "$HONCHO_URL/v3/workspaces/my-app/peers/user-123/chat" \
 requires `peer_target`). Like the session allowlist, it **fails closed**: a
 contradiction is rejected with a `422` rather than silently widened, a scope
 with no member sessions recalls nothing, and an empty list (`scope=[]`) is
-rejected rather than treated as "no boundary". Per-surface caps and error
+rejected rather than treated as "no boundary". On workspace chat the same
+exclusion holds: pass `scope` or `session_id`, never both. Per-surface caps and error
 shapes are in the [API reference](/v3/api-reference/endpoint/scopes/get-or-create-scope).
 
 ## Provenance, Not Topic

--- a/docs/v3/documentation/features/advanced/search.mdx
+++ b/docs/v3/documentation/features/advanced/search.mdx
@@ -10,6 +10,8 @@ Honcho's search functionality allows you to find relevant messages and conversat
 Search is hybrid: it combines full-text (keyword) matching with semantic (vector) similarity. Keyword matches are available the instant a message is created. Semantic matches depend on the message's embedding, which is generated in the background, so a freshly created message may take a few seconds to surface in semantic results. If you need to assert on semantic results immediately after writing (for example in tests), wait briefly or poll.
 </Note>
 
+Search returns the messages themselves. When you want a synthesized answer across the workspace rather than a result list, use [workspace chat](/v3/documentation/features/chat#workspace-chat).
+
 ## Search Scopes
 
 ### Workspace Search

--- a/docs/v3/documentation/features/advanced/streaming-response.mdx
+++ b/docs/v3/documentation/features/advanced/streaming-response.mdx
@@ -99,6 +99,29 @@ for chunk in response_stream.iter_text():
 ```
 </CodeGroup>
 
+## Streaming Workspace Chat
+
+[Workspace chat](/v3/documentation/features/chat#workspace-chat) streams the same way through `chat_stream` / `chatStream` on the client. There is no peer to anchor the question; the agent reads across every peer in the workspace.
+
+<CodeGroup>
+```python Python
+for chunk in honcho.chat_stream("What themes come up across all users this week?"):
+    print(chunk, end="", flush=True)
+```
+
+```typescript TypeScript
+(async () => {
+    const stream = await honcho.chatStream("What themes come up across all users this week?");
+
+    for await (const chunk of stream) {
+      process.stdout.write(chunk);
+    }
+})();
+```
+</CodeGroup>
+
+Over REST, both endpoints return `text/event-stream` when `stream` is `true`. Each event is `{"delta": {"content": "..."}, "done": false}`, followed by a final `{"done": true}`.
+
 ## Working with Streaming Data
 
 When working with streaming responses, consider these patterns:

--- a/docs/v3/documentation/features/advanced/structured-outputs.mdx
+++ b/docs/v3/documentation/features/advanced/structured-outputs.mdx
@@ -105,6 +105,60 @@ curl -X POST "$HONCHO_URL/v3/workspaces/my-app/peers/user-123/chat" \
 
 At the API level, `content` in the response is always a string. When `response_format` is set, it is a JSON-encoded object conforming to your schema.
 
+## Workspace Chat
+
+`response_format` is accepted on [workspace chat](/v3/documentation/features/chat#workspace-chat) too. The Python client parses a Pydantic model for you; the TypeScript client takes a JSON Schema object and returns the JSON string.
+
+<CodeGroup>
+```python Python
+class Theme(BaseModel):
+    name: str
+    peers: list[str]
+
+class Themes(BaseModel):
+    themes: list[Theme]
+
+result = honcho.chat("What themes recur across peers?", response_format=Themes)
+# result is a Themes instance (or None)
+```
+
+```typescript TypeScript
+const raw = await honcho.chat("What themes recur across peers?", {
+  responseFormat: {
+    type: "object",
+    properties: {
+      themes: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { name: { type: "string" }, peers: { type: "array", items: { type: "string" } } },
+          required: ["name", "peers"],
+        },
+      },
+    },
+    required: ["themes"],
+  },
+});
+const result = raw ? JSON.parse(raw) : null;
+```
+
+```bash cURL
+curl -X POST "$HONCHO_URL/v3/workspaces/my-app/chat" \
+  -H "Authorization: Bearer $HONCHO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "What themes recur across peers?",
+    "response_format": {
+      "type": "object",
+      "properties": {
+        "themes": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["themes"]
+    }
+  }'
+```
+</CodeGroup>
+
 ## Streaming
 
 `response_format` works with streaming. The stream emits the JSON answer incrementally as raw text chunks; the accumulated text is a valid JSON string once the stream completes. To enable streaming the SDKs cannot parse streamed responses for you, you parse the final string yourself:

--- a/docs/v3/documentation/features/chat.mdx
+++ b/docs/v3/documentation/features/chat.mdx
@@ -1,11 +1,21 @@
 ---
 title: "Chat Endpoint"
-description: "An endpoint for reasoning about your users"
+description: "Ask Honcho questions about one peer, or across a whole workspace"
 sidebarTitle: "Chat Endpoint"
 icon: "message-question"
 ---
 
-The Chat endpoint (`peer.chat()`) is the natural language interface to Honcho's reasoning. Instead of manually retrieving conclusions, your LLM can ask questions and get synthesized answers based on all the reasoning Honcho has done about a peer. Think of it as agent-to-agent communication.
+The Chat endpoint is the natural language interface to Honcho's reasoning. Instead of manually retrieving conclusions, your LLM can ask questions and get synthesized answers based on all the reasoning Honcho has done. Think of it as agent-to-agent communication.
+
+There are two ways to ask:
+
+| | `peer.chat()` | `honcho.chat()` |
+|--|---------------|-----------------|
+| Answers from | One peer's representation, from an observer's perspective | Every peer in the workspace, with no anchor peer |
+| Good for | Personalization, per-user decisions, "what does this peer know about that peer" | Cross-peer themes, team-wide questions, "what does this workspace know" |
+| Endpoint | `POST /v3/workspaces/{workspace_id}/peers/{peer_id}/chat` | `POST /v3/workspaces/{workspace_id}/chat` |
+
+Most applications start with peer chat. Jump to [Workspace Chat](#workspace-chat) when the question spans more than one peer.
 
 ## Basic Usage
 
@@ -41,11 +51,11 @@ console.log(answer);
 ```
 </CodeGroup>
 
-The chat endpoint searches through the peer's representation--all the conclusions Honcho has reasoned about them--and synthesizes a natural language answer.
+Peer chat searches through the peer's representation--all the conclusions Honcho has reasoned about them--and synthesizes a natural language answer.
 
 ## Reasoning Level
 
-Use `reasoning_level` to trade off speed against depth for a specific chat request. It is optional and defaults to `low`. Accepted values are `minimal`, `low`, `medium`, `high`, and `max`.
+Use `reasoning_level` to trade off speed against depth for a specific chat request. It is optional and defaults to `low`. Accepted values are `minimal`, `low`, `medium`, `high`, and `max`. The same levels apply to [workspace chat](#workspace-chat).
 
 The reasoning level controls which model the request is routed to, the tools used by the agent, the thinking budget, the maximum tool-iteration count, and output token limits.
 
@@ -158,6 +168,194 @@ const status = await peer.chat(
 
 The agent runs its full reasoning loop either way — only the final answer is formatted to your schema. See [Structured Outputs](/v3/documentation/features/advanced/structured-outputs) for the supported schema subset, streaming behavior, and best practices.
 
+## Workspace Chat
+
+`honcho.chat()` asks a question of the whole workspace. There is no observer
+peer and no `target`: the agent orients itself with workspace stats and the
+most active peers, works out which peers are relevant to the question, and then
+reads their memory pair by pair.
+
+### When to Use It
+
+Reach for workspace chat when the question is about more than one peer, or when
+you don't know which peer holds the answer:
+
+- "What themes come up across all users this week?"
+- "Which peers have mentioned the billing migration?"
+- "Where do Alice and Bob disagree?"
+- "What does this workspace know about deployment incidents?"
+
+Stay with `peer.chat()` when you need a perspective (what one peer knows about
+another), when you're personalizing for a single user, or when the caller only
+holds a peer-scoped key.
+
+### Asking the Workspace
+
+`chat()` lives on the client, not on a peer:
+
+<CodeGroup>
+```python Python
+from honcho import Honcho
+
+honcho = Honcho(workspace_id="my-app")
+
+answer = honcho.chat("What themes appear across all peers this week?")
+print(answer)
+# "Three themes recur: onboarding friction (alice, dana), ..."
+```
+
+```typescript TypeScript
+import { Honcho } from '@honcho-ai/sdk';
+
+const honcho = new Honcho({ workspaceId: "my-app" });
+
+const answer = await honcho.chat("What themes appear across all peers this week?");
+console.log(answer);
+```
+
+```bash cURL
+curl -X POST "$HONCHO_URL/v3/workspaces/my-app/chat" \
+  -H "Authorization: Bearer $HONCHO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What themes appear across all peers this week?", "reasoning_level": "low"}'
+```
+</CodeGroup>
+
+The response body is `{"content": "..."}`, or `{"content": null}` when nothing
+relevant was found. The SDKs return the string directly (`None` / `null` for no
+answer).
+
+### Narrowing Recall
+
+Two options narrow what the agent can read. They are mutually exclusive.
+
+**`session`** (`session_id` on the REST body) narrows message tools to one
+session. Conclusion recall is unaffected.
+
+<CodeGroup>
+```python Python
+answer = honcho.chat("What was decided in this thread?", session=session.id)
+```
+
+```typescript TypeScript
+const answer = await honcho.chat("What was decided in this thread?", { session: session.id });
+```
+</CodeGroup>
+
+**`scope`** restricts recall to the union of the named
+[scopes](/v3/documentation/features/advanced/scopes)' member sessions. On
+workspace chat this is *always* the allowlist arm, even for a single name,
+because there is no observer to swap. A scope with no member sessions recalls
+nothing rather than everything.
+
+<CodeGroup>
+```python Python
+answer = honcho.chat("What came up in therapy-related sessions?", scope="therapy")
+answer = honcho.chat("What came up at intake?", scope=["therapy", "intake"])
+```
+
+```typescript TypeScript
+const answer = await honcho.chat("What came up in therapy-related sessions?", { scope: "therapy" });
+const both = await honcho.chat("What came up at intake?", { scope: ["therapy", "intake"] });
+```
+</CodeGroup>
+
+Workspace chat does not accept `filters` or `target`.
+
+### Streaming
+
+Use `chat_stream` / `chatStream` for incremental output. The stream yields text
+chunks; the REST endpoint sends `text/event-stream` when `stream` is `true`.
+
+<CodeGroup>
+```python Python
+for chunk in honcho.chat_stream("Summarize the open disagreements between peers"):
+    print(chunk, end="", flush=True)
+```
+
+```typescript TypeScript
+const stream = await honcho.chatStream("Summarize the open disagreements between peers");
+for await (const chunk of stream) {
+  process.stdout.write(chunk);
+}
+```
+</CodeGroup>
+
+### Workspace Structured Outputs
+
+`response_format` works the same way as on peer chat. In Python, passing a
+Pydantic model returns a parsed instance; passing a raw JSON Schema returns a
+JSON string. The TypeScript client accepts a JSON Schema object and returns the
+JSON string for you to parse.
+
+<CodeGroup>
+```python Python
+from pydantic import BaseModel
+
+class Theme(BaseModel):
+    name: str
+    peers: list[str]
+
+class Themes(BaseModel):
+    themes: list[Theme]
+
+result = honcho.chat("What themes recur across peers?", response_format=Themes)
+# result is a Themes instance (or None)
+```
+
+```typescript TypeScript
+const raw = await honcho.chat("What themes recur across peers?", {
+  responseFormat: {
+    type: "object",
+    properties: {
+      themes: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { name: { type: "string" }, peers: { type: "array", items: { type: "string" } } },
+          required: ["name", "peers"],
+        },
+      },
+    },
+    required: ["themes"],
+  },
+});
+const result = raw ? JSON.parse(raw) : null;
+```
+</CodeGroup>
+
+### How Workspace Chat Answers
+
+When you call `honcho.chat(query)`:
+
+1. Honcho prefetches an orientation overview: workspace stats, the most active peers, and their peer cards. This is a routing aid, not the corpus.
+2. The agent is required to make at least one tool call before answering, so the overview alone is never mistaken for the whole workspace.
+3. Message search runs workspace-wide and reveals which peers discussed a topic. Conclusion search stays pair-scoped: the agent names an `observer` and `observed` per call, and results come back attributed as `[observer->observed]`.
+4. The agent synthesizes a grounded answer, citing which peers the evidence came from.
+
+Keeping conclusion search pair-scoped avoids diluting retrieval with a
+workspace-flat top-k, and matches how memory is stored: one collection per
+`(observer, observed)` pair.
+
+### Authentication
+
+Workspace chat requires a workspace- or admin-level key. Peer- and
+session-scoped keys are rejected with `401` regardless of the other options.
+See [Manage API Keys](/v3/documentation/reference/platform#3-manage-api-keys) for scoping
+rules.
+
+### Peer Chat vs Workspace Chat
+
+| | `peer.chat()` | `honcho.chat()` |
+|--|---------------|-----------------|
+| Perspective | Observer peer, optional `target` | None, whole workspace |
+| `session` / `session_id` | Yes | Yes (message tools only) |
+| `scope` | Single name swaps the observer; a list is an allowlist | Always an allowlist, even a single name |
+| `filters` (session allowlist) | Yes | No |
+| `reasoning_level`, `response_format`, streaming | Yes | Yes |
+| Key required | Peer, workspace, or admin | Workspace or admin |
+| CLI / Explore UI | `honcho peer chat`, Explore Chat tab | API and SDK only |
+
 ## Integration Patterns
 
 ### Dynamic Prompt Enhancement
@@ -253,6 +451,26 @@ const goals = await peer.chat("What are the user's main goals or objectives?");
 ```
 </CodeGroup>
 
+### Team Digests
+
+Use workspace chat where the unit of interest is the group rather than one user:
+
+<CodeGroup>
+```python Python
+digest = honcho.chat(
+    "Summarize what each peer worked on this week and any blockers they raised.",
+    reasoning_level="medium",
+)
+```
+
+```typescript TypeScript
+const digest = await honcho.chat(
+  "Summarize what each peer worked on this week and any blockers they raised.",
+  { reasoningLevel: "medium" },
+);
+```
+</CodeGroup>
+
 ## How Honcho Answers
 
 When you call `peer.chat(query)`:
@@ -262,7 +480,7 @@ When you call `peer.chat(query)`:
 3. Combines them with segments of source messages, if needed, to gather more context
 4. Synthesizes them into a coherent natural language response to your query
 
-Honcho [reasoning](/v3/documentation/core-concepts/reasoning) runs continuously in the background, processing new messages and updating representations. The chat endpoint always has access to Honcho's latest conclusions about the peer.
+Honcho [reasoning](/v3/documentation/core-concepts/reasoning) runs continuously in the background, processing new messages and updating representations. The chat endpoint always has access to Honcho's latest conclusions about the peer. Workspace chat follows the same loop with a different starting point; see [How Workspace Chat Answers](#how-workspace-chat-answers).
 
 ## Best Practices
 
@@ -274,6 +492,9 @@ The chat endpoint shines when your LLM decides what it needs to know. This creat
 
 ### Use for runtime decisions
 Don't just use chat for LLM prompts - use it to drive application logic, routing, and feature flags based on user behavior.
+
+### Pick the right entry point
+Peer chat for one peer's perspective, workspace chat for questions that span peers. Asking `honcho.chat()` about a single known peer works, but costs a routing step that `peer.chat()` skips.
 
 ### Combine with context()
 Use `context()` for conversation context and `peer.chat()` for specific insights. They complement each other.

--- a/docs/v3/documentation/introduction/quickstart.mdx
+++ b/docs/v3/documentation/introduction/quickstart.mdx
@@ -231,6 +231,18 @@ user.chat("What should I know about this user? 3 sentences max").then((response)
 ```
 </CodeGroup>
 
+Peer chat answers about one peer. Once a workspace has several, `honcho.chat()` asks across all of them:
+
+<CodeGroup>
+```python Python
+response = honcho.chat("What themes appear across every peer in this workspace?")
+```
+
+```typescript TypeScript
+const response = await honcho.chat("What themes appear across every peer in this workspace?");
+```
+</CodeGroup>
+
 <Tip>
 Honcho needs a short amount of time to process messages you write to it. There are several utilities to [check the status](/v3/documentation/features/advanced/queue-status) of the queue. Honcho also offers numerous ways to query reasoning to fit latency needs: see the [Get Context](/v3/documentation/features/get-context) page.
 </Tip>

--- a/docs/v3/documentation/reference/cli.mdx
+++ b/docs/v3/documentation/reference/cli.mdx
@@ -152,6 +152,10 @@ CI pipelines and agent runtimes can branch on these without parsing stderr.
 
 <CliCommands />
 
+<Note>
+  `honcho peer chat` covers peer chat only. [Workspace chat](/v3/documentation/features/chat#workspace-chat) has no CLI command yet; use the API or SDKs.
+</Note>
+
 ## Workflows
 
 ### Inspect an unfamiliar workspace

--- a/docs/v3/documentation/reference/platform.mdx
+++ b/docs/v3/documentation/reference/platform.mdx
@@ -110,7 +110,7 @@ Click into any peer to navigate to their respective utilities page. Next to the 
 
 Utilities include:
 - **Message search** across all sessions for a `Peer`
-- **Chat** to query `Peer` representations with an optional session scope (results vary based on the `Peer`'s configuration)
+- **Chat** to query `Peer` representations with an optional session scope (results vary based on the `Peer`'s configuration). [Workspace chat](/v3/documentation/features/chat#workspace-chat) is available through the API and SDKs only.
 
 <Frame>
   <img src="/images/app-screenshots/chat-endpoint.png" alt="Chat Endpoint" width="1200" height="800" loading="lazy" decoding="async" fetchpriority="low" />

--- a/docs/v3/documentation/reference/sdk.mdx
+++ b/docs/v3/documentation/reference/sdk.mdx
@@ -200,6 +200,10 @@ sessions = honcho.sessions()
 # Search across all content in workspace
 results = honcho.search(query)
 
+# Ask a question across every peer in the workspace
+answer = honcho.chat(query)
+stream = honcho.chat_stream(query)
+
 # Workspace metadata management
 metadata = honcho.get_metadata()
 honcho.set_metadata(dict)
@@ -235,6 +239,10 @@ const sessions = await honcho.sessions();
 // Search across all content in workspace (returns Page<any>)
 const results = await honcho.search(query);
 
+// Ask a question across every peer in the workspace
+const answer = await honcho.chat(query);
+const stream = await honcho.chatStream(query);
+
 // Workspace metadata management
 const metadata = await honcho.getMetadata();
 await honcho.setMetadata(metadata);
@@ -250,6 +258,77 @@ await honcho.deleteWorkspace(workspaceId);
 <Info>
 `peer()` and `session()` always make a get-or-create API call, returning objects with cached metadata, configuration, and timestamps.
 </Info>
+
+### Workspace Chat
+
+`honcho.chat()` asks a question of the whole workspace rather than one peer's representation. It lives on the client, not on `Peer`, and takes no `target`: the agent works out which peers are relevant and reads their memory pair by pair. See [Workspace Chat](/v3/documentation/features/chat#workspace-chat) for when to use it over `peer.chat()`.
+
+<CodeGroup>
+```python Python
+# Cross-peer question
+answer = honcho.chat("What themes appear across all peers this week?")
+
+# Narrow message tools to one session
+answer = honcho.chat("What was decided in this thread?", session="session-1")
+
+# Restrict recall to a scope's member sessions (always an allowlist; mutually exclusive with session)
+answer = honcho.chat("What came up in therapy sessions?", scope="therapy")
+answer = honcho.chat("What came up at intake?", scope=["therapy", "intake"])
+
+# Deeper reasoning
+answer = honcho.chat("Where do peers disagree?", reasoning_level="high")
+
+# Structured output: a Pydantic model returns a parsed instance, a JSON Schema dict returns a JSON string
+result = honcho.chat("List recurring themes", response_format=Themes)
+
+# Streaming
+for chunk in honcho.chat_stream("Summarize the workspace"):
+    print(chunk, end="", flush=True)
+
+# Async mirrors
+answer = await honcho.aio.chat("What themes appear across all peers?")
+async for chunk in await honcho.aio.chat_stream("Summarize the workspace"):
+    print(chunk, end="", flush=True)
+```
+
+```typescript TypeScript
+// Cross-peer question
+const answer = await honcho.chat("What themes appear across all peers this week?");
+
+// Narrow message tools to one session
+const threadAnswer = await honcho.chat("What was decided in this thread?", {
+  session: "session-1"
+});
+
+// Restrict recall to a scope's member sessions (always an allowlist; mutually exclusive with session)
+const scoped = await honcho.chat("What came up in therapy sessions?", { scope: "therapy" });
+const union = await honcho.chat("What came up at intake?", { scope: ["therapy", "intake"] });
+
+// Deeper reasoning
+const deeper = await honcho.chat("Where do peers disagree?", { reasoningLevel: "high" });
+
+// Structured output: pass a JSON Schema object, receive a JSON string
+const raw = await honcho.chat("List recurring themes", {
+  responseFormat: { type: "object", properties: { themes: { type: "array", items: { type: "string" } } }, required: ["themes"] }
+});
+
+// Streaming
+const stream = await honcho.chatStream("Summarize the workspace");
+for await (const chunk of stream) {
+  process.stdout.write(chunk);
+}
+```
+</CodeGroup>
+
+| Option | Python | TypeScript | Notes |
+|--------|--------|------------|-------|
+| Query | `query` (positional) | `query` (positional) | Required, 1 to 10,000 characters |
+| Session | `session=` | `session` | Session ID or object. Narrows message tools only |
+| Scope | `scope=` | `scope` | One name or a list. Always an allowlist; mutually exclusive with session |
+| Reasoning level | `reasoning_level=` | `reasoningLevel` | `minimal`, `low` (default), `medium`, `high`, `max` |
+| Response format | `response_format=` | `responseFormat` | Pydantic model or JSON Schema (Python); JSON Schema (TypeScript) |
+
+Workspace chat requires a workspace- or admin-level key. There is no `target` or `filters` option.
 
 ### Peer
 

--- a/docs/v3/openapi.json
+++ b/docs/v3/openapi.json
@@ -267,6 +267,60 @@
         }
       }
     },
+    "/v3/workspaces/{workspace_id}/chat": {
+      "post": {
+        "tags": ["workspaces"],
+        "summary": "Workspace Chat",
+        "description": "Query the entire workspace using natural language. Runs the Dialectic agent over every peer in the workspace rather than a single (observer, observed) pair: there is no anchor peer and no `target`.\n\nPass `session_id` to narrow message tools to one session, or `scope` to restrict recall to the union of the named scopes' member sessions (always an allowlist, even for a single name; a scope with no member sessions recalls nothing). `session_id` and `scope` are mutually exclusive.\n\nSet `stream: true` to receive the answer as a `text/event-stream` of `{\"delta\": {\"content\": ...}, \"done\": false}` chunks terminated by `{\"done\": true}`. Requires a workspace- or admin-level key.",
+        "operationId": "chat_v3_workspaces__workspace_id__chat_post",
+        "security": [{ "HTTPBearer": [] }],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Workspace Id" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/WorkspaceChatOptions" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "content": {
+                      "anyOf": [{ "type": "string" }, { "type": "null" }],
+                      "title": "Content"
+                    }
+                  },
+                  "required": ["content"],
+                  "title": "DialecticResponse",
+                  "type": "object"
+                }
+              },
+              "text/event-stream": {}
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v3/workspaces/{workspace_id}/queue/status": {
       "get": {
         "tags": ["workspaces"],
@@ -4377,6 +4431,56 @@
         "type": "object",
         "required": ["id", "created_at"],
         "title": "Workspace"
+      },
+      "WorkspaceChatOptions": {
+        "properties": {
+          "session_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Session Id",
+            "description": "Optional session to scope message tools to"
+          },
+          "query": {
+            "type": "string",
+            "maxLength": 10000,
+            "minLength": 1,
+            "title": "Query",
+            "description": "Workspace chat prompt"
+          },
+          "stream": { "type": "boolean", "title": "Stream", "default": false },
+          "reasoning_level": {
+            "type": "string",
+            "enum": ["minimal", "low", "medium", "high", "max"],
+            "title": "Reasoning Level",
+            "description": "Level of reasoning to apply: minimal, low, medium, high, or max",
+            "default": "low"
+          },
+          "response_format": {
+            "anyOf": [
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
+            ],
+            "title": "Response Format",
+            "description": "Optional JSON Schema (root type 'object') the response must conform to. When provided, `content` is a JSON string matching this schema."
+          },
+          "scope": {
+            "anyOf": [
+              { "type": "string" },
+              {
+                "items": { "type": "string" },
+                "type": "array",
+                "maxItems": 100,
+                "minItems": 1
+              },
+              { "type": "null" }
+            ],
+            "title": "Scope",
+            "description": "Optional (unprefixed) scope name(s) restricting recall to the union of the scopes' member sessions (explicit allowlist, fail-closed: an empty union recalls nothing). Mutually exclusive with `session_id`. Requires a workspace- or admin-level key."
+          }
+        },
+        "type": "object",
+        "required": ["query"],
+        "title": "WorkspaceChatOptions",
+        "description": "Options for workspace-level chat (no anchor peer; see DialecticOptions)."
       },
       "WorkspaceConfiguration": {
         "properties": {

--- a/docs/v3/openapi.json
+++ b/docs/v3/openapi.json
@@ -711,7 +711,7 @@
     "/v3/workspaces/{workspace_id}/peers/{peer_id}/chat": {
       "post": {
         "tags": ["peers"],
-        "summary": "Chat",
+        "summary": "Peer Chat",
         "description": "Query a Peer's representation using natural language. Performs agentic search and reasoning to comprehensively\nanswer the query based on all latent knowledge gathered about the peer from their messages and conclusions.",
         "operationId": "chat_v3_workspaces__workspace_id__peers__peer_id__chat_post",
         "security": [{ "HTTPBearer": [] }],

--- a/src/routers/peers.py
+++ b/src/routers/peers.py
@@ -228,6 +228,7 @@ async def get_sessions_for_peer(
 
 @router.post(
     "/{peer_id}/chat",
+    summary="Peer Chat",
     responses={
         200: {
             "content": {

--- a/src/routers/workspaces.py
+++ b/src/routers/workspaces.py
@@ -289,6 +289,7 @@ async def schedule_dream(
 
 @router.post(
     "/{workspace_id}/chat",
+    summary="Workspace Chat",
     responses={
         200: {
             "content": {


### PR DESCRIPTION

## Description

Bring docs to parity with POST /v3/workspaces/{workspace_id}/chat (#931):

## Proofs

N/A

## Checklist

- [ ] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace-wide chat through the API and Python and TypeScript SDKs.
  * Supports cross-peer questions, scoped or session-based recall, streaming responses, reasoning levels, and structured outputs.
  * Added workspace chat API reference and navigation.

* **Documentation**
  * Updated guides, quickstart content, SDK references, and architecture documentation with workspace chat usage and peer-versus-workspace guidance.
  * Clarified that workspace chat is available through APIs and SDKs, not the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->