### PR TITLE
Populate CloudEvents Instrumentation

### DIFF
--- a/docs/v3/contributing/configuration.mdx
+++ b/docs/v3/contributing/configuration.mdx
@@ -642,6 +642,42 @@ TELEMETRY_MAX_RETRIES=3
 TELEMETRY_MAX_BUFFER_SIZE=10000
 ```
 
+#### Trace payloads
+
+Enable content-addressed LLM traces alongside telemetry:
+
+```bash
+TELEMETRY_ENABLED=true
+TELEMETRY_TRACE_PAYLOADS_ENABLED=true
+# Optional: an empty list captures all call purposes.
+TELEMETRY_TRACE_PURPOSES='["dialectic.answer", "deriver.representation", "summary.short", "summary.long"]'
+```
+
+`llm.call.traced` and `embedding.call.traced` use schema version 2. LLM traces
+record each provider attempt, including retries, fallback calls, stream setup
+failures, and interrupted streams. Stream traces preserve the output received
+before interruption. `trace.content` remains at schema version 1.
+
+| Fields | Meaning |
+| --- | --- |
+| `workspace_name`, `session_id` | Workspace and canonical internal session ID, when the operation has a session. Session names are not used as trace identity. |
+| `run_id`, `trace_id`, `span_id`, `parent_span_id`, `iteration`, `step_seq` | Run and call correlation. Single-call operations can have a null iteration and step zero. |
+| `observers`, `observed`, `peer_name`, `agent_type`, `track_name` | LLM producer identity. `observers` lists every observer the call writes to, including single-observer agents, so batched derivation is not a special case. |
+| `source_message_ids`, `queue_item_ids` | Public message IDs and internal queue IDs associated with the LLM operation. Summary message IDs cover its current input window; these fields do not enumerate retrieved tool context or history compressed into an earlier summary. |
+| `duration_ms`, `outcome`, `error_class`, `attempt`, `retry_attempts`, `is_final_attempt` | Execution diagnostics for both LLM and embedding calls. `is_final_attempt` means the configured retry budget is exhausted, so an earlier successful attempt can have `false`. |
+| `was_stream`, `was_fallback`, `effective_max_output_tokens` | LLM execution mode, selected fallback, and effective output limit. |
+| `system_prompt_ref`, `system_prompt_refs`, `output_reasoning_ref` | References into `trace.content` for the system prompt and normalized provider reasoning details. `system_prompt_refs` lists each system message as the provider saw it; `system_prompt_ref` is a single ref for the whole system prompt — the lone message when there is one, otherwise their concatenation shipped under its own hash. |
+
+Fields remain null or empty when unavailable or inapplicable. Root spans have no
+parent; `parent_event_id` is populated only when a caller supplies an actual
+causal event ID. `raw_response_ref` remains reserved because capture stores
+normalized responses rather than provider wire payloads. Stream token counts
+include only usage exposed by the normalized backend; embedding input tokens
+remain estimates. Older trace payloads can omit the new fields.
+
+The CloudEvent ID formula is unchanged. Use the identity and correlation fields
+in `data` to group calls; content references continue to deduplicate by hash.
+
 ### Sentry
 
 ```bash

--- a/docs/v3/contributing/configuration.mdx
+++ b/docs/v3/contributing/configuration.mdx
@@ -792,6 +792,8 @@ ENABLED = false
 
 [telemetry]
 ENABLED = false
+TRACE_PAYLOADS_ENABLED = false
+TRACE_PURPOSES = []
 
 [vector_store]
 TYPE = "pgvector"

--- a/src/deriver/consumer.py
+++ b/src/deriver/consumer.py
@@ -132,6 +132,7 @@ async def process_item(queue_item: models.QueueItem) -> None:
                 validated.message_seq_in_session,
                 message_public_id,
                 validated.configuration,
+                queue_item_id=queue_item.id,
             )
             log_performance_metrics("summary", f"{workspace_name}_{message_id}")
 
@@ -146,7 +147,7 @@ async def process_item(queue_item: models.QueueItem) -> None:
                     queue_payload,
                 )
                 raise ValueError(f"Invalid payload structure: {str(e)}") from e
-            await process_dream(validated, workspace_name)
+            await process_dream(validated, workspace_name, queue_item_id=queue_item.id)
 
     elif task_type == "deletion":
         with sentry_sdk.start_transaction(name="process_deletion_task", op="deriver"):
@@ -202,6 +203,8 @@ async def process_representation_batch(
     observers: list[str] | None,
     observed: str | None,
     queue_item_message_ids: list[int],
+    session_id: str | None = None,
+    queue_item_ids: list[int] | None = None,
     hit_batch_token_cap: bool = False,
     was_flush_enabled: bool = False,
     batch_max_tokens: int = 0,
@@ -215,6 +218,8 @@ async def process_representation_batch(
         observers: List of observers for the messages
         observed: The observed of the messages
         queue_item_message_ids: Message IDs from queue items
+        session_id: Canonical Session.id from the queue.
+        queue_item_ids: Queue rows that triggered this batch, when available.
         hit_batch_token_cap: whether the queue batcher clamped this batch to fit
         was_flush_enabled: snapshot of DERIVER.FLUSH_ENABLED at fetch time
         batch_max_tokens: DERIVER.REPRESENTATION_BATCH_TARGET_INPUT_TOKENS snapshot
@@ -232,6 +237,8 @@ async def process_representation_batch(
         observers=observers,
         observed=observed,
         queue_item_message_ids=queue_item_message_ids,
+        session_id=session_id,
+        queue_item_ids=queue_item_ids,
         hit_batch_token_cap=hit_batch_token_cap,
         was_flush_enabled=was_flush_enabled,
         batch_max_tokens=batch_max_tokens,

--- a/src/deriver/deriver.py
+++ b/src/deriver/deriver.py
@@ -45,6 +45,8 @@ async def process_representation_tasks_batch(
     observers: list[str],
     observed: str,
     queue_item_message_ids: list[int],
+    session_id: str | None = None,
+    queue_item_ids: list[int] | None = None,
     hit_batch_token_cap: bool = False,
     was_flush_enabled: bool = False,
     batch_max_tokens: int = 0,
@@ -58,6 +60,8 @@ async def process_representation_tasks_batch(
         observers: List of observer peer IDs (collections to save to).
         observed: The observed peer ID.
         queue_item_message_ids: Message IDs from queue items being processed
+        session_id: Canonical Session.id from the queue, resolved if not provided.
+        queue_item_ids: Queue rows that triggered this batch, when available.
         hit_batch_token_cap: queue batcher clamped this batch to fit
         was_flush_enabled: DERIVER.FLUSH_ENABLED snapshot at batch time
         batch_max_tokens: DERIVER.REPRESENTATION_BATCH_TARGET_INPUT_TOKENS snapshot
@@ -71,20 +75,23 @@ async def process_representation_tasks_batch(
     latest_message = messages[-1]
     earliest_message = messages[0]
 
-    # Get configuration if not provided
+    # Reuse the queue's canonical session ID, resolving it for direct/legacy callers.
     # TODO: this appears to be a very rare edge case coming out of `get_queue_item_batch` in queue_manager.py,
     # possible that we can remove this and require configuration to come through with the payload.
-    if message_level_configuration is None:
+    if message_level_configuration is None or session_id is None:
         async with tracked_db("minimal_deriver.get_config") as db:
-            message_level_configuration = get_configuration(
-                None,
-                await crud.get_session(
-                    db, latest_message.session_name, latest_message.workspace_name
-                ),
-                await crud.get_workspace(
-                    db, workspace_name=latest_message.workspace_name
-                ),
+            session = await crud.get_session(
+                db, latest_message.session_name, latest_message.workspace_name
             )
+            session_id = session.id
+            if message_level_configuration is None:
+                message_level_configuration = get_configuration(
+                    None,
+                    session,
+                    await crud.get_workspace(
+                        db, workspace_name=latest_message.workspace_name
+                    ),
+                )
 
     # Skip if disabled
     if message_level_configuration.reasoning.enabled is False:
@@ -160,9 +167,16 @@ async def process_representation_tasks_batch(
         trace_name="minimal_deriver",
         telemetry=LLMTelemetryContext(
             workspace_name=latest_message.workspace_name,
+            session_id=session_id,
             call_purpose=CallPurpose.DERIVER_REPRESENTATION.value,
             parent_category="representation",
+            agent_type="deriver",
+            observers=observers,
             observed=observed,
+            source_message_ids=[
+                m.public_id for m in messages if m.id in queue_item_message_ids_set
+            ],
+            queue_item_ids=queue_item_ids or [],
             track_name="Minimal Deriver",
             trace_id=trace_id,
             span_id=trace_id,

--- a/src/deriver/queue_manager.py
+++ b/src/deriver/queue_manager.py
@@ -689,6 +689,10 @@ class QueueManager:
                                     observers=observers,
                                     observed=work_unit.observed,
                                     queue_item_message_ids=queue_item_message_ids,
+                                    session_id=items_to_process[0].session_id,
+                                    queue_item_ids=[
+                                        item.id for item in items_to_process
+                                    ],
                                     hit_batch_token_cap=batch_result.hit_batch_token_cap,
                                     was_flush_enabled=batch_result.was_flush_enabled,
                                     batch_max_tokens=batch_result.batch_max_tokens,

--- a/src/dialectic/core.py
+++ b/src/dialectic/core.py
@@ -392,6 +392,9 @@ class DialecticAgent:
             trace_id=self._run_id,
             span_id=self._run_id,
             session_id=self.session_id,
+            observer=self.observer,
+            observers=[self.observer],
+            observed=self.observed,
             peer_name=self.observed,
             track_name=track_name,
         )

--- a/src/dreamer/orchestrator.py
+++ b/src/dreamer/orchestrator.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import sentry_sdk
@@ -79,6 +79,7 @@ async def run_dream(
     delay_reason: str | None = None,
     documents_since_last_dream_at_schedule: int | None = None,
     document_threshold: int | None = None,
+    queue_item_id: int | None = None,
 ) -> DreamResult | None:
     """
     Run a full dream cycle with optional surprisal-based sampling.
@@ -204,6 +205,8 @@ async def run_dream(
                 hints=exploration_hints,
                 configuration=configuration,
                 parent_run_id=run_id,
+                session_id=session.id if session else None,
+                queue_item_id=queue_item_id,
             )
             logger.info(
                 f"[{run_id}] Deduction completed: {deduction_result.content[:200]}..."
@@ -232,6 +235,8 @@ async def run_dream(
                 hints=exploration_hints,
                 configuration=configuration,
                 parent_run_id=run_id,
+                session_id=session.id if session else None,
+                queue_item_id=queue_item_id,
             )
             logger.info(
                 f"[{run_id}] Induction completed: {induction_result.content[:200]}..."
@@ -321,6 +326,7 @@ async def run_card_refresh_dream(
     dream_type: str | None = None,
     trigger_reason: str | None = None,
     delay_reason: str | None = None,
+    queue_item_id: int | None = None,
 ) -> DreamResult | None:
     """
     Run a lightweight card-only refresh dream.
@@ -384,6 +390,8 @@ async def run_card_refresh_dream(
                 session_name=session_name,
                 configuration=configuration,
                 parent_run_id=run_id,
+                session_id=session.id if session else None,
+                queue_item_id=queue_item_id,
             )
             logger.info(
                 f"[{run_id}] Card refresh completed: {specialist_result.content[:200]}..."
@@ -484,6 +492,8 @@ def _create_queries_from_surprisal(
 async def process_dream(
     payload: DreamPayload,
     workspace_name: str,
+    *,
+    queue_item_id: int | None = None,
 ) -> None:
     """
     Process a dream task by performing collection maintenance operations.
@@ -512,6 +522,7 @@ DREAM: {payload.dream_type} documents for {workspace_name}/{payload.observer}/{p
                     delay_reason=payload.delay_reason,
                     documents_since_last_dream_at_schedule=payload.documents_since_last_dream_at_schedule,
                     document_threshold=payload.document_threshold,
+                    queue_item_id=queue_item_id,
                 )
 
                 # Log completion (telemetry event already emitted in run_dream)
@@ -523,7 +534,7 @@ DREAM: {payload.dream_type} documents for {workspace_name}/{payload.observer}/{p
                     )
 
                     # Both guard fields advance together only on successful consolidation.
-                    now_iso = datetime.now(timezone.utc).isoformat()
+                    now_iso = datetime.now(UTC).isoformat()
                     async with tracked_db("dream.guard_pair_write") as db:
                         collection = await crud.get_collection(
                             db,
@@ -561,6 +572,7 @@ DREAM: {payload.dream_type} documents for {workspace_name}/{payload.observer}/{p
                     observed=payload.observed,
                     session_name=payload.session_name,
                     rebuild=payload.rebuild,
+                    queue_item_id=queue_item_id,
                     dream_type=payload.dream_type.value,
                     trigger_reason=payload.trigger_reason,
                     delay_reason=payload.delay_reason,

--- a/src/dreamer/orchestrator.py
+++ b/src/dreamer/orchestrator.py
@@ -119,6 +119,7 @@ async def run_dream(
 
         workspace = await crud.get_workspace(db, workspace_name=workspace_name)
         configuration = get_configuration(None, session, workspace)
+        resolved_session_id = session.id if session else None
     if not configuration.dream.enabled:
         logger.info(
             f"[{run_id}] Dreams disabled for {workspace_name}/{session_name}, skipping dream"
@@ -205,7 +206,7 @@ async def run_dream(
                 hints=exploration_hints,
                 configuration=configuration,
                 parent_run_id=run_id,
-                session_id=session.id if session else None,
+                session_id=resolved_session_id,
                 queue_item_id=queue_item_id,
             )
             logger.info(
@@ -235,7 +236,7 @@ async def run_dream(
                 hints=exploration_hints,
                 configuration=configuration,
                 parent_run_id=run_id,
-                session_id=session.id if session else None,
+                session_id=resolved_session_id,
                 queue_item_id=queue_item_id,
             )
             logger.info(
@@ -366,6 +367,7 @@ async def run_card_refresh_dream(
 
         workspace = await crud.get_workspace(db, workspace_name=workspace_name)
         configuration = get_configuration(None, session, workspace)
+        resolved_session_id = session.id if session else None
     if not configuration.dream.enabled:
         logger.info(
             f"[{run_id}] Dreams disabled for {workspace_name}/{session_name}, skipping card refresh"
@@ -390,7 +392,7 @@ async def run_card_refresh_dream(
                 session_name=session_name,
                 configuration=configuration,
                 parent_run_id=run_id,
-                session_id=session.id if session else None,
+                session_id=resolved_session_id,
                 queue_item_id=queue_item_id,
             )
             logger.info(

--- a/src/dreamer/specialists.py
+++ b/src/dreamer/specialists.py
@@ -213,6 +213,9 @@ If you update it, send the full deduplicated list and remove stale entries.
         hints: list[str] | None = None,
         configuration: ResolvedConfiguration | None = None,
         parent_run_id: str | None = None,
+        *,
+        session_id: str | None = None,
+        queue_item_id: int | None = None,
     ) -> SpecialistResult:
         """
         Run the specialist agent.
@@ -266,6 +269,11 @@ If you update it, send the full deduplicated list and remove stale entries.
         try:
             # Short-lived DB session for preflight operations
             async with tracked_db("dream.specialist.preflight") as db:
+                if session_name is not None and session_id is None:
+                    session = await crud.get_session(
+                        db, workspace_name=workspace_name, session_name=session_name
+                    )
+                    session_id = session.id
                 await crud.get_peer(db, workspace_name, observer)
                 if observer != observed:
                     await crud.get_peer(db, workspace_name, observed)
@@ -365,6 +373,9 @@ If you update it, send the full deduplicated list and remove stale entries.
                     observer=observer,
                     observed=observed,
                     track_name=f"Dreamer/{self.name}",
+                    observers=[observer],
+                    session_id=session_id,
+                    queue_item_ids=[queue_item_id] if queue_item_id is not None else [],
                 ),
             )
 

--- a/src/embedding_client.py
+++ b/src/embedding_client.py
@@ -35,6 +35,8 @@ async def _emit_embedding_call(
     input_tokens_estimate: int,
     fn: Callable[[], Awaitable[_T]],
     is_final_attempt: bool = True,
+    attempt: int = 1,
+    retry_attempts: int = 1,
 ) -> _T:
     """time a single embedding-provider call, emit
     `embedding.call.completed` on both success and exception, and return the
@@ -72,6 +74,8 @@ async def _emit_embedding_call(
             outcome=outcome,
             error=error,
             is_final_attempt=is_final_attempt,
+            attempt=attempt,
+            retry_attempts=retry_attempts,
         )
 
 
@@ -85,6 +89,8 @@ def _publish_embedding_event(
     outcome: Literal["success", "error", "cancelled"],
     error: BaseException | None,
     is_final_attempt: bool,
+    attempt: int = 1,
+    retry_attempts: int = 1,
 ) -> None:
     """Build and emit the EmbeddingCallCompletedEvent. Best-effort."""
     try:
@@ -146,6 +152,14 @@ def _publish_embedding_event(
                     span_id=span_id,
                     parent_span_id=run_id,
                     session_id=get_embedding_session_id(),
+                    workspace_name=get_embedding_workspace_name(),
+                    run_id=run_id,
+                    attempt=attempt,
+                    retry_attempts=retry_attempts,
+                    is_final_attempt=is_final_attempt,
+                    duration_ms=duration_ms,
+                    outcome=outcome,
+                    error_class=type(error).__name__ if error is not None else None,
                     call_purpose=purpose_slug,
                     parent_category=get_embedding_parent_category(),
                     provider=provider,
@@ -596,6 +610,8 @@ class _EmbeddingClient:
                     input_tokens_estimate=batch_tokens_estimate,
                     fn=_call_provider,
                     is_final_attempt=(attempt >= max_retries - 1),
+                    attempt=attempt + 1,
+                    retry_attempts=max_retries,
                 )
                 return dict(result)
 

--- a/src/llm/backend.py
+++ b/src/llm/backend.py
@@ -27,7 +27,7 @@ class CompletionResult:
     output_tokens: int = 0
     cache_creation_input_tokens: int = 0
     cache_read_input_tokens: int = 0
-    finish_reason: str = "stop"
+    finish_reason: str | None = "stop"
     tool_calls: list[ToolCallResult] = field(default_factory=list)
     thinking_content: str | None = None
     thinking_blocks: list[dict[str, Any]] = field(default_factory=list)

--- a/src/llm/capture.py
+++ b/src/llm/capture.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Protocol, cast, runtime_checkable
+from typing import Any, Literal, Protocol, cast, runtime_checkable
 
 from src.config import settings
 
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 ROLE_OUTPUT = "assistant"
 ROLE_TOOL_SCHEMA = "__tool_schema__"
 ROLE_THINKING = "__thinking__"
+ROLE_REASONING = "__reasoning__"
 
 
 def canonical_json(obj: Any) -> str:
@@ -143,6 +144,16 @@ class CapturedLLMCall:
     was_stream: bool
     # True when any input message was clipped to TRACE_MAX_BYTES.
     input_truncated: bool = False
+    observers: list[str] = field(default_factory=list)
+    source_message_ids: list[str] = field(default_factory=list)
+    queue_item_ids: list[int] = field(default_factory=list)
+    parent_event_id: str | None = None
+    duration_ms: float | None = None
+    outcome: Literal["success", "error", "cancelled"] | None = None
+    error_class: str | None = None
+    retry_attempts: int | None = None
+    is_final_attempt: bool | None = None
+    effective_max_output_tokens: int | None = None
 
 
 def _normalize_message(
@@ -279,6 +290,11 @@ def build_captured_call(
     was_fallback: bool,
     was_stream: bool,
     finish_reason: str | None,
+    duration_ms: float | None = None,
+    outcome: Literal["success", "error", "cancelled"] | None = None,
+    error_class: str | None = None,
+    retry_attempts: int | None = None,
+    effective_max_output_tokens: int | None = None,
 ) -> CapturedLLMCall:
     """Assemble a `CapturedLLMCall` from telemetry + the provider result."""
     memo = telemetry.hash_memo if telemetry is not None else None
@@ -326,6 +342,18 @@ def build_captured_call(
         cache_creation_tokens=result.cache_creation_input_tokens if result else 0,
         was_stream=was_stream,
         input_truncated=input_truncated,
+        observers=list(telemetry.observers) if telemetry else [],
+        source_message_ids=list(telemetry.source_message_ids) if telemetry else [],
+        queue_item_ids=list(telemetry.queue_item_ids) if telemetry else [],
+        parent_event_id=telemetry.parent_event_id if telemetry else None,
+        duration_ms=duration_ms,
+        outcome=outcome,
+        error_class=error_class,
+        retry_attempts=retry_attempts,
+        is_final_attempt=(
+            attempt >= retry_attempts if retry_attempts is not None else None
+        ),
+        effective_max_output_tokens=effective_max_output_tokens,
     )
 
 

--- a/src/llm/executor.py
+++ b/src/llm/executor.py
@@ -133,7 +133,7 @@ def _outcome_from_error(
     """
     if err is None:
         return "success"
-    if isinstance(err, asyncio.CancelledError):
+    if isinstance(err, asyncio.CancelledError | GeneratorExit):
         return "cancelled"
     return "error"
 
@@ -244,29 +244,45 @@ def infer_provider_label(
     return None
 
 
-def _maybe_dispatch_capture(
+def _emit_call_telemetry(
     *,
     plan: AttemptPlan | None,
     telemetry: LLMTelemetryContext | None,
     provider: ModelTransport,
     model: str,
+    max_tokens: int,
+    started_at: float,
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]] | None,
     tool_choice: Any,
+    was_stream: bool,
     result: BackendCompletionResult | None,
     error: BaseException | None,
 ) -> None:
-    """Build a CapturedLLMCall and fan it out to registered exporters.
+    """Record one provider attempt in both telemetry streams from the same facts.
 
-    No-op when payload capture is off
-    `has_exporters()` is checked BEFORE building.
-    Best-effort: never raises into the call path.
+    The captured-payload half is skipped entirely when no exporter is
+    registered, and both halves are best-effort: telemetry never raises into
+    the call path.
     """
+    duration_ms = (time.perf_counter() - started_at) * 1000
+    outcome = _outcome_from_error(error)
+    _emit_llm_call_completed(
+        plan=plan,
+        telemetry=telemetry,
+        provider=provider,
+        model=model,
+        max_tokens=max_tokens,
+        duration_ms=duration_ms,
+        has_tools=bool(tools),
+        was_stream=was_stream,
+        outcome=outcome,
+        result=result,
+        error=error,
+    )
     if not has_exporters():
         return
     try:
-        outcome = _outcome_from_error(error)
-        finish_reason = result.finish_reason if result is not None else outcome
         dispatch_captured_call(
             build_captured_call(
                 telemetry=telemetry,
@@ -279,8 +295,17 @@ def _maybe_dispatch_capture(
                 result=result,
                 attempt=plan.attempt if plan is not None else 1,
                 was_fallback=plan.is_fallback if plan is not None else False,
-                was_stream=False,
-                finish_reason=finish_reason,
+                was_stream=was_stream,
+                finish_reason=(
+                    result.finish_reason
+                    if result is not None and error is None
+                    else outcome
+                ),
+                duration_ms=duration_ms,
+                outcome=outcome,
+                error_class=type(error).__name__ if error is not None else None,
+                retry_attempts=plan.retry_attempts if plan is not None else 1,
+                effective_max_output_tokens=max_tokens,
             )
         )
     except Exception:  # pragma: no cover - best-effort telemetry
@@ -430,14 +455,11 @@ async def honcho_llm_call_inner(
     The outer src/llm/api.py `honcho_llm_call` handles retry + fallback +
     tool orchestration on top of this.
 
-    Emits one LLMCallCompletedEvent per call. On the stream path, setup
-    runs inside the awaited coroutine (so it sits inside any outer retry
-    wrapper) and emits its own event on failure; the wrapping generator
-    emits a second event from its finally block after drain completes or
-    raises. `was_stream` is True for streamed calls. Token counts are
-    zero on the stream path because provider token totals aren't surfaced
-    post-stream at this layer; aggregate envelopes (DialecticCompletedEvent
-    etc.) carry the accurate totals.
+    Emits one completed event and, when enabled, one captured trace per
+    provider attempt. Stream setup failures are recorded inside the awaited
+    coroutine, within the retry boundary. Successfully opened streams are
+    recorded when drained or interrupted, preserving partial output and any
+    output token count reported by the backend.
     """
     client = client_override or default_client(provider)
     if client is None:
@@ -499,7 +521,7 @@ async def honcho_llm_call_inner(
         #
         # Drain failures stay unretried by design (chunks may have already
         # been sent to the client) and report via the wrapper's finally.
-        # Token counts are 0 on this path; aggregate envelopes carry totals.
+        # Only output token counts are available from normalized stream chunks.
         stream_start = time.perf_counter()
         try:
             stream_iter = await execute_stream(
@@ -514,16 +536,17 @@ async def honcho_llm_call_inner(
                 extra_params=call_extras,
             )
         except BaseException as exc:
-            _emit_llm_call_completed(
+            _emit_call_telemetry(
                 plan=plan,
                 telemetry=telemetry,
                 provider=provider,
                 model=model,
                 max_tokens=max_tokens,
-                duration_ms=(time.perf_counter() - stream_start) * 1000,
-                has_tools=bool(tools),
+                started_at=stream_start,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
                 was_stream=True,
-                outcome=_outcome_from_error(exc),
                 result=None,
                 error=exc,
             )
@@ -531,24 +554,35 @@ async def honcho_llm_call_inner(
 
         async def _wrap_stream() -> AsyncIterator[HonchoLLMCallStreamChunk]:
             stream_error: BaseException | None = None
+            capture_output = has_exporters()
+            parts: list[str] = []
+            result = BackendCompletionResult()
             try:
                 async for chunk in stream_iter:
+                    if capture_output and chunk.content:
+                        parts.append(chunk.content)
+                    if chunk.output_tokens is not None:
+                        result.output_tokens = chunk.output_tokens
+                    if chunk.finish_reason is not None:
+                        result.finish_reason = chunk.finish_reason
                     yield stream_chunk_to_response_chunk(chunk)
             except BaseException as exc:
                 stream_error = exc
                 raise
             finally:
-                _emit_llm_call_completed(
+                result.content = "".join(parts)
+                _emit_call_telemetry(
                     plan=plan,
                     telemetry=telemetry,
                     provider=provider,
                     model=model,
                     max_tokens=max_tokens,
-                    duration_ms=(time.perf_counter() - stream_start) * 1000,
-                    has_tools=bool(tools),
+                    started_at=stream_start,
+                    messages=messages,
+                    tools=tools,
+                    tool_choice=tool_choice,
                     was_stream=True,
-                    outcome=_outcome_from_error(stream_error),
-                    result=None,
+                    result=result,
                     error=stream_error,
                 )
 
@@ -583,27 +617,17 @@ async def honcho_llm_call_inner(
         error = exc
         raise
     finally:
-        _emit_llm_call_completed(
+        _emit_call_telemetry(
             plan=plan,
             telemetry=telemetry,
             provider=provider,
             model=model,
             max_tokens=max_tokens,
-            duration_ms=(time.perf_counter() - start) * 1000,
-            has_tools=bool(tools),
-            was_stream=False,
-            outcome=_outcome_from_error(error),
-            result=backend_result,
-            error=error,
-        )
-        _maybe_dispatch_capture(
-            plan=plan,
-            telemetry=telemetry,
-            provider=provider,
-            model=model,
+            started_at=start,
             messages=messages,
             tools=tools,
             tool_choice=tool_choice,
+            was_stream=False,
             result=backend_result,
             error=error,
         )

--- a/src/llm/executor.py
+++ b/src/llm/executor.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any, Literal, TypeVar, overload
 
 from pydantic import BaseModel
@@ -556,16 +556,20 @@ async def honcho_llm_call_inner(
             stream_error: BaseException | None = None
             capture_output = has_exporters()
             parts: list[str] = []
-            result = BackendCompletionResult()
+            result = BackendCompletionResult(finish_reason=None)
             try:
-                async for chunk in stream_iter:
-                    if capture_output and chunk.content:
-                        parts.append(chunk.content)
-                    if chunk.output_tokens is not None:
-                        result.output_tokens = chunk.output_tokens
-                    if chunk.finish_reason is not None:
-                        result.finish_reason = chunk.finish_reason
-                    yield stream_chunk_to_response_chunk(chunk)
+                try:
+                    async for chunk in stream_iter:
+                        if capture_output and chunk.content:
+                            parts.append(chunk.content)
+                        if chunk.output_tokens is not None:
+                            result.output_tokens = chunk.output_tokens
+                        if chunk.finish_reason is not None:
+                            result.finish_reason = chunk.finish_reason
+                        yield stream_chunk_to_response_chunk(chunk)
+                finally:
+                    if isinstance(stream_iter, AsyncGenerator):
+                        await stream_iter.aclose()
             except BaseException as exc:
                 stream_error = exc
                 raise

--- a/src/llm/tool_loop.py
+++ b/src/llm/tool_loop.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from typing import Any, ParamSpec, TypeVar
 
 from pydantic import BaseModel
@@ -30,12 +30,7 @@ from src.utils.types import (
     set_last_tool_metadata,
 )
 
-from .capture import (
-    build_captured_call,
-    dispatch_captured_call,
-    has_exporters,
-)
-from .executor import honcho_llm_call_inner, infer_provider_label
+from .executor import honcho_llm_call_inner
 from .registry import history_adapter_for_provider
 from .runtime import (
     AttemptPlan,
@@ -107,46 +102,6 @@ def _telemetry_for_iteration(
         step_seq=step_seq,
         parent_span_id=base.span_identity(),
     )
-
-
-def _make_stream_capture_finalizer(
-    telemetry: LLMTelemetryContext | None,
-    plan: AttemptPlan,
-    messages: list[dict[str, Any]],
-) -> Callable[[str, str], None] | None:
-    """Build the streamed-call capture finalizer, or None when capture is off.
-
-    Snapshots the input messages now and returns a closure the streaming wrapper
-    calls on drain with `(streamed_text, finish_reason)`. Tool calls already ran
-    in the loop, so the final streamed turn is text-only. Returns None when no
-    exporter is registered.
-    """
-    if not has_exporters():
-        return None
-    captured_messages = list(messages)
-
-    def _finalize(text: str, finish_reason: str) -> None:
-        from .backend import CompletionResult as BackendCompletionResult
-
-        result = BackendCompletionResult(content=text, finish_reason=finish_reason)
-        dispatch_captured_call(
-            build_captured_call(
-                telemetry=telemetry,
-                transport=str(plan.provider),
-                provider_label=infer_provider_label(plan.provider, plan.model, plan),
-                model=plan.model,
-                messages=captured_messages,
-                tools=None,
-                tool_choice=None,
-                result=result,
-                attempt=plan.attempt,
-                was_fallback=plan.is_fallback,
-                was_stream=True,
-                finish_reason=finish_reason,
-            )
-        )
-
-    return _finalize
 
 
 def _emit_agent_iteration(
@@ -331,8 +286,12 @@ async def stream_final_response(
     else:
         stream = await _setup_stream()
 
-    async for chunk in stream:
-        yield chunk
+    try:
+        async for chunk in stream:
+            yield chunk
+    finally:
+        if isinstance(stream, AsyncGenerator):
+            await stream.aclose()
 
 
 @_with_iteration_scope
@@ -551,9 +510,6 @@ async def execute_tool_loop(
                         iterations=iteration + 1,
                         hit_input_token_cap=hit_input_token_cap,
                         langfuse_run_handle=langfuse_run_handle,
-                        capture_finalizer=_make_stream_capture_finalizer(
-                            stream_telemetry, winning_plan, conversation_messages
-                        ),
                     )
 
                 response.tool_calls_made = all_tool_calls
@@ -717,9 +673,6 @@ async def execute_tool_loop(
             iterations=iteration + 1,
             hit_input_token_cap=hit_input_token_cap,
             langfuse_run_handle=langfuse_run_handle,
-            capture_finalizer=_make_stream_capture_finalizer(
-                stream_telemetry, winning_plan, conversation_messages
-            ),
         )
 
     current_attempt.set(1)

--- a/src/llm/types.py
+++ b/src/llm/types.py
@@ -6,9 +6,7 @@ of the migration toward src/llm/ owning all non-embedding LLM orchestration.
 
 from __future__ import annotations
 
-import asyncio
-import logging
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
@@ -21,7 +19,6 @@ if TYPE_CHECKING:
 
     from src.llm.capture import CapturedMessage
 
-logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -90,9 +87,21 @@ class LLMTelemetryContext:
     # Optional peer context (dream agents pass observer/observed; dialectic
     # passes peer_name). Kept here so AgentIterationEvent can populate
     # them without a separate threading path.
+    #
+    # `observer` is the tool-loop agent's single observer — it reaches
+    # AgentIterationEvent and the Langfuse tags, which only fire for dialectic
+    # and the dream specialists, and those have exactly one by construction.
+    # `observers` is every collection the call writes to, so the deriver's
+    # fan-out has somewhere to go; single-observer agents set both. Set
+    # `observers` always; set `observer` only when there is genuinely one.
     observer: str | None = None
     observed: str | None = None
     peer_name: str | None = None
+    observers: list[str] = field(default_factory=list)
+    # Source work, distinct from messages retrieved later by agent tools.
+    source_message_ids: list[str] = field(default_factory=list)
+    queue_item_ids: list[int] = field(default_factory=list)
+    parent_event_id: str | None = None
     # Used to group traces (should not use session_name because it is not unique)
     session_id: str | None = None
     # Tool-related context: agent_type is the human-readable identifier of the
@@ -184,13 +193,6 @@ class StreamingResponseWithMetadata:
     as the run span's output and the span is closed. Without this transfer,
     streaming traces would show blank output because the synchronous return
     happens before any chunks arrive.
-
-    `capture_finalizer` (optional) closes the replay-grade content capture for
-    a streamed call. The synchronous return happens before any chunks arrive,
-    so the streamed text only exists once the stream drains — the wrapper calls
-    the finalizer with `(accumulated_text, finish_reason)` in its `finally`.
-    A partial/aborted stream still finalizes, with `finish_reason` =
-    "cancelled"/"error".
     """
 
     _stream: AsyncIterator[HonchoLLMCallStreamChunk]
@@ -203,7 +205,6 @@ class StreamingResponseWithMetadata:
     iterations: int
     hit_input_token_cap: bool
     _langfuse_run_handle: Any | None
-    _capture_finalizer: Callable[[str, str], None] | None
 
     def __init__(
         self,
@@ -217,7 +218,6 @@ class StreamingResponseWithMetadata:
         iterations: int = 0,
         hit_input_token_cap: bool = False,
         langfuse_run_handle: Any | None = None,
-        capture_finalizer: Callable[[str, str], None] | None = None,
     ):
         self._stream = stream
         self.tool_calls_made = tool_calls_made
@@ -229,7 +229,6 @@ class StreamingResponseWithMetadata:
         self.iterations = iterations
         self.hit_input_token_cap = hit_input_token_cap
         self._langfuse_run_handle = langfuse_run_handle
-        self._capture_finalizer = capture_finalizer
 
     def __aiter__(self) -> AsyncIterator[HonchoLLMCallStreamChunk]:
         # Wrap the underlying iterator to capture final-stream output_tokens
@@ -243,23 +242,14 @@ class StreamingResponseWithMetadata:
         self,
     ) -> AsyncIterator[HonchoLLMCallStreamChunk]:
         final_stream_output_tokens = 0
-        # Accumulate the streamed text when either consumer needs it: the
-        # Langfuse run span (stamped as output on drain) or the content-capture
-        # finalizer.
-        accumulate = (
-            self._langfuse_run_handle is not None or self._capture_finalizer is not None
-        )
+        accumulate = self._langfuse_run_handle is not None
         accumulated_text: list[str] = []
-        last_finish_reason: str | None = None
-        stream_error: BaseException | None = None
         try:
             async for chunk in self._stream:
                 if chunk.output_tokens is not None:
                     # Take the LATEST value, not the sum — providers report
                     # the cumulative usage in the final chunk, not deltas.
                     final_stream_output_tokens = chunk.output_tokens
-                if chunk.finish_reasons:
-                    last_finish_reason = chunk.finish_reasons[-1]
                 if accumulate and chunk.content:
                     accumulated_text.append(chunk.content)
                 yield chunk
@@ -268,10 +258,12 @@ class StreamingResponseWithMetadata:
             # see the true cost.
             if final_stream_output_tokens > 0:
                 self.output_tokens += final_stream_output_tokens
-        except BaseException as exc:
-            stream_error = exc
-            raise
         finally:
+            # Closing the public iterator must finalize the provider's trace now,
+            # even when the caller stops before the next chunk arrives.
+            stream = self._stream
+            if isinstance(stream, AsyncGenerator):
+                await stream.aclose()
             text = "".join(accumulated_text)
             # Close the run span once, stamping the streamed text as its
             # output. In `finally` so an early-exit caller still closes
@@ -280,24 +272,6 @@ class StreamingResponseWithMetadata:
             if handle is not None:
                 self._langfuse_run_handle = None
                 handle.end(output=text or None)
-            # Finalize the content capture with the full streamed text. Even a
-            # partial/aborted stream captures, tagged with the right outcome.
-            finalizer = self._capture_finalizer
-            if finalizer is not None:
-                self._capture_finalizer = None
-                finish_reason = (
-                    (last_finish_reason or "stop")
-                    if stream_error is None
-                    else (
-                        "cancelled"
-                        if isinstance(stream_error, asyncio.CancelledError)
-                        else "error"
-                    )
-                )
-                try:
-                    finalizer(text, finish_reason)
-                except Exception:  # pragma: no cover - best-effort telemetry
-                    logger.debug("Stream capture finalizer failed", exc_info=True)
 
 
 __all__ = [

--- a/src/telemetry/events/trace.py
+++ b/src/telemetry/events/trace.py
@@ -19,7 +19,7 @@ the exact context a model saw, content-addressed to keep payload O(N):
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 from pydantic import Field
 
@@ -37,7 +37,7 @@ class LLMCallTracedEvent(BaseEvent):
     """
 
     _event_type: ClassVar[str] = "llm.call.traced"
-    _schema_version: ClassVar[int] = 1
+    _schema_version: ClassVar[int] = 2
     _category: ClassVar[str] = "trace"
     _volume_class: ClassVar[str] = "ground_truth"
 
@@ -50,12 +50,25 @@ class LLMCallTracedEvent(BaseEvent):
     attempt: int = 1
     was_fallback: bool = False
     parent_event_id: str | None = None
+    run_id: str | None = None
 
     # --- Path identity ---
     call_purpose: str | None = None
     parent_category: str | None = None
     # Used for grouping traces
     session_id: str | None = None
+    workspace_name: str | None = None
+    # Every producer populates `observers`, including single-observer agents —
+    # there is no scalar `observer`, because a batched derivation has no single
+    # one and a joined string would name no peer.
+    observers: list[str] = Field(default_factory=list)
+    observed: str | None = None
+    peer_name: str | None = None
+    agent_type: str | None = None
+    track_name: str | None = None
+    # IDs of the work that triggered this call, not all retrieved context.
+    source_message_ids: list[str] = Field(default_factory=list)
+    queue_item_ids: list[int] = Field(default_factory=list)
     transport: ModelTransport
     provider_label: str | None = None
     model: str
@@ -63,6 +76,7 @@ class LLMCallTracedEvent(BaseEvent):
     # --- Context window (content-addressed) ---
     input_message_refs: list[str] = Field(default_factory=list)
     system_prompt_ref: str | None = None
+    system_prompt_refs: list[str] = Field(default_factory=list)
     tool_schema_refs: list[str] = Field(default_factory=list)
     tool_choice: Any = None
 
@@ -70,10 +84,19 @@ class LLMCallTracedEvent(BaseEvent):
     output_content_ref: str | None = None
     output_tool_calls: list[dict[str, Any]] = Field(default_factory=list)
     output_thinking_ref: str | None = None
+    output_reasoning_ref: str | None = None
     output_signatures: list[str] = Field(default_factory=list)
     # Reserved: Honcho captures the normalized request/response, not wire bytes.
     raw_response_ref: str | None = None
     finish_reason: str | None = None
+    # Optional for v1 archives and callers without execution diagnostics.
+    was_stream: bool | None = None
+    duration_ms: float | None = None
+    outcome: Literal["success", "error", "cancelled"] | None = None
+    error_class: str | None = None
+    retry_attempts: int | None = None
+    is_final_attempt: bool | None = None
+    effective_max_output_tokens: int | None = None
 
     # --- Accounting copy (stream stands alone; NOT joined to llm.call.completed) ---
     provider_input_tokens: int = 0
@@ -92,7 +115,7 @@ class EmbeddingCallTracedEvent(BaseEvent):
     """One trace-stream record per embedding-provider call."""
 
     _event_type: ClassVar[str] = "embedding.call.traced"
-    _schema_version: ClassVar[int] = 1
+    _schema_version: ClassVar[int] = 2
     _category: ClassVar[str] = "trace"
     _volume_class: ClassVar[str] = "ground_truth"
 
@@ -104,12 +127,19 @@ class EmbeddingCallTracedEvent(BaseEvent):
     step_seq: int = 0
     attempt: int = 1
     session_id: str | None = None
+    run_id: str | None = None
+    workspace_name: str | None = None
 
     # --- Path identity ---
     call_purpose: str | None = None
     parent_category: str | None = None
     provider: str
     model: str
+    duration_ms: float | None = None
+    outcome: Literal["success", "error", "cancelled"] | None = None
+    error_class: str | None = None
+    retry_attempts: int | None = None
+    is_final_attempt: bool | None = None
 
     # --- Accounting copy ---
     # v1: input tokens are a tiktoken ESTIMATE (no authoritative provider count is

--- a/src/telemetry/trace_exporter.py
+++ b/src/telemetry/trace_exporter.py
@@ -16,9 +16,11 @@ from typing import Any
 from src.config import settings
 from src.llm.capture import (
     ROLE_OUTPUT,
+    ROLE_REASONING,
     ROLE_THINKING,
     ROLE_TOOL_SCHEMA,
     CapturedLLMCall,
+    canonical_json,
     clip_for_trace,
     compute_content_hash,
 )
@@ -46,8 +48,13 @@ class TraceExporter:
 
         # --- Context window: reuse precomputed input-message hashes ---
         input_message_refs: list[str] = []
+        system_prompt_refs: list[str] = []
+        system_prompt_parts: list[Any] = []
         for message in call.input_messages:
             input_message_refs.append(message.content_hash)
+            if message.role == "system":
+                system_prompt_refs.append(message.content_hash)
+                system_prompt_parts.append(message.content)
             self._emit_content(
                 run_key,
                 content_hash=message.content_hash,
@@ -88,6 +95,33 @@ class TraceExporter:
             if block.get("signature")
         ]
 
+        # One ref for "the system prompt", however many turns carried it. A lone
+        # system message reuses its own hash (so the ref is the message, and the
+        # dedup store already shipped it); several are concatenated and shipped
+        # under their own hash. The joiner is ours, not the provider's, so the
+        # byte-exact turns stay addressable via `system_prompt_refs`.
+        system_prompt_ref: str | None = None
+        if len(system_prompt_refs) == 1:
+            system_prompt_ref = system_prompt_refs[0]
+        elif system_prompt_refs:
+            system_prompt_ref, truncated = self._emit_hashed_content(
+                run_key,
+                "system",
+                "\n\n".join(
+                    part if isinstance(part, str) else canonical_json(part)
+                    for part in system_prompt_parts
+                ),
+                honcho_authored=True,
+            )
+            was_truncated = was_truncated or truncated
+
+        output_reasoning_ref: str | None = None
+        if call.reasoning_details:
+            output_reasoning_ref, truncated = self._emit_hashed_content(
+                run_key, ROLE_REASONING, call.reasoning_details
+            )
+            was_truncated = was_truncated or truncated
+
         emit_trace(
             LLMCallTracedEvent(
                 trace_id=call.trace_id,
@@ -97,20 +131,40 @@ class TraceExporter:
                 step_seq=call.step_seq,
                 attempt=call.attempt,
                 was_fallback=call.was_fallback,
+                parent_event_id=call.parent_event_id,
+                run_id=call.run_id,
                 call_purpose=call.call_purpose,
                 parent_category=call.parent_category,
                 session_id=call.session_id,
+                workspace_name=call.workspace_name,
+                observers=call.observers,
+                observed=call.observed,
+                peer_name=call.peer_name,
+                agent_type=call.agent_type,
+                track_name=call.track_name,
+                source_message_ids=call.source_message_ids,
+                queue_item_ids=call.queue_item_ids,
                 transport=call.transport,  # pyright: ignore[reportArgumentType]
                 provider_label=call.provider_label,
                 model=call.model,
                 input_message_refs=input_message_refs,
+                system_prompt_ref=system_prompt_ref,
+                system_prompt_refs=system_prompt_refs,
                 tool_schema_refs=tool_schema_refs,
                 tool_choice=call.tool_choice,
                 output_content_ref=output_content_ref,
                 output_tool_calls=call.output_tool_calls,
                 output_thinking_ref=output_thinking_ref,
+                output_reasoning_ref=output_reasoning_ref,
                 output_signatures=signatures,
                 finish_reason=call.finish_reason,
+                was_stream=call.was_stream,
+                duration_ms=call.duration_ms,
+                outcome=call.outcome,
+                error_class=call.error_class,
+                retry_attempts=call.retry_attempts,
+                is_final_attempt=call.is_final_attempt,
+                effective_max_output_tokens=call.effective_max_output_tokens,
                 provider_input_tokens=call.input_tokens,
                 provider_output_tokens=call.output_tokens,
                 cache_read_tokens=call.cache_read_tokens,

--- a/src/telemetry/trace_exporter.py
+++ b/src/telemetry/trace_exporter.py
@@ -118,7 +118,7 @@ class TraceExporter:
         output_reasoning_ref: str | None = None
         if call.reasoning_details:
             output_reasoning_ref, truncated = self._emit_hashed_content(
-                run_key, ROLE_REASONING, call.reasoning_details
+                run_key, ROLE_REASONING, canonical_json(call.reasoning_details)
             )
             was_truncated = was_truncated or truncated
 

--- a/src/utils/summarizer.py
+++ b/src/utils/summarizer.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import time
+from dataclasses import replace
 from enum import Enum
 from functools import cache
 from inspect import cleandoc as c
@@ -202,7 +203,7 @@ async def create_short_summary(
     input_tokens: int,
     previous_summary: str | None = None,
     *,
-    workspace_name: str | None = None,
+    telemetry: LLMTelemetryContext | None = None,
 ) -> HonchoLLMCallResponse[str]:
     # input_tokens indicates how many tokens the message list + previous summary take up
     # we want to optimize short summaries to be smaller than the actual content being summarized
@@ -221,16 +222,16 @@ async def create_short_summary(
     )
 
     # Mint a root span id.
-    # No session_id or run_id for tracing
     trace_id = generate_nanoid()
     return await honcho_llm_call(
         model_config=_get_summary_model_config(),
         prompt=prompt,
         max_tokens=settings.SUMMARY.MAX_TOKENS_SHORT,
-        telemetry=LLMTelemetryContext(
-            workspace_name=workspace_name,
+        telemetry=replace(
+            telemetry or LLMTelemetryContext(),
             call_purpose=CallPurpose.SUMMARY_SHORT.value,
             parent_category="summary",
+            agent_type="summarizer",
             trace_id=trace_id,
             span_id=trace_id,
             track_name="Short Summary",
@@ -243,7 +244,7 @@ async def create_long_summary(
     formatted_messages: str,
     previous_summary: str | None = None,
     *,
-    workspace_name: str | None = None,
+    telemetry: LLMTelemetryContext | None = None,
 ) -> HonchoLLMCallResponse[str]:
     # the word/token ratio is roughly 4:3 so we multiply by 0.75.
     # LLMs *seem* to respond better to getting asked for a word count but should workshop this.
@@ -259,16 +260,16 @@ async def create_long_summary(
     )
 
     # Mint a root span id.
-    # No session_id or run_id for tracing
     trace_id = generate_nanoid()
     return await honcho_llm_call(
         model_config=_get_summary_model_config(),
         prompt=prompt,
         max_tokens=settings.SUMMARY.MAX_TOKENS_LONG,
-        telemetry=LLMTelemetryContext(
-            workspace_name=workspace_name,
+        telemetry=replace(
+            telemetry or LLMTelemetryContext(),
             call_purpose=CallPurpose.SUMMARY_LONG.value,
             parent_category="summary",
+            agent_type="summarizer",
             trace_id=trace_id,
             span_id=trace_id,
             track_name="Long Summary",
@@ -283,6 +284,8 @@ async def summarize_if_needed(
     message_seq_in_session: int,
     message_public_id: str,
     configuration: schemas.ResolvedConfiguration,
+    *,
+    queue_item_id: int | None = None,
 ) -> None:
     """
     Create short/long summaries if thresholds met.
@@ -297,6 +300,7 @@ async def summarize_if_needed(
         message_seq_in_session: The sequence number of the message in the session
         message_public_id: The public ID of the message
         configuration: The resolved configuration for the message
+        queue_item_id: Queue row that triggered this summary, when available.
     """
     if configuration.summary.enabled is False:
         return
@@ -323,6 +327,7 @@ async def summarize_if_needed(
                 message_public_id=message_public_id,
                 summary_type=SummaryType.LONG,
                 configuration=configuration,
+                queue_item_id=queue_item_id,
             )
             accumulate_metric(
                 f"summary_{workspace_name}_{message_id}",
@@ -340,6 +345,7 @@ async def summarize_if_needed(
                 message_public_id=message_public_id,
                 summary_type=SummaryType.SHORT,
                 configuration=configuration,
+                queue_item_id=queue_item_id,
             )
             accumulate_metric(
                 f"summary_{workspace_name}_{message_id}",
@@ -364,6 +370,7 @@ async def summarize_if_needed(
                 message_public_id=message_public_id,
                 summary_type=SummaryType.LONG,
                 configuration=configuration,
+                queue_item_id=queue_item_id,
             )
             accumulate_metric(
                 f"summary_{workspace_name}_{message_id}",
@@ -380,6 +387,7 @@ async def summarize_if_needed(
                 message_public_id=message_public_id,
                 summary_type=SummaryType.SHORT,
                 configuration=configuration,
+                queue_item_id=queue_item_id,
             )
             accumulate_metric(
                 f"summary_{workspace_name}_{message_id}",
@@ -398,6 +406,7 @@ async def _create_and_save_summary(
     message_public_id: str,
     summary_type: SummaryType,
     configuration: schemas.ResolvedConfiguration,
+    queue_item_id: int | None = None,
 ) -> None:
     """
     Create a new summary and save it to the database.
@@ -411,9 +420,13 @@ async def _create_and_save_summary(
     summary_start = time.perf_counter()
 
     async with tracked_db("summary.fetch_data") as db:
-        latest_summary = await get_summary(
-            db, workspace_name, session_name, summary_type
-        )
+        try:
+            session = await crud.get_session(db, session_name, workspace_name)
+        except ResourceNotFoundException:
+            return
+        session_id = session.id
+        summaries: dict[str, Summary] = session.internal_metadata.get(SUMMARIES_KEY, {})
+        latest_summary = summaries.get(summary_type.value)
         if latest_summary:
             latest_summary_message_id = latest_summary["message_id"]
             # Skip if latest summary already covers message.
@@ -447,6 +460,7 @@ async def _create_and_save_summary(
         last_message_id = messages[-1].id
         last_message_content_preview = messages[-1].content[:30]
         message_count = len(messages)
+        source_message_ids = [message.public_id for message in messages]
 
         messages_tokens = sum([message.token_count for message in messages])
         previous_summary_tokens = latest_summary["token_count"] if latest_summary else 0
@@ -466,7 +480,12 @@ async def _create_and_save_summary(
         last_message_id=last_message_id,
         last_message_content_preview=last_message_content_preview,
         message_count=message_count,
-        workspace_name=workspace_name,
+        telemetry=LLMTelemetryContext(
+            workspace_name=workspace_name,
+            session_id=session_id,
+            source_message_ids=source_message_ids,
+            queue_item_ids=[queue_item_id] if queue_item_id is not None else [],
+        ),
     )
 
     # Compute scaffold tokens up front (cheap + idempotent) so both the
@@ -562,7 +581,7 @@ async def _create_summary(
     last_message_content_preview: str,
     message_count: int,
     *,
-    workspace_name: str | None = None,
+    telemetry: LLMTelemetryContext | None = None,
 ) -> tuple[Summary, bool, int, int]:
     """
     Generate a summary of the provided messages using an LLM.
@@ -576,6 +595,7 @@ async def _create_summary(
         last_message_id: ID of the last message
         last_message_content_preview: Preview of last message content for fallback
         message_count: Number of messages for fallback
+        telemetry: Source identity carried through summary generation.
 
     Returns:
         A tuple of (Summary, is_fallback, llm_input_tokens, llm_output_tokens)
@@ -594,13 +614,13 @@ async def _create_summary(
                 formatted_messages,
                 input_tokens,
                 previous_summary_text,
-                workspace_name=workspace_name,
+                telemetry=telemetry,
             )
         else:
             response = await create_long_summary(
                 formatted_messages,
                 previous_summary_text,
-                workspace_name=workspace_name,
+                telemetry=telemetry,
             )
 
         summary_text = response.content

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -960,6 +960,7 @@ def mock_tracked_db(request: pytest.FixtureRequest):
         "src.dependencies.tracked_db",
         "src.deriver.queue_manager.tracked_db",
         "src.deriver.consumer.tracked_db",
+        "src.deriver.deriver.tracked_db",
         "src.deriver.enqueue.tracked_db",
         "src.routers.peers.tracked_db",
         "src.routers.workspaces.tracked_db",

--- a/tests/crud/test_deriver_metrics_query.py
+++ b/tests/crud/test_deriver_metrics_query.py
@@ -101,8 +101,17 @@ class TestDeriverMetrics:
         self,
         db_session: AsyncSession,
         sample_data: tuple[models.Workspace, models.Peer],
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        """A small, fresh batch is real work that a deriver would not yet claim."""
+        """A small, fresh batch is real work that a deriver would not yet claim.
+
+        The accumulation gate is skipped entirely when DERIVER_FLUSH_ENABLED is
+        True, which makes every unprocessed work unit eligible, so this test
+        forces it False regardless of what the process env has set (benches
+        commonly enable flush mode for immediate processing).
+        """
+        monkeypatch.setattr(settings.DERIVER, "FLUSH_ENABLED", False)
+
         workspace, peer = sample_data
         session = await _make_session(db_session, workspace)
 

--- a/tests/deriver/test_deriver_processing.py
+++ b/tests/deriver/test_deriver_processing.py
@@ -55,6 +55,7 @@ class TestDeriverProcessing:
                 observers=["bob"],
                 observed="alice",
                 queue_item_message_ids=[1],
+                session_id="canonical-session-1",
             )
 
         await_args = mock_llm_call.await_args
@@ -116,6 +117,7 @@ class TestDeriverProcessing:
                 observers=["bob"],
                 observed="alice",
                 queue_item_message_ids=[1],
+                session_id="canonical-session-1",
             )
 
         # Telemetry must fire *before* the raise so a total save failure is still
@@ -175,6 +177,7 @@ class TestDeriverProcessing:
                 observers=["bob", "carol"],
                 observed="alice",
                 queue_item_message_ids=[1],
+                session_id="canonical-session-1",
             )
 
         assert emitted, "expected a telemetry event to be emitted"
@@ -231,6 +234,7 @@ class TestDeriverProcessing:
                 observers=["bob", "carol"],
                 observed="alice",
                 queue_item_message_ids=[1],
+                session_id="canonical-session-1",
             )
 
         assert emitted, "expected telemetry to be emitted before the raised failure"
@@ -284,6 +288,7 @@ class TestDeriverProcessing:
                 observers=["bob"],
                 observed="alice",
                 queue_item_message_ids=[1],
+                session_id="canonical-session-1",
             )
 
         mock_estimate_prompt_tokens.assert_called_once_with(
@@ -424,6 +429,7 @@ class TestDeriverProcessing:
                 observers=["bob"],
                 observed="alice",
                 queue_item_message_ids=[1],
+                session_id="canonical-session-1",
             )
 
         assert any(
@@ -479,6 +485,7 @@ class TestDeriverProcessing:
                 observers=["bob"],
                 observed="alice",
                 queue_item_message_ids=[1],
+                session_id="canonical-session-1",
             )
 
         assert any(
@@ -549,6 +556,7 @@ class TestDeriverProcessing:
                 observers=["bob", "carol"],
                 observed="alice",
                 queue_item_message_ids=[1],
+                session_id="canonical-session-1",
             )
 
         assert len(emitted) == 1

--- a/tests/dreamer/test_model_config_usage.py
+++ b/tests/dreamer/test_model_config_usage.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -83,8 +84,10 @@ def test_deduction_specialist_can_update_peer_card() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("session_id", [None, "canonical-session"])
 async def test_deduction_specialist_uses_nested_model_config(
     monkeypatch: pytest.MonkeyPatch,
+    session_id: str | None,
 ) -> None:
     monkeypatch.setattr(settings.METRICS, "ENABLED", False)
     specialist = DeductionSpecialist()
@@ -96,6 +99,10 @@ async def test_deduction_specialist_uses_nested_model_config(
     )
 
     with (
+        patch(
+            "src.dreamer.specialists.crud.get_session",
+            new=AsyncMock(return_value=SimpleNamespace(id="canonical-session")),
+        ) as get_session,
         patch(
             "src.dreamer.specialists.crud.get_peer",
             new=AsyncMock(),
@@ -118,12 +125,28 @@ async def test_deduction_specialist_uses_nested_model_config(
             observer="alice",
             observed="alice",
             session_name="session",
+            session_id=session_id,
+            queue_item_id=42,
         )
 
     await_args = mock_llm_call.await_args
     if await_args is None:
         raise AssertionError("Expected dreamer LLM call")
     kwargs = await_args.kwargs
+    telemetry = kwargs["telemetry"]
+    assert telemetry.session_id == "canonical-session"
+    assert telemetry.queue_item_ids == [42]
+    assert telemetry.observer == telemetry.observed == "alice"
+    assert telemetry.observers == ["alice"]
+    if session_id is None:
+        get_session.assert_awaited_once()
+        assert get_session.await_args is not None
+        assert get_session.await_args.kwargs == {
+            "workspace_name": "workspace",
+            "session_name": "session",
+        }
+    else:
+        get_session.assert_not_awaited()
     expected_config = settings.DREAM.DEDUCTION_MODEL_CONFIG
 
     assert result.content == "done"

--- a/tests/llm/test_capture.py
+++ b/tests/llm/test_capture.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
-
 import pytest
 
 from src.llm import capture
@@ -16,65 +14,7 @@ from src.llm.capture import (
     clip_for_trace,
     compute_content_hash,
 )
-from src.llm.types import (
-    HonchoLLMCallStreamChunk,
-    LLMTelemetryContext,
-    StreamingResponseWithMetadata,
-)
-
-
-async def _chunks(
-    texts: list[str], *, raise_after: BaseException | None = None
-) -> AsyncIterator[HonchoLLMCallStreamChunk]:
-    for text in texts:
-        yield HonchoLLMCallStreamChunk(content=text)
-    if raise_after is not None:
-        raise raise_after
-
-
-def _wrapper(
-    stream: AsyncIterator[HonchoLLMCallStreamChunk],
-    recorder: list[tuple[str, str]],
-):
-    return StreamingResponseWithMetadata(
-        stream=stream,
-        tool_calls_made=[],
-        input_tokens=0,
-        output_tokens=0,
-        cache_creation_input_tokens=0,
-        cache_read_input_tokens=0,
-        capture_finalizer=lambda text, reason: recorder.append((text, reason)),
-    )
-
-
-class TestStreamingCaptureFinalizer:
-    async def test_clean_drain_captures_stop(self):
-        recorded: list[tuple[str, str]] = []
-        wrapper = _wrapper(_chunks(["hel", "lo"]), recorded)
-        async for _ in wrapper:
-            pass
-        assert recorded == [("hello", "stop")]
-
-    async def test_error_drain_captures_error_and_partial_text(self):
-        recorded: list[tuple[str, str]] = []
-        wrapper = _wrapper(_chunks(["par"], raise_after=RuntimeError("boom")), recorded)
-        with pytest.raises(RuntimeError):
-            async for _ in wrapper:
-                pass
-        # Partial text still captured, tagged error.
-        assert recorded == [("par", "error")]
-
-    async def test_cancelled_drain_captures_cancelled(self):
-        import asyncio
-
-        recorded: list[tuple[str, str]] = []
-        wrapper = _wrapper(
-            _chunks(["x"], raise_after=asyncio.CancelledError()), recorded
-        )
-        with pytest.raises(asyncio.CancelledError):
-            async for _ in wrapper:
-                pass
-        assert recorded == [("x", "cancelled")]
+from src.llm.types import LLMTelemetryContext
 
 
 class TestContentHash:

--- a/tests/llm/test_telemetry_llm_call.py
+++ b/tests/llm/test_telemetry_llm_call.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from src.llm.backend import CompletionResult as BackendCompletionResult
+from src.llm.backend import StreamChunk
 from src.llm.executor import _emit_llm_call_completed
 from src.llm.runtime import AttemptPlan
 from src.llm.types import LLMTelemetryContext
@@ -370,7 +371,7 @@ class TestExecutorEndToEnd:
 
         async def _cancelling_stream() -> AsyncIterator[Any]:
             # one chunk then cancel — simulates a client disconnect mid-stream.
-            yield object()  # caller's `async for` consumes this
+            yield StreamChunk(content="partial")
             raise asyncio.CancelledError()
 
         async def _setup_stream(*_args: Any, **_kwargs: Any) -> AsyncIterator[Any]:
@@ -754,9 +755,7 @@ class TestStreamingResponseRunHandleClose:
 
         from src.llm.types import HonchoLLMCallStreamChunk
 
-        agen = cast(
-            "AsyncGenerator[HonchoLLMCallStreamChunk, None]", wrapper.__aiter__()
-        )
+        agen = cast("AsyncGenerator[HonchoLLMCallStreamChunk]", wrapper.__aiter__())
         first = await agen.__anext__()
         assert first.content == "hel"
         await agen.aclose()

--- a/tests/telemetry/test_cross_agent_trace.py
+++ b/tests/telemetry/test_cross_agent_trace.py
@@ -101,29 +101,30 @@ def test_dialectic_global_has_no_session(spy: SpyExporter):
     assert spy.calls[-1].session_id is None
 
 
-# --- Background agents: sessionless single-shot / shared-tree contracts -----
+# --- Background agents: single-shot / shared-tree contracts -----------------
 
 
 @pytest.mark.parametrize(
     ("call_purpose", "parent_category", "track_name"),
     [
         ("deriver.representation", "representation", "Minimal Deriver"),
-        ("summary.short", "summary", None),
+        ("summary.short", "summary", "Short Summary"),
+        ("summary.long", "summary", "Long Summary"),
     ],
 )
-def test_background_agents_are_sessionless_single_shot(
+def test_background_agents_keep_session_identity_in_single_shot_traces(
     spy: SpyExporter,
     call_purpose: str,
     parent_category: str,
     track_name: str | None,
 ):
-    # Deriver + summarizer mirror their src/ contexts: trace_id == span_id, no
-    # run_id/session_id, self-rooted.
+    # Producer paths are exercised in test_session_trace_identity.py.
     tid = f"{parent_category}-trace"
     _dispatch(
         LLMTelemetryContext(
             workspace_name="ws",
             call_purpose=call_purpose,
+            session_id="canonical-session-id",
             parent_category=parent_category,
             track_name=track_name,
             trace_id=tid,
@@ -131,7 +132,7 @@ def test_background_agents_are_sessionless_single_shot(
         )
     )
     call = spy.calls[-1]
-    assert call.session_id is None
+    assert call.session_id == "canonical-session-id"
     assert call.run_id is None
     assert call.trace_id == call.span_id == tid
     assert call.parent_span_id is None

--- a/tests/telemetry/test_embedding_trace.py
+++ b/tests/telemetry/test_embedding_trace.py
@@ -58,6 +58,13 @@ def test_embedding_traced_event_carries_correlation(
     assert ev.parent_span_id == "run-1"
     assert ev.span_id and ev.span_id != "run-1"
     assert ev.session_id == "sess-1"
+    assert ev.workspace_name == "ws"
+    assert ev.run_id == "run-1"
+    assert ev.duration_ms == 1.0
+    assert ev.outcome == "success"
+    assert ev.error_class is None
+    assert ev.attempt == ev.retry_attempts == 1
+    assert ev.is_final_attempt is True
     assert ev.call_purpose == "dialectic.prefetch"
     assert ev.parent_category == "dialectic"
     assert ev.provider == "openai" and ev.model == "text-embedding-3"

--- a/tests/telemetry/test_session_trace_identity.py
+++ b/tests/telemetry/test_session_trace_identity.py
@@ -1,0 +1,301 @@
+"""Canonical session identity from background producers through trace export."""
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from nanoid import generate as generate_nanoid
+from sqlalchemy.ext.asyncio import AsyncSession
+from tenacity import wait_none
+
+from src import crud, dependencies, models
+from src.config import ConfiguredModelSettings, FallbackModelSettings, settings
+from src.deriver import deriver
+from src.deriver.consumer import process_item, process_representation_batch
+from src.llm import api, capture, executor, runtime
+from src.llm.backend import CompletionResult, ProviderBackend
+from src.telemetry import trace_exporter
+from src.telemetry.events.base import BaseEvent
+from src.telemetry.events.trace import LLMCallTracedEvent, TraceContentEvent
+from src.utils import summarizer
+from src.utils.config_helpers import get_configuration
+from src.utils.queue_payload import SummaryPayload
+from src.utils.representation import PromptRepresentation
+
+
+@pytest.fixture(autouse=True)
+def mock_llm_call_functions() -> None:
+    """Override the suite's summary mocks to exercise the real producers."""
+
+
+@pytest.fixture
+def trace_events(monkeypatch: pytest.MonkeyPatch) -> list[BaseEvent]:
+    events: list[BaseEvent] = []
+    monkeypatch.setattr(settings.TELEMETRY, "TRACE_PAYLOADS_ENABLED", True)
+    monkeypatch.setattr(settings.TELEMETRY, "TRACE_PURPOSES", [])
+    monkeypatch.setattr(trace_exporter, "emit_trace", events.append)
+    capture.clear_exporters()
+    capture.register_exporter(trace_exporter.TraceExporter())
+    return events
+
+
+@pytest.fixture(params=[False, True], ids=["primary", "retry-and-fallback"])
+def backend(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncMock:
+    """Run real retry/planning/capture code with deterministic provider responses."""
+    retry = request.param
+    db_open = ContextVar("session_trace_db_open", default=False)
+    tracked_db = dependencies.tracked_db
+
+    @asynccontextmanager
+    async def track_connection(
+        operation: str, *, read_only: bool = False
+    ) -> AsyncGenerator[AsyncSession]:
+        token = db_open.set(True)
+        try:
+            async with tracked_db(operation, read_only=read_only) as db:
+                yield db
+        finally:
+            db_open.reset(token)
+
+    monkeypatch.setattr(summarizer, "tracked_db", track_connection)
+    monkeypatch.setattr(deriver, "tracked_db", track_connection)
+
+    async def complete(**kwargs: Any) -> CompletionResult:
+        assert not db_open.get(), "DB connection held during inference"
+        if retry and runtime.current_attempt.get() < 3:
+            raise TimeoutError("synthetic provider timeout")
+        content = (
+            PromptRepresentation(explicit=[])
+            if kwargs.get("response_format") is PromptRepresentation
+            else "Synthetic conversation summary."
+        )
+        return CompletionResult(
+            content=content, input_tokens=500, output_tokens=10, finish_reason="stop"
+        )
+
+    fake = AsyncMock(spec=ProviderBackend)
+    fake.complete.side_effect = complete
+    config = ConfiguredModelSettings(
+        model="synthetic-primary",
+        transport="openai",
+        fallback=FallbackModelSettings(model="synthetic-fallback", transport="openai"),
+    )
+    monkeypatch.setattr(settings.DERIVER, "MODEL_CONFIG", config)
+    monkeypatch.setattr(settings.SUMMARY, "MODEL_CONFIG", config)
+    monkeypatch.setattr(runtime, "client_for_model_config", Mock(return_value=Mock()))
+    monkeypatch.setattr(executor, "backend_for_provider", Mock(return_value=fake))
+    monkeypatch.setattr(api, "wait_exponential", Mock(return_value=wait_none()))
+    return fake
+
+
+@pytest.fixture
+async def conversations(
+    db_session: AsyncSession,
+) -> list[tuple[models.Session, list[models.Message]]]:
+    """Two names in one workspace, plus the same name in another workspace."""
+    conversations: list[tuple[models.Session, list[models.Message]]] = []
+    for names in (("same-name", "other-name"), ("same-name",)):
+        workspace = models.Workspace(name=generate_nanoid())
+        db_session.add(workspace)
+        await db_session.flush()
+        peer = models.Peer(name="alice", workspace_name=workspace.name)
+        db_session.add(peer)
+        await db_session.flush()
+        for name in names:
+            session = models.Session(
+                name=name,
+                workspace_name=workspace.name,
+                configuration={
+                    "reasoning": {"enabled": True},
+                    "summary": {
+                        "enabled": True,
+                        "messages_per_short_summary": 2,
+                        "messages_per_long_summary": 3,
+                    },
+                },
+            )
+            db_session.add(session)
+            await db_session.flush()
+            messages = [
+                models.Message(
+                    workspace_name=workspace.name,
+                    session_name=name,
+                    peer_name=peer.name,
+                    content=f"Synthetic message {seq}",
+                    seq_in_session=seq,
+                    token_count=5,
+                )
+                for seq in range(1, 7)
+            ]
+            db_session.add_all(messages)
+            conversations.append((session, messages))
+    await db_session.commit()
+    return conversations
+
+
+@pytest.mark.parametrize("session_source", ["queue", "lookup", "configuration"])
+async def test_background_session_identity(
+    session_source: str,
+    conversations: list[tuple[models.Session, list[models.Message]]],
+    backend: AsyncMock,
+    trace_events: list[BaseEvent],
+) -> None:
+    session_ids = {session.id for session, _ in conversations}
+    assert len(session_ids) == 3
+
+    for session, messages in conversations:
+        start = len(trace_events)
+        configuration = get_configuration(None, session)
+        await process_representation_batch(
+            messages=messages,
+            message_level_configuration=(
+                None if session_source == "configuration" else configuration
+            ),
+            observers=["alice"],
+            observed="alice",
+            queue_item_message_ids=[m.id for m in messages],
+            session_id=session.id if session_source == "queue" else None,
+            queue_item_ids=[101, 102],
+        )
+
+        # Short only, long only, then concurrent incremental short + long.
+        for seq in (2, 3, 6):
+            message = messages[seq - 1]
+            await process_item(
+                models.QueueItem(
+                    id=200 + seq,
+                    task_type="summary",
+                    workspace_name=session.workspace_name,
+                    session_id=session.id,
+                    message_id=message.id,
+                    payload=SummaryPayload(
+                        session_name=session.name,
+                        message_seq_in_session=seq,
+                        message_public_id=message.public_id,
+                        configuration=configuration,
+                    ).model_dump(),
+                )
+            )
+
+        traced = [
+            event
+            for event in trace_events[start:]
+            if isinstance(event, LLMCallTracedEvent)
+        ]
+        assert {event.call_purpose for event in traced} == {
+            "deriver.representation",
+            "summary.short",
+            "summary.long",
+        }
+        assert {event.session_id for event in traced} == {session.id}
+        assert {event.workspace_name for event in traced} == {session.workspace_name}
+        public_ids = {m.public_id for m in messages}
+        for event in traced:
+            assert event.source_message_ids
+            assert set(event.source_message_ids) <= public_ids
+            assert event.duration_ms is not None and event.duration_ms >= 0
+            assert event.was_stream is False
+            assert event.retry_attempts == 3
+            assert event.is_final_attempt == (event.attempt == 3)
+            assert event.effective_max_output_tokens
+            assert event.outcome == (
+                "error" if event.finish_reason == "error" else "success"
+            )
+            assert event.error_class == (
+                "TimeoutError" if event.outcome == "error" else None
+            )
+            if event.call_purpose == "deriver.representation":
+                assert set(event.source_message_ids) == public_ids
+                assert event.queue_item_ids == [101, 102]
+                assert event.observers == ["alice"]
+                assert event.observed == "alice"
+                assert event.agent_type == "deriver"
+            else:
+                assert len(event.queue_item_ids) == 1
+                assert event.queue_item_ids[0] in {202, 203, 206}
+                assert event.agent_type == "summarizer"
+        assert all(event.trace_id == event.span_id for event in traced)
+        assert all(event.trace_id != session.id for event in traced)
+        successes = [event for event in traced if event.finish_reason == "stop"]
+        assert len(successes) == 5
+        assert sum(event.call_purpose == "summary.short" for event in successes) == 2
+        assert sum(event.call_purpose == "summary.long" for event in successes) == 2
+        if any(event.was_fallback for event in traced):
+            assert len(traced) == 15
+            for event in successes:
+                attempts = [e for e in traced if e.trace_id == event.trace_id]
+                assert [e.attempt for e in attempts] == [1, 2, 3]
+                assert [e.was_fallback for e in attempts] == [False, False, True]
+                assert event.model == "synthetic-fallback"
+        else:
+            assert len(traced) == 5
+
+        content_hashes = {
+            event.content_hash
+            for event in trace_events[start:]
+            if isinstance(event, TraceContentEvent)
+        }
+        for event in traced:
+            assert event.input_message_refs
+            assert set(event.input_message_refs) <= content_hashes
+            if event.output_content_ref:
+                assert event.output_content_ref in content_hashes
+            restored = LLMCallTracedEvent.model_validate_json(event.model_dump_json())
+            assert restored.session_id == session.id
+
+    assert backend.complete.await_count == sum(
+        isinstance(event, LLMCallTracedEvent) for event in trace_events
+    )
+
+
+async def test_queue_session_id_avoids_lookup(
+    conversations: list[tuple[models.Session, list[models.Message]]],
+    backend: AsyncMock,
+    trace_events: list[BaseEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session, messages = conversations[0]
+    lookup = AsyncMock(side_effect=AssertionError("unnecessary session lookup"))
+    monkeypatch.setattr(crud, "get_session", lookup)
+    await process_representation_batch(
+        messages,
+        get_configuration(None, session),
+        observers=["alice", "bob"],
+        observed="alice",
+        queue_item_message_ids=[messages[-1].id],
+        session_id=session.id,
+    )
+    lookup.assert_not_awaited()
+    assert backend.complete.await_count > 0
+    assert {
+        e.session_id for e in trace_events if isinstance(e, LLMCallTracedEvent)
+    } == {session.id}
+    for event in trace_events:
+        if isinstance(event, LLMCallTracedEvent):
+            assert event.observers == ["alice", "bob"]
+            assert event.source_message_ids == [messages[-1].public_id]
+
+
+async def test_sessionless_summaries_remain_nullable(
+    backend: AsyncMock, trace_events: list[BaseEvent]
+) -> None:
+    await summarizer.create_short_summary("Synthetic conversation", input_tokens=5)
+    await summarizer.create_long_summary("Synthetic conversation")
+    traced = [e for e in trace_events if isinstance(e, LLMCallTracedEvent)]
+    assert backend.complete.await_count == len(traced)
+    assert {e.call_purpose for e in traced} == {"summary.short", "summary.long"}
+    for event in traced:
+        assert event.session_id is None
+        assert (
+            LLMCallTracedEvent.model_validate_json(event.model_dump_json()).session_id
+            is None
+        )
+        legacy = event.model_dump()
+        del legacy["session_id"]
+        assert LLMCallTracedEvent.model_validate(legacy).session_id is None

--- a/tests/telemetry/test_session_trace_identity.py
+++ b/tests/telemetry/test_session_trace_identity.py
@@ -8,13 +8,20 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from nanoid import generate as generate_nanoid
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from tenacity import wait_none
 
 from src import crud, dependencies, models
 from src.config import ConfiguredModelSettings, FallbackModelSettings, settings
+from src.dependencies import tracked_db
 from src.deriver import deriver
 from src.deriver.consumer import process_item, process_representation_batch
+from src.dreamer import orchestrator
+from src.dreamer.specialists import (
+    SPECIALISTS,
+    CardRefreshSpecialist,
+    SpecialistResult,
+)
 from src.llm import api, capture, executor, runtime
 from src.llm.backend import CompletionResult, ProviderBackend
 from src.telemetry import trace_exporter
@@ -137,6 +144,58 @@ async def conversations(
             conversations.append((session, messages))
     await db_session.commit()
     return conversations
+
+
+@pytest.mark.parametrize("card_refresh", [False, True])
+@pytest.mark.parametrize("with_session", [False, True])
+async def test_dream_resolves_session_id_before_db_cleanup(
+    card_refresh: bool,
+    with_session: bool,
+    conversations: list[tuple[models.Session, list[models.Message]]],
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session, _ = conversations[0]
+    monkeypatch.setattr(settings.DREAM, "ENABLED", True)
+    monkeypatch.setattr(settings.DREAM.SURPRISAL, "ENABLED", False)
+    monkeypatch.setattr(
+        dependencies,
+        "SessionLocal",
+        async_sessionmaker(db_engine, expire_on_commit=False),
+    )
+    monkeypatch.setattr(orchestrator, "tracked_db", tracked_db)
+    run = AsyncMock(
+        return_value=SpecialistResult(
+            run_id="specialist",
+            specialist_type="card_refresh" if card_refresh else "deduction",
+            iterations=1,
+            tool_calls_count=0,
+            input_tokens=1,
+            output_tokens=1,
+            duration_ms=1,
+            success=True,
+            content="done",
+        )
+    )
+    if card_refresh:
+        monkeypatch.setattr(CardRefreshSpecialist, "run", run)
+        dream = orchestrator.run_card_refresh_dream
+    else:
+        for specialist in SPECIALISTS.values():
+            monkeypatch.setattr(specialist, "run", run)
+        dream = orchestrator.run_dream
+
+    result = await dream(
+        workspace_name=session.workspace_name,
+        observer="alice",
+        observed="alice",
+        session_name=session.name if with_session else None,
+    )
+
+    assert result is not None and result.deduction_success
+    assert run.await_count == (1 if card_refresh else 2)
+    for call in run.await_args_list:
+        assert call.kwargs["session_id"] == (session.id if with_session else None)
 
 
 @pytest.mark.parametrize("session_source", ["queue", "lookup", "configuration"])

--- a/tests/telemetry/test_trace_capture_paths.py
+++ b/tests/telemetry/test_trace_capture_paths.py
@@ -132,7 +132,9 @@ async def test_export_preserves_identity_and_content(
             f"instruction {i}" for i in range(system_count)
         )
     assert trace.output_reasoning_ref is not None
-    assert content[trace.output_reasoning_ref].content == reasoning
+    assert content[trace.output_reasoning_ref].content == capture.canonical_json(
+        reasoning
+    )
     assert trace.duration_ms == completed.duration_ms
     assert backend.complete.await_args is not None
     assert (
@@ -154,15 +156,27 @@ async def test_export_preserves_identity_and_content(
 async def test_stream_records_partial_output_and_outcome(
     ending: str, with_tools: bool, backend: AsyncMock, recorded: list[BaseEvent]
 ) -> None:
+    events_at_cleanup: list[list[BaseEvent]] = []
+
     async def chunks() -> AsyncIterator[StreamChunk]:
-        yield StreamChunk(content="partial", output_tokens=2)
-        if ending == "error":
-            raise RuntimeError("synthetic disconnect")
-        if ending == "cancelled":
-            raise asyncio.CancelledError()
-        yield StreamChunk(
-            content=" answer", is_done=True, finish_reason="length", output_tokens=4
-        )
+        try:
+            yield StreamChunk(content="partial", output_tokens=2)
+            if ending == "error":
+                raise RuntimeError("synthetic disconnect")
+            if ending == "cancelled":
+                raise asyncio.CancelledError()
+            yield StreamChunk(
+                content=" answer", is_done=True, finish_reason="length", output_tokens=4
+            )
+        finally:
+            events_at_cleanup.append(
+                [
+                    event
+                    for event in recorded
+                    if isinstance(event, LLMCallCompletedEvent | LLMCallTracedEvent)
+                    and event.was_stream
+                ]
+            )
 
     def setup(**_: Any) -> AsyncIterator[StreamChunk]:
         return chunks()
@@ -198,6 +212,7 @@ async def test_stream_records_partial_output_and_outcome(
     (trace,) = [
         e for e in recorded if isinstance(e, LLMCallTracedEvent) and e.was_stream
     ]
+    assert events_at_cleanup == [[]]
     (completed,) = [
         e for e in recorded if isinstance(e, LLMCallCompletedEvent) and e.was_stream
     ]
@@ -223,6 +238,7 @@ async def test_stream_records_partial_output_and_outcome(
         }[ending]
     )
     assert trace.finish_reason == ("length" if ending == "success" else trace.outcome)
+    assert completed.finish_reason == ("length" if ending == "success" else None)
     assert trace.provider_output_tokens == (4 if ending == "success" else 2)
     assert trace.was_stream is True and trace.session_id == "session"
     assert trace.duration_ms == completed.duration_ms

--- a/tests/telemetry/test_trace_capture_paths.py
+++ b/tests/telemetry/test_trace_capture_paths.py
@@ -1,0 +1,287 @@
+"""Real executor/capture/export paths, with only the provider replaced."""
+
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from tenacity import wait_none
+
+from src.config import (
+    ConfiguredModelSettings,
+    FallbackModelSettings,
+    ModelConfig,
+    settings,
+)
+from src.llm import api, capture, executor, runtime, tool_loop
+from src.llm.backend import CompletionResult, ProviderBackend, StreamChunk
+from src.llm.types import HonchoLLMCallStreamChunk, LLMTelemetryContext
+from src.telemetry import events, trace_exporter
+from src.telemetry.events import BaseEvent, LLMCallCompletedEvent
+from src.telemetry.events.trace import LLMCallTracedEvent, TraceContentEvent
+
+LOOKUP_TOOL: dict[str, Any] = {
+    "name": "lookup",
+    "description": "Lookup",
+    "parameters": {"type": "object", "properties": {}},
+}
+
+
+@pytest.fixture
+def recorded(monkeypatch: pytest.MonkeyPatch) -> list[BaseEvent]:
+    recorded: list[BaseEvent] = []
+    capture.clear_exporters()
+    capture.register_exporter(trace_exporter.TraceExporter())
+    monkeypatch.setattr(settings.TELEMETRY, "TRACE_PAYLOADS_ENABLED", True)
+    monkeypatch.setattr(settings.TELEMETRY, "TRACE_PURPOSES", [])
+    monkeypatch.setattr(trace_exporter, "emit_trace", recorded.append)
+    monkeypatch.setattr(events, "emit", recorded.append)
+    return recorded
+
+
+@pytest.fixture
+def backend(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    backend = AsyncMock(spec=ProviderBackend)
+    backend.complete.return_value = CompletionResult(content="answer")
+    monkeypatch.setattr(executor, "backend_for_provider", Mock(return_value=backend))
+    monkeypatch.setattr(runtime, "client_for_model_config", Mock(return_value=Mock()))
+    monkeypatch.setattr(api, "wait_exponential", Mock(return_value=wait_none()))
+    monkeypatch.setattr(tool_loop, "wait_exponential", Mock(return_value=wait_none()))
+    return backend
+
+
+@pytest.mark.parametrize("system_count", [0, 1, 2])
+async def test_export_preserves_identity_and_content(
+    system_count: int, backend: AsyncMock, recorded: list[BaseEvent]
+) -> None:
+    context = LLMTelemetryContext(
+        workspace_name="ws",
+        session_id="session",
+        observer="alice",
+        observers=["alice", "bob"],
+        observed="carol",
+        peer_name="carol",
+        agent_type="dialectic",
+        track_name="Dialectic",
+        run_id="run",
+        trace_id="trace",
+        span_id="span",
+        parent_span_id="parent",
+        parent_event_id="upstream-event",
+        call_purpose="dialectic.answer",
+        parent_category="dialectic",
+        source_message_ids=["message"],
+        queue_item_ids=[7],
+    )
+    reasoning = [{"type": "reasoning.text", "text": "provider reasoning"}]
+    backend.complete.return_value = CompletionResult(
+        content="answer",
+        input_tokens=20,
+        output_tokens=5,
+        reasoning_details=reasoning,
+    )
+    await api.honcho_llm_call(
+        model_config=ModelConfig(
+            transport="openai", model="synthetic", max_output_tokens=64
+        ),
+        prompt="question",
+        max_tokens=128,
+        telemetry=context,
+        messages=[
+            {"role": "system", "content": f"instruction {i}"}
+            for i in range(system_count)
+        ]
+        + [{"role": "user", "content": "question"}],
+    )
+    (trace,) = [e for e in recorded if isinstance(e, LLMCallTracedEvent)]
+    (completed,) = [e for e in recorded if isinstance(e, LLMCallCompletedEvent)]
+    content = {e.content_hash: e for e in recorded if isinstance(e, TraceContentEvent)}
+    for field in (
+        "workspace_name",
+        "session_id",
+        "observers",
+        "observed",
+        "peer_name",
+        "agent_type",
+        "track_name",
+        "run_id",
+        "trace_id",
+        "span_id",
+        "parent_span_id",
+        "parent_event_id",
+        "source_message_ids",
+        "queue_item_ids",
+    ):
+        assert getattr(trace, field) == getattr(context, field)
+    assert trace.schema_version() == 2
+    assert len(trace.system_prompt_refs) == system_count
+    assert [content[ref].content for ref in trace.system_prompt_refs] == [
+        f"instruction {i}" for i in range(system_count)
+    ]
+    # One ref for the whole system prompt: the message itself when there is one,
+    # the concatenation of all of them when there are several.
+    if system_count == 0:
+        assert trace.system_prompt_ref is None
+    elif system_count == 1:
+        assert trace.system_prompt_ref == trace.system_prompt_refs[0]
+    else:
+        assert trace.system_prompt_ref is not None
+        assert trace.system_prompt_ref not in trace.system_prompt_refs
+        assert content[trace.system_prompt_ref].content == "\n\n".join(
+            f"instruction {i}" for i in range(system_count)
+        )
+    assert trace.output_reasoning_ref is not None
+    assert content[trace.output_reasoning_ref].content == reasoning
+    assert trace.duration_ms == completed.duration_ms
+    assert backend.complete.await_args is not None
+    assert (
+        trace.effective_max_output_tokens
+        == backend.complete.await_args.kwargs["max_tokens"]
+        == 128
+    )
+    assert trace.outcome == "success" and trace.error_class is None
+    assert trace.was_stream is False
+    assert trace.provider_input_tokens == 20 and trace.provider_output_tokens == 5
+    assert trace.raw_response_ref is None
+    context.observers.append("later")
+    context.queue_item_ids.append(8)
+    assert trace.observers == ["alice", "bob"] and trace.queue_item_ids == [7]
+
+
+@pytest.mark.parametrize("ending", ["success", "error", "cancelled", "closed"])
+@pytest.mark.parametrize("with_tools", [False, True])
+async def test_stream_records_partial_output_and_outcome(
+    ending: str, with_tools: bool, backend: AsyncMock, recorded: list[BaseEvent]
+) -> None:
+    async def chunks() -> AsyncIterator[StreamChunk]:
+        yield StreamChunk(content="partial", output_tokens=2)
+        if ending == "error":
+            raise RuntimeError("synthetic disconnect")
+        if ending == "cancelled":
+            raise asyncio.CancelledError()
+        yield StreamChunk(
+            content=" answer", is_done=True, finish_reason="length", output_tokens=4
+        )
+
+    def setup(**_: Any) -> AsyncIterator[StreamChunk]:
+        return chunks()
+
+    backend.stream.side_effect = setup
+    stream = await api.honcho_llm_call(
+        model_config=ModelConfig(transport="openai", model="synthetic"),
+        prompt="question",
+        max_tokens=128,
+        stream=True,
+        stream_final_only=with_tools,
+        tools=[LOOKUP_TOOL] if with_tools else None,
+        tool_executor=Mock() if with_tools else None,
+        telemetry=LLMTelemetryContext(
+            trace_id="trace", span_id="span", session_id="session"
+        ),
+    )
+    if ending == "closed":
+        iterator = stream.__aiter__()
+        assert isinstance(iterator, AsyncGenerator)
+        closable = cast(AsyncGenerator[HonchoLLMCallStreamChunk], iterator)
+        assert await anext(closable)
+        await closable.aclose()
+    elif ending in {"error", "cancelled"}:
+        with pytest.raises(
+            RuntimeError if ending == "error" else asyncio.CancelledError
+        ):
+            async for _ in stream:
+                pass
+    else:
+        assert "".join([chunk.content async for chunk in stream]) == "partial answer"
+
+    (trace,) = [
+        e for e in recorded if isinstance(e, LLMCallTracedEvent) and e.was_stream
+    ]
+    (completed,) = [
+        e for e in recorded if isinstance(e, LLMCallCompletedEvent) and e.was_stream
+    ]
+    content = {
+        e.content_hash: e.content for e in recorded if isinstance(e, TraceContentEvent)
+    }
+    assert trace.output_content_ref is not None
+    assert content[trace.output_content_ref] == (
+        "partial answer" if ending == "success" else "partial"
+    )
+    assert (
+        trace.outcome
+        == completed.outcome
+        == ("cancelled" if ending == "closed" else ending)
+    )
+    assert (
+        trace.error_class
+        == {
+            "success": None,
+            "error": "RuntimeError",
+            "cancelled": "CancelledError",
+            "closed": "GeneratorExit",
+        }[ending]
+    )
+    assert trace.finish_reason == ("length" if ending == "success" else trace.outcome)
+    assert trace.provider_output_tokens == (4 if ending == "success" else 2)
+    assert trace.was_stream is True and trace.session_id == "session"
+    assert trace.duration_ms == completed.duration_ms
+
+
+@pytest.mark.parametrize("with_tools", [False, True])
+async def test_stream_setup_retries_record_each_actual_attempt_once(
+    with_tools: bool, backend: AsyncMock, recorded: list[BaseEvent]
+) -> None:
+    attempts = 0
+
+    async def chunks() -> AsyncIterator[StreamChunk]:
+        yield StreamChunk(content="answer", is_done=True, finish_reason="stop")
+
+    def setup(**_: Any) -> AsyncIterator[StreamChunk]:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise TimeoutError("synthetic setup failure")
+        return chunks()
+
+    backend.stream.side_effect = setup
+    stream = await api.honcho_llm_call(
+        model_config=ConfiguredModelSettings(
+            transport="openai",
+            model="primary",
+            fallback=FallbackModelSettings(transport="openai", model="fallback"),
+        ),
+        prompt="question",
+        max_tokens=64,
+        stream=True,
+        stream_final_only=with_tools,
+        tools=[LOOKUP_TOOL] if with_tools else None,
+        tool_executor=Mock() if with_tools else None,
+        telemetry=LLMTelemetryContext(
+            trace_id="trace", span_id="span", session_id="session"
+        ),
+    )
+    assert "".join([chunk.content async for chunk in stream]) == "answer"
+    traces = [e for e in recorded if isinstance(e, LLMCallTracedEvent)]
+    streamed = [e for e in traces if e.was_stream]
+    assert len(traces) == backend.complete.await_count + attempts
+    assert [e.attempt for e in streamed] == [1, 2, 3]
+    assert [e.outcome for e in streamed] == ["error", "error", "success"]
+    assert [e.is_final_attempt for e in streamed] == [False, False, True]
+    assert all(e.retry_attempts == 3 and e.session_id == "session" for e in streamed)
+    # Tool-loop final streams retry the selected model; plain calls reselect fallback.
+    assert [e.was_fallback for e in streamed] == (
+        [False] * 3 if with_tools else [False, False, True]
+    )
+    assert streamed[-1].model == ("primary" if with_tools else "fallback")
+
+
+def test_legacy_trace_loads_without_execution_metadata() -> None:
+    legacy = LLMCallTracedEvent.model_validate({"transport": "openai", "model": "old"})
+    assert legacy.was_stream is None and legacy.outcome is None
+    assert legacy.duration_ms is None and legacy.retry_attempts is None
+    assert legacy.observers == legacy.source_message_ids == legacy.queue_item_ids == []
+    enriched = legacy.model_copy(
+        update={"workspace_name": "ws", "source_message_ids": ["m"]}
+    )
+    assert enriched.generate_id() == legacy.generate_id()

--- a/tests/telemetry/test_trace_events.py
+++ b/tests/telemetry/test_trace_events.py
@@ -8,7 +8,13 @@ from typing import Any
 import pytest
 
 from src.llm.backend import CompletionResult
-from src.llm.capture import CapturedLLMCall, build_captured_call
+from src.llm.capture import (
+    ROLE_REASONING,
+    CapturedLLMCall,
+    build_captured_call,
+    canonical_json,
+    compute_content_hash,
+)
 from src.telemetry import trace_session
 from src.telemetry.events.trace import LLMCallTracedEvent, TraceContentEvent
 
@@ -166,6 +172,45 @@ def _captured(
 
 
 class TestTraceExporter:
+    @pytest.mark.parametrize("max_bytes", [0, 64, 4096])
+    def test_reasoning_is_serialized_before_clipping(
+        self,
+        trace_on: _FakeTraceEmitter,
+        monkeypatch: pytest.MonkeyPatch,
+        max_bytes: int,
+    ):
+        from src.config import settings
+        from src.telemetry.trace_exporter import TraceExporter
+
+        monkeypatch.setattr(settings.TELEMETRY, "TRACE_MAX_BYTES", max_bytes)
+        call = _captured([])
+        reasoning = {"type": "reasoning.text", "text": "思考" * 100}
+        exporter = TraceExporter()
+        for detail in (reasoning, dict(reversed(list(reasoning.items())))):
+            call.reasoning_details = [detail]
+            exporter.export(call)
+
+        (content,) = [
+            e
+            for e in trace_on.events
+            if isinstance(e, TraceContentEvent) and e.role == ROLE_REASONING
+        ]
+        assert isinstance(content.content, str)
+        truncated = max_bytes == 64
+        if truncated:
+            assert len(content.content.encode("utf-8")) <= max_bytes
+            assert content.content.endswith("…[truncated]")
+        else:
+            assert content.content == canonical_json([reasoning])
+        assert content.content_hash == compute_content_hash(
+            ROLE_REASONING, content.content, None
+        )
+        traced = [e for e in trace_on.events if isinstance(e, LLMCallTracedEvent)]
+        assert len(traced) == 2
+        for event in traced:
+            assert event.output_reasoning_ref == content.content_hash
+            assert event.was_truncated is truncated
+
     def test_refs_match_emitted_content(self, trace_on: _FakeTraceEmitter):
         from src.telemetry.trace_exporter import TraceExporter
 


### PR DESCRIPTION
…LLM traces

Trace events could not be grouped by conversation: session_name is not unique across workspaces, and the background producers emitted no session at all. Thread the canonical Session.id from the queue through the deriver, summarizer and dream specialists so every trace carries it, falling back to a lookup only for callers that don't already have one.

Widen the trace envelope with the identity and execution context needed to attribute a call without joining another stream:

- workspace_name, session_id, observers, observed, agent_type, track_name
- source_message_ids and queue_item_ids for the work that triggered the call
- duration_ms, outcome, error_class, retry_attempts, is_final_attempt, was_stream and effective_max_output_tokens, recorded per provider attempt
- system_prompt_ref now covers the whole system prompt (the lone system message, or the concatenation of several) alongside system_prompt_refs
- output_reasoning_ref for normalized provider reasoning details

Observers are carried as an array only; there is no scalar observer on the traced event, because a batched derivation has no single one and a joined string would name no peer. The scalar stays on LLMTelemetryContext for the tool-loop path, whose agents have exactly one observer by construction.

Streamed calls previously reported almost nothing: the capture finalizer ran in the response wrapper, outside the executor, so setup failures, interrupted streams and output token counts were lost. Fold capture into honcho_llm_call_inner and close the provider generator explicitly, so a drained, cancelled, errored or closed stream each records exactly once at the provider boundary, preserving the output received before interruption.

LLMCallTracedEvent and EmbeddingCallTracedEvent go to schema version 2; the new fields are nullable so v1 archives still load. trace.content is unchanged.

## Description

<!-- 2-3 sentences about what problem this PR solves and how -->

## Proofs

<!-- Add screenshots, logs, files as a proof that this change works -->

## Checklist

- [ ] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.

<!-- Fixes #XXX -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CloudEvents telemetry traces now include session, workspace, observer, source, stream, retry, timing, outcome, and token-limit details.
  - LLM traces support references to system prompts and reasoning content.
  - Embedding traces now report run identity, duration, retry status, and outcomes.
  - Trace data preserves partial streaming output and distinguishes successful, failed, and cancelled calls.
  - Trace records now correlate activity with source messages and queue items.

- **Documentation**
  - Added configuration guidance for CloudEvents trace payloads, including schema version 2 fields and content references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->