### PR TITLE
feat(mcp): expose scope, workspace level chat, and pagination in the MCP server

### DIFF
--- a/harness-plugin-core/README.md
+++ b/harness-plugin-core/README.md
@@ -10,7 +10,7 @@ const cfg = loadConfig({ host: 'harness' })
 const cfg = resolveConfig(file, { host: 'harness', overlay: { workspace: 'harness', auth: { apiKey } } })
 ```
 
-Locally: `"@honcho-ai/harness-plugin-core": "file:../harness-plugin-core"` (bun imports the TypeScript source).
+Install: `bun add @honcho-ai/harness-plugin-core`. Locally: `"@honcho-ai/harness-plugin-core": "file:../harness-plugin-core"` (bun imports the TypeScript source).
 
 ## File shape
 

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to `honcho-mcp` will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+This package versions independently of the Honcho API, `@honcho-ai/sdk`, and host plugins.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-09-08
+
+### Added
+
+- Scopes: `list_scopes`, `get_scope_sessions`, and `scope`/`sessions` on `chat` (Honcho v3.1.0+)
+- Pagination on `list_sessions` and `get_session_messages`
+- `workspace_chat` for reasoned questions across all peers (Honcho v3.1.0+)

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -36,6 +36,8 @@ Every workspace-scoped tool takes a `workspace_id` argument. If you set `X-Honch
 
 **Sessions:** `create_session`, `list_sessions`, `delete_session`, `clone_session`, `add_peers_to_session`, `remove_peers_from_session`, `get_session_peers`, `inspect_session`, `add_messages_to_session`, `get_session_messages`, `get_session_message`, `get_session_context`
 
+**Scopes:** `list_scopes`, `get_scope_sessions`
+
 **Conclusions:** `list_conclusions`, `query_conclusions`, `create_conclusions`, `delete_conclusion`
 
 **System:** `schedule_dream`, `get_queue_status`
@@ -52,7 +54,8 @@ src/
   types.ts              # ToolContext, result helpers
   tools/
     workspace.ts        # inspect, list, search, metadata
-    peers.ts            # CRUD, chat, card, context, representation
+    peers.ts            # CRUD, chat (session / scope / sessions recall bounds), card, context, representation
+    scopes.ts           # list scopes, list a scope's sessions
     sessions.ts         # CRUD, peers, messages, inspect, context, clone
     conclusions.ts      # list, query, create, delete
     system.ts           # dream, queue status

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -30,9 +30,9 @@ Every workspace-scoped tool takes a `workspace_id` argument. If you set `X-Honch
 
 ## Available Tools
 
-**Workspace:** `list_workspaces` (id, metadata, created_at), `create_workspace` (get-or-create with optional metadata), `inspect_workspace` (aggregates metadata, configuration, and peer/session IDs), `search` (semantic search scoped by optional peer/session params), `get_metadata`, `set_metadata`
+**Workspace:** `list_workspaces` (id, metadata, created_at), `create_workspace` (get-or-create with optional metadata), `inspect_workspace` (aggregates metadata, configuration, and peer/session IDs), `search` (semantic search scoped by optional peer/session params), `workspace_chat` (reasoned answer across all peers; optional session / scope recall bounds), `get_metadata`, `set_metadata`
 
-**Peers:** `create_peer`, `list_peers`, `chat`, `get_peer_card`, `set_peer_card`, `get_peer_context`, `get_representation`
+**Peers:** `create_peer`, `list_peers`, `chat` (reasoned answer about one peer; optional session / scope / sessions recall bounds), `get_peer_card`, `set_peer_card`, `get_peer_context`, `get_representation`
 
 **Sessions:** `create_session`, `list_sessions`, `delete_session`, `clone_session`, `add_peers_to_session`, `remove_peers_from_session`, `get_session_peers`, `inspect_session`, `add_messages_to_session`, `get_session_messages`, `get_session_message`, `get_session_context`
 
@@ -53,7 +53,7 @@ src/
   config.ts             # HonchoConfig, parseConfig(), createClientFactory()
   types.ts              # ToolContext, result helpers
   tools/
-    workspace.ts        # inspect, list, search, metadata
+    workspace.ts        # inspect, list, search, workspace_chat, metadata
     peers.ts            # CRUD, chat (session / scope / sessions recall bounds), card, context, representation
     scopes.ts           # list scopes, list a scope's sessions
     sessions.ts         # CRUD, peers, messages, inspect, context, clone

--- a/mcp/bun.lock
+++ b/mcp/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "honcho-mcp-proxy",
       "dependencies": {
-        "@honcho-ai/sdk": "^2.2.0",
+        "@honcho-ai/sdk": "^2.4.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "agents": "^0.4.0",
         "nanoid": "^5.1.7",
@@ -107,7 +107,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.4", "", { "os": "win32", "cpu": "x64" }, "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ=="],
 
-    "@honcho-ai/sdk": ["@honcho-ai/sdk@2.2.0", "", { "dependencies": { "zod": "4.0.0" } }, "sha512-SyygN+BrpUB2fRjhwcYmT+tcEhHrKmbj9nOZLVUFY7M5YBswJ+mZb/CeLpNbRh+QQTU8F8JWY3lQat95c6nwmA=="],
+    "@honcho-ai/sdk": ["@honcho-ai/sdk@2.4.0", "", { "dependencies": { "zod": "4.0.0" } }, "sha512-nZE0RJOY3/KhHZdJ9T/fan8Wr26R6Q8s+5GhFpbWwHmnR6680S0r++hoeRpHzcngiU/3cmNQW248pdWpSwU2+Q=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 

--- a/mcp/instructions.md
+++ b/mcp/instructions.md
@@ -115,7 +115,7 @@ The full API for advanced use cases.
 | --- | --- |
 | `create_peer` | Register a new participant (user or agent) |
 | `list_peers` | See all participants in the workspace |
-| `chat` | Ask Honcho what it knows about any peer. Accepts optional `reasoning_level` (`minimal`–`max`) to control depth vs. speed. |
+| `chat` | Ask Honcho what it knows about any peer. Accepts optional `reasoning_level` (`minimal`–`max`) to control depth vs. speed. Confine recall with `session_id` (one session), `scope` (a scope name for that scope's reasoned view, or a list of names as an explicit-only allowlist), or `sessions` (an ad hoc session-ID allowlist, explicit-only). |
 | `get_peer_card` | Get compact biographical facts about a peer |
 | `set_peer_card` | Manually set/correct facts about a peer |
 | `get_peer_context` | Get full context (representation + peer card) |
@@ -126,7 +126,7 @@ The full API for advanced use cases.
 | Tool | When to use |
 | --- | --- |
 | `create_session` | Create or get a session with the given ID |
-| `list_sessions` | Discover existing conversations |
+| `list_sessions` | Discover existing conversations (paginated: `page`, `size`, `reverse`) |
 | `delete_session` | Permanently remove a session |
 | `clone_session` | Fork a conversation (optionally up to a specific message) |
 | `add_peers_to_session` | Add peers to a session with optional per-session config |
@@ -134,7 +134,9 @@ The full API for advanced use cases.
 | `get_session_peers` | See who is in a session |
 | `inspect_session` | Inspect detailed session structure/metadata |
 | `add_messages_to_session` | Add messages from specific peers |
-| `get_session_messages` | Read conversation history (paginated, with optional metadata filters) |
+| `get_session_messages` | Read conversation history (paginated: `page`, `size`, `reverse`; optional metadata filters) |
+| `list_scopes` | List the workspace's scopes — named session sets that act as recall boundaries |
+| `get_scope_sessions` | List the sessions a scope covers (paginated) |
 | `get_session_message` | Get a single message from a session by ID |
 | `get_session_context` | Get LLM-ready context (messages + summary) |
 

--- a/mcp/instructions.md
+++ b/mcp/instructions.md
@@ -106,6 +106,7 @@ The full API for advanced use cases.
 | `create_workspace` | Get or create a workspace when none of the listed ones fit |
 | `inspect_workspace` | Inspect a single workspace's details. Requires `workspace_id`. |
 | `search` | Semantic search across messages — scope with optional `peer_id` or `session_id` params |
+| `workspace_chat` | Ask Honcho a question about the whole workspace — reasons across all peers. Use for cross-peer themes or questions not about one peer; use `chat` for a single peer. Accepts optional `reasoning_level`, and `session_id` / `scope` to confine recall. |
 | `get_metadata` | Read metadata for workspace, peer, or session (scope with optional `peer_id` or `session_id`) |
 | `set_metadata` | Store metadata for workspace, peer, or session (scope with optional `peer_id` or `session_id`) |
 
@@ -115,7 +116,7 @@ The full API for advanced use cases.
 | --- | --- |
 | `create_peer` | Register a new participant (user or agent) |
 | `list_peers` | See all participants in the workspace |
-| `chat` | Ask Honcho what it knows about any peer. Accepts optional `reasoning_level` (`minimal`–`max`) to control depth vs. speed. Confine recall with `session_id` (one session), `scope` (a scope name for that scope's reasoned view, or a list of names as an explicit-only allowlist), or `sessions` (an ad hoc session-ID allowlist, explicit-only). |
+| `chat` | Ask Honcho what it knows about one peer (`peer_id` required). Use `workspace_chat` for the whole workspace. Accepts optional `reasoning_level` (`minimal`–`max`) to control depth vs. speed. Confine recall with `session_id` (one session), `scope` (a scope name for that scope's reasoned view, or a list of names as an explicit-only allowlist), or `sessions` (an ad hoc session-ID allowlist, explicit-only). |
 | `get_peer_card` | Get compact biographical facts about a peer |
 | `set_peer_card` | Manually set/correct facts about a peer |
 | `get_peer_context` | Get full context (representation + peer card) |

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -17,7 +17,7 @@
     "deploy:staging": "wrangler deploy --env staging"
   },
   "dependencies": {
-    "@honcho-ai/sdk": "^2.2.0",
+    "@honcho-ai/sdk": "^2.4.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "agents": "^0.4.0",
     "nanoid": "^5.1.7",

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -3,6 +3,7 @@ import type { ToolContext } from "./types.js";
 import { register as registerWorkspaceTools } from "./tools/workspace.js";
 import { register as registerPeerTools } from "./tools/peers.js";
 import { register as registerSessionTools } from "./tools/sessions.js";
+import { register as registerScopeTools } from "./tools/scopes.js";
 import { register as registerConclusionTools } from "./tools/conclusions.js";
 import { register as registerSystemTools } from "./tools/system.js";
 import instructions from "../instructions.md";
@@ -19,6 +20,7 @@ export function createServer(ctx: ToolContext): McpServer {
   registerWorkspaceTools(server, ctx);
   registerPeerTools(server, ctx);
   registerSessionTools(server, ctx);
+  registerScopeTools(server, ctx);
   registerConclusionTools(server, ctx);
   registerSystemTools(server, ctx);
 

--- a/mcp/src/tools/peers.ts
+++ b/mcp/src/tools/peers.ts
@@ -93,6 +93,19 @@ export function register(server: McpServer, ctx: ToolContext) {
           .string()
           .optional()
           .describe("Optional: scope the query to a specific session."),
+        scope: z
+          .union([z.string(), z.array(z.string()).max(100)])
+          .optional()
+          .describe(
+            "Optional: confine recall to a scope. A single scope name answers from that scope's own reasoned view (all conclusion levels). A list of scope names is an allowlist: explicit conclusions from the union of their sessions only.",
+          ),
+        sessions: z
+          .array(z.string())
+          .max(1000)
+          .optional()
+          .describe(
+            "Optional: allowlist of session IDs to confine recall to (explicit conclusions only). Use for an ad hoc boundary without provisioning a scope.",
+          ),
         reasoning_level: z
           .enum(["minimal", "low", "medium", "high", "max"])
           .optional()
@@ -105,6 +118,8 @@ export function register(server: McpServer, ctx: ToolContext) {
       query,
       target_peer_id,
       session_id,
+      scope,
+      sessions,
       reasoning_level,
     }) => {
       try {
@@ -112,6 +127,8 @@ export function register(server: McpServer, ctx: ToolContext) {
         const result = await peer.chat(query, {
           target: target_peer_id,
           session: session_id,
+          scope,
+          sessions,
           reasoningLevel: reasoning_level,
         });
         return textResult(result ?? "None");

--- a/mcp/src/tools/peers.ts
+++ b/mcp/src/tools/peers.ts
@@ -75,8 +75,9 @@ export function register(server: McpServer, ctx: ToolContext) {
     "chat",
     {
       description: [
-        "Ask a natural-language question about a peer's knowledge and get an answer from Honcho's reasoning system.",
-        "Use this to query what Honcho knows about any peer — their preferences, history, personality, etc.",
+        "Ask a natural-language question about ONE peer and get an answer from Honcho's reasoning system.",
+        "Requires `peer_id`. Answers from that peer's representation only — not the rest of the workspace.",
+        "For cross-peer themes or questions not tied to one peer, use `workspace_chat`.",
         "Returns a natural-language answer, or 'None' if no relevant information exists.",
       ].join("\n"),
       inputSchema: {

--- a/mcp/src/tools/scopes.ts
+++ b/mcp/src/tools/scopes.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolContext } from "../types.js";
+import { textResult, errorResult, workspaceIdSchema } from "../types.js";
+
+const pageSchema = z.number().int().min(1).optional().describe("Page number (1-indexed).");
+const sizeSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(100)
+  .optional()
+  .describe("Results per page (max 100).");
+
+export function register(server: McpServer, ctx: ToolContext) {
+  // ── list_scopes ─────────────────────────────────────────────────────
+  server.registerTool(
+    "list_scopes",
+    {
+      description: [
+        "List the scopes in a workspace (paginated).",
+        "A scope is a named set of sessions that acts as a recall boundary: chat with scope=<name> answers only from that scope's sessions.",
+        "Returns each scope's id, metadata, and created_at.",
+      ].join("\n"),
+      inputSchema: {
+        workspace_id: workspaceIdSchema(ctx),
+        page: pageSchema,
+        size: sizeSchema,
+      },
+    },
+    async ({ workspace_id, page: pageNum, size }) => {
+      try {
+        const page = await ctx.clientFor(workspace_id).scopes({ page: pageNum, size });
+        return textResult({
+          scopes: page.items.map((s) => ({
+            id: s.id,
+            metadata: s.metadata ?? {},
+            created_at: s.createdAt,
+          })),
+          total: page.total,
+          page: page.page,
+          pages: page.pages,
+        });
+      } catch (e) {
+        return errorResult(
+          `Failed to list scopes: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    },
+  );
+
+  // ── get_scope_sessions ──────────────────────────────────────────────
+  server.registerTool(
+    "get_scope_sessions",
+    {
+      description: [
+        "List the sessions that belong to a scope (paginated).",
+        "Use this to see which conversations a recall boundary covers.",
+        "Returns session IDs with pagination metadata.",
+      ].join("\n"),
+      inputSchema: {
+        workspace_id: workspaceIdSchema(ctx),
+        scope_id: z.string().describe("The scope to list sessions for."),
+        page: pageSchema,
+        size: sizeSchema,
+      },
+    },
+    async ({ workspace_id, scope_id, page: pageNum, size }) => {
+      try {
+        const scope = await ctx.clientFor(workspace_id).scope(scope_id);
+        const page = await scope.sessions({ page: pageNum, size });
+        return textResult({
+          scope_id,
+          sessions: page.items.map((s) => ({ id: s.id })),
+          total: page.total,
+          page: page.page,
+          pages: page.pages,
+        });
+      } catch (e) {
+        return errorResult(
+          `Failed to list scope sessions: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    },
+  );
+}

--- a/mcp/src/tools/sessions.ts
+++ b/mcp/src/tools/sessions.ts
@@ -44,15 +44,20 @@ export function register(server: McpServer, ctx: ToolContext) {
       description: [
         "List sessions in the given workspace (paginated).",
         "Use this to discover existing conversations.",
-        "Returns session IDs with pagination metadata.",
+        "Returns session IDs with pagination metadata; pass page/size to walk past the first page.",
       ].join("\n"),
       inputSchema: {
         workspace_id: workspaceIdSchema(ctx),
+        page: z.number().int().min(1).optional().describe("Page number (1-indexed)."),
+        size: z.number().int().min(1).max(100).optional().describe("Results per page (max 100)."),
+        reverse: z.boolean().optional().describe("Newest first when true."),
       },
     },
-    async ({ workspace_id }) => {
+    async ({ workspace_id, page: pageNum, size, reverse }) => {
       try {
-        const page = await ctx.clientFor(workspace_id).sessions();
+        const page = await ctx
+          .clientFor(workspace_id)
+          .sessions({ page: pageNum, size, reverse });
         return textResult({
           sessions: page.items.map((s) => ({ id: s.id })),
           total: page.total,
@@ -335,7 +340,7 @@ export function register(server: McpServer, ctx: ToolContext) {
       description: [
         "Get messages from a session (paginated), with optional metadata filtering.",
         "Use this to read the conversation history.",
-        "Returns the first page of messages with pagination metadata.",
+        "Returns one page of messages with pagination metadata; pass page/size to walk past the first page.",
       ].join("\n"),
       inputSchema: {
         workspace_id: workspaceIdSchema(ctx),
@@ -344,12 +349,15 @@ export function register(server: McpServer, ctx: ToolContext) {
           .record(z.string(), z.unknown())
           .optional()
           .describe("Optional metadata filter criteria."),
+        page: z.number().int().min(1).optional().describe("Page number (1-indexed)."),
+        size: z.number().int().min(1).max(100).optional().describe("Results per page (max 100)."),
+        reverse: z.boolean().optional().describe("Newest first when true."),
       },
     },
-    async ({ workspace_id, session_id, filters }) => {
+    async ({ workspace_id, session_id, filters, page: pageNum, size, reverse }) => {
       try {
         const session = await ctx.clientFor(workspace_id).session(session_id);
-        const page = await session.messages(filters);
+        const page = await session.messages({ filters, page: pageNum, size, reverse });
         return textResult({
           messages: formatMessages(page.items),
           total: page.total,

--- a/mcp/src/tools/workspace.ts
+++ b/mcp/src/tools/workspace.ts
@@ -281,6 +281,51 @@ export function register(server: McpServer, ctx: ToolContext) {
     },
   );
 
+  // ── workspace_chat ──────────────────────────────────────────────
+  server.registerTool(
+    "workspace_chat",
+    {
+      description: [
+        "Ask a natural-language question about the whole workspace and get an answer from Honcho's reasoning system.",
+        "Reasons across ALL peers and their conclusions — use for cross-peer analysis, common themes, or questions not tied to one peer.",
+        "For questions about a single peer, use `chat` instead.",
+        "Returns a natural-language answer, or 'None' if no relevant information exists.",
+      ].join("\n"),
+      inputSchema: {
+        workspace_id: workspaceIdSchema(ctx),
+        query: z.string().describe("Natural-language question."),
+        session_id: z
+          .string()
+          .optional()
+          .describe("Optional: scope the query to a specific session."),
+        scope: z
+          .union([z.string(), z.array(z.string()).max(100)])
+          .optional()
+          .describe(
+            "Optional: confine recall to a scope. A single scope name answers from that scope's own reasoned view (all conclusion levels). A list of scope names is an allowlist: explicit conclusions from the union of their sessions only.",
+          ),
+        reasoning_level: z
+          .enum(["minimal", "low", "medium", "high", "max"])
+          .optional()
+          .describe("Reasoning effort. Higher = more detailed but slower."),
+      },
+    },
+    async ({ workspace_id, query, session_id, scope, reasoning_level }) => {
+      try {
+        const result = await ctx.clientFor(workspace_id).chat(query, {
+          session: session_id,
+          scope,
+          reasoningLevel: reasoning_level,
+        });
+        return textResult(result ?? "None");
+      } catch (e) {
+        return errorResult(
+          `Workspace chat failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    },
+  );
+
   // ── get_metadata ──────────────────────────────────────────────────
   server.registerTool(
     "get_metadata",


### PR DESCRIPTION
## Description

The bundled MCP server was pinned to `@honcho-ai/sdk@2.2.0`, so none of the 2.4.0 recall-boundary, paging, or workspace-chat options were reachable from an MCP client: `list_sessions` and `get_session_messages` could only return the first page, `chat` could only be confined to a single `session_id`, there was no way to see a workspace's scopes, and there was no workspace-level dialectic.

This bumps the SDK to 2.4.0 and surfaces those options as tools/params. `chat` gains optional `scope` (a scope name, or a list of names as an explicit-only allowlist) and `sessions` (an ad hoc session-ID allowlist), and its description now states it answers about one peer. A new `workspace_chat` tool asks a reasoned question across all peers (optional `session_id`, `scope`, `reasoning_level`). `list_sessions` / `get_session_messages` accept `page`, `size`, `reverse`. Two new read-only tools, `list_scopes` and `get_scope_sessions`, live in `mcp/src/tools/scopes.ts`. `mcp/README.md` and `mcp/instructions.md` document the additions.

## Proofs

* `cd mcp && bun install --frozen-lockfile && bun run tsc --noEmit` → clean (exit 0) against `@honcho-ai/sdk@2.4.0`.
* Smoke-tested over stdio against [api.honcho.dev](http://api.honcho.dev): `list_scopes` / `get_scope_sessions` return the scopes provisioned in the `claude-code-scopes` workspace, and `chat` with `scope=<name>` vs. `sessions=[...]` returns different, boundary-respecting answers to the same query.
* Smoke-tested `workspace_chat` over stdio against the committed sandbox (`sandbox/sandbox.sh up`, mock provider): plain / `session_id` / `scope` (string) / `scope` (list) all returned a synthetic answer with `isError` unset and hit `POST /v3/workspaces/sandbox/chat` 200; a nonexistent scope returned `Workspace chat failed: Scope no-such-scope not found…` (404); peer `chat` still routed to `POST .../peers/assistant/chat`. Against a pre-v3.1.0 local image, `workspace_chat` 404s cleanly and peer tools keep working.
* No test suite exists under `mcp/` (the package has no `test` script); the SDK contract is enforced by the typecheck above.

## Checklist

- [X] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.
  * No dedicated issue; the author has write permission on the repo, which the issue gate treats as exempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace-wide chat for questions spanning multiple peers, with optional session, scope, and reasoning controls.
  * Added tools to discover scopes and list sessions within a scope, including pagination and metadata.
  * Added scope and session filters to peer chat requests.
  * Added pagination and reverse-order options to session and message history listings.

* **Documentation**
  * Updated MCP documentation with new tools, recall boundaries, pagination guidance, and architecture details.
  * Added package installation guidance and a changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->