### PR TITLE
fix(workspaces): return 404 on delete when Redis still holds a deleted workspace

### DIFF
--- a/src/crud/__init__.py
+++ b/src/crud/__init__.py
@@ -91,12 +91,14 @@ from .workspace import (
     WorkspaceStats,
     check_no_active_sessions,
     delete_workspace,
+    evict_workspace_cache,
     get_active_peers,
     get_all_workspaces,
     get_or_create_workspace,
     get_workspace,
     get_workspace_stats,
     update_workspace,
+    workspace_exists,
 )
 
 __all__ = [
@@ -188,6 +190,8 @@ __all__ = [
     "WorkspaceDeletionResult",
     "check_no_active_sessions",
     "delete_workspace",
+    "evict_workspace_cache",
+    "workspace_exists",
     "get_or_create_workspace",
     "get_workspace",
     "get_all_workspaces",

--- a/src/crud/workspace.py
+++ b/src/crud/workspace.py
@@ -282,6 +282,22 @@ async def update_workspace(
     return honcho_workspace
 
 
+async def workspace_exists(db: AsyncSession, workspace_name: str) -> bool:
+    """Check Postgres directly for a workspace row.
+
+    Bypasses the Redis-cached fetch. Destructive routes must not act on a cached
+    entry for a workspace the deriver has already deleted (DEV-2646).
+    """
+    return bool(
+        await db.scalar(select(exists().where(models.Workspace.name == workspace_name)))
+    )
+
+
+async def evict_workspace_cache(workspace_name: str) -> None:
+    """Drop the cached workspace entry so later lookups go back to Postgres."""
+    await safe_cache_delete(workspace_cache_key(workspace_name))
+
+
 async def check_no_active_sessions(db: AsyncSession, workspace_name: str) -> None:
     """
     Verify that a workspace has no active sessions.

--- a/src/routers/workspaces.py
+++ b/src/routers/workspaces.py
@@ -8,7 +8,9 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Respon
 from fastapi.responses import StreamingResponse
 from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlalchemy import apaginate
+from psycopg.errors import ForeignKeyViolation
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, models, schemas
@@ -17,7 +19,11 @@ from src.crud.message import get_peer_session_names
 from src.dependencies import db, read_db, tracked_db
 from src.deriver.enqueue import enqueue_deletion, enqueue_dream
 from src.dialectic.chat import workspace_chat, workspace_chat_stream
-from src.exceptions import AuthenticationException, ValidationException
+from src.exceptions import (
+    AuthenticationException,
+    ResourceNotFoundException,
+    ValidationException,
+)
 from src.security import JWTParams, require_auth
 from src.telemetry import prometheus_metrics
 from src.utils.filter import MAX_SESSION_ALLOWLIST_ENTRIES
@@ -129,17 +135,27 @@ async def delete_workspace(
     Returns 409 Conflict if the workspace contains active sessions.
     Delete all sessions first, then delete the workspace.
 
+    Returns 404 if the workspace row is gone, even when Redis still holds an entry
+    for it from before the deriver ran the deletion.
+
     This action cannot be undone.
     """
-    # Verify workspace exists
-    await crud.get_workspace(db, workspace_name=workspace_id)
+    if not await crud.workspace_exists(db, workspace_name=workspace_id):
+        await crud.evict_workspace_cache(workspace_id)
+        raise ResourceNotFoundException(f"Workspace {workspace_id} not found")
 
-    # Check for active sessions before accepting
     await crud.check_no_active_sessions(db, workspace_name=workspace_id)
 
-    # Enqueue for background deletion
-    await enqueue_deletion(workspace_id, "workspace", workspace_id, db_session=db)
-    await db.commit()
+    try:
+        await enqueue_deletion(workspace_id, "workspace", workspace_id, db_session=db)
+        await db.commit()
+    except IntegrityError as e:
+        # The deriver deleted the workspace between the existence check and the insert.
+        if not isinstance(e.orig, ForeignKeyViolation):
+            raise
+        await db.rollback()
+        await crud.evict_workspace_cache(workspace_id)
+        raise ResourceNotFoundException(f"Workspace {workspace_id} not found") from None
 
     return {"message": "Workspace deletion accepted"}
 

--- a/tests/routes/test_workspace_delete_cache.py
+++ b/tests/routes/test_workspace_delete_cache.py
@@ -1,0 +1,89 @@
+"""Workspace delete must return 404, not 500, once the row is gone.
+
+The workspace lookup used elsewhere goes through the Redis-backed
+`_fetch_workspace`. In production the deriver runs with the cache disabled, so
+its cascade never clears Redis and the API keeps serving the deleted workspace
+until TTL. A DELETE that trusted that entry passed its existence check and then
+failed the queue insert on `fk_queue_workspace_name` (Sentry HONCHO-19W/19X,
+DEV-2646).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from nanoid import generate as generate_nanoid
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import crud
+from src.cache.client import cache
+from src.crud.workspace import workspace_cache_key
+
+
+def _create_and_warm(client: TestClient, name: str) -> None:
+    assert client.post("/v3/workspaces", json={"name": name}).status_code in (200, 201)
+    # Second get-or-create goes through the @cache-decorated fetch.
+    assert client.post("/v3/workspaces", json={"name": name}).status_code in (200, 201)
+
+
+@pytest.mark.asyncio
+async def test_delete_after_cascade_clears_cache_and_returns_404(
+    client: TestClient, db_session: AsyncSession
+):
+    name = str(generate_nanoid())
+    _create_and_warm(client, name)
+    assert await cache.get(workspace_cache_key(name)) is not None
+
+    assert client.delete(f"/v3/workspaces/{name}").status_code == 202
+
+    # What the deriver's process_deletion runs.
+    await crud.delete_workspace(db_session, workspace_name=name)
+
+    assert await cache.get(workspace_cache_key(name)) is None
+    response = client.delete(f"/v3/workspaces/{name}")
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.asyncio
+async def test_delete_with_stale_cache_returns_404_and_evicts(
+    client: TestClient, db_session: AsyncSession
+):
+    """Models a deriver whose cache invalidation never reaches the API's Redis."""
+    name = str(generate_nanoid())
+    _create_and_warm(client, name)
+    assert client.delete(f"/v3/workspaces/{name}").status_code == 202
+
+    with patch("src.crud.workspace.cache.delete_match", new=AsyncMock()):
+        await crud.delete_workspace(db_session, workspace_name=name)
+
+    # Row is gone, Redis still says the workspace exists.
+    assert await cache.get(workspace_cache_key(name)) is not None
+
+    response = client.delete(f"/v3/workspaces/{name}")
+    assert response.status_code == 404, response.text
+    assert await cache.get(workspace_cache_key(name)) is None
+
+    # With the ghost evicted, get-or-create recreates the workspace for real.
+    assert client.post("/v3/workspaces", json={"name": name}).status_code in (200, 201)
+    assert client.delete(f"/v3/workspaces/{name}").status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_delete_racing_cascade_returns_404(
+    client: TestClient, db_session: AsyncSession
+):
+    """The deriver drops the row between the existence check and the queue insert."""
+    name = str(generate_nanoid())
+    _create_and_warm(client, name)
+    assert client.delete(f"/v3/workspaces/{name}").status_code == 202
+
+    with patch("src.crud.workspace.cache.delete_match", new=AsyncMock()):
+        await crud.delete_workspace(db_session, workspace_name=name)
+
+    with patch(
+        "src.routers.workspaces.crud.workspace_exists", new=AsyncMock(return_value=True)
+    ):
+        response = client.delete(f"/v3/workspaces/{name}")
+
+    assert response.status_code == 404, response.text
+    assert await cache.get(workspace_cache_key(name)) is None


### PR DESCRIPTION
## Summary

`DELETE /v3/workspaces/{id}` returns 404 instead of 500 when the workspace row is already gone but Redis still holds the workspace.

## Bug fixed

The route resolved the workspace through `crud.get_workspace`, which reads the cashews-cached `_fetch_workspace`. The deriver cascade clears that key after commit, but production deriver pods run with `CACHE_ENABLED=false` (gitops `honcho-deriver.yaml`), so the clear lands in process memory and Redis keeps the entry until TTL. A later DELETE passed the existence check and the queue insert failed on `fk_queue_workspace_name`. The global handler returned 500. Sentry HONCHO-19W and HONCHO-19X hold about 380 of these since June, three per client call because the SDK retries 500.

## Route change

`delete_workspace` now checks Postgres directly with `crud.workspace_exists`. When the row is missing it evicts the cached entry and raises 404, so the next get-or-create recreates the workspace instead of returning the ghost. If the deriver drops the row between that check and the enqueue, the `ForeignKeyViolation` maps to the same 404 after a rollback. Other integrity errors still propagate.

## Tests

`tests/routes/test_workspace_delete_cache.py` covers the same-Redis path, the stale-Redis path with recreate after eviction, and the race path.

## Follow-up

Every cache invalidation that runs inside the deriver is still a no-op against Redis in production: peer card writes from the Dreamer and collection deletes. That needs a deployment or invalidation-path change, tracked in DEV-2646.

Fixes DEV-2646. Related: DEV-2439, DEV-1882.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace deletion now returns a clear `404` response when the workspace does not exist.
  - Stale cached workspace data is removed during deletion, preventing outdated entries from being reused.
  - Handles deletion races reliably when a workspace is removed concurrently.

- **Tests**
  - Added coverage for missing workspaces, stale cache cleanup, concurrent deletion scenarios, and cache recreation after eviction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->