### PR TITLE
feat(sdk): add get_scope / getScope for non-creating scope lookups

### DIFF
--- a/docs/v3/documentation/features/advanced/scopes.mdx
+++ b/docs/v3/documentation/features/advanced/scopes.mdx
@@ -113,6 +113,9 @@ honcho = Honcho(workspace_id="my-app")
 # Get or create — idempotent; passing metadata updates the existing scope
 therapy = honcho.scope("therapy")
 
+# Look up without creating — raises NotFoundError if the scope doesn't exist
+existing = honcho.get_scope("therapy")
+
 # Add existing sessions (max 100 per call)
 therapy.add_sessions(["therapy-session-1", "therapy-session-2"])
 
@@ -136,6 +139,9 @@ const honcho = new Honcho({ workspaceId: "my-app" });
 
 // Get or create — idempotent; passing metadata updates the existing scope
 const therapy = await honcho.scope("therapy");
+
+// Look up without creating — rejects with NotFoundError if the scope doesn't exist
+const existing = await honcho.getScope("therapy");
 
 // Add existing sessions (max 100 per call)
 await therapy.addSessions(["therapy-session-1", "therapy-session-2"]);
@@ -164,6 +170,10 @@ curl -X POST "$HONCHO_URL/v3/workspaces/my-app/scopes" \
   -H "Content-Type: application/json" \
   -d '{"id": "therapy"}'
 
+# Look up without creating (404 if missing)
+curl "$HONCHO_URL/v3/workspaces/my-app/scopes/therapy" \
+  -H "Authorization: Bearer $HONCHO_API_KEY"
+
 # Add sessions
 curl -X POST "$HONCHO_URL/v3/workspaces/my-app/scopes/therapy/sessions" \
   -H "Authorization: Bearer $HONCHO_API_KEY" \
@@ -182,7 +192,9 @@ curl -X DELETE "$HONCHO_URL/v3/workspaces/my-app/scopes/therapy/sessions/therapy
 
 Scope IDs are unprefixed, must match `^[a-zA-Z0-9_-]+$`, and are at most 506
 characters. Get-or-create is idempotent: if the scope already exists, the same
-call returns it, and any `metadata` you pass is written onto it.
+call returns it, and any `metadata` you pass is written onto it. When a lookup
+must not create anything — resolving a user-supplied name, for example — use
+`get_scope` / `getScope` instead, which fails with a not-found error.
 
 <Note>
 Every scopes route — and every read that passes `scope` — requires a

--- a/docs/v3/documentation/features/advanced/scopes.mdx
+++ b/docs/v3/documentation/features/advanced/scopes.mdx
@@ -193,7 +193,7 @@ curl -X DELETE "$HONCHO_URL/v3/workspaces/my-app/scopes/therapy/sessions/therapy
 Scope IDs are unprefixed, must match `^[a-zA-Z0-9_-]+$`, and are at most 506
 characters. Get-or-create is idempotent: if the scope already exists, the same
 call returns it, and any `metadata` you pass is written onto it. When a lookup
-must not create anything — resolving a user-supplied name, for example — use
+must not create a scope — resolving a user-supplied name, for example — use
 `get_scope` / `getScope` instead, which fails with a not-found error.
 
 <Note>

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `honcho.get_scope(id)` (sync and async) fetches an existing scope by ID and raises `NotFoundError` when it does not exist. Unlike `honcho.scope()`, it never creates the scope, so lookups cannot provision a recall boundary by accident.
 - Optional per-call `timeout` on synchronous and asynchronous `Peer.chat()`. It overrides the timeout for each HTTP attempt; when omitted or set to `None`, the client-wide timeout configured on `Honcho` remains in effect.
 
 ## [2.4.0] - 2026-08-25

--- a/sdks/python/src/honcho/aio.py
+++ b/sdks/python/src/honcho/aio.py
@@ -417,6 +417,39 @@ class HonchoAio(AsyncMetadataConfigMixin):
             created_at=scope_data.created_at,
         )
 
+    async def get_scope(
+        self,
+        id: str,  # noqa: A002
+    ) -> Scope:
+        """
+        Get an existing scope by ID asynchronously, without creating it.
+
+        Unlike :meth:`scope`, this never creates the scope, so it is safe for
+        lookups where a typo must not provision a new recall boundary.
+
+        Args:
+            id: Unprefixed scope name, unique within the workspace.
+
+        Returns:
+            A Scope object for managing membership.
+
+        Raises:
+            ValueError: If the scope ID is invalid.
+            NotFoundError: If no scope with this ID exists in the workspace.
+        """
+        validate_scope_id(id)
+        await self._honcho._ensure_workspace_async()
+        data = await self._honcho._async_http_client.get(
+            routes.scope(self._honcho.workspace_id, id)
+        )
+        scope_data = ScopeResponse.model_validate(data)
+        return Scope(
+            id,
+            self._honcho,
+            metadata=scope_data.metadata,
+            created_at=scope_data.created_at,
+        )
+
     async def scopes(
         self,
         *,

--- a/sdks/python/src/honcho/client.py
+++ b/sdks/python/src/honcho/client.py
@@ -584,6 +584,40 @@ class Honcho(BaseModel, MetadataConfigMixin):  # pyright: ignore[reportUnsafeMul
             created_at=scope_data.created_at,
         )
 
+    @validate_call
+    def get_scope(
+        self,
+        id: str = Field(  # noqa: A002
+            ..., min_length=1, description="Unprefixed name for the scope"
+        ),
+    ) -> Scope:
+        """
+        Get an existing scope by ID without creating it.
+
+        Unlike :meth:`scope`, this never creates the scope, so it is safe for
+        lookups where a typo must not provision a new recall boundary.
+
+        Args:
+            id: Unprefixed scope name, unique within the workspace.
+
+        Returns:
+            A Scope object for managing membership.
+
+        Raises:
+            ValueError: If the scope ID is invalid.
+            NotFoundError: If no scope with this ID exists in the workspace.
+        """
+        validate_scope_id(id)
+        self._ensure_workspace()
+        data = self._http.get(routes.scope(self.workspace_id, id))
+        scope_data = ScopeResponse.model_validate(data)
+        return Scope(
+            id,
+            self,
+            metadata=scope_data.metadata,
+            created_at=scope_data.created_at,
+        )
+
     def scopes(
         self,
         *,

--- a/sdks/python/src/honcho/http/routes.py
+++ b/sdks/python/src/honcho/http/routes.py
@@ -115,6 +115,10 @@ def scopes_list(workspace_id: str) -> str:
     return f"/{API_VERSION}/workspaces/{workspace_id}/scopes/list"
 
 
+def scope(workspace_id: str, scope_id: str) -> str:
+    return f"/{API_VERSION}/workspaces/{workspace_id}/scopes/{scope_id}"
+
+
 def scope_sessions(workspace_id: str, scope_id: str) -> str:
     return f"/{API_VERSION}/workspaces/{workspace_id}/scopes/{scope_id}/sessions"
 

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `honcho.getScope(id)` fetches an existing scope by ID and rejects with `NotFoundError` when it does not exist. Unlike `honcho.scope()`, it never creates the scope, so lookups cannot provision a recall boundary by accident.
+
 ## [2.4.0] - 2026-08-25
 
 ### Added

--- a/sdks/typescript/__tests__/scope.unit.test.ts
+++ b/sdks/typescript/__tests__/scope.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { ZodError } from 'zod'
+import { Honcho } from '../src/client'
 import type { HonchoHTTPClient } from '../src/http/client'
 import { Peer } from '../src/peer'
 import { Scope } from '../src/scope'
@@ -15,7 +16,9 @@ function capturingHttp(response: unknown): {
   body: () => Record<string, unknown> | undefined
   query: () => Record<string, unknown> | undefined
   path: () => string | undefined
+  method: () => string | undefined
 } {
+  let capturedMethod: string | undefined
   let capturedBody: Record<string, unknown> | undefined
   let capturedQuery: Record<string, unknown> | undefined
   let capturedPath: string | undefined
@@ -24,6 +27,7 @@ function capturingHttp(response: unknown): {
       path: string,
       options?: { body?: Record<string, unknown> }
     ) => {
+      capturedMethod = 'post'
       capturedPath = path
       capturedBody = options?.body
       return response
@@ -32,11 +36,13 @@ function capturingHttp(response: unknown): {
       path: string,
       options?: { query?: Record<string, unknown> }
     ) => {
+      capturedMethod = 'get'
       capturedPath = path
       capturedQuery = options?.query
       return response
     },
     delete: async (path: string) => {
+      capturedMethod = 'delete'
       capturedPath = path
       return undefined
     },
@@ -46,6 +52,7 @@ function capturingHttp(response: unknown): {
     body: () => capturedBody,
     query: () => capturedQuery,
     path: () => capturedPath,
+    method: () => capturedMethod,
   }
 }
 
@@ -385,5 +392,28 @@ describe('Scope membership and status', () => {
     const status = await scope.status()
 
     expect(status.backfillStatus).toEqual({})
+  })
+})
+
+describe('getScope', () => {
+  test('GETs the scope route and never POSTs a get-or-create', async () => {
+    const honcho = new Honcho({ apiKey: 'test', workspaceId: 'ws' })
+    const captured = capturingHttp({
+      id: 'therapy',
+      metadata: { k: 'v' },
+      created_at: '2026-09-10T00:00:00Z',
+    })
+    ;(honcho as unknown as { _http: HonchoHTTPClient })._http = captured.http
+    ;(honcho as unknown as { _ensureWorkspace: () => Promise<void> })._ensureWorkspace =
+      async () => undefined
+
+    const scope = await honcho.getScope('therapy')
+
+    expect(captured.method()).toBe('get')
+    expect(captured.path()).toBe('/v3/workspaces/ws/scopes/therapy')
+    expect(captured.body()).toBeUndefined()
+    expect(scope.id).toBe('therapy')
+    expect(scope.metadata).toEqual({ k: 'v' })
+    expect(scope.createdAt).toBe('2026-09-10T00:00:00Z')
   })
 })

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -339,6 +339,15 @@ export class Honcho {
     )
   }
 
+  private async _getScope(
+    workspaceId: string,
+    scopeId: string
+  ): Promise<ScopeResponse> {
+    return this._http.get<ScopeResponse>(
+      `/${API_VERSION}/workspaces/${workspaceId}/scopes/${scopeId}`
+    )
+  }
+
   private async _listScopes(
     workspaceId: string,
     params?: {
@@ -664,6 +673,32 @@ export class Honcho {
       id: validatedId,
       metadata: options?.metadata,
     })
+    return new Scope(
+      validatedId,
+      this.workspaceId,
+      this._http,
+      scopeData.metadata ?? undefined,
+      () => this._ensureWorkspace(),
+      scopeData.created_at
+    )
+  }
+
+  /**
+   * Get an existing scope by ID without creating it.
+   *
+   * Unlike {@link scope}, this never creates the scope, so it is safe for
+   * lookups where a typo must not provision a new recall boundary.
+   *
+   * @param id - Unprefixed scope name, unique within the workspace
+   * @returns Promise resolving to a Scope object for managing membership
+   * @throws {NotFoundError} if no scope with this ID exists in the workspace
+   * @throws Error if the scope ID is empty or invalid
+   */
+  async getScope(id: string): Promise<Scope> {
+    await this._ensureWorkspace()
+    const validatedId = ScopeIdSchema.parse(id)
+
+    const scopeData = await this._getScope(this.workspaceId, validatedId)
     return new Scope(
       validatedId,
       this.workspaceId,

--- a/tests/sdk/test_scope_lookup.py
+++ b/tests/sdk/test_scope_lookup.py
@@ -1,0 +1,32 @@
+"""`honcho.get_scope()` looks a scope up without the get-or-create side effect."""
+
+import pytest
+
+from sdks.python.src.honcho.client import Honcho
+from sdks.python.src.honcho.http.exceptions import NotFoundError
+
+
+@pytest.mark.asyncio
+async def test_get_scope_returns_existing_without_creating_missing(
+    client_fixture: tuple[Honcho, str],
+):
+    honcho_client, client_type = client_fixture
+
+    if client_type == "async":
+        created = await honcho_client.aio.scope("lookup-me", metadata={"k": "v"})
+        found = await honcho_client.aio.get_scope("lookup-me")
+        with pytest.raises(NotFoundError):
+            await honcho_client.aio.get_scope("never-created")
+        listed = {s.id for s in (await honcho_client.aio.scopes()).items}
+    else:
+        created = honcho_client.scope("lookup-me", metadata={"k": "v"})
+        found = honcho_client.get_scope("lookup-me")
+        with pytest.raises(NotFoundError):
+            honcho_client.get_scope("never-created")
+        listed = {s.id for s in honcho_client.scopes().items}
+
+    assert found.id == created.id
+    assert found.metadata == {"k": "v"}
+    assert found.created_at == created.created_at
+    # The failed lookup must not have provisioned the scope as a side effect.
+    assert "never-created" not in listed


### PR DESCRIPTION
## Description

`honcho.scope(id)` is the only public way to obtain a `Scope` in both SDKs, and it is get-or-create: it POSTs before returning, so looking up a name that doesn't exist silently provisions an empty scope, and Honcho has no scope delete. Every client that just wanted to *find* a scope has had to work around it — the MCP server (#1161) constructs `Scope` directly to skip the POST, and the CLI (#1162) walks `scopes()` and matches by name.

This exposes the existing `GET /v3/workspaces/{id}/scopes/{scope_id}` route as `honcho.get_scope(id)` (sync and `.aio`) in the Python SDK and `honcho.getScope(id)` in the TypeScript SDK. Both validate the id, never create anything, and surface the server's 404 as `NotFoundError`. Changelog entries and the scopes docs page (Python / TypeScript / REST snippets plus a sentence on when to prefer the lookup) are included. No server change.

Once this ships in an SDK release, #1161 and #1162 can drop their workarounds in a follow-up.

## Proofs

* `pytest tests/sdk/test_scope_lookup.py` → `2 passed` (sync and async): `get_scope` returns the scope `scope()` created with matching id/metadata/created_at, `get_scope("never-created")` raises `NotFoundError`, and `scopes()` afterwards still does not list `never-created`.
* `sdks/typescript`: `bun run tsc --noEmit` clean; `scope.unit.test.ts` → `26 pass, 0 fail`, including the new case asserting `getScope` issues a `GET /v3/workspaces/ws/scopes/therapy` with no body and never a POST.
* `ruff check` / `ruff format --check` clean on the touched Python files; pre-commit (basedpyright, biome, TypeScript type check) passed on commit.

## Checklist

- [x] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.
  * No dedicated issue; same-surface follow-on to #1139 / #1161 by an author with write permission, which the issue gate treats as exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scope lookup methods to the Python and TypeScript SDKs.
  - Retrieve existing scopes without creating them automatically.
  - Missing scopes return a not-found error.
  - Added synchronous and asynchronous Python support.

- **Documentation**
  - Documented scope lookup usage across Python, TypeScript, and REST APIs, including not-found behavior and lookup versus get-or-create operations.

- **Tests**
  - Added coverage for successful lookups, missing scopes, metadata preservation, and prevention of unintended scope creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->