### PR TITLE
fix(peer-card): refuse an over-cap card update instead of truncating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Qdrant vector store backend (`VECTOR_STORE_TYPE=qdrant`) as an optional `qdrant` extra (#683)
 
+### Fixed
+
+- `update_peer_card` truncated an over-cap list down to `MAX_PEER_CARD_FACTS` and still reported the update as successful, so the model was never told that the marker it had just derived had been dropped, and which entries survived came down to arrival order rather than durability — a card sitting at the cap could never take a new entry again. An over-cap list is now refused as a whole, the stored card is left untouched, and the tool result states how many entries to free and how (merge entries that describe the same thing into one, or drop the least durable ones), so the model can consolidate inside the tool loop it is already in. The dreamer's peer-card prompt section and the `update_peer_card` tool description carry the matching rule (#1144)
+
 ## [3.1.1] - 2026-09-02
 
 ### Changed

--- a/src/dreamer/specialists.py
+++ b/src/dreamer/specialists.py
@@ -127,7 +127,16 @@ For each legacy entry:
 
 When in doubt about a specific legacy entry, prefer migrating it (so valid info isn't lost) over dropping it. Splitting one dense legacy entry into multiple correctly-prefixed entries is fine and encouraged (e.g. a semicolon-separated `Tech Stack:` dump can become several `ATTRIBUTE:` lines, one per durable tool/platform).
 
-Call `update_peer_card` with the complete deduplicated list when there is a durable identity update to record, or when the existing card needs migration. Entries that do not start with one of the four allowed prefixes will be rejected. Keep concise (max 40 entries)."""
+Call `update_peer_card` with the complete deduplicated list when there is a durable identity update to record, or when the existing card needs migration. Entries that do not start with one of the four allowed prefixes will be rejected. Keep concise (max 40 entries).
+
+### When the card is at the cap
+
+A list longer than the cap is refused as a whole — nothing is written and the existing card stays as it was. So when the card is already full and you have a new durable marker, make room in the same call instead of appending:
+
+- Merge entries that describe the same thing into one entry. Several entries stating one mapping, tool, or rule each can often become one entry that carries the same information, as long as it stays a single concise marker within the per-entry length cap.
+- Otherwise drop the least durable entries — the ones most likely to change or already implied by another entry.
+
+If the tool reports that your list was over the cap, consolidate further and call it again with the complete list. Do not respond by dropping the new marker and re-sending the old card unchanged."""
 
 
 class BaseSpecialist(ABC):

--- a/src/utils/agent_tools.py
+++ b/src/utils/agent_tools.py
@@ -536,6 +536,9 @@ TOOLS: dict[str, dict[str, Any]] = {
                     "type": "array",
                     "description": (
                         "Complete deduplicated peer card list (max 40 entries). "
+                        "A longer list is refused as a whole and nothing is written, so "
+                        "consolidate before sending: merge entries that describe the same "
+                        "thing into one, or drop the least durable ones. "
                         "Each entry must start with one of the allowed prefixes "
                         "(`IDENTITY: `, `ATTRIBUTE: `, `RELATIONSHIP: `, `INSTRUCTION: `) "
                         "followed by one concise identity marker. Entries without an allowed prefix are rejected."
@@ -1807,14 +1810,33 @@ async def _handle_update_peer_card(
             return _format_rejection_feedback(f"all {rejected_count}")
         return "Peer card content was empty after normalization, no update performed."
 
+    # An over-cap list is refused as a whole instead of truncated. Truncating
+    # reported success while dropping the tail, so the model never learned that
+    # the marker it had just derived was gone, and which entries survived came
+    # down to arrival order rather than durability. Refusing hands that decision
+    # back to the model, which still has tool iterations left to consolidate.
     if len(normalized_peer_card) > MAX_PEER_CARD_FACTS:
+        surplus = len(normalized_peer_card) - MAX_PEER_CARD_FACTS
         logger.warning(
-            "Peer card update exceeded max facts (%s), truncating from %s to %s",
+            "Peer card update exceeded max facts (%s): %s entries sent for %s/%s/%s, keeping existing card",
             MAX_PEER_CARD_FACTS,
             len(normalized_peer_card),
-            MAX_PEER_CARD_FACTS,
+            ctx.workspace_name,
+            ctx.observer,
+            ctx.observed,
         )
-        normalized_peer_card = normalized_peer_card[:MAX_PEER_CARD_FACTS]
+        feedback = (
+            f"Peer card not updated: {len(normalized_peer_card)} entries were sent "
+            f"but the cap is {MAX_PEER_CARD_FACTS}. The existing card is unchanged. "
+            f"Free up at least {surplus} "
+            f"{'entry' if surplus == 1 else 'entries'} — merge entries that describe "
+            "the same thing into one, or drop the least durable ones — then call "
+            "`update_peer_card` again with the complete list."
+        )
+        if rejected_count:
+            total = len(normalized_peer_card) + rejected_count
+            feedback = f"{feedback} {_format_rejection_feedback(f'{rejected_count} of {total}')}"
+        return feedback
 
     async with ctx.db_lock, tracked_db("tool.update_peer_card") as db:
         await crud.set_peer_card(

--- a/tests/utils/test_agent_tools.py
+++ b/tests/utils/test_agent_tools.py
@@ -1305,7 +1305,7 @@ class TestUpdatePeerCard:
         assert peer_card is not None
         assert "IDENTITY: Name: John" in peer_card
 
-    async def test_deduplicates_and_caps_peer_card(
+    async def test_deduplicates_and_normalizes_peer_card(
         self,
         db_session: AsyncSession,
         tool_test_data: Any,
@@ -1315,17 +1315,15 @@ class TestUpdatePeerCard:
         workspace, peer1, peer2, _, _, _ = tool_test_data
         ctx = make_tool_context()
 
-        oversized = [
+        messy = [
             "IDENTITY: Name: John",
             "  IDENTITY: Name: John  ",
             "",
             "   ",
         ]
-        oversized.extend(
-            [f"IDENTITY: Aliases: alias-{i}" for i in range(MAX_PEER_CARD_FACTS + 5)]
-        )
+        messy.extend([f"IDENTITY: Aliases: alias-{i}" for i in range(5)])
 
-        await _handle_update_peer_card(ctx, {"content": oversized})
+        await _handle_update_peer_card(ctx, {"content": messy})
 
         # Refresh the observer so the identity map picks up the committed update
         await db_session.refresh(peer1)
@@ -1336,9 +1334,67 @@ class TestUpdatePeerCard:
             observed=peer2.name,
         )
         assert peer_card is not None
-        assert len(peer_card) == MAX_PEER_CARD_FACTS
+        assert len(peer_card) == 6
         assert all(line.strip() for line in peer_card)
         assert peer_card.count("IDENTITY: Name: John") == 1
+
+    async def test_over_cap_update_is_refused_and_keeps_existing_card(
+        self,
+        db_session: AsyncSession,
+        tool_test_data: Any,
+        make_tool_context: Callable[..., ToolContext],
+    ):
+        """A full card plus one new marker is refused, not truncated.
+
+        Reproduces the observed failure: the dreamer sent MAX_PEER_CARD_FACTS + 1
+        entries against a card already at the cap, the surplus entry was cut
+        silently, and the tool still reported the update as successful — so the
+        model had no way to learn that the marker it just derived was dropped.
+        """
+        workspace, peer1, peer2, _, _, _ = tool_test_data
+        ctx = make_tool_context()
+
+        full_card = [
+            f"IDENTITY: Aliases: alias-{i}" for i in range(MAX_PEER_CARD_FACTS)
+        ]
+        await _handle_update_peer_card(ctx, {"content": full_card})
+
+        result = await _handle_update_peer_card(
+            ctx, {"content": [*full_card, "ATTRIBUTE: Timezone: Europe/Berlin"]}
+        )
+
+        assert "not updated" in result
+        assert str(MAX_PEER_CARD_FACTS + 1) in result
+        # Singular, so the model is told to free exactly one entry.
+        assert "1 entry " in result
+
+        await db_session.refresh(peer1)
+        peer_card = await crud.get_peer_card(
+            db_session,
+            workspace_name=workspace.name,
+            observer=peer1.name,
+            observed=peer2.name,
+        )
+        assert peer_card == full_card
+
+    async def test_over_cap_feedback_also_reports_rejected_entries(
+        self,
+        tool_test_data: Any,
+        make_tool_context: Callable[..., ToolContext],
+    ):
+        """An over-cap list carrying invalid entries surfaces both problems."""
+        ctx = make_tool_context()
+
+        over_cap = [
+            f"IDENTITY: Aliases: alias-{i}" for i in range(MAX_PEER_CARD_FACTS + 1)
+        ]
+
+        result = await _handle_update_peer_card(
+            ctx, {"content": [*over_cap, "no prefix at all"]}
+        )
+
+        assert "not updated" in result
+        assert "structural validation" in result
 
     async def test_none_content_preserves_existing_card(
         self,


### PR DESCRIPTION
## Description

`update_peer_card` truncated an over-cap list down to `MAX_PEER_CARD_FACTS` and still reported the update as successful, so the model was never told that the marker it had just derived had been dropped, and a card sitting at the cap could never take a new entry again. This refuses an over-cap list as a whole, leaves the stored card untouched, and returns a result that states how many entries to free and how — reusing the feedback path the function already has for structurally invalid entries, so the model can consolidate inside the tool loop it is already in.

The dreamer's peer-card prompt section and the `update_peer_card` tool description carry the matching rule, so the contract is stated where the model reads it rather than only enforced where it writes.

## Proofs

The tool result a specialist now gets when it sends 41 entries against a card at the cap:

```
Peer card not updated: 41 entries were sent but the cap is 40. The existing card is
unchanged. Free up at least 1 entry — merge entries that describe the same thing into
one, or drop the least durable ones — then call `update_peer_card` again with the
complete list.
```

Nothing is written on that path, and it returns before touching the database. When an over-cap list also carries structurally invalid entries, both problems are reported in one result.

Test suite on this branch, against Postgres with pgvector:

```
$ uv run pytest tests/utils/test_agent_tools.py tests/dreamer/ -q
168 passed in 13.17s
```

`ruff check`, `ruff format --check` and `basedpyright` are clean on the three changed files. `ruff check src/` still reports the 41 pre-existing findings on `main`; none of them come from this diff.

**One deliberate test change worth a reviewer's attention:** `test_deduplicates_and_caps_peer_card` asserted the truncating contract (`len(peer_card) == MAX_PEER_CARD_FACTS` after an over-cap send), so it is split rather than edited in place. Its dedup and normalization assertions live on in `test_deduplicates_and_normalizes_peer_card`, and the cap behaviour is now covered by `test_over_cap_update_is_refused_and_keeps_existing_card`, which reproduces the 41-entries-against-a-full-card case end to end.

Not included on purpose: no ranking or pinning of entries (unnecessary once the model can consolidate itself), and `MAX_PEER_CARD_FACTS` stays a constant rather than becoming a setting — both felt like separate discussions.

## Checklist

- [x] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.

Fixes #1143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Peer card updates that exceed the 40-entry limit are now rejected instead of being silently truncated.
  - Existing peer card data remains unchanged when an update is rejected.
  - Update feedback now reports how many entries must be removed and recommends merging duplicates or removing less durable entries.
  - Guidance now helps consolidate oversized peer cards and retry successfully.
- **Documentation**
  - Added an unreleased changelog entry describing the corrected peer card update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->