### PR TITLE
feat(cli): add workspace chat for cross-peer reasoned questions

### DIFF
--- a/docs/snippets/cli-commands.mdx
+++ b/docs/snippets/cli-commands.mdx
@@ -570,9 +570,21 @@ honcho stop
 
 ## honcho workspace
 
-List, create, inspect, delete, and search workspaces.
+List, create, inspect, chat, delete, and search workspaces.
 
 <AccordionGroup>
+<Accordion title="chat">
+Query the dialectic across all peers in the workspace.
+
+```bash
+honcho workspace chat <query>
+```
+
+<ParamField path="query" type="string" required />
+<ParamField path="--reasoning" type="string">
+  Reasoning level: minimal, low, medium, high, max. Short alias: `-r`.
+</ParamField>
+</Accordion>
 <Accordion title="create">
 Create or get a workspace.
 

--- a/docs/v3/documentation/reference/cli.mdx
+++ b/docs/v3/documentation/reference/cli.mdx
@@ -223,7 +223,7 @@ honcho session view <session_id> --last 50
 
 ### Dialectic returns bad answers
 
-When `honcho peer chat` or the dialectic API is hallucinating or missing context.
+When `honcho peer chat`, `honcho workspace chat`, or the dialectic API is hallucinating or missing context.
 
 ```bash
 # What does the peer card actually say?
@@ -234,6 +234,9 @@ honcho conclusion search "topic" --observer <peer_id> --json
 
 # Reproduce the query against the CLI
 honcho peer chat <peer_id> "what do you know about X?" --json
+
+# Cross-peer question — not tied to one peer
+honcho workspace chat "what themes show up across peers?" --json
 ```
 
 ## Scripting & automation

--- a/honcho-cli/CHANGELOG.md
+++ b/honcho-cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `honcho workspace chat` for reasoned questions across all peers (Honcho v3.1.0+)
+
 ## [0.1.4] - 2026-08-26
 
 ### Added

--- a/honcho-cli/README.md
+++ b/honcho-cli/README.md
@@ -75,6 +75,7 @@ honcho stop --wipe     # also delete volumes
 | `honcho workspace list` | List accessible workspaces |
 | `honcho workspace create <id>` | Create or get a workspace |
 | `honcho workspace inspect` | Peers, sessions, config for a workspace |
+| `honcho workspace chat <query>` | Query the dialectic across all peers (optional `-s` / `--reasoning`) |
 | `honcho workspace search <query>` | Search messages across workspace |
 | `honcho workspace queue-status` | Deriver queue status (filter with `--observer` / `--sender`) |
 | `honcho workspace delete <id>` | Delete a workspace. Use `--dry-run` to preview, `--cascade` to also delete sessions, `--yes` to skip the confirm prompt |

--- a/honcho-cli/pyproject.toml
+++ b/honcho-cli/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
     "click>=8.0.0",
     "typer>=0.15.0",
-    "honcho-ai>=2.0.0",
+    "honcho-ai>=2.4.0",
     "rich>=13.0.0",
     "httpx>=0.27.0",
 ]

--- a/honcho-cli/src/honcho_cli/_help.py
+++ b/honcho-cli/src/honcho_cli/_help.py
@@ -80,7 +80,7 @@ def print_welcome(console: Console) -> None:
         ("[dim]pattern[/dim]", r"[dim]honcho <command> \[args] \[-w workspace] \[-p peer] \[-s session][/dim]"),
         ("[dim]example[/dim]", "[dim]honcho peer chat \"what does alice prefer?\" -p alice -w agents[/dim]"),
         ("", ""),
-        ("workspace",  "list · create · search · delete · inspect · queue-status"),
+        ("workspace",  "list · create · search · chat · delete · inspect · queue-status"),
         ("peer",       "list · create · search · inspect · card · chat"),
         ("",           "get-metadata · set-metadata · representation"),
         ("session",    "list · create · search · delete · inspect · view · add-peers"),
@@ -91,6 +91,7 @@ def print_welcome(console: Console) -> None:
         ("config",     "inspect current configuration"),
     ]
     memory_rows = [
+        ("honcho workspace chat \"...\" -w <workspace>", "query the Dialectic across all peers"),
         ("honcho peer chat \"...\" -p <peer> -w <workspace>", "query the Dialectic about a peer"),
         ("honcho peer inspect -p <peer> -w <workspace>", "dashboard: peer card + recent conclusions + configuration"),
         ("honcho peer representation -p <peer> -w <workspace>", "global peer representation"),

--- a/honcho-cli/src/honcho_cli/commands/workspace.py
+++ b/honcho-cli/src/honcho_cli/commands/workspace.py
@@ -1,4 +1,4 @@
-"""Workspace commands: list, inspect, create, delete, search, queue-status."""
+"""Workspace commands: list, inspect, create, delete, search, chat, queue-status."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from honcho_cli.validation import validate_resource_id
 from honcho_cli._help import HonchoTyperGroup
 from honcho_cli.common import add_common_options, get_client, get_resolved_config, handle_cmd_flags
 
-app = typer.Typer(cls=HonchoTyperGroup, help="List, create, inspect, delete, and search workspaces.")
+app = typer.Typer(cls=HonchoTyperGroup, help="List, create, inspect, chat, delete, and search workspaces.")
 add_common_options(app)
 
 
@@ -209,6 +209,36 @@ def delete(
         print_result(result)
     except Exception as e:
         _handle_error(e, "workspace", workspace_id)
+
+
+@app.command()
+def chat(
+    query: str = typer.Argument(help="Question to ask about the workspace"),
+    reasoning: Optional[str] = typer.Option(None, "--reasoning", "-r", help="Reasoning level: minimal, low, medium, high, max"),
+    workspace: Optional[str] = typer.Option(None, "--workspace", "-w", help="Override workspace ID"),
+    session: Optional[str] = typer.Option(None, "--session", "-s", help="Override session ID"),
+    json_output: bool = typer.Option(False, "--json", help="Force JSON output"),
+) -> None:
+    """Query the dialectic across all peers in the workspace."""
+
+    _REASONING_LEVELS = ("minimal", "low", "medium", "high", "max")
+    if reasoning and reasoning not in _REASONING_LEVELS:
+        print_error("INVALID_REASONING", f"--reasoning must be one of: {', '.join(_REASONING_LEVELS)}")
+        raise typer.Exit(1)
+
+    handle_cmd_flags(json_output=json_output, workspace=workspace, session=session)
+    wid = _get_workspace_id(None)
+    client, config = get_client()
+
+    try:
+        response = client.chat(
+            query,
+            session=config.session_id or None,
+            reasoning_level=reasoning or None,
+        )
+        print_result({"workspace_id": wid, "query": query, "response": response})
+    except Exception as e:
+        _handle_error(e, "workspace", wid)
 
 
 @app.command()

--- a/honcho-cli/tests/test_commands.py
+++ b/honcho-cli/tests/test_commands.py
@@ -200,6 +200,28 @@ class TestJsonContract:
             "created_at": "2026-01-01T00:00:00Z",
         }]
 
+    def test_workspace_chat_json_object_shape(self, cfg, runner):
+        cfg.write_text(json.dumps({"apiKey": "k", "environmentUrl": "http://localhost:8000"}))
+        client = MagicMock()
+        client.chat.return_value = "across both peers"
+        config = MagicMock(workspace_id="ws1", session_id="sess1")
+        with patch("honcho_cli.commands.workspace.get_client", return_value=(client, config)):
+            result = runner.invoke(
+                app,
+                ["workspace", "chat", "what themes?", "-w", "ws1", "-s", "sess1", "-r", "low"],
+            )
+        assert result.exit_code == 0, result.stderr
+        assert json.loads(result.stdout) == {
+            "workspace_id": "ws1",
+            "query": "what themes?",
+            "response": "across both peers",
+        }
+        client.chat.assert_called_once_with(
+            "what themes?",
+            session="sess1",
+            reasoning_level="low",
+        )
+
     def test_message_get_returns_single_json_object(self, cfg, runner):
         cfg.write_text(json.dumps({"apiKey": "k", "environmentUrl": "http://localhost:8000"}))
         msg = MagicMock(
@@ -478,3 +500,9 @@ class TestExitCodes:
             result = runner.invoke(app, ["peer", "inspect", "missing", "-w", "ws1"])
         assert result.exit_code == 1
         assert json.loads(result.stderr)["error"]["code"] == "PEER_NOT_FOUND"
+
+    def test_workspace_chat_invalid_reasoning_exits_nonzero(self, cfg, runner):
+        cfg.write_text(json.dumps({"apiKey": "k", "environmentUrl": "http://localhost:8000"}))
+        result = runner.invoke(app, ["workspace", "chat", "what themes?", "-w", "ws1", "-r", "nope"])
+        assert result.exit_code == 1
+        assert json.loads(result.stderr)["error"]["code"] == "INVALID_REASONING"

--- a/skills/honcho-cli/SKILL.md
+++ b/skills/honcho-cli/SKILL.md
@@ -19,7 +19,7 @@ allowed-tools: Bash(honcho:*), Bash(jq:*), Read, Grep
 
 - `honcho config` — CLI configuration
 - `honcho start` / `stop` / `status` — local Docker stack (does not change `environmentUrl`). First start pins the Honcho image digest and writes `config.toml` into the profile. Pass `--setup basic` or `--setup advanced` for an interactive config wizard (TTY only; writes `.env` overrides). `honcho status` lists every profile; pass `--profile` for one.
-- `honcho workspace` — inspect, delete, search
+- `honcho workspace` — inspect, delete, search, chat
 - `honcho peer` — inspect, card, chat, search
 - `honcho session` — inspect, view (transcript), context, summaries
 - `honcho message` — list and get
@@ -74,6 +74,7 @@ honcho session summaries <session_id> --json
 
 ```bash
 honcho workspace search "query" --json
+honcho workspace chat "what themes show up across peers?" --json
 honcho peer search <peer_id> "query" --json
 ```
 
@@ -114,4 +115,5 @@ honcho conclusion search "topic" --observer <peer_id> --json
 
 # Exercise the dialectic directly
 honcho peer chat <peer_id> "what do you know about X?" --json
+honcho workspace chat "what themes show up across peers?" --json
 ```


### PR DESCRIPTION
## Description

The CLI could query the dialectic about one peer (`honcho peer chat`) but had no way to ask a reasoned question across all peers, even though the API and SDK have exposed workspace-level chat since Honcho v3.1.0 / `honcho-ai` 2.4.0.

This adds `honcho workspace chat <query>` with the same optional `-w` / `-s` / `--reasoning` (`-r`) flags as peer chat. `peer chat` stays the default one-peer path; workspace chat is for cross-peer themes. The CLI now requires `honcho-ai>=2.4.0`. README, welcome help, the CLI skill, and the generated command snippet document the new command.

## Proofs

* `uv run --package honcho-cli pytest honcho-cli/tests/test_commands.py` → 32 passed, including JSON shape / flag forwarding for `workspace chat` and `INVALID_REASONING` on a bad `--reasoning` value.
* `uv run --package honcho-cli python honcho-cli/scripts/generate_cli_docs.py` regenerated `docs/snippets/cli-commands.mdx`.

## Checklist

- [X] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.
  * No dedicated issue; the author has write permission on the repo, which the issue gate treats as exempt.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `honcho workspace chat <query>` for asking questions across workspace peers.
  * Supports optional session scoping, reasoning levels, and JSON-formatted responses.
  * Provides structured errors for invalid reasoning options.

* **Documentation**
  * Added workspace chat usage examples to CLI help, README, reference guides, troubleshooting workflows, and the workspace search walkthrough.
  * Added a changelog entry describing workspace chat availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->