### PR TITLE
feat(mcp): add scope membership tools

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 This package versions independently of the Honcho API, `@honcho-ai/sdk`, and host plugins.
 
+## [Unreleased]
+
+### Added
+
+- Scope membership tools: `create_scope`, `add_sessions_to_scope`,
+  `remove_session_from_scope`, and `get_scope_status` (Honcho v3.1.0+), so
+  clients can provision recall boundaries instead of only reading them.
+
 ## [0.1.0] - 2026-09-09
 
 ### Added

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -36,7 +36,7 @@ Every workspace-scoped tool takes a `workspace_id` argument. If you set `X-Honch
 
 **Sessions:** `create_session`, `list_sessions`, `delete_session`, `clone_session`, `add_peers_to_session`, `remove_peers_from_session`, `get_session_peers`, `inspect_session`, `add_messages_to_session`, `get_session_messages`, `get_session_message`, `get_session_context`
 
-**Scopes:** `list_scopes`, `get_scope_sessions`
+**Scopes:** `list_scopes`, `get_scope_sessions`, `create_scope` (get-or-create with optional metadata), `add_sessions_to_scope`, `remove_session_from_scope`, `get_scope_status` (backfill progress per session)
 
 **Conclusions:** `list_conclusions`, `query_conclusions`, `create_conclusions`, `delete_conclusion`
 
@@ -55,7 +55,7 @@ src/
   tools/
     workspace.ts        # inspect, list, search, workspace_chat, metadata
     peers.ts            # CRUD, chat (session / scope / sessions recall bounds), card, context, representation
-    scopes.ts           # list scopes, list a scope's sessions
+    scopes.ts           # list/create scopes, scope membership, backfill status
     sessions.ts         # CRUD, peers, messages, inspect, context, clone
     conclusions.ts      # list, query, create, delete
     system.ts           # dream, queue status

--- a/mcp/instructions.md
+++ b/mcp/instructions.md
@@ -138,6 +138,10 @@ The full API for advanced use cases.
 | `get_session_messages` | Read conversation history (paginated: `page`, `size`, `reverse`; optional metadata filters) |
 | `list_scopes` | List the workspace's scopes — named session sets that act as recall boundaries |
 | `get_scope_sessions` | List the sessions a scope covers (paginated) |
+| `create_scope` | Get or create a scope, with optional metadata (label, description, example queries) |
+| `add_sessions_to_scope` | Put existing sessions inside a scope's recall boundary (max 100 per call; history backfills asynchronously) |
+| `remove_session_from_scope` | Take a session back out of a scope |
+| `get_scope_status` | Check whether a scope's backfill has caught up before trusting scoped recall |
 | `get_session_message` | Get a single message from a session by ID |
 | `get_session_context` | Get LLM-ready context (messages + summary) |
 

--- a/mcp/src/tools/scopes.test.ts
+++ b/mcp/src/tools/scopes.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { honchoClients } from "../config.js";
+import { register } from "./scopes.js";
+
+const config = {
+  apiKey: "test-key",
+  baseUrl: "https://honcho.test",
+  workspaceId: "test-workspace",
+};
+const requests: { method: string; path: string }[] = [];
+const originalFetch = globalThis.fetch;
+let responseBody: object;
+let responseStatus: number;
+let client: Client;
+let server: McpServer;
+
+beforeEach(async () => {
+  requests.length = 0;
+  responseBody = { backfill_status: {} };
+  responseStatus = 200;
+  globalThis.fetch = async (input, init) => {
+    requests.push({ method: init?.method ?? "GET", path: new URL(String(input)).pathname });
+    return Response.json(responseBody, { status: responseStatus });
+  };
+  server = new McpServer({ name: "test", version: "1.0.0" });
+  register(server, { config, ...honchoClients(config) });
+  client = new Client({ name: "test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+});
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  await client.close();
+  await server.close();
+});
+
+test("scope status counts known states and preserves unknown session details", async () => {
+  const updated_at = "2026-09-10T00:00:00Z";
+  const sessions = {
+    first: { state: "pending", updated_at },
+    second: { state: "pending", updated_at },
+    done: { state: "completed", updated_at, docs_copied: 0 },
+    failed: { state: "failed", updated_at },
+    unknown: { state: "paused", updated_at },
+    inherited: { state: "constructor", updated_at },
+    reserved: { state: "scope_id", updated_at },
+  };
+  responseBody = { backfill_status: sessions };
+  const result = await client.callTool({
+    name: "get_scope_status",
+    arguments: { scope_id: "test-scope" },
+  });
+  expect(result.isError).not.toBe(true);
+  expect(result.content).toEqual([{
+    type: "text",
+    text: JSON.stringify({ scope_id: "test-scope", pending: 2, completed: 1, failed: 1, sessions }),
+  }]);
+});
+
+const existingScopeTools = [
+  ["get_scope_status", "GET", "/status"],
+  ["get_scope_sessions", "POST", "/sessions/list"],
+  ["remove_session_from_scope", "DELETE", "/sessions/test-session"],
+];
+
+test.each(existingScopeTools)("%s rejects invalid scope IDs before HTTP", async (name) => {
+  for (const scope_id of ["..", "%2e%2e", "../other", "valid?typo", "valid#typo", "scope.prefixed", "", "a".repeat(507)]) {
+    const result = await client.callTool({
+      name,
+      arguments: { scope_id, session_id: "test-session" },
+    });
+    expect(requests).toEqual([]);
+    expect(result.isError).toBe(true);
+  }
+});
+
+test.each(existingScopeTools)("%s returns missing-scope errors without creating scopes", async (name, method, suffix) => {
+  responseStatus = 404;
+  responseBody = { detail: "Scope Test_scope-123 not found in workspace test-workspace" };
+  const result = await client.callTool({
+    name,
+    arguments: { scope_id: "Test_scope-123", session_id: "test-session" },
+  });
+  expect(result.isError).toBe(true);
+  expect(requests).toEqual([{
+    method,
+    path: `/v3/workspaces/test-workspace/scopes/Test_scope-123${suffix}`,
+  }]);
+});

--- a/mcp/src/tools/scopes.ts
+++ b/mcp/src/tools/scopes.ts
@@ -1,7 +1,18 @@
 import { z } from "zod";
+import { Scope } from "@honcho-ai/sdk";
+import type { Honcho } from "@honcho-ai/sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ToolContext } from "../types.js";
 import { textResult, errorResult, workspaceIdSchema } from "../types.js";
+
+/**
+ * Reference an existing scope without the get-or-create round trip that
+ * `honcho.scope()` performs, so read/remove tools never create a scope as a
+ * side effect. The server returns 404 if the scope does not exist.
+ */
+function existingScope(honcho: Honcho, scopeId: string): Scope {
+  return new Scope(scopeId, honcho.workspaceId, honcho.http);
+}
 
 const pageSchema = z.number().int().min(1).optional().describe("Page number (1-indexed).");
 const sizeSchema = z
@@ -49,6 +60,138 @@ export function register(server: McpServer, ctx: ToolContext) {
     },
   );
 
+  // ── create_scope ────────────────────────────────────────────────────
+  server.registerTool(
+    "create_scope",
+    {
+      description: [
+        "Get or create a scope with the given ID.",
+        "A scope is a named set of sessions that acts as a recall boundary. Optional metadata (e.g. a label, description, example queries) is stored with it.",
+        "Sessions are added separately with add_sessions_to_scope. Returns the scope's id, metadata, and created_at.",
+      ].join("\n"),
+      inputSchema: {
+        workspace_id: workspaceIdSchema(ctx),
+        scope_id: z
+          .string()
+          .describe("Scope name, unique within the workspace (e.g. 'therapy', 'honcho-core')."),
+        metadata: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("Optional metadata to store with the scope."),
+      },
+    },
+    async ({ workspace_id, scope_id, metadata }) => {
+      try {
+        const scope = await ctx
+          .clientFor(workspace_id)
+          .scope(scope_id, metadata ? { metadata } : undefined);
+        return textResult({
+          id: scope.id,
+          metadata: scope.metadata ?? {},
+          created_at: scope.createdAt,
+        });
+      } catch (e) {
+        return errorResult(
+          `Failed to create scope: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    },
+  );
+
+  // ── add_sessions_to_scope ───────────────────────────────────────────
+  server.registerTool(
+    "add_sessions_to_scope",
+    {
+      description: [
+        "Add sessions to a scope. Every session must already exist; re-adding a member is a no-op.",
+        "Sessions that already hold messages are backfilled into the scope asynchronously — poll get_scope_status before relying on scoped recall for them.",
+        "At most 100 sessions per call.",
+      ].join("\n"),
+      inputSchema: {
+        workspace_id: workspaceIdSchema(ctx),
+        scope_id: z.string().describe("The scope to add sessions to."),
+        session_ids: z
+          .array(z.string())
+          .min(1)
+          .max(100)
+          .describe("Session IDs to add (max 100)."),
+      },
+    },
+    async ({ workspace_id, scope_id, session_ids }) => {
+      try {
+        const scope = await ctx.clientFor(workspace_id).scope(scope_id);
+        await scope.addSessions(session_ids);
+        return textResult({ scope_id, added: session_ids.length });
+      } catch (e) {
+        return errorResult(
+          `Failed to add sessions to scope: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    },
+  );
+
+  // ── remove_session_from_scope ───────────────────────────────────────
+  server.registerTool(
+    "remove_session_from_scope",
+    {
+      description: [
+        "Remove a session from a scope.",
+        "Conclusions derived while it was a member are reconciled out asynchronously; the session itself is untouched.",
+      ].join("\n"),
+      inputSchema: {
+        workspace_id: workspaceIdSchema(ctx),
+        scope_id: z.string().describe("The scope to remove the session from."),
+        session_id: z.string().describe("The session to remove."),
+      },
+    },
+    async ({ workspace_id, scope_id, session_id }) => {
+      try {
+        const scope = existingScope(ctx.clientFor(workspace_id), scope_id);
+        await scope.removeSession(session_id);
+        return textResult({ scope_id, removed: session_id });
+      } catch (e) {
+        return errorResult(
+          `Failed to remove session from scope: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    },
+  );
+
+  // ── get_scope_status ────────────────────────────────────────────────
+  server.registerTool(
+    "get_scope_status",
+    {
+      description: [
+        "Get backfill progress for a scope, keyed by session ID.",
+        "Each entry is pending, completed, or failed. Only sessions with a backfill enqueued appear, so an empty result means nothing is outstanding.",
+        "Use this after add_sessions_to_scope to tell 'the scope hasn't caught up yet' apart from 'there is nothing to recall'.",
+      ].join("\n"),
+      inputSchema: {
+        workspace_id: workspaceIdSchema(ctx),
+        scope_id: z.string().describe("The scope to check."),
+      },
+    },
+    async ({ workspace_id, scope_id }) => {
+      try {
+        const scope = existingScope(ctx.clientFor(workspace_id), scope_id);
+        const status = await scope.status();
+        const entries = Object.entries(status.backfillStatus);
+        const counts = { pending: 0, completed: 0, failed: 0 };
+        const sessions: Record<string, { state: string; updated_at: string; docs_copied?: number }> = {};
+        for (const [sid, st] of entries) {
+          counts[st.state] += 1;
+          sessions[sid] = { state: st.state, updated_at: st.updatedAt };
+          if (st.docsCopied !== undefined) sessions[sid].docs_copied = st.docsCopied;
+        }
+        return textResult({ scope_id, ...counts, sessions });
+      } catch (e) {
+        return errorResult(
+          `Failed to get scope status: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    },
+  );
+
   // ── get_scope_sessions ──────────────────────────────────────────────
   server.registerTool(
     "get_scope_sessions",
@@ -67,7 +210,7 @@ export function register(server: McpServer, ctx: ToolContext) {
     },
     async ({ workspace_id, scope_id, page: pageNum, size }) => {
       try {
-        const scope = await ctx.clientFor(workspace_id).scope(scope_id);
+        const scope = existingScope(ctx.clientFor(workspace_id), scope_id);
         const page = await scope.sessions({ page: pageNum, size });
         return textResult({
           scope_id,

--- a/mcp/src/tools/scopes.ts
+++ b/mcp/src/tools/scopes.ts
@@ -5,13 +5,20 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ToolContext } from "../types.js";
 import { textResult, errorResult, workspaceIdSchema } from "../types.js";
 
+// Match the SDK's scope ID rules; the constructor bypasses honcho.scope() validation.
+const scopeIdSchema = z
+  .string()
+  .min(1)
+  .max(512 - "scope.".length)
+  .regex(/^[a-zA-Z0-9_-]+$/, "Scope ID may only contain letters, numbers, underscores, and hyphens");
+
 /**
  * Reference an existing scope without the get-or-create round trip that
  * `honcho.scope()` performs, so read/remove tools never create a scope as a
  * side effect. The server returns 404 if the scope does not exist.
  */
 function existingScope(honcho: Honcho, scopeId: string): Scope {
-  return new Scope(scopeId, honcho.workspaceId, honcho.http);
+  return new Scope(scopeIdSchema.parse(scopeId), honcho.workspaceId, honcho.http);
 }
 
 const pageSchema = z.number().int().min(1).optional().describe("Page number (1-indexed).");
@@ -179,7 +186,9 @@ export function register(server: McpServer, ctx: ToolContext) {
         const counts = { pending: 0, completed: 0, failed: 0 };
         const sessions: Record<string, { state: string; updated_at: string; docs_copied?: number }> = {};
         for (const [sid, st] of entries) {
-          counts[st.state] += 1;
+          if (Object.hasOwn(counts, st.state)) {
+            counts[st.state] += 1;
+          }
           sessions[sid] = { state: st.state, updated_at: st.updatedAt };
           if (st.docsCopied !== undefined) sessions[sid].docs_copied = st.docsCopied;
         }


### PR DESCRIPTION
## Description

The MCP server could read scopes (`list_scopes`, `get_scope_sessions`, `scope` on `chat`) since #1139, but had no way to create one or change its
 membership, so an MCP client could only use recall boundaries someone had provisioned through the SDK. This adds `create_scope` (get-or-create with optional metadata), `add_sessions_to_scope` (max 100 per call), `remove_session_from_scope`, and `get_scope_status` (per-session backfill state with pending/completed/failed counts) in `mcp/src/tools/scopes.ts`.

It also makes the read/remove tools reference an existing scope directly instead of going through the SDK's get-or-create `honcho.scope()`, so `get_scope_sessions` on a missing scope now returns the server's 404 instead of silently creating the scope. `mcp/README.md`, `mcp/instructions.md`, and `mcp/CHANGELOG.md` document the additions.

The immediate consumer is the shareable Scopes Replay artifact, which uses these tools to write Claude-proposed scopes back to the viewer's own workspace through the mcp.honcho.dev connector.

## Proofs

* `cd mcp && bunx tsc --noEmit` → clean (exit 0).
* Smoke-tested every scope tool over stdio (`bun src/stdio.ts`) against api.honcho.dev in a throwaway workspace (deleted afterwards):
  * `create_scope` with `{label, desc, queries}` metadata → `{"id":"smoke-scope","metadata":{...},"created_at":...}`; calling it again without metadata returned the existing scope with its metadata intact (idempotent).
  * `add_sessions_to_scope` with two sessions → `{"scope_id":"smoke-scope","added":2}`; `get_scope_sessions` then listed both.
  * `get_scope_status` right after adding a session with messages → `{"pending":1,"completed":0,"failed":0,"sessions":{"smoke-s1":{"state":"pending",...}}}`.
  * `remove_session_from_scope` → `{"scope_id":"smoke-scope","removed":"smoke-s2"}`; `get_scope_sessions` then listed one.
  * `add_sessions_to_scope` with a nonexistent session → `isError` with `Session(s) ['does-not-exist'] not found in workspace ...`.
  * `get_scope_sessions` / `remove_session_from_scope` on a nonexistent scope → `isError` with `Scope no-such-scope-2 not found in workspace ...` (previously this would have created the scope).
* No test suite exists under `mcp/` (the package has no `test` script); the SDK contract is enforced by the typecheck above.

## Checklist

- [x] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.
  * No dedicated issue; follows #1139 (same surface, same author with write permission, which the issue gate treats as exempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added tools to create scopes, add or remove sessions, and check asynchronous session backfill status.

- **Bug Fixes**
  - Operations targeting an existing scope no longer create missing scopes automatically; unavailable scopes return a not-found response.
  - Invalid scope identifiers are rejected before requests are sent.

- **Documentation**
  - Updated available tools, session tools, architecture notes, and changelog documentation to describe scope management capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->