### PR TITLE
feat(cli): add --scope and --sessions recall bounds on chat

### DIFF
--- a/docs/snippets/cli-commands.mdx
+++ b/docs/snippets/cli-commands.mdx
@@ -218,7 +218,7 @@ honcho peer chat <query>
   Reasoning level: minimal, low, medium, high, max. Short alias: `-r`.
 </ParamField>
 <ParamField path="--scope" type="string">
-  Confine recall to a scope. Repeat or comma-separate for an explicit-only allowlist of names. Mutually exclusive with --sessions and -s.
+  Confine recall to a scope. One name answers from that scope's own view; several names (repeat or comma-separate) are an explicit-only allowlist of their sessions. Mutually exclusive with --sessions and -s.
 </ParamField>
 <ParamField path="--sessions" type="string">
   Ad hoc session-ID allowlist (repeat or comma-separate). Explicit conclusions only. Mutually exclusive with --scope and -s.
@@ -591,7 +591,7 @@ honcho workspace chat <query>
   Reasoning level: minimal, low, medium, high, max. Short alias: `-r`.
 </ParamField>
 <ParamField path="--scope" type="string">
-  Confine recall to a scope. Repeat or comma-separate for an explicit-only allowlist of names. Mutually exclusive with -s.
+  Confine recall to a scope. One name answers from that scope's own view; several names (repeat or comma-separate) are an explicit-only allowlist of their sessions. Mutually exclusive with -s.
 </ParamField>
 </Accordion>
 <Accordion title="create">

--- a/docs/snippets/cli-commands.mdx
+++ b/docs/snippets/cli-commands.mdx
@@ -217,6 +217,12 @@ honcho peer chat <query>
 <ParamField path="--reasoning" type="string">
   Reasoning level: minimal, low, medium, high, max. Short alias: `-r`.
 </ParamField>
+<ParamField path="--scope" type="string">
+  Confine recall to a scope. Repeat or comma-separate for an explicit-only allowlist of names. Mutually exclusive with --sessions and -s.
+</ParamField>
+<ParamField path="--sessions" type="string">
+  Ad hoc session-ID allowlist (repeat or comma-separate). Explicit conclusions only. Mutually exclusive with --scope and -s.
+</ParamField>
 </Accordion>
 <Accordion title="create">
 Create or get a peer.
@@ -583,6 +589,9 @@ honcho workspace chat <query>
 <ParamField path="query" type="string" required />
 <ParamField path="--reasoning" type="string">
   Reasoning level: minimal, low, medium, high, max. Short alias: `-r`.
+</ParamField>
+<ParamField path="--scope" type="string">
+  Confine recall to a scope. Repeat or comma-separate for an explicit-only allowlist of names. Mutually exclusive with -s.
 </ParamField>
 </Accordion>
 <Accordion title="create">

--- a/docs/v3/documentation/reference/cli.mdx
+++ b/docs/v3/documentation/reference/cli.mdx
@@ -235,8 +235,12 @@ honcho conclusion search "topic" --observer <peer_id> --json
 # Reproduce the query against the CLI
 honcho peer chat <peer_id> "what do you know about X?" --json
 
+# Confine recall to a named scope
+honcho peer chat <peer_id> "what happened here?" --scope my-project --json
+
 # Cross-peer question — not tied to one peer
 honcho workspace chat "what themes show up across peers?" --json
+honcho workspace chat "what happened in this project?" --scope my-project --json
 ```
 
 ## Scripting & automation

--- a/honcho-cli/CHANGELOG.md
+++ b/honcho-cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - `honcho workspace chat` for reasoned questions across all peers (Honcho v3.1.0+)
+- `--scope` on `honcho workspace chat` and `honcho peer chat`, and `--sessions` on `honcho peer chat`, to confine recall (Honcho v3.1.0+)
 
 ## [0.1.4] - 2026-08-26
 

--- a/honcho-cli/README.md
+++ b/honcho-cli/README.md
@@ -75,7 +75,7 @@ honcho stop --wipe     # also delete volumes
 | `honcho workspace list` | List accessible workspaces |
 | `honcho workspace create <id>` | Create or get a workspace |
 | `honcho workspace inspect` | Peers, sessions, config for a workspace |
-| `honcho workspace chat <query>` | Query the dialectic across all peers (optional `-s` / `--reasoning`) |
+| `honcho workspace chat <query>` | Query the dialectic across all peers (optional `-s` / `--scope` / `--reasoning`) |
 | `honcho workspace search <query>` | Search messages across workspace |
 | `honcho workspace queue-status` | Deriver queue status (filter with `--observer` / `--sender`) |
 | `honcho workspace delete <id>` | Delete a workspace. Use `--dry-run` to preview, `--cascade` to also delete sessions, `--yes` to skip the confirm prompt |
@@ -88,7 +88,7 @@ honcho stop --wipe     # also delete volumes
 | `honcho peer create <id>` | Create or get a peer |
 | `honcho peer inspect <id>` | Card, session count, recent conclusions |
 | `honcho peer card <id>` | Raw peer card content |
-| `honcho peer chat <query>` | Query the dialectic about a peer (peer via `-p` / `HONCHO_PEER_ID`) |
+| `honcho peer chat <query>` | Query the dialectic about a peer (peer via `-p` / `HONCHO_PEER_ID`; optional `--scope` / `--sessions`) |
 | `honcho peer representation <id>` | Formatted representation |
 | `honcho peer search <query>` | Search a peer's messages (peer via `-p` / `HONCHO_PEER_ID`) |
 | `honcho peer get-metadata <id>` / `set-metadata` | Metadata operations |

--- a/honcho-cli/src/honcho_cli/commands/peer.py
+++ b/honcho-cli/src/honcho_cli/commands/peer.py
@@ -15,7 +15,7 @@ from honcho_cli.recall import parse_csv_repeatable, reject_incompatible_recall, 
 from honcho_cli.validation import validate_resource_id
 
 from honcho_cli._help import HonchoTyperGroup
-from honcho_cli.common import add_common_options, get_client, get_resolved_config, handle_cmd_flags
+from honcho_cli.common import add_common_options, get_client, get_flag_overrides, get_resolved_config, handle_cmd_flags
 
 app = typer.Typer(cls=HonchoTyperGroup, help="List, create, chat with, search, and manage peers and their representations.")
 add_common_options(app)
@@ -134,7 +134,7 @@ def chat(
     scope: Optional[list[str]] = typer.Option(
         None,
         "--scope",
-        help="Confine recall to a scope. Repeat or comma-separate for an explicit-only allowlist of names. Mutually exclusive with --sessions and -s.",
+        help="Confine recall to a scope. One name answers from that scope's own view; several names (repeat or comma-separate) are an explicit-only allowlist of their sessions. Mutually exclusive with --sessions and -s.",
     ),
     sessions: Optional[list[str]] = typer.Option(
         None,
@@ -156,12 +156,14 @@ def chat(
     handle_cmd_flags(json_output=json_output, workspace=workspace, peer=peer, session=session)
     pid = _get_peer_id(None)
     client, config = get_client()
-    p = client.peer(pid)
-    scope_names = parse_csv_repeatable(scope, kind="scope")
-    session_allowlist = parse_csv_repeatable(sessions, kind="session")
+    scope_names = parse_csv_repeatable(scope, kind="scope", flag="--scope")
+    session_allowlist = parse_csv_repeatable(sessions, kind="session", flag="--sessions")
     session_id = config.session_id or None
     reject_incompatible_recall(
-        session_id=session_id, scope=scope_names, sessions=session_allowlist
+        session_id=session_id,
+        scope=scope_names,
+        sessions=session_allowlist,
+        session_from_env=not get_flag_overrides()["session"],
     )
 
     chat_kwargs: dict[str, object] = {
@@ -176,6 +178,7 @@ def chat(
         chat_kwargs["sessions"] = session_allowlist
 
     try:
+        p = client.peer(pid)
         response = p.chat(query, **chat_kwargs)
         print_result({"peer_id": pid, "query": query, "response": response})
     except Exception as e:

--- a/honcho-cli/src/honcho_cli/commands/peer.py
+++ b/honcho-cli/src/honcho_cli/commands/peer.py
@@ -9,8 +9,9 @@ import typer
 
 from honcho.api_types import PeerConfig
 
-from honcho_cli.commands.workspace import _config_to_dict, _handle_error, _raw_list
+from honcho_cli.commands.workspace import _config_to_dict, _handle_chat_error, _handle_error, _raw_list
 from honcho_cli.output import print_error, print_result, use_json
+from honcho_cli.recall import parse_csv_repeatable, reject_incompatible_recall, scope_for_sdk
 from honcho_cli.validation import validate_resource_id
 
 from honcho_cli._help import HonchoTyperGroup
@@ -130,6 +131,16 @@ def chat(
     query: str = typer.Argument(help="Question to ask about the peer"),
     target: Optional[str] = typer.Option(None, help="Target peer for perspective"),
     reasoning: Optional[str] = typer.Option(None, "--reasoning", "-r", help="Reasoning level: minimal, low, medium, high, max"),
+    scope: Optional[list[str]] = typer.Option(
+        None,
+        "--scope",
+        help="Confine recall to a scope. Repeat or comma-separate for an explicit-only allowlist of names. Mutually exclusive with --sessions and -s.",
+    ),
+    sessions: Optional[list[str]] = typer.Option(
+        None,
+        "--sessions",
+        help="Ad hoc session-ID allowlist (repeat or comma-separate). Explicit conclusions only. Mutually exclusive with --scope and -s.",
+    ),
     workspace: Optional[str] = typer.Option(None, "--workspace", "-w", help="Override workspace ID"),
     peer: Optional[str] = typer.Option(None, "--peer", "-p", help="Override peer ID"),
     session: Optional[str] = typer.Option(None, "--session", "-s", help="Override session ID"),
@@ -139,7 +150,6 @@ def chat(
 
     _REASONING_LEVELS = ("minimal", "low", "medium", "high", "max")
     if reasoning and reasoning not in _REASONING_LEVELS:
-        from honcho_cli.output import print_error
         print_error("INVALID_REASONING", f"--reasoning must be one of: {', '.join(_REASONING_LEVELS)}")
         raise typer.Exit(1)
 
@@ -147,17 +157,29 @@ def chat(
     pid = _get_peer_id(None)
     client, config = get_client()
     p = client.peer(pid)
+    scope_names = parse_csv_repeatable(scope, kind="scope")
+    session_allowlist = parse_csv_repeatable(sessions, kind="session")
+    session_id = config.session_id or None
+    reject_incompatible_recall(
+        session_id=session_id, scope=scope_names, sessions=session_allowlist
+    )
+
+    chat_kwargs: dict[str, object] = {
+        "target": target,
+        "session": session_id,
+        "reasoning_level": reasoning or None,
+    }
+    scope_arg = scope_for_sdk(scope_names)
+    if scope_arg is not None:
+        chat_kwargs["scope"] = scope_arg
+    if session_allowlist is not None:
+        chat_kwargs["sessions"] = session_allowlist
 
     try:
-        response = p.chat(
-            query,
-            target=target,
-            session=config.session_id or None,
-            reasoning_level=reasoning or None,
-        )
+        response = p.chat(query, **chat_kwargs)
         print_result({"peer_id": pid, "query": query, "response": response})
     except Exception as e:
-        _handle_error(e, "peer", pid)
+        _handle_chat_error(e, "peer", pid)
 
 
 @app.command()

--- a/honcho-cli/src/honcho_cli/commands/workspace.py
+++ b/honcho-cli/src/honcho_cli/commands/workspace.py
@@ -17,6 +17,7 @@ from honcho import (
 )
 
 from honcho_cli.output import print_error, print_result, status, use_json
+from honcho_cli.recall import parse_csv_repeatable, reject_incompatible_recall, scope_for_sdk
 from honcho_cli.validation import validate_resource_id
 
 from honcho_cli._help import HonchoTyperGroup
@@ -215,6 +216,11 @@ def delete(
 def chat(
     query: str = typer.Argument(help="Question to ask about the workspace"),
     reasoning: Optional[str] = typer.Option(None, "--reasoning", "-r", help="Reasoning level: minimal, low, medium, high, max"),
+    scope: Optional[list[str]] = typer.Option(
+        None,
+        "--scope",
+        help="Confine recall to a scope. Repeat or comma-separate for an explicit-only allowlist of names. Mutually exclusive with -s.",
+    ),
     workspace: Optional[str] = typer.Option(None, "--workspace", "-w", help="Override workspace ID"),
     session: Optional[str] = typer.Option(None, "--session", "-s", help="Override session ID"),
     json_output: bool = typer.Option(False, "--json", help="Force JSON output"),
@@ -229,16 +235,23 @@ def chat(
     handle_cmd_flags(json_output=json_output, workspace=workspace, session=session)
     wid = _get_workspace_id(None)
     client, config = get_client()
+    scope_names = parse_csv_repeatable(scope, kind="scope")
+    session_id = config.session_id or None
+    reject_incompatible_recall(session_id=session_id, scope=scope_names)
+
+    chat_kwargs: dict[str, object] = {
+        "session": session_id,
+        "reasoning_level": reasoning or None,
+    }
+    scope_arg = scope_for_sdk(scope_names)
+    if scope_arg is not None:
+        chat_kwargs["scope"] = scope_arg
 
     try:
-        response = client.chat(
-            query,
-            session=config.session_id or None,
-            reasoning_level=reasoning or None,
-        )
+        response = client.chat(query, **chat_kwargs)
         print_result({"workspace_id": wid, "query": query, "response": response})
     except Exception as e:
-        _handle_error(e, "workspace", wid)
+        _handle_chat_error(e, "workspace", wid)
 
 
 @app.command()
@@ -313,6 +326,21 @@ def _config_to_dict(config) -> dict:
             result[k] = _config_to_dict(v) if hasattr(v, "__dict__") and not isinstance(v, str) else v
         return result
     return config
+
+
+def _handle_chat_error(e: Exception, resource: str, resource_id: str) -> None:
+    """Like ``_handle_error``, but keep the server/SDK message.
+
+    Chat 404s include scope misses (``Scope X not found in workspace Y``). Rewriting
+    those as ``Workspace 'id' not found`` would hide the real error.
+    """
+    if isinstance(e, NotFoundError):
+        print_error("NOT_FOUND", str(e), {resource: resource_id})
+        raise typer.Exit(1)
+    if isinstance(e, ValueError):
+        print_error("INVALID_ARGUMENT", str(e), {resource: resource_id})
+        raise typer.Exit(1)
+    _handle_error(e, resource, resource_id)
 
 
 def _handle_error(e: Exception, resource: str, resource_id: str) -> None:

--- a/honcho-cli/src/honcho_cli/commands/workspace.py
+++ b/honcho-cli/src/honcho_cli/commands/workspace.py
@@ -21,7 +21,7 @@ from honcho_cli.recall import parse_csv_repeatable, reject_incompatible_recall, 
 from honcho_cli.validation import validate_resource_id
 
 from honcho_cli._help import HonchoTyperGroup
-from honcho_cli.common import add_common_options, get_client, get_resolved_config, handle_cmd_flags
+from honcho_cli.common import add_common_options, get_client, get_flag_overrides, get_resolved_config, handle_cmd_flags
 
 app = typer.Typer(cls=HonchoTyperGroup, help="List, create, inspect, chat, delete, and search workspaces.")
 add_common_options(app)
@@ -219,7 +219,7 @@ def chat(
     scope: Optional[list[str]] = typer.Option(
         None,
         "--scope",
-        help="Confine recall to a scope. Repeat or comma-separate for an explicit-only allowlist of names. Mutually exclusive with -s.",
+        help="Confine recall to a scope. One name answers from that scope's own view; several names (repeat or comma-separate) are an explicit-only allowlist of their sessions. Mutually exclusive with -s.",
     ),
     workspace: Optional[str] = typer.Option(None, "--workspace", "-w", help="Override workspace ID"),
     session: Optional[str] = typer.Option(None, "--session", "-s", help="Override session ID"),
@@ -235,9 +235,13 @@ def chat(
     handle_cmd_flags(json_output=json_output, workspace=workspace, session=session)
     wid = _get_workspace_id(None)
     client, config = get_client()
-    scope_names = parse_csv_repeatable(scope, kind="scope")
+    scope_names = parse_csv_repeatable(scope, kind="scope", flag="--scope")
     session_id = config.session_id or None
-    reject_incompatible_recall(session_id=session_id, scope=scope_names)
+    reject_incompatible_recall(
+        session_id=session_id,
+        scope=scope_names,
+        session_from_env=not get_flag_overrides()["session"],
+    )
 
     chat_kwargs: dict[str, object] = {
         "session": session_id,

--- a/honcho-cli/src/honcho_cli/recall.py
+++ b/honcho-cli/src/honcho_cli/recall.py
@@ -18,8 +18,16 @@ from honcho_cli.output import print_error
 from honcho_cli.validation import validate_resource_id
 
 
-def parse_csv_repeatable(values: list[str] | None, *, kind: str) -> list[str] | None:
-    """Flatten repeatable and/or comma-separated flag values, de-duped in order."""
+def parse_csv_repeatable(
+    values: list[str] | None, *, kind: str, flag: str
+) -> list[str] | None:
+    """Flatten repeatable and/or comma-separated flag values, de-duped in order.
+
+    A flag that was given but holds no names (``--scope ""``, ``--sessions ,``)
+    is an error rather than "no bound": the server rejects an empty allowlist
+    for the same reason, and silently widening recall to the whole workspace
+    is the wrong default for a caller that built the value programmatically.
+    """
     if not values:
         return None
     seen: set[str] = set()
@@ -31,7 +39,13 @@ def parse_csv_repeatable(values: list[str] | None, *, kind: str) -> list[str] | 
                 continue
             seen.add(name)
             out.append(validate_resource_id(name, kind))
-    return out or None
+    if not out:
+        print_error(
+            "EMPTY_RECALL_BOUND",
+            f"{flag} was given but contains no {kind} names",
+        )
+        raise typer.Exit(1)
+    return out
 
 
 def scope_for_sdk(names: list[str] | None) -> str | list[str] | None:
@@ -48,18 +62,33 @@ def reject_incompatible_recall(
     session_id: str | None,
     scope: list[str] | None,
     sessions: list[str] | None = None,
+    session_from_env: bool = False,
 ) -> None:
-    """Exit if more than one of -s / --scope / --sessions is set."""
-    present: list[str] = []
-    if session_id:
-        present.append("-s/--session")
+    """Exit if more than one of -s / --scope / --sessions is set.
+
+    ``session_from_env`` marks a session that arrived through ``HONCHO_SESSION_ID``
+    rather than a typed ``-s``, so the error can name the variable the caller
+    never typed and how to clear it for one command.
+    """
+    bounds: list[str] = []
     if scope:
-        present.append("--scope")
+        bounds.append("--scope")
     if sessions:
-        present.append("--sessions")
-    if len(present) > 1:
-        print_error(
-            "INCOMPATIBLE_FLAGS",
-            f"{' and '.join(present)} are mutually exclusive",
-        )
-        raise typer.Exit(1)
+        bounds.append("--sessions")
+    if len(bounds) > 1:
+        _exit_incompatible(f"{' and '.join(bounds)} are mutually exclusive")
+    if session_id and bounds:
+        flag = bounds[0]
+        if session_from_env:
+            _exit_incompatible(
+                f"{flag} was not applied: recall is already confined to session "
+                f"'{session_id}' by HONCHO_SESSION_ID in your environment, and a "
+                f"session cannot be combined with {flag}. If that session is not what "
+                f"you meant, unset it for this command: `env -u HONCHO_SESSION_ID honcho ...`"
+            )
+        _exit_incompatible(f"-s/--session and {flag} are mutually exclusive")
+
+
+def _exit_incompatible(message: str) -> None:
+    print_error("INCOMPATIBLE_FLAGS", message)
+    raise typer.Exit(1)

--- a/honcho-cli/src/honcho_cli/recall.py
+++ b/honcho-cli/src/honcho_cli/recall.py
@@ -1,0 +1,65 @@
+"""Recall-boundary flags shared by CLI chat (and later representation / search).
+
+Flag shape (DEV-2690 / DEV-2472):
+
+- ``--scope <name>``: repeatable, or comma-separated. One name is that scope's
+  reasoned view; several names are an explicit-only allowlist of their sessions.
+- ``--sessions <id,...>``: repeatable or comma-separated session-ID allowlist
+  (explicit conclusions only). Peer chat only — workspace chat has no SDK
+  ``sessions`` option.
+- ``-s`` / ``--session``, ``--scope``, and ``--sessions`` are mutually exclusive.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from honcho_cli.output import print_error
+from honcho_cli.validation import validate_resource_id
+
+
+def parse_csv_repeatable(values: list[str] | None, *, kind: str) -> list[str] | None:
+    """Flatten repeatable and/or comma-separated flag values, de-duped in order."""
+    if not values:
+        return None
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in values:
+        for part in raw.split(","):
+            name = part.strip()
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            out.append(validate_resource_id(name, kind))
+    return out or None
+
+
+def scope_for_sdk(names: list[str] | None) -> str | list[str] | None:
+    """One name stays a string (full scope view); several become a list (allowlist)."""
+    if not names:
+        return None
+    if len(names) == 1:
+        return names[0]
+    return names
+
+
+def reject_incompatible_recall(
+    *,
+    session_id: str | None,
+    scope: list[str] | None,
+    sessions: list[str] | None = None,
+) -> None:
+    """Exit if more than one of -s / --scope / --sessions is set."""
+    present: list[str] = []
+    if session_id:
+        present.append("-s/--session")
+    if scope:
+        present.append("--scope")
+    if sessions:
+        present.append("--sessions")
+    if len(present) > 1:
+        print_error(
+            "INCOMPATIBLE_FLAGS",
+            f"{' and '.join(present)} are mutually exclusive",
+        )
+        raise typer.Exit(1)

--- a/honcho-cli/tests/test_commands.py
+++ b/honcho-cli/tests/test_commands.py
@@ -222,6 +222,83 @@ class TestJsonContract:
             reasoning_level="low",
         )
 
+    def test_workspace_chat_forwards_single_scope(self, cfg, runner):
+        cfg.write_text(json.dumps({"apiKey": "k", "environmentUrl": "http://localhost:8000"}))
+        client = MagicMock()
+        client.chat.return_value = "scoped"
+        config = MagicMock(workspace_id="ws1", session_id="")
+        with patch("honcho_cli.commands.workspace.get_client", return_value=(client, config)):
+            result = runner.invoke(
+                app,
+                ["workspace", "chat", "what themes?", "-w", "ws1", "--scope", "therapy"],
+            )
+        assert result.exit_code == 0, result.stderr
+        client.chat.assert_called_once_with(
+            "what themes?",
+            session=None,
+            reasoning_level=None,
+            scope="therapy",
+        )
+
+    def test_workspace_chat_forwards_scope_allowlist(self, cfg, runner):
+        cfg.write_text(json.dumps({"apiKey": "k", "environmentUrl": "http://localhost:8000"}))
+        client = MagicMock()
+        client.chat.return_value = "allowlist"
+        config = MagicMock(workspace_id="ws1", session_id="")
+        with patch("honcho_cli.commands.workspace.get_client", return_value=(client, config)):
+            result = runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "chat",
+                    "what themes?",
+                    "-w",
+                    "ws1",
+                    "--scope",
+                    "therapy",
+                    "--scope",
+                    "work,home",
+                ],
+            )
+        assert result.exit_code == 0, result.stderr
+        client.chat.assert_called_once_with(
+            "what themes?",
+            session=None,
+            reasoning_level=None,
+            scope=["therapy", "work", "home"],
+        )
+
+    def test_peer_chat_forwards_sessions_allowlist(self, cfg, runner):
+        cfg.write_text(json.dumps({"apiKey": "k", "environmentUrl": "http://localhost:8000"}))
+        peer = MagicMock()
+        peer.chat.return_value = "from those sessions"
+        client = MagicMock()
+        client.peer.return_value = peer
+        config = MagicMock(workspace_id="ws1", peer_id="alice", session_id="")
+        with patch("honcho_cli.commands.peer.get_client", return_value=(client, config)):
+            result = runner.invoke(
+                app,
+                [
+                    "peer",
+                    "chat",
+                    "what happened?",
+                    "-w",
+                    "ws1",
+                    "-p",
+                    "alice",
+                    "--sessions",
+                    "s1,s2",
+                ],
+            )
+        assert result.exit_code == 0, result.stderr
+        peer.chat.assert_called_once_with(
+            "what happened?",
+            target=None,
+            session=None,
+            reasoning_level=None,
+            sessions=["s1", "s2"],
+        )
+
     def test_message_get_returns_single_json_object(self, cfg, runner):
         cfg.write_text(json.dumps({"apiKey": "k", "environmentUrl": "http://localhost:8000"}))
         msg = MagicMock(
@@ -506,3 +583,56 @@ class TestExitCodes:
         result = runner.invoke(app, ["workspace", "chat", "what themes?", "-w", "ws1", "-r", "nope"])
         assert result.exit_code == 1
         assert json.loads(result.stderr)["error"]["code"] == "INVALID_REASONING"
+
+    def test_workspace_chat_scope_and_session_are_exclusive(self, cfg, runner):
+        cfg.write_text(json.dumps({"apiKey": "k", "environmentUrl": "http://localhost:8000"}))
+        config = MagicMock(workspace_id="ws1", session_id="sess1")
+        with patch("honcho_cli.commands.workspace.get_client", return_value=(MagicMock(), config)):
+            result = runner.invoke(
+                app,
+                ["workspace", "chat", "q", "-w", "ws1", "-s", "sess1", "--scope", "therapy"],
+            )
+        assert result.exit_code == 1
+        assert json.loads(result.stderr)["error"]["code"] == "INCOMPATIBLE_FLAGS"
+
+    def test_peer_chat_scope_and_sessions_are_exclusive(self, cfg, runner):
+        cfg.write_text(json.dumps({"apiKey": "k", "environmentUrl": "http://localhost:8000"}))
+        config = MagicMock(workspace_id="ws1", peer_id="alice", session_id="")
+        with patch("honcho_cli.commands.peer.get_client", return_value=(MagicMock(), config)):
+            result = runner.invoke(
+                app,
+                [
+                    "peer",
+                    "chat",
+                    "q",
+                    "-w",
+                    "ws1",
+                    "-p",
+                    "alice",
+                    "--scope",
+                    "therapy",
+                    "--sessions",
+                    "s1",
+                ],
+            )
+        assert result.exit_code == 1
+        assert json.loads(result.stderr)["error"]["code"] == "INCOMPATIBLE_FLAGS"
+
+    def test_workspace_chat_bad_scope_keeps_server_message(self, cfg, runner):
+        from honcho import NotFoundError
+
+        cfg.write_text(json.dumps({"apiKey": "k", "environmentUrl": "http://localhost:8000"}))
+        client = MagicMock()
+        client.chat.side_effect = NotFoundError(
+            "Scope no-such-scope not found in workspace ws1"
+        )
+        config = MagicMock(workspace_id="ws1", session_id="")
+        with patch("honcho_cli.commands.workspace.get_client", return_value=(client, config)):
+            result = runner.invoke(
+                app,
+                ["workspace", "chat", "q", "-w", "ws1", "--scope", "no-such-scope"],
+            )
+        assert result.exit_code == 1
+        err = json.loads(result.stderr)["error"]
+        assert err["code"] == "NOT_FOUND"
+        assert err["message"] == "Scope no-such-scope not found in workspace ws1"

--- a/honcho-cli/tests/test_commands.py
+++ b/honcho-cli/tests/test_commands.py
@@ -618,6 +618,19 @@ class TestExitCodes:
         assert result.exit_code == 1
         assert json.loads(result.stderr)["error"]["code"] == "INCOMPATIBLE_FLAGS"
 
+    def test_workspace_chat_env_session_conflict_names_the_variable(self, cfg, runner):
+        cfg.write_text(json.dumps({"apiKey": "k", "environmentUrl": "http://localhost:8000"}))
+        # session_id populated but no -s typed: it came from HONCHO_SESSION_ID
+        config = MagicMock(workspace_id="ws1", session_id="ambient")
+        with patch("honcho_cli.commands.workspace.get_client", return_value=(MagicMock(), config)):
+            result = runner.invoke(app, ["workspace", "chat", "q", "-w", "ws1", "--scope", "therapy"])
+        assert result.exit_code == 1
+        err = json.loads(result.stderr)["error"]
+        assert err["code"] == "INCOMPATIBLE_FLAGS"
+        assert "--scope was not applied" in err["message"]
+        assert "'ambient' by HONCHO_SESSION_ID" in err["message"]
+        assert "env -u HONCHO_SESSION_ID" in err["message"]
+
     def test_workspace_chat_bad_scope_keeps_server_message(self, cfg, runner):
         from honcho import NotFoundError
 

--- a/honcho-cli/tests/test_recall.py
+++ b/honcho-cli/tests/test_recall.py
@@ -1,0 +1,57 @@
+"""Recall-boundary flag parsing (DEV-2690)."""
+
+from __future__ import annotations
+
+import pytest
+import typer
+
+from honcho_cli.recall import parse_csv_repeatable, reject_incompatible_recall, scope_for_sdk
+
+
+class TestParseCsvRepeatable:
+    def test_none_and_empty(self):
+        assert parse_csv_repeatable(None, kind="scope") is None
+        assert parse_csv_repeatable([], kind="scope") is None
+
+    def test_repeatable_and_csv(self):
+        assert parse_csv_repeatable(["therapy", "work,home"], kind="scope") == [
+            "therapy",
+            "work",
+            "home",
+        ]
+
+    def test_dedupes_and_strips(self):
+        assert parse_csv_repeatable([" therapy ", "therapy,work"], kind="scope") == [
+            "therapy",
+            "work",
+        ]
+
+    def test_rejects_unsafe_id(self):
+        with pytest.raises(SystemExit):
+            parse_csv_repeatable(["bad/slash"], kind="scope")
+
+
+class TestScopeForSdk:
+    def test_single_stays_string(self):
+        assert scope_for_sdk(["therapy"]) == "therapy"
+
+    def test_several_become_list(self):
+        assert scope_for_sdk(["therapy", "work"]) == ["therapy", "work"]
+
+    def test_none(self):
+        assert scope_for_sdk(None) is None
+
+
+class TestRejectIncompatible:
+    def test_one_bound_ok(self):
+        reject_incompatible_recall(session_id="s1", scope=None, sessions=None)
+        reject_incompatible_recall(session_id=None, scope=["a"], sessions=None)
+        reject_incompatible_recall(session_id=None, scope=None, sessions=["s1"])
+
+    def test_scope_and_session(self):
+        with pytest.raises(typer.Exit):
+            reject_incompatible_recall(session_id="s1", scope=["a"], sessions=None)
+
+    def test_scope_and_sessions(self):
+        with pytest.raises(typer.Exit):
+            reject_incompatible_recall(session_id=None, scope=["a"], sessions=["s1"])

--- a/honcho-cli/tests/test_recall.py
+++ b/honcho-cli/tests/test_recall.py
@@ -10,25 +10,30 @@ from honcho_cli.recall import parse_csv_repeatable, reject_incompatible_recall, 
 
 class TestParseCsvRepeatable:
     def test_none_and_empty(self):
-        assert parse_csv_repeatable(None, kind="scope") is None
-        assert parse_csv_repeatable([], kind="scope") is None
+        assert parse_csv_repeatable(None, kind="scope", flag="--scope") is None
+        assert parse_csv_repeatable([], kind="scope", flag="--scope") is None
 
     def test_repeatable_and_csv(self):
-        assert parse_csv_repeatable(["therapy", "work,home"], kind="scope") == [
+        assert parse_csv_repeatable(["therapy", "work,home"], kind="scope", flag="--scope") == [
             "therapy",
             "work",
             "home",
         ]
 
     def test_dedupes_and_strips(self):
-        assert parse_csv_repeatable([" therapy ", "therapy,work"], kind="scope") == [
+        assert parse_csv_repeatable([" therapy ", "therapy,work"], kind="scope", flag="--scope") == [
             "therapy",
             "work",
         ]
 
+    def test_given_but_empty_is_an_error(self):
+        for values in ([""], [","], [" , "]):
+            with pytest.raises(typer.Exit):
+                parse_csv_repeatable(values, kind="session", flag="--sessions")
+
     def test_rejects_unsafe_id(self):
         with pytest.raises(SystemExit):
-            parse_csv_repeatable(["bad/slash"], kind="scope")
+            parse_csv_repeatable(["bad/slash"], kind="scope", flag="--scope")
 
 
 class TestScopeForSdk:

--- a/skills/honcho-cli/SKILL.md
+++ b/skills/honcho-cli/SKILL.md
@@ -75,6 +75,7 @@ honcho session summaries <session_id> --json
 ```bash
 honcho workspace search "query" --json
 honcho workspace chat "what themes show up across peers?" --json
+honcho workspace chat "what happened in this project?" --scope my-project --json
 honcho peer search <peer_id> "query" --json
 ```
 
@@ -115,5 +116,6 @@ honcho conclusion search "topic" --observer <peer_id> --json
 
 # Exercise the dialectic directly
 honcho peer chat <peer_id> "what do you know about X?" --json
+honcho peer chat <peer_id> "what happened here?" --scope my-project --json
 honcho workspace chat "what themes show up across peers?" --json
 ```


### PR DESCRIPTION
## Description

CLI chat could only confine recall with `-s` (one session). The API, SDK, and MCP already accept a named `--scope` (one name = that scope's reasoned view; several names = explicit-only allowlist) and, on peer chat, an ad hoc `--sessions` allowlist.

This adds those flags on `honcho peer chat` and `--scope` on `honcho workspace chat` (workspace SDK/MCP have no `sessions` option). `-s`, `--scope`, and `--sessions` are mutually exclusive. A missing scope keeps the server's 404 text instead of rewriting it as a workspace/peer miss. Shared parser lives in `honcho_cli/recall.py` for [DEV-2472](https://linear.app/plastic-labs/issue/DEV-2472/support-scopes-in-cli) to reuse. Tracks [DEV-2690](https://linear.app/plastic-labs/issue/DEV-2690/honcho-chat-scope-and-sessions-recall-boundaries).

## Proofs

* `uv run --package honcho-cli pytest honcho-cli/tests/test_commands.py honcho-cli/tests/test_recall.py` → 48 passed (single `--scope` as string, CSV/repeatable allowlist, `--sessions` on peer chat, exclusive flags, bad-scope 404 message unchanged).
* `uv run --package honcho-cli python honcho-cli/scripts/generate_cli_docs.py` regenerated `docs/snippets/cli-commands.mdx`.
* Live check against the `claude-code-scopes` demo workspace was not run in this session.

## Checklist

- [X] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.
  * Linear [DEV-2690](https://linear.app/plastic-labs/issue/DEV-2690/honcho-chat-scope-and-sessions-recall-boundaries); no GitHub issue. Author has write permission on the repo, which the issue gate treats as exempt.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--scope` support to workspace and peer chat for scoped recall.
  - Added `--sessions` support to peer chat for limiting recall to selected sessions.
  - Supports repeatable and comma-separated values with validation and duplicate removal.
  - Clarified single-scope and multi-scope recall behavior.

- **Bug Fixes**
  - Prevents incompatible recall options from being combined.
  - Preserves clear server-provided scope and validation messages.

- **Documentation**
  - Updated CLI references, examples, README guidance, skill documentation, and changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->