### PR TITLE
feat(deriver): skip startup poll jitter when the API owns scheduling

### DIFF
--- a/docs/v3/contributing/configuration.mdx
+++ b/docs/v3/contributing/configuration.mdx
@@ -440,7 +440,8 @@ DERIVER_POLLING_BACKOFF_ENABLED=true
 DERIVER_POLLING_SLEEP_MAX_INTERVAL_SECONDS=30.0
 DERIVER_POLLING_BACKOFF_MULTIPLIER=2.0
 # Jitter so instances that start together don't poll in lockstep. Startup: sleep
-# a random delay in [0, value] before the first poll (0.0 disables). Per-cycle:
+# a random delay in [0, value] before the first poll (0.0 disables; only applies
+# when DERIVER_SCHEDULER=deriver). Per-cycle:
 # multiply every poll sleep by a random factor in [1-ratio, 1+ratio] (0.0 disables).
 DERIVER_POLLING_STARTUP_JITTER_SECONDS=30.0
 DERIVER_POLLING_JITTER_RATIO=0.5

--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -233,7 +233,8 @@ class QueueManager:
         # Run the polling loop directly in this task
         logger.debug("Starting polling loop directly")
         try:
-            await self._sleep_startup_jitter()
+            if settings.DERIVER.SCHEDULER == "deriver":
+                await self._sleep_startup_jitter()
             await self.polling_loop()
         finally:
             await self.cleanup()

--- a/tests/deriver/test_queue_processing.py
+++ b/tests/deriver/test_queue_processing.py
@@ -357,6 +357,38 @@ class TestQueueProcessing:
 
         assert start.await_count == 0
 
+    async def test_initialize_skips_startup_jitter_when_api_owns_scheduling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "api")
+        queue_manager = QueueManager()
+
+        with (
+            patch.object(queue_manager.reconciler_scheduler, "start", AsyncMock()),
+            patch.object(queue_manager, "_sleep_startup_jitter", AsyncMock()) as jitter,
+            patch.object(queue_manager, "polling_loop", AsyncMock()),
+            patch.object(queue_manager, "cleanup", AsyncMock()),
+        ):
+            await queue_manager.initialize()
+
+        assert jitter.await_count == 0
+
+    async def test_initialize_sleeps_startup_jitter_when_deriver_owns_scheduling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings.DERIVER, "SCHEDULER", "deriver")
+        queue_manager = QueueManager()
+
+        with (
+            patch.object(queue_manager.reconciler_scheduler, "start", AsyncMock()),
+            patch.object(queue_manager, "_sleep_startup_jitter", AsyncMock()) as jitter,
+            patch.object(queue_manager, "polling_loop", AsyncMock()),
+            patch.object(queue_manager, "cleanup", AsyncMock()),
+        ):
+            await queue_manager.initialize()
+
+        assert jitter.await_count == 1
+
     async def test_polling_loop_skips_stale_cleanup_when_api_owns_scheduling(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Description

If `DERIVER.SCHEDULER` is `api` (meaning the API endpoint is running all the timer logic), this removes the initial delay the deriver takes before starting to consume events.

With this change, the deriver will check the queue and handle queue events immediately. This makes it efficient to turn the deriver on/off as the `/deriver/metrics` in the API endpoint dictate whether the deriver has work to do (with some stickiness/hysteresis).

## Proofs

```bash
uv run pytest tests/
uv run basedpyright
uv run ruff check src/ tests/
```

Tests against E2E environment running:

- Deriver stopped, API enqueued 2 dream rows and 1 sync_vectors row on its own; `/deriver/metrics` showed them eligible
- New messages showed up in /deriver/metrics `1.5` seconds after POST
- Deriver claimed work `1.01` seconds after launch. On the other hand, with `DERIVER_SCHEDULER=deriver` deriver waited `29` seconds before claiming work
- First boot claimed dreams, representation rows, and sync_vectors in one pass; both dreams completed (7 deductive, 5 inductive docs, collection metadata advanced)
- After draining, metrics returned to `0`, deriver stayed alive, exited cleanly on SIGTERM with `0` pending rows
- Two derivers launched at once split 8 work units 4/4, no duplicate claims, no errors, both exited cleanly
- Stale claim with no deriver alive was reaped by the API; fresh deriver claimed the freed work 2.39 s after launch and processed it
- API log showed `0` errors for the whole run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Updates**
  - Startup polling jitter now applies only when the deriver scheduler is selected. Other scheduler configurations begin polling immediately.

- **Documentation**
  - Clarified when startup jitter applies and that the setting is evaluated per polling cycle.

- **Tests**
  - Added coverage verifying jitter behavior for deriver- and API-managed scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->