### PR TITLE
feat(ci): close pull requests that have gone quiet on the author

### DIFF
--- a/.github/scripts/issue-gate.js
+++ b/.github/scripts/issue-gate.js
@@ -221,7 +221,9 @@ const ACTIVITY = `
         }
         comments(last: 50) { nodes { createdAt author { login } } }
         timelineItems(last: 50, itemTypes: [LABELED_EVENT]) {
-          nodes { ... on LabeledEvent { createdAt label { name } } }
+          nodes {
+            ... on LabeledEvent { createdAt actor { __typename } label { name } }
+          }
         }
       }
     }
@@ -233,6 +235,18 @@ const latest = (stamps) =>
   stamps.filter(Boolean).map(Date.parse).reduce((a, b) => (b > a ? b : a), 0);
 
 const loginOf = (node) => (node && node.author && node.author.login) || null;
+
+/**
+ * A hand-back label applied by a person.
+ *
+ * Same reasoning as `isHandback`: applying a label needs triage permission, so
+ * any human who can do it has standing — but a workflow holding `issues: write`
+ * does not, and must not be able to start a clock on work no human reviewed.
+ */
+const isHandbackLabel = (node) =>
+  Boolean(node.label) &&
+  HANDBACK_LABELS.includes(node.label.name) &&
+  !isBot({ type: node.actor && node.actor.__typename });
 
 /** A changes-requested review that actually hands the pull request back. */
 const isHandback = (review, prAuthor) =>
@@ -265,9 +279,7 @@ async function prActivity({ github, owner, repo, pr }) {
       ...node.reviews.nodes
         .filter((r) => r.state === 'CHANGES_REQUESTED' && isHandback(r, author))
         .map((r) => r.submittedAt),
-      ...node.timelineItems.nodes
-        .filter((n) => n.label && HANDBACK_LABELS.includes(n.label.name))
-        .map((n) => n.createdAt),
+      ...node.timelineItems.nodes.filter(isHandbackLabel).map((n) => n.createdAt),
     ]),
     answered: latest([
       ...node.commits.nodes.map((n) => n.commit.committedDate),
@@ -448,6 +460,25 @@ async function runSweep({ github, core, context, dryRun }) {
     }
 
     if (hasLabel(pr, STALE_LABEL)) {
+      // The label is not proof that we put it there, and the situation can have
+      // changed since we did. Re-establish both before acting on it, or a
+      // maintainer approving a warned pull request still sees it closed 72h
+      // later — exactly what CONTRIBUTING.md promises will not happen.
+      const exempt = await exemptReason({ github, owner, repo, pr });
+      if (exempt) {
+        await act(`#${pr.number}: ${exempt} — standing down`, () =>
+          clearStale({ github, owner, repo, pr }));
+        continue;
+      }
+
+      const activity = await prActivity({ github, owner, repo, pr });
+      const { turn, why } = whoseTurn(activity);
+      if (turn !== 'author') {
+        await act(`#${pr.number}: no longer waiting on the author (${why}) — standing down`, () =>
+          clearStale({ github, owner, repo, pr }));
+        continue;
+      }
+
       const [notice] = await findNotices({
         github, owner, repo, number: pr.number, marker: STALE_MARKER,
       });
@@ -462,8 +493,10 @@ async function runSweep({ github, core, context, dryRun }) {
         continue;
       }
 
-      const { answered } = await prActivity({ github, owner, repo, pr });
-      if (answered > Date.parse(notice.created_at)) {
+      // Still their turn, but they answered and were handed back again since
+      // the warning. Clear it so the next warning starts its own clock rather
+      // than closing them out on a window they already responded to.
+      if (activity.answered > Date.parse(notice.created_at)) {
         await act(`#${pr.number}: author replied after the warning — standing down`, () =>
           clearStale({ github, owner, repo, pr }));
         continue;
@@ -536,7 +569,7 @@ async function runSweep({ github, core, context, dryRun }) {
 
 module.exports = {
   checkGate, runGate, runSweep, noticeBody, findNotices, exemptReason,
-  prActivity, whoseTurn, staleNoticeBody, isHandback,
+  prActivity, whoseTurn, staleNoticeBody, isHandback, isHandbackLabel,
   REQUIRED_LABEL, GATE_LABEL, EXEMPT_LABEL, MARKER, GRACE_HOURS, DRAFT_STALE_DAYS,
   STALE_LABEL, STALE_MARKER, NO_AUTOCLOSE_LABEL, HANDBACK_LABELS, HANDBACK_ASSOCIATIONS,
   RESPONSE_STALE_DAYS, STALE_GRACE_HOURS, UNREVIEWED_STALE_DAYS, MAX_STALE_CLOSES,

--- a/.github/scripts/issue-gate.js
+++ b/.github/scripts/issue-gate.js
@@ -25,6 +25,38 @@ const GRACE_HOURS = 72;
 // Days without activity before a draft from outside the org is closed.
 const DRAFT_STALE_DAYS = 30;
 
+// The contributor response SLA from CONTRIBUTING.md, in days. The clock runs
+// only while the pull request is waiting on its author — see `whoseTurn`.
+const RESPONSE_STALE_DAYS = 7;
+
+// Hours between the stale warning and the close. Same shape as GRACE_HOURS:
+// nobody gets closed without having been told first.
+const STALE_GRACE_HOURS = 72;
+
+// Days a pull request waiting on *us* may sit idle before it is closed.
+// `null` disables that pass, which is the intended default: a pull request no
+// maintainer has looked at is our backlog, not a contributor SLA breach.
+const UNREVIEWED_STALE_DAYS = null;
+
+// Ceiling on stale closes per sweep. The open queue predates this policy, so a
+// mistake here should cost a handful of pull requests and not the whole list.
+const MAX_STALE_CLOSES = 10;
+
+const STALE_LABEL = 'stale';
+const STALE_MARKER = '<!-- pr-stale -->';
+
+// Manual pin. Overrides the stale pass on a single pull request.
+const NO_AUTOCLOSE_LABEL = 'no-autoclose';
+
+// Labels a maintainer applies to hand a pull request back to its author. Doing
+// so starts the SLA clock, exactly like a changes-requested review.
+const HANDBACK_LABELS = ['needs-changes'];
+
+// Associations that count as a maintainer hand-back. `CONTRIBUTOR` is missing on
+// purpose: review bots run as CONTRIBUTOR, and a bot asking for changes must not
+// start a clock that closes work no human has looked at.
+const HANDBACK_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+
 const hasLabel = (pr, name) => (pr.labels || []).some((l) => l.name === name);
 
 const isBot = (account) => Boolean(account) && account.type === 'Bot';
@@ -149,11 +181,11 @@ function noticeBody({ owner, repo, reason }) {
  * never be told, and `runSweep` would then measure the grace window from the
  * stranger's timestamp and close them unwarned.
  */
-async function findNotices({ github, owner, repo, number }) {
+async function findNotices({ github, owner, repo, number, marker = MARKER }) {
   const comments = await github.paginate(github.rest.issues.listComments, {
     owner, repo, issue_number: number, per_page: 100,
   });
-  return comments.filter((c) => isBot(c.user) && (c.body || '').includes(MARKER));
+  return comments.filter((c) => isBot(c.user) && (c.body || '').includes(marker));
 }
 
 /**
@@ -175,6 +207,129 @@ async function clearGate({ github, owner, repo, pr }) {
       .deleteComment({ owner, repo, comment_id: notice.id })
       .catch(() => {});
   }
+}
+
+const ACTIVITY = `
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        author { login }
+        reviewDecision
+        commits(last: 1) { nodes { commit { committedDate } } }
+        reviews(last: 30) {
+          nodes { state submittedAt authorAssociation author { login __typename } }
+        }
+        comments(last: 50) { nodes { createdAt author { login } } }
+        timelineItems(last: 50, itemTypes: [LABELED_EVENT]) {
+          nodes { ... on LabeledEvent { createdAt label { name } } }
+        }
+      }
+    }
+  }
+`;
+
+/** Most recent of a list of timestamps, in epoch ms. 0 when there are none. */
+const latest = (stamps) =>
+  stamps.filter(Boolean).map(Date.parse).reduce((a, b) => (b > a ? b : a), 0);
+
+const loginOf = (node) => (node && node.author && node.author.login) || null;
+
+/** A changes-requested review that actually hands the pull request back. */
+const isHandback = (review, prAuthor) =>
+  loginOf(review) !== prAuthor &&
+  !isBot({ type: review.author && review.author.__typename }) &&
+  HANDBACK_ASSOCIATIONS.includes(review.authorAssociation);
+
+/**
+ * When we last handed a pull request back to its author, and when they last
+ * did anything about it.
+ *
+ * `asked` counts only explicit hand-backs by a human maintainer: a
+ * changes-requested review, or one of HANDBACK_LABELS. A passing remark in a
+ * comment deliberately does not — the clock should start on an action a
+ * maintainer took on purpose, and never on a review bot's verdict.
+ *
+ * `answered` uses the last commit's `committedDate`, which can predate the push
+ * that carried it. The skew only ever makes a reply look older than it was, so
+ * the error runs toward leaving a pull request open.
+ */
+async function prActivity({ github, owner, repo, pr }) {
+  const data = await github.graphql(ACTIVITY, { owner, repo, number: pr.number });
+  const node = data.repository.pullRequest;
+  const author = loginOf(node);
+
+  return {
+    author,
+    reviewDecision: node.reviewDecision,
+    asked: latest([
+      ...node.reviews.nodes
+        .filter((r) => r.state === 'CHANGES_REQUESTED' && isHandback(r, author))
+        .map((r) => r.submittedAt),
+      ...node.timelineItems.nodes
+        .filter((n) => n.label && HANDBACK_LABELS.includes(n.label.name))
+        .map((n) => n.createdAt),
+    ]),
+    answered: latest([
+      ...node.commits.nodes.map((n) => n.commit.committedDate),
+      ...node.comments.nodes.filter((c) => loginOf(c) === author).map((c) => c.createdAt),
+      ...node.reviews.nodes.filter((r) => loginOf(r) === author).map((r) => r.submittedAt),
+    ]),
+  };
+}
+
+/**
+ * Whose turn it is. Pure, so the table in issue-gate.test.js can cover it.
+ *
+ * Only `author` is inside the SLA. Everything else is our queue: closing work
+ * nobody reviewed would punish contributors for our own backlog, which is the
+ * opposite of what the response window is for.
+ *
+ * @returns {{turn: 'author'|'maintainer', why: string}}
+ */
+function whoseTurn({ reviewDecision, asked, answered }) {
+  if (reviewDecision === 'APPROVED') return { turn: 'maintainer', why: 'approved, waiting on merge' };
+  if (!asked) return { turn: 'maintainer', why: 'never handed back to the author' };
+  if (answered > asked) return { turn: 'maintainer', why: 'author already replied to the hand-back' };
+  return { turn: 'author', why: 'handed back, no reply since' };
+}
+
+/** Undo a stale warning, so a later one is measured from its own timestamp. */
+async function clearStale({ github, owner, repo, pr }) {
+  if (hasLabel(pr, STALE_LABEL)) {
+    await github.rest.issues
+      .removeLabel({ owner, repo, issue_number: pr.number, name: STALE_LABEL })
+      .catch(() => {});
+  }
+  const notices = await findNotices({
+    github, owner, repo, number: pr.number, marker: STALE_MARKER,
+  });
+  for (const notice of notices) {
+    await github.rest.issues
+      .deleteComment({ owner, repo, comment_id: notice.id })
+      .catch(() => {});
+  }
+}
+
+function staleNoticeBody({ owner, repo, days }) {
+  return [
+    STALE_MARKER,
+    `This pull request has been waiting on you for ${Math.round(days)} days.`,
+    '',
+    `We asked for changes and have not heard back. Honcho gives open source contributions a ${RESPONSE_STALE_DAYS} day response window — see [CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md#review) — so this is the ping before it runs out.`,
+    '',
+    `**This will close automatically in ${STALE_GRACE_HOURS} hours unless something happens here.** A push is enough. So is a comment saying you need more time — we would much rather hold the pull request open than lose the work.`,
+    '',
+    `Closing is not a judgement on the code. The branch stays on your fork, and reopening puts it straight back in the queue.`,
+  ].join('\n');
+}
+
+function staleCloseBody() {
+  return (
+    `Closing this after ${RESPONSE_STALE_DAYS} days with no reply to the requested changes, ` +
+    `so the review queue reflects what is actually moving. Nothing here is lost — push to the ` +
+    `branch and reopen whenever you pick it back up, or say so in [Discord](${DISCORD}) and a ` +
+    `maintainer will reopen it for you.`
+  );
 }
 
 /**
@@ -217,9 +372,20 @@ async function runSweep({ github, core, context, dryRun }) {
     if (!dryRun) await fn();
   };
 
+  // A pull request can qualify for more than one pass. Whichever closes it
+  // first owns it; the rest must not comment on a pull request already closed.
+  const closed = new Set();
+
   const close = (pr, body) => async () => {
     await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
     await github.rest.pulls.update({ owner, repo, pull_number: pr.number, state: 'closed' });
+  };
+
+  // Marks the pull request closed for the rest of this run, dry or not, so the
+  // dry-run log shows the same set of actions a live run would take.
+  const closing = (pr, body) => {
+    closed.add(pr.number);
+    return close(pr, body);
   };
 
   const prs = await github.paginate(github.rest.pulls.list, {
@@ -257,14 +423,102 @@ async function runSweep({ github, core, context, dryRun }) {
       continue;
     }
 
-    await act(`#${pr.number}: closing — notified ${Math.round(hours)}h ago, still failing`, close(pr,
+    await act(`#${pr.number}: closing — notified ${Math.round(hours)}h ago, still failing`, closing(pr,
       `Closing this: ${GRACE_HOURS} hours have passed and the gate is still not clear. This is not a judgement on the code. Link an approved issue and reopen — it goes straight into the review queue.`,
     ));
+  }
+
+  // Stale pull requests waiting on their author. The window in CONTRIBUTING.md
+  // is a *response* SLA, so it runs only while the ball is in the contributor's
+  // court — `whoseTurn` is what decides that, and the log says which way it
+  // went for every candidate. Warn first, close a grace period later.
+  //
+  // The STALE_LABEL is the cheap test for "already warned": `pulls.list`
+  // carries labels, and the warning itself bumps `updated_at`, so idle time
+  // stops being a usable clock the moment we post one.
+  let budget = MAX_STALE_CLOSES;
+
+  for (const pr of prs) {
+    if (closed.has(pr.number)) continue;
+    if (pr.draft) continue;                   // the stale-draft pass below owns drafts
+    if (hasLabel(pr, GATE_LABEL)) continue;   // the gate pass above owns these
+    if (hasLabel(pr, NO_AUTOCLOSE_LABEL)) {
+      core.info(`#${pr.number}: pinned by ${NO_AUTOCLOSE_LABEL}`);
+      continue;
+    }
+
+    if (hasLabel(pr, STALE_LABEL)) {
+      const [notice] = await findNotices({
+        github, owner, repo, number: pr.number, marker: STALE_MARKER,
+      });
+      if (!notice) {
+        core.warning(`#${pr.number}: ${STALE_LABEL} but no warning comment — re-warning`);
+        await act(`#${pr.number}: re-posting the stale warning`, async () => {
+          await github.rest.issues.createComment({
+            owner, repo, issue_number: pr.number,
+            body: staleNoticeBody({ owner, repo, days: RESPONSE_STALE_DAYS }),
+          });
+        });
+        continue;
+      }
+
+      const { answered } = await prActivity({ github, owner, repo, pr });
+      if (answered > Date.parse(notice.created_at)) {
+        await act(`#${pr.number}: author replied after the warning — standing down`, () =>
+          clearStale({ github, owner, repo, pr }));
+        continue;
+      }
+
+      const waited = (Date.now() - Date.parse(notice.created_at)) / 3_600_000;
+      if (waited < STALE_GRACE_HOURS) {
+        core.info(`#${pr.number}: ${Math.round(STALE_GRACE_HOURS - waited)}h left after the warning`);
+        continue;
+      }
+      if (budget <= 0) {
+        core.warning(`#${pr.number}: ready to close but the ${MAX_STALE_CLOSES}-close budget is spent`);
+        continue;
+      }
+      budget -= 1;
+      await act(`#${pr.number}: closing — warned ${Math.round(waited)}h ago, no reply`,
+        closing(pr, staleCloseBody()));
+      continue;
+    }
+
+    // `updated_at` is an upper bound on every timestamp on the pull request, so
+    // anything fresher than the shortest window cannot be stale under any rule.
+    const idle = (Date.now() - Date.parse(pr.updated_at)) / 86_400_000;
+    if (idle < RESPONSE_STALE_DAYS) continue;
+
+    const exempt = await exemptReason({ github, owner, repo, pr });
+    if (exempt) {
+      core.info(`#${pr.number}: leaving idle pull request alone — ${exempt}`);
+      continue;
+    }
+
+    const activity = await prActivity({ github, owner, repo, pr });
+    const { turn, why } = whoseTurn(activity);
+    const window = turn === 'author' ? RESPONSE_STALE_DAYS : UNREVIEWED_STALE_DAYS;
+
+    if (window === null || idle < window) {
+      core.info(`#${pr.number}: ${Math.round(idle)}d idle, waiting on ${turn} — ${why}`);
+      continue;
+    }
+
+    await act(`#${pr.number}: warning — ${Math.round(idle)}d idle, ${why}`, async () => {
+      await github.rest.issues.addLabels({
+        owner, repo, issue_number: pr.number, labels: [STALE_LABEL],
+      });
+      await github.rest.issues.createComment({
+        owner, repo, issue_number: pr.number,
+        body: staleNoticeBody({ owner, repo, days: idle }),
+      });
+    });
   }
 
   // Stale drafts. The gate skips drafts entirely, so they never carry the label;
   // this pass keys off inactivity and applies the shared exemptions itself.
   for (const pr of prs.filter((p) => p.draft)) {
+    if (closed.has(pr.number)) continue;
     const exempt = await exemptReason({ github, owner, repo, pr });
     if (exempt) {
       core.info(`#${pr.number}: leaving stale draft alone — ${exempt}`);
@@ -274,7 +528,7 @@ async function runSweep({ github, core, context, dryRun }) {
     const days = (Date.now() - Date.parse(pr.updated_at)) / 86_400_000;
     if (days < DRAFT_STALE_DAYS) continue;
 
-    await act(`#${pr.number}: closing stale draft — ${Math.round(days)}d without activity`, close(pr,
+    await act(`#${pr.number}: closing stale draft — ${Math.round(days)}d without activity`, closing(pr,
       `Closing this draft after ${DRAFT_STALE_DAYS} days without activity, to keep the pull request list readable. Reopen whenever you pick it back up — nothing here is lost.`,
     ));
   }
@@ -282,5 +536,8 @@ async function runSweep({ github, core, context, dryRun }) {
 
 module.exports = {
   checkGate, runGate, runSweep, noticeBody, findNotices, exemptReason,
+  prActivity, whoseTurn, staleNoticeBody, isHandback,
   REQUIRED_LABEL, GATE_LABEL, EXEMPT_LABEL, MARKER, GRACE_HOURS, DRAFT_STALE_DAYS,
+  STALE_LABEL, STALE_MARKER, NO_AUTOCLOSE_LABEL, HANDBACK_LABELS, HANDBACK_ASSOCIATIONS,
+  RESPONSE_STALE_DAYS, STALE_GRACE_HOURS, UNREVIEWED_STALE_DAYS, MAX_STALE_CLOSES,
 };

--- a/.github/scripts/issue-gate.test.js
+++ b/.github/scripts/issue-gate.test.js
@@ -7,7 +7,10 @@
 
 const assert = require('node:assert');
 const {
-  checkGate, findNotices, runSweep, REQUIRED_LABEL, EXEMPT_LABEL, MARKER,
+  checkGate, findNotices, runSweep, whoseTurn,
+  REQUIRED_LABEL, EXEMPT_LABEL, MARKER,
+  STALE_LABEL, STALE_MARKER, NO_AUTOCLOSE_LABEL,
+  RESPONSE_STALE_DAYS, STALE_GRACE_HOURS,
 } = require('./issue-gate.js');
 
 const pull = (over = {}) => ({
@@ -94,6 +97,161 @@ const noticeCases = [
      { id: 5, user: { type: 'Bot' }, body: MARKER, created_at: 'y' }], 1],
 ];
 
+// --- whoseTurn: only an unanswered hand-back is inside the SLA -------------
+// Pure decision table. The stale pass closes on `author` and nothing else, so
+// every branch that returns `maintainer` is a pull request we must not touch.
+const HOUR = 3600_000;
+const t = (hoursAgo) => Date.now() - hoursAgo * HOUR;
+
+const turnCases = [
+  ['never handed back is ours',
+    { asked: 0, answered: t(900) }, 'maintainer'],
+  ['approved is ours even after a hand-back',
+    { reviewDecision: 'APPROVED', asked: t(900), answered: 0 }, 'maintainer'],
+  ['hand-back with no reply is theirs',
+    { reviewDecision: 'CHANGES_REQUESTED', asked: t(900), answered: 0 }, 'author'],
+  ['hand-back the author replied to is ours',
+    { reviewDecision: 'CHANGES_REQUESTED', asked: t(900), answered: t(100) }, 'maintainer'],
+  ['reply older than the hand-back is still theirs',
+    { reviewDecision: 'CHANGES_REQUESTED', asked: t(100), answered: t(900) }, 'author'],
+  ['a re-review after the author replied is theirs again',
+    { reviewDecision: 'CHANGES_REQUESTED', asked: t(50), answered: t(100) }, 'author'],
+];
+
+// --- runSweep: the stale pass ---------------------------------------------
+// Records every write the sweep makes, so a case can assert on "warned but not
+// closed" — the distinction the whole warn-then-close design rests on.
+const idleDays = (days) => new Date(Date.now() - days * 86400_000).toISOString();
+
+function sweepHarness({ pr, activity = {}, comments = [], permission }) {
+  const log = { closed: [], comments: [], labels: [], unlabels: [], deleted: [] };
+  const github = {
+    paginate: async (route) => (route === 'pulls' ? [pr] : comments),
+    // Serves both queries the sweep issues: the gate's closing-issue lookup and
+    // the stale pass's activity lookup.
+    graphql: async () => ({
+      repository: { pullRequest: {
+        closingIssuesReferences: { nodes: [] },
+        author: { login: (pr.user || {}).login || 'alice' },
+        reviewDecision: activity.reviewDecision || null,
+        commits: { nodes: activity.commit ? [{ commit: { committedDate: activity.commit } }] : [] },
+        reviews: { nodes: activity.reviews || [] },
+        comments: { nodes: activity.comments || [] },
+        timelineItems: { nodes: activity.labeled || [] },
+      } },
+    }),
+    rest: {
+      pulls: {
+        list: 'pulls',
+        update: async ({ pull_number }) => log.closed.push(pull_number),
+      },
+      issues: {
+        listComments: 'comments',
+        createComment: async ({ body }) => log.comments.push(body),
+        addLabels: async ({ labels }) => log.labels.push(...labels),
+        removeLabel: async ({ name }) => log.unlabels.push(name),
+        deleteComment: async ({ comment_id }) => log.deleted.push(comment_id),
+      },
+      repos: {
+        getCollaboratorPermissionLevel: async () => {
+          if (!permission) return notCollaborator();
+          return { data: { permission } };
+        },
+      },
+    },
+  };
+  return runSweep({
+    github, core: { info() {}, warning() {} },
+    context: { repo: { owner: 'o', repo: 'r' } }, dryRun: false,
+  }).then(() => log);
+}
+
+const open = (over = {}) => ({
+  number: 20, draft: false, state: 'open', labels: [],
+  user: { type: 'User', login: 'alice' },
+  updated_at: idleDays(RESPONSE_STALE_DAYS + 5),
+  ...over,
+});
+
+const staleNotice = (hoursAgo) => [{
+  id: 99, user: { type: 'Bot' }, body: `${STALE_MARKER}\nwarned`,
+  created_at: new Date(t(hoursAgo)).toISOString(),
+}];
+
+const review = (over = {}) => ({
+  state: 'CHANGES_REQUESTED', submittedAt: new Date(t(400)).toISOString(),
+  authorAssociation: 'MEMBER', author: { login: 'maintainer', __typename: 'User' },
+  ...over,
+});
+
+const handedBack = { reviewDecision: 'CHANGES_REQUESTED', reviews: [review()] };
+
+// A review bot runs as CONTRIBUTOR and can submit CHANGES_REQUESTED. If that
+// counted, the sweeper would close pull requests no human ever looked at.
+const botHandedBack = { reviewDecision: 'CHANGES_REQUESTED', reviews: [review({
+  authorAssociation: 'CONTRIBUTOR', author: { login: 'coderabbitai', __typename: 'Bot' },
+})] };
+
+const staleCases = [
+  ['idle hand-back is warned, not closed',
+    { pr: open(), activity: handedBack },
+    (l) => l.closed.length === 0 && l.labels.includes(STALE_LABEL)
+      && l.comments.some((c) => c.includes(STALE_MARKER))],
+
+  ['a bot requesting changes does not start the clock',
+    { pr: open(), activity: botHandedBack },
+    (l) => l.closed.length === 0 && l.labels.length === 0 && l.comments.length === 0],
+
+  ['the author requesting changes on their own pull request does not count',
+    { pr: open(), activity: { reviewDecision: 'CHANGES_REQUESTED', reviews: [review({
+      authorAssociation: 'NONE', author: { login: 'alice', __typename: 'User' } })] } },
+    (l) => l.closed.length === 0 && l.comments.length === 0],
+
+  ['idle pull request nobody reviewed is left completely alone',
+    { pr: open(), activity: {} },
+    (l) => l.closed.length === 0 && l.labels.length === 0 && l.comments.length === 0],
+
+  ['approved and idle is left alone',
+    { pr: open(), activity: { ...handedBack, reviewDecision: 'APPROVED' } },
+    (l) => l.closed.length === 0 && l.comments.length === 0],
+
+  ['fresh hand-back is left alone',
+    { pr: open({ updated_at: idleDays(1) }), activity: handedBack },
+    (l) => l.closed.length === 0 && l.comments.length === 0],
+
+  ['a writer is never warned',
+    { pr: open(), activity: handedBack, permission: 'write' },
+    (l) => l.closed.length === 0 && l.comments.length === 0],
+
+  [`${NO_AUTOCLOSE_LABEL} pins it`,
+    { pr: open({ labels: [{ name: NO_AUTOCLOSE_LABEL }] }), activity: handedBack },
+    (l) => l.closed.length === 0 && l.comments.length === 0],
+
+  ['a draft is left to the stale-draft pass',
+    { pr: open({ draft: true, updated_at: idleDays(8) }), activity: handedBack },
+    (l) => l.closed.length === 0 && l.comments.length === 0],
+
+  ['warned and still silent past the grace window closes',
+    { pr: open({ labels: [{ name: STALE_LABEL }], updated_at: idleDays(0) }),
+      comments: staleNotice(STALE_GRACE_HOURS + 1), activity: handedBack },
+    (l) => l.closed.length === 1],
+
+  ['warned but still inside the grace window does not close',
+    { pr: open({ labels: [{ name: STALE_LABEL }], updated_at: idleDays(0) }),
+      comments: staleNotice(STALE_GRACE_HOURS - 10), activity: handedBack },
+    (l) => l.closed.length === 0],
+
+  ['a reply after the warning stands the close down',
+    { pr: open({ labels: [{ name: STALE_LABEL }], updated_at: idleDays(0) }),
+      comments: staleNotice(STALE_GRACE_HOURS + 1),
+      activity: { ...handedBack, commit: new Date(t(1)).toISOString() } },
+    (l) => l.closed.length === 0 && l.unlabels.includes(STALE_LABEL) && l.deleted.includes(99)],
+
+  ['the gate label wins — one clock at a time',
+    { pr: open({ labels: [{ name: 'needs-approved-issue' }] }), activity: handedBack },
+    (l) => l.labels.includes(STALE_LABEL) === false],
+];
+
 // --- runSweep: the stale-draft pass must honour every exemption ------------
 const draft = (over) => ({
   number: 9, draft: true, state: 'open', labels: [],
@@ -142,6 +300,16 @@ const sweepCases = [
     if (got === want) console.log(`  ok   ${name}`);
     else { failed++; console.log(`  FAIL ${name} -> ${got} notices, wanted ${want}`); }
   }
+  for (const [name, activity, want] of turnCases) {
+    const got = whoseTurn({ reviewDecision: null, ...activity }).turn;
+    if (got === want) console.log(`  ok   ${name}`);
+    else { failed++; console.log(`  FAIL ${name} -> ${got}, wanted ${want}`); }
+  }
+  for (const [name, setup, ok] of staleCases) {
+    const log = await sweepHarness(setup);
+    if (ok(log)) console.log(`  ok   ${name}`);
+    else { failed++; console.log(`  FAIL ${name} -> ${JSON.stringify(log)}`); }
+  }
   for (const [name, pr, want, permission] of sweepCases) {
     const got = (await sweepClosed(pr, permission)).length;
     if (got === want) console.log(`  ok   ${name}`);
@@ -157,5 +325,7 @@ const sweepCases = [
     }
   }
   assert.strictEqual(failed, 0, `${failed} case(s) failed`);
-  console.log(`\n${cases.length + noticeCases.length + sweepCases.length} passed`);
+  const total = cases.length + noticeCases.length + sweepCases.length
+    + turnCases.length + staleCases.length;
+  console.log(`\n${total} passed`);
 })();

--- a/.github/scripts/issue-gate.test.js
+++ b/.github/scripts/issue-gate.test.js
@@ -186,6 +186,12 @@ const review = (over = {}) => ({
 
 const handedBack = { reviewDecision: 'CHANGES_REQUESTED', reviews: [review()] };
 
+// The `needs-changes` label is the other way a maintainer starts the clock.
+const labelled = (over = {}) => ({
+  createdAt: new Date(t(400)).toISOString(), label: { name: 'needs-changes' },
+  actor: { __typename: 'User' }, ...over,
+});
+
 // A review bot runs as CONTRIBUTOR and can submit CHANGES_REQUESTED. If that
 // counted, the sweeper would close pull requests no human ever looked at.
 const botHandedBack = { reviewDecision: 'CHANGES_REQUESTED', reviews: [review({
@@ -197,6 +203,35 @@ const staleCases = [
     { pr: open(), activity: handedBack },
     (l) => l.closed.length === 0 && l.labels.includes(STALE_LABEL)
       && l.comments.some((c) => c.includes(STALE_MARKER))],
+
+  // A `needs-changes` label starts the clock too, so it needs the same guard:
+  // a workflow holding `issues: write` must not be able to apply it and close
+  // work no human reviewed.
+  ['a human applying needs-changes starts the clock',
+    { pr: open(), activity: { labeled: [labelled()] } },
+    (l) => l.labels.includes(STALE_LABEL) && l.closed.length === 0],
+
+  ['a bot applying needs-changes does not start the clock',
+    { pr: open(), activity: { labeled: [labelled({ actor: { __typename: 'Bot' } })] } },
+    (l) => l.closed.length === 0 && l.labels.length === 0 && l.comments.length === 0],
+
+  // Once warned, the label alone must not be trusted: the situation can change
+  // during the grace window, and the label is one a human can apply by hand.
+  ['approving after the warning stands the close down',
+    { pr: open({ labels: [{ name: STALE_LABEL }], updated_at: idleDays(0) }),
+      comments: staleNotice(STALE_GRACE_HOURS + 1),
+      activity: { ...handedBack, reviewDecision: 'APPROVED' } },
+    (l) => l.closed.length === 0 && l.unlabels.includes(STALE_LABEL) && l.deleted.includes(99)],
+
+  ['a writer carrying the stale label is stood down, not closed',
+    { pr: open({ labels: [{ name: STALE_LABEL }], updated_at: idleDays(0) }),
+      comments: staleNotice(STALE_GRACE_HOURS + 1), activity: handedBack, permission: 'write' },
+    (l) => l.closed.length === 0 && l.unlabels.includes(STALE_LABEL)],
+
+  ['a hand-back never reviewed by a human is stood down once warned',
+    { pr: open({ labels: [{ name: STALE_LABEL }], updated_at: idleDays(0) }),
+      comments: staleNotice(STALE_GRACE_HOURS + 1), activity: {} },
+    (l) => l.closed.length === 0 && l.unlabels.includes(STALE_LABEL)],
 
   ['a bot requesting changes does not start the clock',
     { pr: open(), activity: botHandedBack },

--- a/.github/workflows/pr-sweeper.yml
+++ b/.github/workflows/pr-sweeper.yml
@@ -6,7 +6,11 @@ name: PR Sweeper
 #      that now link an approved issue; close the ones still failing 72h after they
 #      were told. The re-check is the point — linking an issue through the sidebar
 #      fires no webhook, so `issue-gate.yml` never sees it.
-#   2. Close drafts from outside the org after 30 days without activity.
+#   2. Warn, and then close, pull requests that have been waiting on their author
+#      for more than 7 days. Only ones waiting on the *author* — a pull request
+#      sitting unreviewed in our queue is our backlog, not an SLA breach, and is
+#      never closed for inactivity.
+#   3. Close drafts from outside the org after 30 days without activity.
 #
 # Runs on `schedule`, so it never touches pull request code and needs none of the
 # `pull_request_target` precautions. Dispatch manually with dry_run to see what it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,8 +374,15 @@ either route works — but a bare `#123` mention is only a reference and does no
 
 If a PR goes quiet, nudge us in [Discord](https://discord.gg/honcho).
 
-Please respond within 7 days - we may close any PRs that have seen no activity within a 7 day
-window. If you need more time, let us know in the PR comments.
+Once a maintainer has asked you for changes, please respond within 7 days. After that a bot
+comments to say the window has run out, and closes the PR 72 hours later if nothing has
+happened. Either of these stops it: a push to the branch, or a comment saying you need more
+time — we would much rather hold a PR open than lose the work. Closing is reversible too;
+reopen and it goes straight back into the review queue.
+
+A PR that is waiting on *us* is never closed for inactivity. If yours has gone quiet on our
+side, that is our backlog and not your problem — nudge us in
+[Discord](https://discord.gg/honcho).
 
 ## Reporting bugs and requesting features
 


### PR DESCRIPTION
## Description

Adds a third pass to the PR sweeper that closes pull requests which have gone quiet **on the author**: 7 days after a maintainer hands one back it gets the `stale` label and a warning comment, and 72h later it closes if nothing has happened since. Any push or comment stands the close down. The clock starts only on a deliberate maintainer action — a `CHANGES_REQUESTED` review or the `needs-changes` label — so nothing closes unless someone consciously asked for something.

Closes DEV-2591. Two things are deliberately *not* in scope, both explained under Proofs: closing PRs nobody reviewed (`UNREVIEWED_STALE_DAYS = null`), and trusting `reviewDecision` as the signal for whose turn it is.

## Proofs

**Tests — 41 pass, the 19 pre-existing ones unchanged:**

```
$ node .github/scripts/issue-gate.test.js
  ok   never handed back is ours
  ok   approved is ours even after a hand-back
  ok   hand-back with no reply is theirs
  ok   hand-back the author replied to is ours
  ok   a bot requesting changes does not start the clock
  ok   idle hand-back is warned, not closed
  ok   idle pull request nobody reviewed is left completely alone
  ok   warned and still silent past the grace window closes
  ok   a reply after the warning stands the close down
  ...
41 passed
```

**Live dry run.** `runSweep` driven against this repo with `dryRun: true` through a `gh`-backed octokit shim whose write methods throw, so it cannot mutate anything:

```
73 open pull requests (dry run)
[dry run] #941: warning — 42d idle, handed back, no reply since
[dry run] #876: warning — 12d idle, handed back, no reply since
#775: 18d idle, waiting on maintainer — author already replied to the hand-back
#563: 133d idle, waiting on maintainer — author already replied to the hand-back
#1049: 16d idle, waiting on maintainer — never handed back to the author
...
--- 116 API calls; UNREVIEWED_STALE_DAYS=null ---
```

**Why `UNREVIEWED_STALE_DAYS` is null.** Measured against the live queue, one flat 7-day rule closes 50 of 73 open PRs — and 47 of those are `REVIEW_REQUIRED`, work no maintainer ever looked at. A contributor cannot miss a response window for a review that never happened, so that pass ships off. The constant is the switch if we decide otherwise:

| unreviewed window | additional PRs closed |
|---|---|
| disabled (this PR) | 0 |
| 120d | 4 |
| 90d | 12 |
| 30d | 30 |
| 7d | 46 |

**Why `whoseTurn` compares timestamps instead of reading `reviewDecision`.** GitHub keeps `reviewDecision` at `CHANGES_REQUESTED` until a *new* review dismisses it — pushing commits does not clear it. Two PRs in the current queue prove it matters:

- **#775** — handed back 2026-06-10, contributor pushed a fix **2026-07-01**
- **#563** — `needs-changes` applied 2026-04-14, contributor pushed **2026-04-28**

Both did exactly what was asked and are waiting on us. Reading `reviewDecision` alone would have closed them with an SLA-breach message.

**Why hand-backs require `OWNER`/`MEMBER`/`COLLABORATOR`.** `coderabbitai` reviews as `type=Bot assoc=CONTRIBUTOR` and can submit `CHANGES_REQUESTED`, which would otherwise start a clock on work no human reviewed.

**Blast radius controls:** capped at 10 closes per sweep, `no-autoclose` pins a PR by hand, drafts stay with the existing 30-day pass, and a PR wearing `needs-approved-issue` is skipped so only one clock ever runs.

**Labels:** `stale` and `no-autoclose` are already created on this repo.

**Reviewer notes.** The second commit is a public policy edit, not a docs tidy — `CONTRIBUTING.md` currently promises we may close "any PRs that have seen no activity within a 7 day window", which is broader than what this implements. It now describes the warn-then-close flow and adds the other half in writing: *a PR waiting on us is never closed for inactivity*. That's the commitment that makes closing the others fair, so it's worth a read on its own.

Suggested first step after merge: dispatch the workflow with `dry_run=true` and check the log matches the run above.

## Checklist

- [ ] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.

<!-- No GitHub issue: tracked in Linear as DEV-2591. The gate exempts authors with write permission, so this PR is not subject to it. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated handling for inactive pull requests.
  - Pull requests awaiting contributor responses for over 7 days receive a warning and may be closed after an additional 72 hours.
  - Inactive external draft pull requests may be closed after 30 days.
  - New activity, approval, or comments requesting more time can prevent automated closure.
  - Automated label activity is excluded from inactivity decisions.

- **Documentation**
  - Updated contribution guidelines with inactivity timelines and guidance for reviews awaiting maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->