### PR TITLE
feat: only enqueue sync_vectors events when they can be done

### DIFF
--- a/src/reconciler/scheduler.py
+++ b/src/reconciler/scheduler.py
@@ -21,7 +21,10 @@ from src import models
 from src.config import settings
 from src.dependencies import tracked_db
 from src.models import QueueItem
-from src.reconciler.sync_vectors import record_pending_embeddings_backlog
+from src.reconciler.sync_vectors import (
+    has_pending_work,
+    record_pending_embeddings_backlog,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -252,6 +255,10 @@ class ReconcilerScheduler:
                 logger.debug(
                     "Task %s already pending in queue, skipping enqueue", task.name
                 )
+                return False
+
+            if task.name == "sync_vectors" and not await has_pending_work(db):
+                logger.debug("Task %s has nothing to do, skipping enqueue", task.name)
                 return False
 
             # Enqueue the task using ORM

--- a/src/reconciler/sync_vectors.py
+++ b/src/reconciler/sync_vectors.py
@@ -51,22 +51,25 @@ def backoff_eligible(
 
 async def has_pending_work(db: AsyncSession) -> bool:
     """True when a reconciliation cycle would find something to sync or clean up."""
-    if await _get_message_embeddings_needing_sync(db, batch_size=1):
-        return True
-    if get_external_vector_store() is not None and await _get_documents_needing_sync(
-        db, batch_size=1
-    ):
-        return True
-    cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-        minutes=5
-    )
-    purgeable = (
-        select(models.Document.id)
-        .where(models.Document.deleted_at.is_not(None))
-        .where(models.Document.deleted_at < cutoff)
-        .limit(1)
-    )
-    return (await db.scalar(purgeable)) is not None
+    cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=5)
+    checks = [
+        select(models.MessageEmbedding.id).where(
+            models.MessageEmbedding.sync_state == "pending",
+            backoff_eligible(models.MessageEmbedding.last_sync_at),
+        ),
+        select(models.Document.id).where(
+            models.Document.deleted_at.is_not(None), models.Document.deleted_at < cutoff
+        ),
+    ]
+    if get_external_vector_store() is not None:
+        checks.append(
+            select(models.Document.id).where(
+                models.Document.deleted_at.is_(None),
+                models.Document.sync_state == "pending",
+                backoff_eligible(models.Document.last_sync_at),
+            )
+        )
+    return any([await db.scalar(c.limit(1)) is not None for c in checks])
 
 
 @dataclass
@@ -604,7 +607,7 @@ async def _cleanup_soft_deleted_documents_pgvector(
     Cleanup soft-deleted documents
     """
 
-    cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+    cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
         minutes=older_than_minutes
     )
 

--- a/src/reconciler/sync_vectors.py
+++ b/src/reconciler/sync_vectors.py
@@ -49,6 +49,26 @@ def backoff_eligible(
     )
 
 
+async def has_pending_work(db: AsyncSession) -> bool:
+    """True when a reconciliation cycle would find something to sync or clean up."""
+    if await _get_message_embeddings_needing_sync(db, batch_size=1):
+        return True
+    if get_external_vector_store() is not None and await _get_documents_needing_sync(
+        db, batch_size=1
+    ):
+        return True
+    cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        minutes=5
+    )
+    purgeable = (
+        select(models.Document.id)
+        .where(models.Document.deleted_at.is_not(None))
+        .where(models.Document.deleted_at < cutoff)
+        .limit(1)
+    )
+    return (await db.scalar(purgeable)) is not None
+
+
 @dataclass
 class ReconciliationMetrics:
     """Metrics for a reconciliation cycle."""

--- a/tests/reconciler/test_sync_vectors_enqueue_gate.py
+++ b/tests/reconciler/test_sync_vectors_enqueue_gate.py
@@ -1,0 +1,152 @@
+"""The sync_vectors row is only enqueued when a reconciliation cycle has work to do."""
+
+import datetime
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+from nanoid import generate as generate_nanoid
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import models
+from src.reconciler import scheduler as scheduler_module
+from src.reconciler.scheduler import RECONCILER_TASKS, ReconcilerScheduler
+from src.reconciler.sync_vectors import has_pending_work
+
+
+@pytest.fixture(autouse=True)
+def _reset_scheduler_singleton():  # pyright: ignore[reportUnusedFunction]
+    ReconcilerScheduler.reset_singleton()
+    yield
+    ReconcilerScheduler.reset_singleton()
+
+
+async def _tenant(
+    db_session: AsyncSession,
+) -> tuple[models.Workspace, models.Peer, models.Session]:
+    workspace = models.Workspace(name=str(generate_nanoid()))
+    db_session.add(workspace)
+    await db_session.commit()
+    peer = models.Peer(name=str(generate_nanoid()), workspace_name=workspace.name)
+    db_session.add(peer)
+    await db_session.commit()
+    session = models.Session(name=str(generate_nanoid()), workspace_name=workspace.name)
+    db_session.add(session)
+    await db_session.commit()
+    return workspace, peer, session
+
+
+async def test_no_work_when_nothing_pending(db_session: AsyncSession) -> None:
+    assert await has_pending_work(db_session) is False
+
+
+async def test_pending_embedding_is_work(db_session: AsyncSession) -> None:
+    workspace, peer, session = await _tenant(db_session)
+    message = models.Message(
+        public_id=str(generate_nanoid()),
+        session_name=session.name,
+        workspace_name=workspace.name,
+        peer_name=peer.name,
+        content="hello",
+        seq_in_session=1,
+    )
+    db_session.add(message)
+    await db_session.commit()
+    db_session.add(
+        models.MessageEmbedding(
+            content=message.content,
+            message_id=message.public_id,
+            workspace_name=workspace.name,
+            session_name=session.name,
+            peer_name=peer.name,
+            sync_state="pending",
+            embedding=None,
+        )
+    )
+    await db_session.commit()
+
+    assert await has_pending_work(db_session) is True
+
+
+async def test_soft_deleted_document_is_work_only_after_grace(
+    db_session: AsyncSession,
+) -> None:
+    workspace, peer, session = await _tenant(db_session)
+    db_session.add(
+        models.Collection(
+            workspace_name=workspace.name, observer=peer.name, observed=peer.name
+        )
+    )
+    await db_session.commit()
+    doc = models.Document(
+        content="gone",
+        workspace_name=workspace.name,
+        observer=peer.name,
+        observed=peer.name,
+        session_name=session.name,
+        sync_state="synced",
+        embedding=[0.0] * 1536,
+        deleted_at=datetime.datetime.now(datetime.timezone.utc),
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    assert await has_pending_work(db_session) is False
+
+    doc.deleted_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        minutes=10
+    )
+    await db_session.commit()
+    assert await has_pending_work(db_session) is True
+
+
+@pytest.mark.parametrize("has_work", [False, True])
+async def test_enqueue_gated_on_pending_work(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch, has_work: bool
+) -> None:
+    @asynccontextmanager
+    async def _db(_: str | None = None) -> AsyncGenerator[AsyncSession, None]:
+        yield db_session
+
+    monkeypatch.setattr(scheduler_module, "tracked_db", _db)
+    monkeypatch.setattr(
+        scheduler_module, "has_pending_work", AsyncMock(return_value=has_work)
+    )
+
+    enqueued = await ReconcilerScheduler()._try_enqueue_task(  # pyright: ignore[reportPrivateUsage]
+        RECONCILER_TASKS["sync_vectors"]
+    )
+    rows = (
+        (
+            await db_session.execute(
+                select(models.QueueItem).where(
+                    models.QueueItem.work_unit_key == "reconciler:sync_vectors"
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert enqueued is has_work
+    assert len(rows) == (1 if has_work else 0)
+
+
+async def test_cleanup_queue_is_not_gated(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    @asynccontextmanager
+    async def _db(_: str | None = None) -> AsyncGenerator[AsyncSession, None]:
+        yield db_session
+
+    monkeypatch.setattr(scheduler_module, "tracked_db", _db)
+    gate = AsyncMock(return_value=False)
+    monkeypatch.setattr(scheduler_module, "has_pending_work", gate)
+
+    enqueued = await ReconcilerScheduler()._try_enqueue_task(  # pyright: ignore[reportPrivateUsage]
+        RECONCILER_TASKS["cleanup_queue"]
+    )
+
+    assert enqueued is True
+    gate.assert_not_awaited()


### PR DESCRIPTION
## Description

The `sync_vectors` reconciler events that normally get enqueued on a timer for the deriver to run now only get enqueued if there's actually useful work for them to do.

The `has_pending_work` SQL queries are based on checks the checks the `sync_vectors` event consumers normally perform.

## Proofs

E2E

- Idle tenant produces no sync_vectors rows over three intervals
- Normal messages embed through best effort, still no `sync_vectors` rows generated
- Forced-pending embedding yields exactly one row, deduped, then processed
- Soft-deleted document yields nothing inside 5 minutes, one row after, then purged
- `DERIVER_SCHEDULER=deriver` still enqueues on work and stays quiet without


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary vector synchronization tasks from being queued when no pending work exists.
  - Continued allowing cleanup tasks to be queued independently.
  - Improved detection of pending embeddings, documents, and eligible soft-deleted records.
  - Preserved synchronization for configured external vector stores when pending work is available.

- **Tests**
  - Added coverage for enqueue gating and pending-work detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->