### PR TITLE
docs(mcp): document local stdio, HTTP, and Docker hosts

### DIFF
--- a/docs/v3/contributing/self-hosting.mdx
+++ b/docs/v3/contributing/self-hosting.mdx
@@ -108,7 +108,9 @@ The first build takes a few minutes (compiling from source). Subsequent starts a
 
 The default image does not include LanceDB. To use `VECTOR_STORE_TYPE=lancedb`, build with `INSTALL_LANCEDB=true docker compose up -d --build`.
 
-This starts four services: **api** (port 8000), **deriver** (background worker), **database** (PostgreSQL with pgvector, port 5432), and **redis** (port 6379). All ports are bound to `127.0.0.1`. Redis caching is enabled by default.
+This starts five services: **api** (port 8000), **deriver** (background worker), **mcp** (Streamable HTTP on port 3000), **database** (PostgreSQL with pgvector, port 5432), and **redis** (port 6379). All ports are bound to `127.0.0.1`. Redis caching is enabled by default.
+
+Point MCP clients at `http://127.0.0.1:3000` — see [Run locally](/v3/guides/integrations/mcp#run-locally) for stdio, HTTP, and Docker.
 
 For development, uncomment the source mount and monitoring sections inside `docker-compose.yml` to enable live reload, Prometheus, and Grafana.
 
@@ -122,6 +124,9 @@ docker compose ps
 
 # Health check (confirms the process is up)
 curl http://localhost:8000/health
+
+# MCP health check
+curl http://localhost:3000/health
 
 # Check the deriver is processing (look for "polling" or "processing" in logs)
 docker compose logs deriver --tail 20

--- a/docs/v3/guides/integrations/mcp.mdx
+++ b/docs/v3/guides/integrations/mcp.mdx
@@ -62,7 +62,7 @@ For best results, create a project and paste these [instructions](https://raw.gi
 ```bash
 claude mcp add honcho \
   --transport http \
-  --url "https://mcp.honcho.dev" \
+  "https://mcp.honcho.dev" \
   --header "Authorization: Bearer hch-your-key-here"
 ```
 
@@ -303,7 +303,7 @@ A long-lived Streamable HTTP process. Clients use the same shape as `https://mcp
 
 ```bash
 cd mcp && bun install
-HONCHO_API_URL=http://127.0.0.1:8000 bun run http
+HOST=127.0.0.1 HONCHO_API_URL=http://127.0.0.1:8000 bun run http
 ```
 
 Then point the client at `http://127.0.0.1:3000`:
@@ -311,7 +311,7 @@ Then point the client at `http://127.0.0.1:3000`:
 ```bash
 claude mcp add honcho \
   --transport http \
-  --url "http://127.0.0.1:3000" \
+  "http://127.0.0.1:3000" \
   --header "Authorization: Bearer hch-your-key-here"
 ```
 
@@ -338,7 +338,7 @@ Or with `mcp-remote`:
 
 Bearer auth is required on every request, including established sessions. Optional `X-Honcho-Workspace-ID` fills `workspace_id` when the tool argument is omitted.
 
-`HOST` defaults to `0.0.0.0`, `PORT` to `3000`. `GET /health` is unauthenticated. MCP is served at `/` and `/mcp`.
+`HOST` defaults to `0.0.0.0` (what Docker needs inside the container). For a laptop run, set `HOST=127.0.0.1`. `PORT` defaults to `3000`. `GET /health` is unauthenticated. MCP is served at `/` and `/mcp`.
 
 Sessions live in process memory — run **one** replica. Idle sessions expire after `MCP_SESSION_IDLE_MS` (default 30 minutes); `MCP_SESSION_MAX` (default 128) caps concurrent sessions.
 
@@ -350,7 +350,7 @@ The HTTP host is what the image runs.
 
 ```bash
 docker build -f mcp/Dockerfile -t honcho-mcp mcp
-docker run --rm -p 3000:3000 \
+docker run --rm -p 127.0.0.1:3000:3000 \
   -e HONCHO_API_URL=http://host.docker.internal:8000 \
   honcho-mcp
 ```

--- a/docs/v3/guides/integrations/mcp.mdx
+++ b/docs/v3/guides/integrations/mcp.mdx
@@ -7,11 +7,15 @@ sidebarTitle: 'MCP'
 
 The Honcho MCP server gives any MCP-compatible AI tool persistent memory and personalization. Connect it once and your AI assistant learns who you are, remembers your preferences, and gets better over time — across every conversation.
 
-**Server URL:** `https://mcp.honcho.dev`
+**Hosted URL:** `https://mcp.honcho.dev`
 
 <Note>
 You'll need an API key from [app.honcho.dev](https://app.honcho.dev) to use the hosted MCP server.
 </Note>
+
+<Tip>
+Self-hosting Honcho, or want the client to spawn the server itself? Skip `mcp.honcho.dev` and [run the MCP server locally](#run-locally) over stdio, Streamable HTTP, or Docker.
+</Tip>
 
 ## Client Setup
 
@@ -239,6 +243,132 @@ To teach Goose the recommended memory flow, save the [instructions](https://raw.
 
 ---
 
+## Run locally
+
+The hosted URL talks to `api.honcho.dev`. If you run Honcho yourself, run the same MCP tools from this repo's `mcp/` package and point them at your instance with `HONCHO_API_URL`.
+
+Install [Bun](https://bun.sh), clone [plastic-labs/honcho](https://github.com/plastic-labs/honcho), then:
+
+```bash
+cd mcp && bun install
+```
+
+<Info>
+The MCP server always requires a key (`HONCHO_API_KEY` for stdio, `Authorization: Bearer` for HTTP) even when Honcho has `AUTH_USE_AUTH=false`. In that case any non-empty value works.
+</Info>
+
+<Note>
+[`honcho start`](/v3/contributing/self-hosting#personal-local-stack-cli) starts API, deriver, Postgres, and Redis — not MCP. Use stdio below, or run the HTTP host next to that stack.
+</Note>
+
+### Stdio
+
+The client spawns the server as a subprocess. Use this when the client only speaks stdio (Claude Desktop, Codex) or you want one process per client.
+
+`--cwd` must point at the `mcp/` package so Bun loads `bunfig.toml`.
+
+**Claude Code:**
+
+```bash
+claude mcp add honcho \
+  -e HONCHO_API_KEY=hch-your-key-here \
+  -e HONCHO_API_URL=http://127.0.0.1:8000 \
+  -e HONCHO_WORKSPACE_ID=my-workspace \
+  -- bun --cwd /absolute/path/to/honcho/mcp src/stdio.ts
+```
+
+**Claude Desktop** (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "honcho": {
+      "command": "bun",
+      "args": ["--cwd", "/absolute/path/to/honcho/mcp", "src/stdio.ts"],
+      "env": {
+        "HONCHO_API_KEY": "hch-your-key-here",
+        "HONCHO_API_URL": "http://127.0.0.1:8000",
+        "HONCHO_WORKSPACE_ID": "my-workspace"
+      }
+    }
+  }
+}
+```
+
+`HONCHO_API_URL` defaults to `https://api.honcho.dev`. `HONCHO_WORKSPACE_ID` is optional; without it, pass `workspace_id` on each tool call.
+
+### HTTP
+
+A long-lived Streamable HTTP process. Clients use the same shape as `https://mcp.honcho.dev` — native HTTP, or `mcp-remote` if they only speak stdio.
+
+```bash
+cd mcp && bun install
+HONCHO_API_URL=http://127.0.0.1:8000 bun run http
+```
+
+Then point the client at `http://127.0.0.1:3000`:
+
+```bash
+claude mcp add honcho \
+  --transport http \
+  --url "http://127.0.0.1:3000" \
+  --header "Authorization: Bearer hch-your-key-here"
+```
+
+Or with `mcp-remote`:
+
+```json
+{
+  "mcpServers": {
+    "honcho": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "http://127.0.0.1:3000",
+        "--header",
+        "Authorization:${AUTH_HEADER}"
+      ],
+      "env": {
+        "AUTH_HEADER": "Bearer hch-your-key-here"
+      }
+    }
+  }
+}
+```
+
+Bearer auth is required on every request, including established sessions. Optional `X-Honcho-Workspace-ID` fills `workspace_id` when the tool argument is omitted.
+
+`HOST` defaults to `0.0.0.0`, `PORT` to `3000`. `GET /health` is unauthenticated. MCP is served at `/` and `/mcp`.
+
+Sessions live in process memory — run **one** replica. Idle sessions expire after `MCP_SESSION_IDLE_MS` (default 30 minutes); `MCP_SESSION_MAX` (default 128) caps concurrent sessions.
+
+### HTTP in Docker
+
+The HTTP host is what the image runs.
+
+**Standalone**, next to a Honcho API on the host:
+
+```bash
+docker build -f mcp/Dockerfile -t honcho-mcp mcp
+docker run --rm -p 3000:3000 \
+  -e HONCHO_API_URL=http://host.docker.internal:8000 \
+  honcho-mcp
+```
+
+On Linux, `host.docker.internal` may need `--add-host=host.docker.internal:host-gateway`.
+
+**Compose:** `docker-compose.yml.example` already includes an `mcp` service beside `api` and `deriver` (`HONCHO_API_URL=http://api:8000`, published at `127.0.0.1:3000`). After `docker compose up -d --build`:
+
+```bash
+curl http://127.0.0.1:3000/health
+```
+
+Point clients at `http://127.0.0.1:3000` the same way as the [HTTP](#http) section above.
+
+See the [local environment guide](/v3/contributing/self-hosting#from-source-docker-compose) for the rest of the stack.
+
+---
+
 ## Workspace
 
 Every workspace-scoped tool takes a `workspace_id` argument. You can also set `X-Honcho-Workspace-ID` on the connection; that value fills `workspace_id` when the argument is omitted.
@@ -270,9 +400,11 @@ On the first conversation there won't be much — but after a few exchanges, Hon
 | Problem | Fix |
 |---------|-----|
 | Tools don't show up | Make sure you fully restarted the client after adding the config. |
-| Authorization errors | Check your API key at [app.honcho.dev](https://app.honcho.dev). It should start with `hch-`. |
-| `npx` not found | Install Node.js — your AI assistant can help with this. |
+| Authorization errors | Hosted: check your API key at [app.honcho.dev](https://app.honcho.dev). It should start with `hch-`. Local HTTP: send `Authorization: Bearer` on **every** request, including after initialize. |
+| `npx` / `bun` not found | Install [Node.js](https://nodejs.org/) (for `npx` / `mcp-remote`) or [Bun](https://bun.sh) (for local stdio / `bun run http`). |
+| Local connection refused | Confirm the MCP process is up (`bun run http`, the compose `mcp` service, or a stdio spawn) and that `HONCHO_API_URL` reaches the API. |
+| Local stdio tools missing | Run `bun install` in `mcp/`. `--cwd` must point at that package so Bun loads `bunfig.toml`. |
 | "No personalization insights found" | Normal for new users. Honcho needs a few conversations to build context. |
-| Connection timeouts | Check that `https://mcp.honcho.dev` is accessible from your network. |
+| Connection timeouts | Hosted: check that `https://mcp.honcho.dev` is reachable. Local: check `http://127.0.0.1:3000/health` or the stdio process logs. |
 
 Need help? Join us on [Discord](https://discord.gg/honcho) or open an issue on [GitHub](https://github.com/plastic-labs/honcho/tree/main/mcp).


### PR DESCRIPTION
## Description

Add docs on how to use MCP with stdio / http / http-in-docker

## Proofs

N/A

## Checklist

- [ ] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added instructions for running the MCP server locally via stdio, Streamable HTTP, or Docker.
  * Documented local configuration, authentication requirements, default ports, sessions, and environment variables.
  * Added self-hosting guidance for the MCP service, including client connection details and health checks.
  * Expanded troubleshooting guidance for local and hosted MCP connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->