### PR TITLE
chore: sync ruff to 0.15.12 and enforce it in CI

### DIFF
--- a/.github/workflows/staticanalysis.yml
+++ b/.github/workflows/staticanalysis.yml
@@ -27,6 +27,20 @@ jobs:
       - name: run basedpyright
         run: uv run basedpyright
 
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: ruff check
+        run: uv run --only-group dev ruff check src tests scripts migrations sdks/python sandbox
+      - name: ruff format
+        run: uv run --only-group dev ruff format --check src tests scripts migrations sdks/python sandbox
+
   issue-gate:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,10 @@ repos:
 
   # Python code formatting and linting with ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.15.12
     hooks:
       # Linter - only on Python directories
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
         files: ^(src/|tests/|scripts/|migrations/|sdks/python/|sandbox/).*\.py$
       # Formatter - only on Python directories

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
 from alembic import context
-from sqlalchemy import engine_from_config, text
+from sqlalchemy import Connection, engine_from_config, text
 
 from src.config import settings
 
@@ -124,13 +124,56 @@ def ensure_session_pooler(connection_uri: str) -> str:
     return connection_uri
 
 
+def _run_migrations_with_connection(
+    connection: Connection, *, owns_transaction: bool
+) -> None:
+    """Prepare the schema on an open connection, then run migrations over it.
+
+    When the caller owns the transaction, schema prep is left for them to commit.
+    """
+
+    # Create schema and commit it outside the main migration transaction
+    connection.execute(text(f"CREATE SCHEMA IF NOT EXISTS {target_metadata.schema};"))
+    connection.execute(
+        text(f"GRANT ALL ON SCHEMA {target_metadata.schema} TO current_user")
+    )
+    # Install pgvector extension if it doesn't exist
+    connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+    # Set and verify search_path
+    connection.execute(
+        text(f"SET search_path TO {target_metadata.schema}, public, extensions")
+    )
+    if owns_transaction:
+        connection.commit()
+
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        version_table_schema=target_metadata.schema,
+        include_schemas=True,
+        include_object=lambda obj, name, type_, reflected, compare_to: (
+            # Only include objects from our target schema
+            getattr(obj, "schema", None) == target_metadata.schema
+            if hasattr(obj, "schema")
+            else True
+        ),
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode.
 
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
-
+    Reuses a connection supplied via ``config.attributes["connection"]`` when
+    the caller provides one; otherwise builds an engine from the config.
     """
+
+    connection = config.attributes.get("connection")
+    if connection is not None:
+        _run_migrations_with_connection(connection, owns_transaction=False)
+        return
 
     configuration = config.get_section(config.config_ini_section)
     if configuration is None:
@@ -150,37 +193,11 @@ def run_migrations_online() -> None:
         },
     )
 
-    with connectable.connect() as connection:
-        # Create schema and commit it outside the main migration transaction
-        connection.execute(
-            text(f"CREATE SCHEMA IF NOT EXISTS {target_metadata.schema};")
-        )
-        connection.execute(
-            text(f"GRANT ALL ON SCHEMA {target_metadata.schema} TO current_user")
-        )
-        # Install pgvector extension if it doesn't exist
-        connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-        # Set and verify search_path
-        connection.execute(
-            text(f"SET search_path TO {target_metadata.schema}, public, extensions")
-        )
-        connection.commit()
-
-        context.configure(
-            connection=connection,
-            target_metadata=target_metadata,
-            version_table_schema=target_metadata.schema,
-            include_schemas=True,
-            include_object=lambda obj, name, type_, reflected, compare_to: (
-                # Only include objects from our target schema
-                getattr(obj, "schema", None) == target_metadata.schema
-                if hasattr(obj, "schema")
-                else True
-            ),
-        )
-
-        with context.begin_transaction():
-            context.run_migrations()
+    try:
+        with connectable.connect() as connection:
+            _run_migrations_with_connection(connection, owns_transaction=True)
+    finally:
+        connectable.dispose()
 
 
 if context.is_offline_mode():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     "coverage>=7.6.0",
     "interrogate>=1.7.0",
     "py-spy>=0.3.14",
-    "ruff>=0.11.2",
+    "ruff==0.15.12",
     "basedpyright>=1.29.4",
     "pre-commit>=4.2.0",
     "pytest-cov>=6.2.1",
@@ -93,7 +93,9 @@ select = [
     # isort
     "I",
 ]
-ignore = ["E501", "B008", "COM812"]
+# UP040/UP042/UP046/UP047: StrEnum and PEP 695 generics are behavior/signature
+# changes, not formatting; adopt deliberately rather than via autofix.
+ignore = ["E501", "B008", "COM812", "UP040", "UP042", "UP046", "UP047"]
 
 [tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["fastapi.Depends"]

--- a/scripts/generate_jwt.py
+++ b/scripts/generate_jwt.py
@@ -110,7 +110,7 @@ def main():
 
     exp_str: str | None = None
     if args.expires:
-        expiry = datetime.datetime.now(datetime.timezone.utc) + args.expires
+        expiry = datetime.datetime.now(datetime.UTC) + args.expires
         exp_str = format_datetime_utc(expiry)
 
     params = JWTParams(

--- a/scripts/test_reasoning_levels.py
+++ b/scripts/test_reasoning_levels.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import os
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
@@ -33,7 +33,7 @@ def parse_datetime(dt_string: str) -> datetime:
         day=date_obj.day,
         hour=time_obj.hour,
         minute=time_obj.minute,
-        tzinfo=timezone.utc,
+        tzinfo=UTC,
     )
 
 

--- a/src/_version.py
+++ b/src/_version.py
@@ -11,11 +11,10 @@ Used by:
 
 from __future__ import annotations
 
+import tomllib
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
-
-import tomllib
 
 
 def _read_version() -> str:

--- a/src/crud/scope.py
+++ b/src/crud/scope.py
@@ -16,7 +16,7 @@ documents plus dependent derived documents).
 """
 
 from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from logging import getLogger
 from typing import Any, Literal
 from typing import cast as py_cast
@@ -528,7 +528,7 @@ async def update_scope_backfill_status(
     """
     entry: dict[str, Any] = {
         "state": state,
-        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "updated_at": datetime.now(UTC).isoformat(),
     }
     if docs_copied is not None:
         entry["docs_copied"] = docs_copied

--- a/src/crud/workspace.py
+++ b/src/crud/workspace.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from logging import getLogger
 from typing import Any
 
@@ -675,7 +675,7 @@ async def get_active_peers(
         return []
     limit = min(limit, 50)
 
-    window_start = datetime.now(timezone.utc) - timedelta(days=ACTIVE_PEER_WINDOW_DAYS)
+    window_start = datetime.now(UTC) - timedelta(days=ACTIVE_PEER_WINDOW_DAYS)
 
     msg_filters = [
         models.Message.workspace_name == workspace_name,

--- a/src/dreamer/dream_scheduler.py
+++ b/src/dreamer/dream_scheduler.py
@@ -1,6 +1,6 @@
 import asyncio
 import contextlib
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from logging import getLogger
 
 import sentry_sdk
@@ -315,7 +315,7 @@ async def check_and_schedule_dream(
             try:
                 last_dream_time = datetime.fromisoformat(last_dream_at)
                 hours_since_last_dream = (
-                    datetime.now(timezone.utc) - last_dream_time
+                    datetime.now(UTC) - last_dream_time
                 ).total_seconds() / 3600
 
                 if hours_since_last_dream < settings.DREAM.MIN_HOURS_BETWEEN_DREAMS:

--- a/src/dreamer/orchestrator.py
+++ b/src/dreamer/orchestrator.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import sentry_sdk
@@ -523,7 +523,7 @@ DREAM: {payload.dream_type} documents for {workspace_name}/{payload.observer}/{p
                     )
 
                     # Both guard fields advance together only on successful consolidation.
-                    now_iso = datetime.now(timezone.utc).isoformat()
+                    now_iso = datetime.now(UTC).isoformat()
                     async with tracked_db("dream.guard_pair_write") as db:
                         collection = await crud.get_collection(
                             db,

--- a/src/llm/backends/gemini.py
+++ b/src/llm/backends/gemini.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any, ClassVar, cast
 
 from google.genai import types as genai_types
@@ -489,7 +489,7 @@ class GeminiBackend:
             )
             expires_at = getattr(cached_content, "expire_time", None)
             if expires_at is None:
-                expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
+                expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
             cached_handle = gemini_cache_store.set(
                 GeminiCacheHandle(
                     key=cache_key,

--- a/src/llm/caching.py
+++ b/src/llm/caching.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections import OrderedDict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from threading import Lock
 from typing import Any
 
@@ -74,7 +74,7 @@ class InMemoryGeminiCacheStore:
             handle = self._handles.get(key)
             if handle is None:
                 return None
-            if handle.expires_at <= datetime.now(timezone.utc):
+            if handle.expires_at <= datetime.now(UTC):
                 self._handles.pop(key, None)
                 return None
             self._handles.move_to_end(key)
@@ -82,7 +82,7 @@ class InMemoryGeminiCacheStore:
 
     def set(self, handle: GeminiCacheHandle) -> GeminiCacheHandle:
         with self._lock:
-            now = datetime.now(timezone.utc)
+            now = datetime.now(UTC)
             expired = [k for k, h in self._handles.items() if h.expires_at <= now]
             for k in expired:
                 self._handles.pop(k, None)

--- a/src/models.py
+++ b/src/models.py
@@ -1,6 +1,6 @@
 import datetime
 from logging import getLogger
-from typing import Any, final
+from typing import Any, final, override
 
 from dotenv import load_dotenv
 from nanoid import generate as generate_nanoid
@@ -23,7 +23,6 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB, TEXT
 from sqlalchemy.orm import Mapped, MappedColumn, mapped_column, relationship
 from sqlalchemy.sql import func
-from typing_extensions import override
 
 from src.config import settings
 from src.utils.types import DocumentLevel, TaskType, VectorSyncState

--- a/src/reconciler/queue_cleanup.py
+++ b/src/reconciler/queue_cleanup.py
@@ -5,7 +5,7 @@ This module provides a periodic cleanup job that removes old processed queue ite
 """
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 from sqlalchemy import CursorResult, delete
@@ -28,7 +28,7 @@ async def cleanup_queue_items() -> int:
         The number of queue items deleted.
     """
     async with tracked_db("cleanup_queue_items") as db:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         error_cutoff = now - timedelta(
             seconds=settings.DERIVER.QUEUE_ERROR_RETENTION_SECONDS
         )

--- a/src/reconciler/scheduler.py
+++ b/src/reconciler/scheduler.py
@@ -10,7 +10,7 @@ for coordination.
 import asyncio
 import contextlib
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import sentry_sdk
 from pydantic import BaseModel
@@ -116,7 +116,7 @@ class ReconcilerScheduler:
 
         self._shutdown_event.clear()
         # Initialize next run times to first interval
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         for task_name, task in RECONCILER_TASKS.items():
             self._next_run[task_name] = now + timedelta(seconds=task.interval_seconds)
 
@@ -137,7 +137,7 @@ class ReconcilerScheduler:
 
         try:
             await asyncio.wait_for(self._scheduler_task, timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning("ReconcilerScheduler shutdown timed out, cancelling task")
             self._scheduler_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -159,7 +159,7 @@ class ReconcilerScheduler:
         """
         try:
             while not self._shutdown_event.is_set():
-                now = datetime.now(timezone.utc)
+                now = datetime.now(UTC)
 
                 # region ai
                 # Refresh on EVERY replica, not just whichever wins the sync_vectors
@@ -193,7 +193,7 @@ class ReconcilerScheduler:
                     next_task_time = min(self._next_run.values())
                     sleep_seconds = max(
                         1.0,  # At least 1 second to avoid busy loop
-                        (next_task_time - datetime.now(timezone.utc)).total_seconds(),
+                        (next_task_time - datetime.now(UTC)).total_seconds(),
                     )
                 else:
                     sleep_seconds = 60.0  # Default if no tasks
@@ -204,7 +204,7 @@ class ReconcilerScheduler:
                         timeout=sleep_seconds,
                     )
                     break  # Shutdown event was set
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     # Timeout means interval elapsed, continue loop
                     pass
 

--- a/src/security.py
+++ b/src/security.py
@@ -118,7 +118,7 @@ def verify_jwt(token: str) -> JWTParams:
             params.exp = decoded["exp"]
             if params.exp:
                 exp_time = parse_datetime_iso(params.exp)
-                current_time = datetime.datetime.now(datetime.timezone.utc)
+                current_time = datetime.datetime.now(datetime.UTC)
                 if exp_time < current_time:
                     raise AuthenticationException("JWT expired")
         if "ad" in decoded:

--- a/src/utils/filter.py
+++ b/src/utils/filter.py
@@ -927,7 +927,7 @@ def _validate_datetime_string(value: str) -> datetime.datetime | None:
         try:
             parsed = datetime.datetime.strptime(value, fmt)
             # Assume UTC timezone for naive datetimes
-            return parsed.replace(tzinfo=datetime.timezone.utc)
+            return parsed.replace(tzinfo=datetime.UTC)
         except ValueError:
             continue
 

--- a/src/utils/formatting.py
+++ b/src/utils/formatting.py
@@ -5,7 +5,7 @@ This module contains helper functions for processing observations, formatting co
 handling temporal metadata, and string escaping for the reasoning system.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 ILIKE_ESCAPE_CHAR = "\\"
 
@@ -63,11 +63,11 @@ def format_datetime_utc(dt: datetime) -> str:
     """
     if dt.tzinfo is None:
         # If no timezone info, assume UTC
-        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.replace(tzinfo=UTC)
 
     # Convert to UTC if not already
-    if dt.tzinfo != timezone.utc:
-        dt = dt.astimezone(timezone.utc)
+    if dt.tzinfo != UTC:
+        dt = dt.astimezone(UTC)
 
     # Remove subsecond precision
     dt = dt.replace(microsecond=0)
@@ -88,7 +88,7 @@ def utc_now_iso() -> str:
         >>> utc_now_iso()
         '2023-01-01T12:34:56Z'
     """
-    return format_datetime_utc(datetime.now(timezone.utc))
+    return format_datetime_utc(datetime.now(UTC))
 
 
 def parse_datetime_iso(iso_string: str) -> datetime:
@@ -142,7 +142,7 @@ def parse_datetime_iso(iso_string: str) -> datetime:
 
         # If no timezone info, assume UTC
         if result.tzinfo is None:
-            result = result.replace(tzinfo=timezone.utc)
+            result = result.replace(tzinfo=UTC)
 
         return result
     except ValueError as e:

--- a/tests/alembic/conftest.py
+++ b/tests/alembic/conftest.py
@@ -25,7 +25,7 @@ ALEMBIC_TEST_DB_URL: URL = CONNECTION_URI.set(database="alembic_migration_tests"
 
 
 @pytest.fixture(scope="session", autouse=True)
-def configure_alembic_settings(alembic_database: str) -> Generator[None, None, None]:
+def configure_alembic_settings(alembic_database: str) -> Generator[None]:
     """Point application settings at the Alembic test database."""
 
     previous_uri = settings.DB.CONNECTION_URI
@@ -54,7 +54,7 @@ def alembic_cfg(alembic_database: str) -> Config:
 
 
 @pytest.fixture(scope="session")
-def alembic_database() -> Generator[str, None, None]:
+def alembic_database() -> Generator[str]:
     """Provision a dedicated DB for Alembic verification tests."""
 
     assert ALEMBIC_TEST_DB_URL.database == "alembic_migration_tests", (
@@ -79,7 +79,7 @@ def alembic_database() -> Generator[str, None, None]:
 
 
 @pytest.fixture
-def alembic_engine(alembic_database: str) -> Generator[Engine, None, None]:
+def alembic_engine(alembic_database: str) -> Generator[Engine]:
     """Yield an engine bound to the Alembic test database."""
 
     engine = create_engine(alembic_database, pool_pre_ping=True)
@@ -92,7 +92,7 @@ def alembic_engine(alembic_database: str) -> Generator[Engine, None, None]:
 @pytest.fixture(autouse=True)
 def reset_schema_between_tests(
     alembic_engine: Engine,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Drop and recreate the schema for a clean slate each test (fast reset)."""
 
     schema = settings.DB.SCHEMA

--- a/tests/alembic/revisions/test_05486ce795d5_make_session_name_required_on_messages.py
+++ b/tests/alembic/revisions/test_05486ce795d5_make_session_name_required_on_messages.py
@@ -85,9 +85,9 @@ def verify_session_name_enforced(verifier: MigrationVerifier) -> None:
             "workspace_name": WORKSPACE_NAME,
         },
     ).one_or_none()
-    assert (
-        session is not None
-    ), "Session with expected name and workspace does not exist"
+    assert session is not None, (
+        "Session with expected name and workspace does not exist"
+    )
 
     message = conn.execute(
         text(

--- a/tests/alembic/revisions/test_110bdf470272_rename_deriver_disabled_to_deriver_.py
+++ b/tests/alembic/revisions/test_110bdf470272_rename_deriver_disabled_to_deriver_.py
@@ -121,9 +121,9 @@ def verify_rename_deriver_disabled_to_deriver(verifier: MigrationVerifier) -> No
     ).one()
     config = session_disabled_true.configuration
     assert "deriver_disabled" not in config, "deriver_disabled should be removed"
-    assert (
-        config.get("deriver_enabled") is False
-    ), "deriver_disabled: true should become deriver_enabled: false"
+    assert config.get("deriver_enabled") is False, (
+        "deriver_disabled: true should become deriver_enabled: false"
+    )
 
     session_disabled_false = conn.execute(
         text(
@@ -136,9 +136,9 @@ def verify_rename_deriver_disabled_to_deriver(verifier: MigrationVerifier) -> No
     ).one()
     config = session_disabled_false.configuration
     assert "deriver_disabled" not in config, "deriver_disabled should be removed"
-    assert (
-        config.get("deriver_enabled") is True
-    ), "deriver_disabled: false should become deriver_enabled: true"
+    assert config.get("deriver_enabled") is True, (
+        "deriver_disabled: false should become deriver_enabled: true"
+    )
 
     session_no_key = conn.execute(
         text(
@@ -151,9 +151,9 @@ def verify_rename_deriver_disabled_to_deriver(verifier: MigrationVerifier) -> No
     ).one()
     config = session_no_key.configuration
     assert "deriver_disabled" not in config, "deriver_disabled should not exist"
-    assert (
-        "deriver_enabled" not in config
-    ), "deriver_enabled should not be added when deriver_disabled was absent"
-    assert (
-        config.get("other_setting") == "value"
-    ), "Other configuration should be preserved"
+    assert "deriver_enabled" not in config, (
+        "deriver_enabled should not be added when deriver_disabled was absent"
+    )
+    assert config.get("other_setting") == "value", (
+        "Other configuration should be preserved"
+    )

--- a/tests/alembic/revisions/test_b8183c5ffb48_codify_document_level_and_times_derived.py
+++ b/tests/alembic/revisions/test_b8183c5ffb48_codify_document_level_and_times_derived.py
@@ -225,9 +225,9 @@ def verify_codify_document_level_and_times_derived(verifier: MigrationVerifier) 
         ),
         {"pattern": "%explicit level and times_derived=3%"},
     ).scalar()
-    assert (
-        times_derived_3 == 1
-    ), f"Expected 1 document with times_derived=3, got {times_derived_3}"
+    assert times_derived_3 == 1, (
+        f"Expected 1 document with times_derived=3, got {times_derived_3}"
+    )
 
     times_derived_5 = conn.execute(
         text(
@@ -236,9 +236,9 @@ def verify_codify_document_level_and_times_derived(verifier: MigrationVerifier) 
         ),
         {"pattern": "%deductive level and times_derived=5%"},
     ).scalar()
-    assert (
-        times_derived_5 == 1
-    ), f"Expected 1 document with times_derived=5, got {times_derived_5}"
+    assert times_derived_5 == 1, (
+        f"Expected 1 document with times_derived=5, got {times_derived_5}"
+    )
 
     times_derived_7 = conn.execute(
         text(
@@ -247,17 +247,17 @@ def verify_codify_document_level_and_times_derived(verifier: MigrationVerifier) 
         ),
         {"pattern": "%only times_derived field%"},
     ).scalar()
-    assert (
-        times_derived_7 == 1
-    ), f"Expected 1 document with times_derived=7, got {times_derived_7}"
+    assert times_derived_7 == 1, (
+        f"Expected 1 document with times_derived=7, got {times_derived_7}"
+    )
 
     # Verify default times_derived=1 was applied to documents without it
     times_derived_1 = conn.execute(
         text(f'SELECT COUNT(*) FROM "{schema}"."documents" WHERE "times_derived" = 1')
     ).scalar()
-    assert (
-        times_derived_1 == 2
-    ), f"Expected 2 documents with times_derived=1, got {times_derived_1}"
+    assert times_derived_1 == 2, (
+        f"Expected 2 documents with times_derived=1, got {times_derived_1}"
+    )
 
     # Verify internal_metadata still contains the original data (NOT removed by migration)
     level_in_metadata = conn.execute(
@@ -266,9 +266,9 @@ def verify_codify_document_level_and_times_derived(verifier: MigrationVerifier) 
         )
     ).scalar()
     # 3 documents had level in metadata (scenarios 1, 2, 4)
-    assert (
-        level_in_metadata == 3
-    ), f"Expected 3 documents with level in metadata, got {level_in_metadata}"
+    assert level_in_metadata == 3, (
+        f"Expected 3 documents with level in metadata, got {level_in_metadata}"
+    )
 
     times_derived_in_metadata = conn.execute(
         text(
@@ -276,9 +276,9 @@ def verify_codify_document_level_and_times_derived(verifier: MigrationVerifier) 
         )
     ).scalar()
     # 3 documents had times_derived in metadata (scenarios 1, 2, 5)
-    assert (
-        times_derived_in_metadata == 3
-    ), f"Expected 3 documents with times_derived in metadata, got {times_derived_in_metadata}"
+    assert times_derived_in_metadata == 3, (
+        f"Expected 3 documents with times_derived in metadata, got {times_derived_in_metadata}"
+    )
 
     # Verify server defaults work for new documents
     new_doc_id = generate_nanoid()
@@ -307,9 +307,9 @@ def verify_codify_document_level_and_times_derived(verifier: MigrationVerifier) 
         ),
         {"id": new_doc_id},
     ).one()
-    assert (
-        new_doc.level == "explicit"
-    ), f"Expected new document to have level='explicit', got {new_doc.level}"
-    assert (
-        new_doc.times_derived == 1
-    ), f"Expected new document to have times_derived=1, got {new_doc.times_derived}"
+    assert new_doc.level == "explicit", (
+        f"Expected new document to have level='explicit', got {new_doc.level}"
+    )
+    assert new_doc.times_derived == 1, (
+        f"Expected new document to have times_derived=1, got {new_doc.times_derived}"
+    )

--- a/tests/alembic/revisions/test_baa22cad81e2_standardize_constraint_names.py
+++ b/tests/alembic/revisions/test_baa22cad81e2_standardize_constraint_names.py
@@ -164,6 +164,6 @@ def verify_standardize_constraint_names(verifier: MigrationVerifier) -> None:
     )
     row = result.fetchone()
     assert row is not None, "FK fk_message_embeddings_message_id_messages not found"
-    assert (
-        row[0] == "c"
-    ), f"FK should have ON DELETE CASCADE (confdeltype='c'), got '{row[0]}'"
+    assert row[0] == "c", (
+        f"FK should have ON DELETE CASCADE (confdeltype='c'), got '{row[0]}'"
+    )

--- a/tests/alembic/revisions/test_bb6fb3a7a643_add_message_seq_in_session_column.py
+++ b/tests/alembic/revisions/test_bb6fb3a7a643_add_message_seq_in_session_column.py
@@ -153,9 +153,9 @@ def verify_add_message_seq_in_session_column(verifier: MigrationVerifier) -> Non
 
     assert len(session_1_messages) == 5, "Expected 5 messages in session 1"
     for i, (content, seq) in enumerate(session_1_messages, start=1):
-        assert (
-            seq == i
-        ), f"Expected seq_in_session={i} for message '{content}', got {seq}"
+        assert seq == i, (
+            f"Expected seq_in_session={i} for message '{content}', got {seq}"
+        )
 
     # Verify sequences start at 1 and are contiguous for session 2
     session_2_messages = conn.execute(
@@ -176,9 +176,9 @@ def verify_add_message_seq_in_session_column(verifier: MigrationVerifier) -> Non
 
     assert len(session_2_messages) == 3, "Expected 3 messages in session 2"
     for i, (content, seq) in enumerate(session_2_messages, start=1):
-        assert (
-            seq == i
-        ), f"Expected seq_in_session={i} for message '{content}', got {seq}"
+        assert seq == i, (
+            f"Expected seq_in_session={i} for message '{content}', got {seq}"
+        )
 
     # Verify uniqueness constraint: no duplicate (workspace, session, seq) tuples
     duplicate_check = conn.execute(
@@ -194,6 +194,6 @@ def verify_add_message_seq_in_session_column(verifier: MigrationVerifier) -> Non
         {"workspace_name": WORKSPACE_NAME},
     ).fetchall()
 
-    assert (
-        len(duplicate_check) == 0
-    ), f"Found duplicate seq_in_session values: {duplicate_check}"
+    assert len(duplicate_check) == 0, (
+        f"Found duplicate seq_in_session values: {duplicate_check}"
+    )

--- a/tests/alembic/revisions/test_e9b705f9adf9_add_server_defaults_to_timestamp_.py
+++ b/tests/alembic/revisions/test_e9b705f9adf9_add_server_defaults_to_timestamp_.py
@@ -40,9 +40,9 @@ def prepare_add_server_defaults(verifier: MigrationVerifier) -> None:
     ]:
         columns = inspector.get_columns(table, schema=schema)
         col_info = next((c for c in columns if c["name"] == column), None)
-        assert (
-            col_info is not None
-        ), f"Column {table}.{column} should exist before migration"
+        assert col_info is not None, (
+            f"Column {table}.{column} should exist before migration"
+        )
 
     # Create test data to ensure existing rows work after migration
     conn.execute(
@@ -118,9 +118,9 @@ def verify_add_server_defaults(verifier: MigrationVerifier) -> None:
     for table, column in timestamp_columns:
         columns = inspector.get_columns(table, schema=schema)
         col_info = next((c for c in columns if c["name"] == column), None)
-        assert (
-            col_info is not None
-        ), f"Column {table}.{column} not found after migration"
+        assert col_info is not None, (
+            f"Column {table}.{column} not found after migration"
+        )
 
         # Check that a server default exists
         default = col_info.get("default")
@@ -152,9 +152,9 @@ def verify_add_server_defaults(verifier: MigrationVerifier) -> None:
     for table, column in jsonb_columns:
         columns = inspector.get_columns(table, schema=schema)
         col_info = next((c for c in columns if c["name"] == column), None)
-        assert (
-            col_info is not None
-        ), f"Column {table}.{column} not found after migration"
+        assert col_info is not None, (
+            f"Column {table}.{column} not found after migration"
+        )
 
         # Check that a server default exists
         default = col_info.get("default")
@@ -172,9 +172,9 @@ def verify_add_server_defaults(verifier: MigrationVerifier) -> None:
     for table, column, expected_default in boolean_columns:
         columns = inspector.get_columns(table, schema=schema)
         col_info = next((c for c in columns if c["name"] == column), None)
-        assert (
-            col_info is not None
-        ), f"Column {table}.{column} not found after migration"
+        assert col_info is not None, (
+            f"Column {table}.{column} not found after migration"
+        )
 
         # Check that a server default exists
         default = col_info.get("default")
@@ -183,9 +183,9 @@ def verify_add_server_defaults(verifier: MigrationVerifier) -> None:
             f"but default is None"
         )
 
-        assert (
-            default == expected_default
-        ), f"Column {table}.{column} should have a server default of {expected_default} after migration, but default is {default}"
+        assert default == expected_default, (
+            f"Column {table}.{column} should have a server default of {expected_default} after migration, but default is {default}"
+        )
 
     # Test that defaults actually work by inserting rows without explicit values
     test_workspace_id = generate_nanoid()
@@ -208,9 +208,9 @@ def verify_add_server_defaults(verifier: MigrationVerifier) -> None:
 
     assert workspace.created_at is not None, "created_at should be auto-populated"
     assert workspace.metadata == {}, "metadata should default to empty object"
-    assert (
-        workspace.internal_metadata == {}
-    ), "internal_metadata should default to empty object"
+    assert workspace.internal_metadata == {}, (
+        "internal_metadata should default to empty object"
+    )
     assert workspace.configuration == {}, "configuration should default to empty object"
 
     # Test peer defaults
@@ -237,9 +237,9 @@ def verify_add_server_defaults(verifier: MigrationVerifier) -> None:
 
     assert peer.created_at is not None, "peer created_at should be auto-populated"
     assert peer.metadata == {}, "peer metadata should default to empty object"
-    assert (
-        peer.internal_metadata == {}
-    ), "peer internal_metadata should default to empty object"
+    assert peer.internal_metadata == {}, (
+        "peer internal_metadata should default to empty object"
+    )
     assert peer.configuration == {}, "peer configuration should default to empty object"
 
     # Test session defaults (including boolean is_active)
@@ -267,18 +267,18 @@ def verify_add_server_defaults(verifier: MigrationVerifier) -> None:
     assert session.created_at is not None, "session created_at should be auto-populated"
     assert session.is_active is True, "session is_active should default to true"
     assert session.metadata == {}, "session metadata should default to empty object"
-    assert (
-        session.internal_metadata == {}
-    ), "session internal_metadata should default to empty object"
-    assert (
-        session.configuration == {}
-    ), "session configuration should default to empty object"
+    assert session.internal_metadata == {}, (
+        "session internal_metadata should default to empty object"
+    )
+    assert session.configuration == {}, (
+        "session configuration should default to empty object"
+    )
 
     # Verify pre-existing data still exists
     existing_workspace = conn.execute(
         text(f'SELECT "id" FROM "{schema}"."workspaces" WHERE "id" = :id'),
         {"id": WORKSPACE_ID},
     ).one_or_none()
-    assert (
-        existing_workspace is not None
-    ), "Pre-existing workspace should still exist after migration"
+    assert existing_workspace is not None, (
+        "Pre-existing workspace should still exist after migration"
+    )

--- a/tests/alembic/revisions/test_ec8f94139b02_codify_workspace_name_and_message_id_in_.py
+++ b/tests/alembic/revisions/test_ec8f94139b02_codify_workspace_name_and_message_id_in_.py
@@ -252,12 +252,12 @@ def verify_codify_workspace_name_and_message_id_in(verifier: MigrationVerifier) 
     ).scalar()
 
     # Should be roughly 50/50 split (we alternate in the insert)
-    assert (
-        ws1_count == 50_000
-    ), f"Expected 50k items with workspace_name_1, got {ws1_count}"
-    assert (
-        ws2_count == 50_000
-    ), f"Expected 50k items with workspace_name_2, got {ws2_count}"
+    assert ws1_count == 50_000, (
+        f"Expected 50k items with workspace_name_1, got {ws1_count}"
+    )
+    assert ws2_count == 50_000, (
+        f"Expected 50k items with workspace_name_2, got {ws2_count}"
+    )
 
     # Verify data transformation: message_id extracted from payload where it exists
     msg_id_count = conn.execute(
@@ -268,9 +268,9 @@ def verify_codify_workspace_name_and_message_id_in(verifier: MigrationVerifier) 
     ).scalar()
 
     # Should be 60k items with message_id (category 1 only)
-    assert (
-        msg_id_count == 60_000
-    ), f"Expected 60k items with message_id, got {msg_id_count}"
+    assert msg_id_count == 60_000, (
+        f"Expected 60k items with message_id, got {msg_id_count}"
+    )
 
     # Verify items without message_id in payload have NULL in column
     null_msg_id_count = conn.execute(
@@ -278,9 +278,9 @@ def verify_codify_workspace_name_and_message_id_in(verifier: MigrationVerifier) 
     ).scalar()
 
     # Should be 40k items (30k without key + 10k with NULL value)
-    assert (
-        null_msg_id_count == 40_000
-    ), f"Expected 40k items with NULL message_id, got {null_msg_id_count}"
+    assert null_msg_id_count == 40_000, (
+        f"Expected 40k items with NULL message_id, got {null_msg_id_count}"
+    )
 
     # Verify workspace_name was removed from payload
     ws_in_payload_count = conn.execute(
@@ -289,9 +289,9 @@ def verify_codify_workspace_name_and_message_id_in(verifier: MigrationVerifier) 
             + "WHERE payload ? 'workspace_name'"
         )
     ).scalar()
-    assert (
-        ws_in_payload_count == 0
-    ), f"Found {ws_in_payload_count} items still with workspace_name in payload"
+    assert ws_in_payload_count == 0, (
+        f"Found {ws_in_payload_count} items still with workspace_name in payload"
+    )
 
     # Verify message_id was removed from payload
     msg_in_payload_count = conn.execute(
@@ -299,9 +299,9 @@ def verify_codify_workspace_name_and_message_id_in(verifier: MigrationVerifier) 
             f'SELECT COUNT(*) FROM "{schema}"."queue" ' + "WHERE payload ? 'message_id'"
         )
     ).scalar()
-    assert (
-        msg_in_payload_count == 0
-    ), f"Found {msg_in_payload_count} items still with message_id in payload"
+    assert msg_in_payload_count == 0, (
+        f"Found {msg_in_payload_count} items still with message_id in payload"
+    )
 
     # Verify other_field remains in payload (data preservation)
     other_field_count = conn.execute(
@@ -310,9 +310,9 @@ def verify_codify_workspace_name_and_message_id_in(verifier: MigrationVerifier) 
             + "WHERE payload ? 'other_field'"
         )
     ).scalar()
-    assert (
-        other_field_count == 100_000
-    ), f"Expected all 100k items to retain other_field in payload, got {other_field_count}"
+    assert other_field_count == 100_000, (
+        f"Expected all 100k items to retain other_field in payload, got {other_field_count}"
+    )
 
     # Spot check: verify a specific queue item was transformed correctly
     sample_item = conn.execute(

--- a/tests/alembic/verifier.py
+++ b/tests/alembic/verifier.py
@@ -53,21 +53,21 @@ class MigrationVerifier:
 
             column_info = next(col for col in columns if col["name"] == column)
             actual_nullable = column_info.get("nullable", True)
-            assert (
-                actual_nullable == nullable
-            ), f"Column {table}.{column} nullability is {actual_nullable}; expected {nullable}"
+            assert actual_nullable == nullable, (
+                f"Column {table}.{column} nullability is {actual_nullable}; expected {nullable}"
+            )
 
     def assert_column_type(self, table: str, column: str, expected_type: type) -> None:
         """Assert that a column has the expected type"""
         columns = self.get_inspector().get_columns(table, schema=self.schema)
         column_info = next((col for col in columns if col["name"] == column), None)
-        assert (
-            column_info is not None
-        ), f"Column {table}.{column} not found after migration {self.revision}"
+        assert column_info is not None, (
+            f"Column {table}.{column} not found after migration {self.revision}"
+        )
         actual_type = column_info["type"]
-        assert isinstance(
-            actual_type, expected_type
-        ), f"Column {table}.{column} has type {type(actual_type).__name__}; expected {expected_type.__name__}"
+        assert isinstance(actual_type, expected_type), (
+            f"Column {table}.{column} has type {type(actual_type).__name__}; expected {expected_type.__name__}"
+        )
 
     def assert_no_nulls(self, table: str, column: str) -> None:
         """Assert that a column has no null values"""
@@ -78,9 +78,9 @@ class MigrationVerifier:
             )
         )
         count = result.scalar() or 0
-        assert (
-            count == 0
-        ), f"Found {count} NULL values in {table}.{column} after migration {self.revision}"
+        assert count == 0, (
+            f"Found {count} NULL values in {table}.{column} after migration {self.revision}"
+        )
 
     def assert_constraint_exists(
         self,
@@ -103,18 +103,18 @@ class MigrationVerifier:
         for table_name, index_name in checks:
             indexes = self.get_inspector().get_indexes(table_name, schema=self.schema)
             names = [idx["name"] for idx in indexes]
-            assert (
-                index_name in names
-            ), f"Index {index_name} not found on {table_name} after migration {self.revision}"
+            assert index_name in names, (
+                f"Index {index_name} not found on {table_name} after migration {self.revision}"
+            )
 
     def assert_indexes_not_exist(self, checks: Sequence[tuple[str, str]]) -> None:
         """Assert that indexes do not exist in the schema"""
         for table_name, index_name in checks:
             indexes = self.get_inspector().get_indexes(table_name, schema=self.schema)
             names = [idx["name"] for idx in indexes]
-            assert (
-                index_name not in names
-            ), f"Index {index_name} still present on {table_name} after migration {self.revision}"
+            assert index_name not in names, (
+                f"Index {index_name} still present on {table_name} after migration {self.revision}"
+            )
 
     def get_inspector(self) -> Inspector:
         """Get the inspector for the connection"""

--- a/tests/bench/coverage.py
+++ b/tests/bench/coverage.py
@@ -44,7 +44,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any, cast
@@ -1363,7 +1363,7 @@ async def main():
     # Save results
     if results:
         args.output_dir.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        ts = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
         out_file = args.output_dir / f"coverage_{ts}.json"
 
         agg: dict[str, Any] = {

--- a/tests/bench/molecular.py
+++ b/tests/bench/molecular.py
@@ -54,7 +54,7 @@ import logging
 import random
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any, cast
@@ -1167,7 +1167,7 @@ async def main():
     # Save results
     if results:
         args.output_dir.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        ts = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
         out_file = args.output_dir / f"molecular_{ts}.json"
 
         agg: dict[str, Any] = {

--- a/tests/crud/test_get_or_create_retry_invalidation.py
+++ b/tests/crud/test_get_or_create_retry_invalidation.py
@@ -110,9 +110,9 @@ async def test_peer_retry_still_invalidates_mutated_peer(
     assert race.fired, "the race must actually have fired"
 
     purged = {call.args[0] for call in mock_delete.await_args_list}
-    assert (
-        peer_cache_key(test_workspace.name, existing_peer.name) in purged
-    ), "the mutated peer's cache key must still be purged after the retry"
+    assert peer_cache_key(test_workspace.name, existing_peer.name) in purged, (
+        "the mutated peer's cache key must still be purged after the retry"
+    )
 
     # The mutation really did land — which is what makes a missed purge stale.
     await db_session.refresh(existing_peer)
@@ -170,9 +170,9 @@ async def test_scope_retry_still_invalidates_mutated_scope(
     assert race.fired, "the race must actually have fired"
 
     purged = {call.args[0] for call in mock_delete.await_args_list}
-    assert (
-        peer_cache_key(test_workspace.name, scope_peer_name(kept_scope)) in purged
-    ), "the mutated scope peer's cache key must still be purged after the retry"
+    assert peer_cache_key(test_workspace.name, scope_peer_name(kept_scope)) in purged, (
+        "the mutated scope peer's cache key must still be purged after the retry"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/crud/test_session.py
+++ b/tests/crud/test_session.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from nanoid import generate as generate_nanoid
@@ -75,7 +75,7 @@ class TestSessionCRUD:
                 )
             )
         ).scalar_one()
-        session_peer.left_at = datetime.now(timezone.utc)
+        session_peer.left_at = datetime.now(UTC)
         await db_session.commit()
 
         await crud.get_or_create_session(
@@ -152,7 +152,7 @@ class TestSessionCRUD:
                 )
             )
         ).scalar_one()
-        session_peer.joined_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        session_peer.joined_at = datetime(2020, 1, 1, tzinfo=UTC)
         await db_session.commit()
 
         await crud.set_peers_for_session(
@@ -164,7 +164,7 @@ class TestSessionCRUD:
         active_joined_at, active_left_at, active_config = (
             await db_session.execute(session_peer_stmt)
         ).one()
-        assert active_joined_at == datetime(2020, 1, 1, tzinfo=timezone.utc)
+        assert active_joined_at == datetime(2020, 1, 1, tzinfo=UTC)
         assert active_left_at is None
         # A replace states the desired end state, so the incoming config lands even
         # though the membership window is untouched.

--- a/tests/deriver/conftest.py
+++ b/tests/deriver/conftest.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import AsyncGenerator, Awaitable, Callable, Sequence
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any, Literal, TypeAlias, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -15,7 +15,7 @@ from src.utils.work_unit import construct_work_unit_key
 
 
 @pytest.fixture(autouse=True)
-async def clean_queue_tables(db_session: AsyncSession) -> AsyncGenerator[None, None]:
+async def clean_queue_tables(db_session: AsyncSession) -> AsyncGenerator[None]:
     """Clean up queue-related tables before each test to ensure isolation.
 
     This prevents webhook queue items and active queue sessions from previous tests
@@ -138,7 +138,7 @@ def create_queue_payload() -> Callable[..., Any]:
             "session_name": message.session_name,
             "message_id": message.id,
             "content": message.content,
-            "created_at": message.created_at or datetime.now(timezone.utc),
+            "created_at": message.created_at or datetime.now(UTC),
             "message_public_id": message.public_id,
         }
 

--- a/tests/deriver/test_enqueue_dream.py
+++ b/tests/deriver/test_enqueue_dream.py
@@ -54,6 +54,6 @@ class TestEnqueueDreamMetadataShape:
                 "enqueue_dream must not need to load the collection — it no "
                 "longer touches dream metadata."
             )
-            assert (
-                mock_session.execute.called
-            ), "enqueue_dream must still insert the QueueItem row."
+            assert mock_session.execute.called, (
+                "enqueue_dream must still insert the QueueItem row."
+            )

--- a/tests/deriver/test_representation_crud.py
+++ b/tests/deriver/test_representation_crud.py
@@ -11,7 +11,7 @@ from src.utils.representation import (
 
 def test_representation_is_empty_and_diff():
     """is_empty and diff_representation behave per the new definitions."""
-    now = datetime.datetime.now(datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.UTC)
     shared_time = now - datetime.timedelta(seconds=10)
     exp_shared_1 = ExplicitObservation(
         content="A",
@@ -48,7 +48,7 @@ def test_representation_is_empty_and_diff():
 
 def test_representation_formatting_methods():
     """__str__ and format_as_markdown produce expected section headers and content."""
-    now = datetime.datetime.now(datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.UTC)
     e = ExplicitObservation(
         content="has a dog",
         created_at=now,
@@ -93,7 +93,7 @@ def test_prompt_representation_conversion():
         #     )
         # ],
     )
-    timestamp = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    timestamp = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
     rep = Representation.from_prompt_representation(
         pr,
         message_ids=[1],

--- a/tests/deriver/test_vector_reconciliation.py
+++ b/tests/deriver/test_vector_reconciliation.py
@@ -404,7 +404,7 @@ class TestBatchProcessing:
         db_session.add(session)
         await db_session.commit()
 
-        now = datetime.datetime.now(datetime.timezone.utc)
+        now = datetime.datetime.now(datetime.UTC)
         ineligible_doc = models.Document(
             content="too soon",
             workspace_name=workspace.name,
@@ -611,7 +611,7 @@ class TestSoftDeleteCleanup:
             observer=peer1.name,
             observed=peer1.name,
             session_name=session.name,
-            deleted_at=datetime.datetime.now(datetime.timezone.utc)
+            deleted_at=datetime.datetime.now(datetime.UTC)
             - datetime.timedelta(minutes=2),  # Only 2 minutes ago
         )
         db_session.add(recent_doc)
@@ -623,7 +623,7 @@ class TestSoftDeleteCleanup:
             observer=peer1.name,
             observed=peer1.name,
             session_name=session.name,
-            deleted_at=datetime.datetime.now(datetime.timezone.utc)
+            deleted_at=datetime.datetime.now(datetime.UTC)
             - datetime.timedelta(minutes=10),  # 10 minutes ago
         )
         db_session.add(old_doc)
@@ -631,9 +631,7 @@ class TestSoftDeleteCleanup:
         await db_session.commit()
 
         # Query for documents ready for cleanup (older than 5 minutes)
-        cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            minutes=5
-        )
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=5)
         stmt = (
             select(models.Document)
             .where(models.Document.deleted_at.is_not(None))
@@ -781,7 +779,7 @@ class TestMessageEmbeddings:
             db_session, workspace, peer
         )
 
-        now = datetime.datetime.now(datetime.timezone.utc)
+        now = datetime.datetime.now(datetime.UTC)
         ineligible_emb.sync_attempts = 1
         ineligible_emb.last_sync_at = now - datetime.timedelta(minutes=9, seconds=59)
         eligible_emb.sync_attempts = 1

--- a/tests/dreamer/test_dreamer_integration.py
+++ b/tests/dreamer/test_dreamer_integration.py
@@ -120,19 +120,19 @@ class TestLastDreamAtCompletionWrite:
             await process_dream(payload, seeded_collection.workspace_name)
 
         dream_meta = await _get_dream_metadata(db_session, seeded_collection)
-        assert (
-            "last_dream_at" in dream_meta
-        ), "process_dream must write last_dream_at when run_dream returns a result"
+        assert "last_dream_at" in dream_meta, (
+            "process_dream must write last_dream_at when run_dream returns a result"
+        )
         # Must be a tz-aware UTC ISO timestamp. A naive datetime.now().isoformat()
         # would pass a loose "T in string" check but corrupt the 8h guard math
         # against tz-aware now() comparisons downstream.
         parsed = datetime.fromisoformat(dream_meta["last_dream_at"])
-        assert (
-            parsed.tzinfo is not None
-        ), f"last_dream_at must be timezone-aware, got {dream_meta['last_dream_at']!r}"
-        assert parsed.utcoffset() == timedelta(
-            0
-        ), f"last_dream_at must be UTC, got offset {parsed.utcoffset()}"
+        assert parsed.tzinfo is not None, (
+            f"last_dream_at must be timezone-aware, got {dream_meta['last_dream_at']!r}"
+        )
+        assert parsed.utcoffset() == timedelta(0), (
+            f"last_dream_at must be UTC, got offset {parsed.utcoffset()}"
+        )
 
     @pytest.mark.asyncio
     async def test_failure_path_leaves_last_dream_at_null(
@@ -598,9 +598,9 @@ class TestGuardPairCoherence:
             "pre-Loop-4 the baseline was consumed at enqueue time and a "
             "silent failure would lock out retries on the same corpus."
         )
-        assert (
-            "last_dream_at" not in dream_meta
-        ), "Failed dream must not advance last_dream_at either."
+        assert "last_dream_at" not in dream_meta, (
+            "Failed dream must not advance last_dream_at either."
+        )
 
         with patch.object(
             _scheduler, "schedule_dream", new_callable=AsyncMock

--- a/tests/integration/test_enqueue.py
+++ b/tests/integration/test_enqueue.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -120,9 +120,9 @@ class TestEnqueueFunction:
         # When deriver is disabled, only summary records should be created (if applicable)
         # Since this is message 1, and 1 % 20 != 0 and 1 % 60 != 0, no summary should be created
         # No representation records should be created either (deriver disabled)
-        assert (
-            final_count == initial_count
-        ), f"Expected no queue items, but got {final_count - initial_count}"
+        assert final_count == initial_count, (
+            f"Expected no queue items, but got {final_count - initial_count}"
+        )
 
     @pytest.mark.asyncio
     async def test_session_normal_processing_single_peer(
@@ -528,7 +528,7 @@ class TestEnqueueFunction:
             )
         )
         session_peer = session_peer_result.scalar_one()
-        session_peer.left_at = datetime.now(timezone.utc)
+        session_peer.left_at = datetime.now(UTC)
         await db_session.commit()
 
         # Create message payload from the peer who left
@@ -609,7 +609,7 @@ class TestEnqueueFunction:
             )
         )
         session_peer = session_peer_result.scalar_one()
-        session_peer.left_at = datetime.now(timezone.utc)
+        session_peer.left_at = datetime.now(UTC)
         await db_session.commit()
 
         # Create message payload
@@ -711,7 +711,7 @@ class TestEnqueueFunction:
                 )
             )
             session_peer = session_peer_result.scalar_one()
-            session_peer.left_at = datetime.now(timezone.utc)
+            session_peer.left_at = datetime.now(UTC)
         await db_session.commit()
 
         # Create message payload from sender
@@ -853,9 +853,9 @@ class TestGetEffectiveObserveMeFunction:
                 observed = f"sender_{i}"
 
             result = get_effective_observe_me(observed, peers_with_configuration)
-            assert (
-                result == expected
-            ), f"Test case {i} failed: peer_config={peer_config}, session_config={session_config}, expected={expected}, got={result}"
+            assert result == expected, (
+                f"Test case {i} failed: peer_config={peer_config}, session_config={session_config}, expected={expected}, got={result}"
+            )
 
 
 @pytest.mark.asyncio
@@ -963,7 +963,7 @@ class TestAdvancedEnqueueEdgeCases:
                 )
             )
             session_peer = session_peer_result.scalar_one()
-            session_peer.left_at = datetime.now(timezone.utc)
+            session_peer.left_at = datetime.now(UTC)
         await db_session.commit()
 
         # Create message payload
@@ -1025,7 +1025,7 @@ class TestAdvancedEnqueueEdgeCases:
 
         # Mark both as having left (observer left first, then sender)
 
-        base_time = datetime.now(timezone.utc)
+        base_time = datetime.now(UTC)
 
         # Observer left first
         observer_session_peer_result = await db_session.execute(
@@ -1169,7 +1169,7 @@ class TestGenerateQueueRecordsSeqInSession:
             "session_name": test_session.name,
             "content": "Test message",
             "seq_in_session": 20,  # Multiple of MESSAGES_PER_SHORT_SUMMARY to trigger summary creation
-            "created_at": datetime.now(timezone.utc),  # Required by create_payload
+            "created_at": datetime.now(UTC),  # Required by create_payload
         }
 
         # Mock the CRUD function to track if it's called
@@ -1246,7 +1246,7 @@ class TestGenerateQueueRecordsSeqInSession:
             "workspace_name": test_workspace.name,
             "session_name": test_session.name,
             "content": "Test message",
-            "created_at": datetime.now(timezone.utc),
+            "created_at": datetime.now(UTC),
             # seq_in_session is MISSING
         }
 

--- a/tests/integration/test_message_embeddings.py
+++ b/tests/integration/test_message_embeddings.py
@@ -5,7 +5,7 @@ These tests verify that message embeddings are created, stored, and can be searc
 """
 
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -58,7 +58,7 @@ def _message(session_name: str, seq_in_session: int) -> models.Message:
         public_id=generate_nanoid(),
         seq_in_session=seq_in_session,
         token_count=1,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
 
@@ -504,7 +504,7 @@ async def test_search_messages_external_lookup_happens_before_tracked_db(
         content="Relevant external search result",
         seq_in_session=1,
         token_count=5,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
     class FakeDb:
@@ -600,8 +600,8 @@ async def test_search_messages_temporal_external_lookup_happens_before_tracked_d
     monkeypatch.setattr(settings.VECTOR_STORE, "TYPE", "external")
 
     call_order: list[str] = []
-    after_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    before_date = datetime(2024, 12, 31, tzinfo=timezone.utc)
+    after_date = datetime(2024, 1, 1, tzinfo=UTC)
+    before_date = datetime(2024, 12, 31, tzinfo=UTC)
     message = models.Message(
         workspace_name="workspace",
         session_name="session",
@@ -609,7 +609,7 @@ async def test_search_messages_temporal_external_lookup_happens_before_tracked_d
         content="Relevant temporal external search result",
         seq_in_session=1,
         token_count=5,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
     class FakeDb:

--- a/tests/integration/test_representation.py
+++ b/tests/integration/test_representation.py
@@ -8,7 +8,7 @@ This test suite covers the full representation workflow including:
 - Working representation retrieval with different strategies
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -87,13 +87,13 @@ class TestRepresentationWorkflow:
         # Create explicit observations
         explicit_obs1 = ExplicitObservation(
             content="User likes dogs",
-            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
             message_ids=[1],
             session_name="test_session",
         )
         explicit_obs2 = ExplicitObservation(
             content="User has a pet named Rover",
-            created_at=datetime(2025, 1, 1, 12, 1, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 12, 1, 0, tzinfo=UTC),
             message_ids=[2],
             session_name="test_session",
         )
@@ -102,7 +102,7 @@ class TestRepresentationWorkflow:
         deductive_obs1 = DeductiveObservation(
             conclusion="User probably has a dog named Rover",
             premises=["User likes dogs", "User has a pet named Rover"],
-            created_at=datetime(2025, 1, 1, 12, 2, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 12, 2, 0, tzinfo=UTC),
             message_ids=[3],
             session_name="test_session",
         )
@@ -143,7 +143,7 @@ class TestRepresentationWorkflow:
             explicit=[
                 ExplicitObservation(
                     content="User likes cats",
-                    created_at=datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+                    created_at=datetime(2025, 1, 1, 10, 0, 0, tzinfo=UTC),
                     message_ids=[1],
                     session_name="session1",
                 )
@@ -155,13 +155,13 @@ class TestRepresentationWorkflow:
             explicit=[
                 ExplicitObservation(
                     content="User likes cats",  # Duplicate
-                    created_at=datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+                    created_at=datetime(2025, 1, 1, 10, 0, 0, tzinfo=UTC),
                     message_ids=[1],
                     session_name="session1",
                 ),
                 ExplicitObservation(
                     content="User likes dogs",  # New
-                    created_at=datetime(2025, 1, 1, 11, 0, 0, tzinfo=timezone.utc),
+                    created_at=datetime(2025, 1, 1, 11, 0, 0, tzinfo=UTC),
                     message_ids=[2],
                     session_name="session1",
                 ),
@@ -185,7 +185,7 @@ class TestRepresentationWorkflow:
             explicit=[
                 ExplicitObservation(
                     content="User likes birds",
-                    created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+                    created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
                     message_ids=[3],
                     session_name="session1",
                 )
@@ -227,7 +227,7 @@ class TestDocumentCreationWorkflow:
                 "message_ids": [1],
                 "session_name": "test_session",
             },
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         with patch(
@@ -323,7 +323,7 @@ class TestDocumentCreationWorkflow:
                 "message_ids": [1],
             },
             session_name="test_session",
-            created_at=datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 10, 0, 0, tzinfo=UTC),
         )
 
         deductive_doc = models.Document(
@@ -338,7 +338,7 @@ class TestDocumentCreationWorkflow:
                 "premises": ["User said they like programming"],
             },
             session_name="test_session",
-            created_at=datetime(2025, 1, 1, 10, 1, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 10, 1, 0, tzinfo=UTC),
         )
 
         # Convert to representation
@@ -417,7 +417,7 @@ class TestPromptRepresentationConversion:
             ],
         )
 
-        timestamp = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        timestamp = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
 
         representation = Representation.from_prompt_representation(
             prompt_rep,
@@ -445,7 +445,7 @@ class TestPromptRepresentationConversion:
             empty_prompt_rep,
             message_ids=[1],
             session_name="test",
-            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
         )
 
         assert representation.is_empty()
@@ -461,21 +461,21 @@ class TestRepresentationHashingAndEquality:
         """Test ExplicitObservation equality and hashing"""
         obs1 = ExplicitObservation(
             content="Test content",
-            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
             message_ids=[1],
             session_name="session1",
         )
 
         obs2 = ExplicitObservation(
             content="Test content",
-            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
             message_ids=[1],
             session_name="session1",
         )
 
         obs3 = ExplicitObservation(
             content="Different content",
-            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
             message_ids=[1],
             session_name="session1",
         )
@@ -494,7 +494,7 @@ class TestRepresentationHashingAndEquality:
         obs1 = DeductiveObservation(
             conclusion="Test conclusion",
             premises=["premise1", "premise2"],
-            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
             message_ids=[1],
             session_name="session1",
         )
@@ -502,7 +502,7 @@ class TestRepresentationHashingAndEquality:
         obs2 = DeductiveObservation(
             conclusion="Test conclusion",
             premises=["premise1", "premise2"],
-            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
             message_ids=[1],
             session_name="session1",
         )
@@ -510,7 +510,7 @@ class TestRepresentationHashingAndEquality:
         obs3 = DeductiveObservation(
             conclusion="Different conclusion",
             premises=["premise1", "premise2"],
-            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
             message_ids=[1],
             session_name="session1",
         )

--- a/tests/integration/test_token_metrics.py
+++ b/tests/integration/test_token_metrics.py
@@ -79,9 +79,9 @@ class PrometheusMetricChecker:
     ) -> None:
         """Assert that the delta matches expected value."""
         delta = self.get_delta(counter, labels, before)
-        assert (
-            delta == expected
-        ), f"{message}: expected delta {expected}, got {delta}. Labels: {labels}"
+        assert delta == expected, (
+            f"{message}: expected delta {expected}, got {delta}. Labels: {labels}"
+        )
 
 
 @pytest.fixture
@@ -591,9 +591,9 @@ class TestDeriverSummaryMetrics:
         delta = metric_checker.get_delta(
             deriver_tokens_processed_counter, labels, before
         )
-        assert (
-            delta == expected_messages_tokens
-        ), f"Expected messages input tokens {expected_messages_tokens}, got {delta}"
+        assert delta == expected_messages_tokens, (
+            f"Expected messages input tokens {expected_messages_tokens}, got {delta}"
+        )
         assert delta > 0, "Expected at least some message tokens to be tracked"
 
     async def test_summary_fallback_does_not_track(
@@ -663,12 +663,12 @@ class TestDeriverSummaryMetrics:
             deriver_tokens_processed_counter, prompt_labels, before_prompt
         )
 
-        assert (
-            output_delta == 0
-        ), f"Expected no output token change on fallback, got {output_delta}"
-        assert (
-            prompt_delta == 0
-        ), f"Expected no prompt token change on fallback, got {prompt_delta}"
+        assert output_delta == 0, (
+            f"Expected no output token change on fallback, got {output_delta}"
+        )
+        assert prompt_delta == 0, (
+            f"Expected no prompt token change on fallback, got {prompt_delta}"
+        )
 
 
 # =============================================================================
@@ -837,9 +837,9 @@ class TestDialecticTokenMetrics:
             dialectic_tokens_processed_counter, output_labels, before_output
         )
 
-        assert (
-            input_delta == 0
-        ), f"Expected no input token change when disabled, got {input_delta}"
-        assert (
-            output_delta == 0
-        ), f"Expected no output token change when disabled, got {output_delta}"
+        assert input_delta == 0, (
+            f"Expected no input token change when disabled, got {input_delta}"
+        )
+        assert output_delta == 0, (
+            f"Expected no output token change when disabled, got {output_delta}"
+        )

--- a/tests/live_llm/test_live_anthropic.py
+++ b/tests/live_llm/test_live_anthropic.py
@@ -71,9 +71,9 @@ async def test_live_anthropic_structured_output_and_prefix_caching(
     assert later_results, "Anthropic caching validation requires at least two calls"
     for result in later_results:
         assert isinstance(result.content, StructuredLiveResponse)
-    assert any(
-        result.cache_read_input_tokens > 0 for result in later_results
-    ), "Anthropic prompt caching did not report a cache hit after repeated identical requests"
+    assert any(result.cache_read_input_tokens > 0 for result in later_results), (
+        "Anthropic prompt caching did not report a cache hit after repeated identical requests"
+    )
 
     assert len(create_calls) == len(results)
     for call in create_calls:

--- a/tests/live_llm/test_live_embeddings.py
+++ b/tests/live_llm/test_live_embeddings.py
@@ -192,9 +192,9 @@ async def test_live_openai_float_encoding_matches_base64(
     base64_response = await openai_client.embeddings.create(**base64_kwargs)
 
     similarity = cosine_similarity(float_vector, base64_response.data[0].embedding)
-    assert (
-        similarity > 0.99999
-    ), f"{spec.id}: float encoding diverges from base64 (cosine={similarity:.8f})"
+    assert similarity > 0.99999, (
+        f"{spec.id}: float encoding diverges from base64 (cosine={similarity:.8f})"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/live_llm/test_live_gemini.py
+++ b/tests/live_llm/test_live_gemini.py
@@ -137,9 +137,9 @@ async def test_live_gemini_thinking_and_tool_replay(
         "thinking_budget": 512,
     }
     assert first.tool_calls, "Gemini should issue a tool call in the first turn"
-    assert any(
-        tool_call.thought_signature for tool_call in first.tool_calls
-    ), "Gemini tool replay should preserve thought signatures"
+    assert any(tool_call.thought_signature for tool_call in first.tool_calls), (
+        "Gemini tool replay should preserve thought signatures"
+    )
 
     tool_call = first.tool_calls[0]
     tool_result = execute_local_tool(tool_call.name, tool_call.input)

--- a/tests/live_llm/test_live_timeouts.py
+++ b/tests/live_llm/test_live_timeouts.py
@@ -112,6 +112,6 @@ async def test_live_tight_provider_timeout_aborts_request(
         )
     elapsed = time.monotonic() - started
 
-    assert (
-        elapsed < TIGHT_TIMEOUT_WALL_CLOCK_LIMIT_SECONDS
-    ), f"tight timeout took {elapsed:.1f}s — per-request timeout likely not applied"
+    assert elapsed < TIGHT_TIMEOUT_WALL_CLOCK_LIMIT_SECONDS, (
+        f"tight timeout took {elapsed:.1f}s — per-request timeout likely not applied"
+    )

--- a/tests/live_llm/test_live_tools_structured_output.py
+++ b/tests/live_llm/test_live_tools_structured_output.py
@@ -90,9 +90,9 @@ async def run_tool_then_structured_flow(
     )
 
     assert first.tool_calls, "first turn should issue a tool call"
-    assert not isinstance(
-        first.content, FavoritePrimeReport
-    ), "tool-call turns carry no consumable content and must not be parsed"
+    assert not isinstance(first.content, FavoritePrimeReport), (
+        "tool-call turns carry no consumable content and must not be parsed"
+    )
 
     tool_call = first.tool_calls[0]
     tool_result = execute_local_tool(tool_call.name, tool_call.input)
@@ -173,9 +173,9 @@ async def test_live_anthropic_tools_with_structured_output(
             "role": "assistant",
             "content": "{",
         }, "the '{' prefill would suppress tool_use blocks"
-        assert "If not responding with a tool call" in str(
-            messages[-1]
-        ), "schema instruction should use the conditional wording with tools"
+        assert "If not responding with a tool call" in str(messages[-1]), (
+            "schema instruction should use the conditional wording with tools"
+        )
 
 
 @pytest.mark.asyncio
@@ -236,11 +236,11 @@ async def test_live_gemini_tools_with_structured_output(
     assert len(generate_calls) >= 2
     for call in generate_calls:
         gen_config = call["kwargs"]["config"]
-        assert (
-            "response_schema" not in gen_config
-        ), "native response_schema + function calling is rejected pre-Gemini 3"
+        assert "response_schema" not in gen_config, (
+            "native response_schema + function calling is rejected pre-Gemini 3"
+        )
         assert "response_mime_type" not in gen_config
         contents = call["kwargs"]["contents"]
-        assert "matching this schema" in str(
-            contents[-1]
-        ), "schema instruction should be injected into the final turn"
+        assert "matching this schema" in str(contents[-1]), (
+            "schema instruction should be injected into the final turn"
+        )

--- a/tests/llm/test_backends/test_gemini.py
+++ b/tests/llm/test_backends/test_gemini.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -290,7 +290,7 @@ async def test_gemini_backend_strips_system_and_tools_when_using_cached_content(
     client.aio.caches.create = AsyncMock(
         return_value=SimpleNamespace(
             name="cachedContents/abc123",
-            expire_time=datetime.now(timezone.utc) + timedelta(minutes=5),
+            expire_time=datetime.now(UTC) + timedelta(minutes=5),
         )
     )
     client.aio.models.generate_content = AsyncMock(

--- a/tests/llm/test_model_config.py
+++ b/tests/llm/test_model_config.py
@@ -324,9 +324,9 @@ def test_app_settings_explicit_vector_store_dimensions_warns_and_overrides() -> 
     messages = [
         str(w.message) for w in captured if issubclass(w.category, DeprecationWarning)
     ]
-    assert any(
-        "VECTOR_STORE_DIMENSIONS is deprecated" in m for m in messages
-    ), f"expected deprecation warning, got {messages!r}"
+    assert any("VECTOR_STORE_DIMENSIONS is deprecated" in m for m in messages), (
+        f"expected deprecation warning, got {messages!r}"
+    )
     assert settings.EMBEDDING.VECTOR_DIMENSIONS == 2048
     assert settings.VECTOR_STORE.DIMENSIONS == 2048, (
         "EMBEDDING.VECTOR_DIMENSIONS should always overwrite the operator-supplied "

--- a/tests/llm/test_telemetry_llm_call.py
+++ b/tests/llm/test_telemetry_llm_call.py
@@ -754,9 +754,7 @@ class TestStreamingResponseRunHandleClose:
 
         from src.llm.types import HonchoLLMCallStreamChunk
 
-        agen = cast(
-            "AsyncGenerator[HonchoLLMCallStreamChunk, None]", wrapper.__aiter__()
-        )
+        agen = cast("AsyncGenerator[HonchoLLMCallStreamChunk]", wrapper.__aiter__())
         first = await agen.__anext__()
         assert first.content == "hel"
         await agen.aclose()

--- a/tests/mock_provider/test_mock_provider.py
+++ b/tests/mock_provider/test_mock_provider.py
@@ -101,9 +101,9 @@ def test_deriver_response_model_round_trips() -> None:
     content = json.dumps(generate(schema))
 
     representation = PromptRepresentation.model_validate_json(content)
-    assert (
-        representation.explicit
-    ), "an empty explicit list is exactly the silent failure this mock avoids"
+    assert representation.explicit, (
+        "an empty explicit list is exactly the silent failure this mock avoids"
+    )
 
 
 def test_json_schema_response_is_never_prose(client: TestClient) -> None:

--- a/tests/reconciler/test_sync_vectors_enqueue_gate.py
+++ b/tests/reconciler/test_sync_vectors_enqueue_gate.py
@@ -88,13 +88,13 @@ async def test_soft_deleted_document_is_work_only_after_grace(
         session_name=session.name,
         sync_state="synced",
         embedding=[0.0] * 1536,
-        deleted_at=datetime.datetime.now(datetime.timezone.utc),
+        deleted_at=datetime.datetime.now(datetime.UTC),
     )
     db_session.add(doc)
     await db_session.commit()
     assert await has_pending_work(db_session) is False
 
-    doc.deleted_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+    doc.deleted_at = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
         minutes=10
     )
     await db_session.commit()
@@ -106,7 +106,7 @@ async def test_enqueue_gated_on_pending_work(
     db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch, has_work: bool
 ) -> None:
     @asynccontextmanager
-    async def _db(_: str | None = None) -> AsyncGenerator[AsyncSession, None]:
+    async def _db(_: str | None = None) -> AsyncGenerator[AsyncSession]:
         yield db_session
 
     monkeypatch.setattr(scheduler_module, "tracked_db", _db)
@@ -137,7 +137,7 @@ async def test_cleanup_queue_is_not_gated(
     db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     @asynccontextmanager
-    async def _db(_: str | None = None) -> AsyncGenerator[AsyncSession, None]:
+    async def _db(_: str | None = None) -> AsyncGenerator[AsyncSession]:
         yield db_session
 
     monkeypatch.setattr(scheduler_module, "tracked_db", _db)

--- a/tests/routes/test_auth_route_policy.py
+++ b/tests/routes/test_auth_route_policy.py
@@ -103,6 +103,6 @@ def test_every_message_route_requires_auth():
     ]
     assert message_routes, "expected to find message routes mounted under the prefix"
     for route in message_routes:
-        assert any(
-            _auth_dependency_calls(route)
-        ), f"{route.methods} {route.path} has no auth dependency"
+        assert any(_auth_dependency_calls(route)), (
+            f"{route.methods} {route.path} has no auth dependency"
+        )

--- a/tests/routes/test_files.py
+++ b/tests/routes/test_files.py
@@ -1,6 +1,7 @@
 # File upload tests for session endpoints
 import io
 import json
+from datetime import UTC
 from typing import Any
 
 import pytest
@@ -462,9 +463,9 @@ async def test_file_upload_with_created_at(
     file_data = io.BytesIO(file_content.encode("utf-8"))
 
     # Prepare created_at timestamp (ISO 8601 format)
-    from datetime import datetime, timezone
+    from datetime import datetime
 
-    test_timestamp = datetime(2023, 1, 15, 10, 30, 45, tzinfo=timezone.utc)
+    test_timestamp = datetime(2023, 1, 15, 10, 30, 45, tzinfo=UTC)
     created_at_str = test_timestamp.isoformat()
 
     files = {"file": ("test_timestamp.txt", file_data, "text/plain")}
@@ -511,9 +512,9 @@ async def test_file_upload_with_all_parameters(
     # Prepare all parameters
     metadata = {"source": "comprehensive_test", "version": "1.0"}
     configuration = {"skip_deriver": False, "test_mode": True}
-    from datetime import datetime, timezone
+    from datetime import datetime
 
-    test_timestamp = datetime(2023, 6, 20, 14, 15, 30, tzinfo=timezone.utc)
+    test_timestamp = datetime(2023, 6, 20, 14, 15, 30, tzinfo=UTC)
     created_at_str = test_timestamp.isoformat()
 
     files = {"file": ("test_all_params.txt", file_data, "text/plain")}

--- a/tests/routes/test_messages.py
+++ b/tests/routes/test_messages.py
@@ -1164,9 +1164,7 @@ async def test_create_message_with_timestamp(
     await db_session.commit()
 
     # Use a specific timestamp for testing
-    custom_timestamp = datetime.datetime(
-        2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
-    )
+    custom_timestamp = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
 
     response = client.post(
         f"/v3/workspaces/{test_workspace.name}/sessions/{test_session.name}/messages",
@@ -1210,9 +1208,7 @@ async def test_create_message_without_timestamp_uses_default(
     await db_session.commit()
 
     # Pad the window to absorb client/Postgres clock skew under Docker.
-    before_request = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-        seconds=1
-    )
+    before_request = datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=1)
 
     response = client.post(
         f"/v3/workspaces/{test_workspace.name}/sessions/{test_session.name}/messages",
@@ -1227,9 +1223,7 @@ async def test_create_message_without_timestamp_uses_default(
         },
     )
 
-    after_request = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
-        seconds=1
-    )
+    after_request = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=1)
 
     assert response.status_code == 201
     data = response.json()
@@ -1261,12 +1255,10 @@ async def test_create_batch_messages_with_mixed_timestamps(
     await db_session.commit()
 
     # Use specific timestamps for testing
-    timestamp1 = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
-    timestamp2 = datetime.datetime(2023, 1, 2, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    timestamp1 = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
+    timestamp2 = datetime.datetime(2023, 1, 2, 12, 0, 0, tzinfo=datetime.UTC)
 
-    before_request = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-        seconds=1
-    )
+    before_request = datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=1)
 
     response = client.post(
         f"/v3/workspaces/{test_workspace.name}/sessions/{test_session.name}/messages",
@@ -1293,9 +1285,7 @@ async def test_create_batch_messages_with_mixed_timestamps(
         },
     )
 
-    after_request = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
-        seconds=1
-    )
+    after_request = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=1)
 
     assert response.status_code == 201
     data = response.json()
@@ -1338,9 +1328,7 @@ async def test_create_message_with_null_timestamp(
     db_session.add(test_session)
     await db_session.commit()
 
-    before_request = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-        seconds=1
-    )
+    before_request = datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=1)
 
     response = client.post(
         f"/v3/workspaces/{test_workspace.name}/sessions/{test_session.name}/messages",
@@ -1356,9 +1344,7 @@ async def test_create_message_with_null_timestamp(
         },
     )
 
-    after_request = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
-        seconds=1
-    )
+    after_request = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=1)
 
     assert response.status_code == 201
     data = response.json()

--- a/tests/routes/test_peers.py
+++ b/tests/routes/test_peers.py
@@ -225,9 +225,7 @@ async def test_get_peers_reverse_uses_id_tiebreaker(
     """Peers with identical created_at fall back to ordering by id (nanoid PK)."""
     test_workspace, _ = sample_data
     reverse_group = f"tiebreaker-peers-{generate_nanoid()}"
-    shared_created_at = datetime.datetime(
-        2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
-    )
+    shared_created_at = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
 
     low_id = "A" * 21
     high_id = "z" * 21
@@ -514,9 +512,7 @@ async def test_get_sessions_for_peer_reverse_uses_id_tiebreaker(
     """Peer-scoped sessions with identical created_at fall back to ordering by id."""
     test_workspace, test_peer = sample_data
     reverse_group = f"tiebreaker-peer-sessions-{generate_nanoid()}"
-    shared_created_at = datetime.datetime(
-        2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
-    )
+    shared_created_at = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
 
     low_id = "A" * 21
     high_id = "z" * 21

--- a/tests/routes/test_scope_route_policy.py
+++ b/tests/routes/test_scope_route_policy.py
@@ -744,9 +744,9 @@ def test_policy_entries_are_well_formed():
                     "status is 422 — missing_status is for the permissive cases"
                 )
             else:
-                assert (
-                    len(case.missing_reason.strip()) > 30
-                ), f"{case.key} tolerates a missing reserved name; say why"
+                assert len(case.missing_reason.strip()) > 30, (
+                    f"{case.key} tolerates a missing reserved name; say why"
+                )
                 assert case.missing_status, (
                     f"{case.key} tolerates a missing reserved name; name the exact "
                     "status(es) it should get, so a 5xx cannot satisfy the case"
@@ -757,9 +757,9 @@ def test_policy_entries_are_well_formed():
                 f"{case.key}: an allow case needs a builder and an expected "
                 "allow_status together, or neither"
             )
-            assert (
-                case.refuse_missing is None
-            ), f"{case.key}: refuse_missing applies to REFUSE cases only"
+            assert case.refuse_missing is None, (
+                f"{case.key}: refuse_missing applies to REFUSE cases only"
+            )
 
 
 _REFUSING = tuple(case for case in POLICY if case.refuse)
@@ -823,9 +823,9 @@ def test_refusing_position_rejects_a_real_scope(
     # A 422 alone proves nothing — a malformed body would also produce one.
     detail = result.text
     if case.schema_level:
-        assert (
-            "pattern" in detail
-        ), f"{case.key} expected a schema-level refusal; detail: {detail[:200]}"
+        assert "pattern" in detail, (
+            f"{case.key} expected a schema-level refusal; detail: {detail[:200]}"
+        )
     else:
         assert "scope" in detail.lower() and backing in detail, (
             f"{case.key} returned 422 but not because of the scope; "

--- a/tests/routes/test_sessions.py
+++ b/tests/routes/test_sessions.py
@@ -289,9 +289,7 @@ async def test_get_sessions_reverse_uses_id_tiebreaker(
     """Sessions with identical created_at fall back to ordering by id (nanoid PK)."""
     test_workspace, _ = sample_data
     reverse_group = f"tiebreaker-sessions-{generate_nanoid()}"
-    shared_created_at = datetime.datetime(
-        2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
-    )
+    shared_created_at = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
 
     low_id = "A" * 21
     high_id = "z" * 21

--- a/tests/routes/test_workspaces.py
+++ b/tests/routes/test_workspaces.py
@@ -173,9 +173,7 @@ async def test_get_all_workspaces_reverse_uses_id_tiebreaker(
 ):
     """Workspaces with identical created_at fall back to ordering by id (nanoid PK)."""
     reverse_group = f"tiebreaker-{generate_nanoid()}"
-    shared_created_at = datetime.datetime(
-        2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
-    )
+    shared_created_at = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
 
     low_id = "A" * 21
     high_id = "z" * 21

--- a/tests/scripts/test_configure_embeddings.py
+++ b/tests/scripts/test_configure_embeddings.py
@@ -121,9 +121,9 @@ async def test_apply_alters_dims_and_recreates_hnsw_indexes(
         assert after_dims == {"documents": target, "message_embeddings": target}
 
         after_indexes = await _hnsw_indexes(db_engine)
-        assert (
-            after_indexes == before_indexes
-        ), "HNSW indexes should be recreated with the same names"
+        assert after_indexes == before_indexes, (
+            "HNSW indexes should be recreated with the same names"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/sdk/sdk_integration_test.py
+++ b/tests/sdk/sdk_integration_test.py
@@ -16,7 +16,7 @@ from sdks.python.src.honcho.session import Session, SessionPeerConfig  # noqa: E
 
 
 @pytest.fixture
-def honcho_test_client(client: TestClient) -> Generator[Honcho, None, None]:
+def honcho_test_client(client: TestClient) -> Generator[Honcho]:
     """
     Returns a Honcho SDK client configured to talk to the test API.
     """

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -47,9 +47,9 @@ async def test_client_init(client_fixture: tuple[Honcho, str], client: TestClien
 
         page += 1
 
-    assert (
-        found_workspace
-    ), f"Workspace {honcho_client.workspace_id} not found in any page of results"
+    assert found_workspace, (
+        f"Workspace {honcho_client.workspace_id} not found in any page of results"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/sdk/test_file_uploads.py
+++ b/tests/sdk/test_file_uploads.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC
 
 import pytest
 
@@ -341,13 +342,13 @@ async def test_file_upload_with_created_at(
     honcho_client, client_type = client_fixture
 
     text_content = "Test file with created_at"
-    from datetime import datetime, timezone
+    from datetime import datetime
     from io import BytesIO
 
     text_file = BytesIO(text_content.encode("utf-8"))
     text_file.name = "test_timestamp.txt"
 
-    test_timestamp = datetime(2023, 1, 15, 10, 30, 45, tzinfo=timezone.utc)
+    test_timestamp = datetime(2023, 1, 15, 10, 30, 45, tzinfo=UTC)
     created_at_str = test_timestamp.isoformat()
 
     if client_type == "async":
@@ -387,7 +388,7 @@ async def test_file_upload_with_all_parameters(
     honcho_client, client_type = client_fixture
 
     text_content = "Test file with all parameters"
-    from datetime import datetime, timezone
+    from datetime import datetime
     from io import BytesIO
 
     text_file = BytesIO(text_content.encode("utf-8"))
@@ -395,7 +396,7 @@ async def test_file_upload_with_all_parameters(
 
     metadata: dict[str, object] = {"source": "comprehensive_test", "version": "1.0"}
     configuration = {"skip_deriver": False, "test_mode": True}
-    test_timestamp = datetime(2023, 6, 20, 14, 15, 30, tzinfo=timezone.utc)
+    test_timestamp = datetime(2023, 6, 20, 14, 15, 30, tzinfo=UTC)
     created_at_str = test_timestamp.isoformat()
 
     if client_type == "async":
@@ -441,13 +442,13 @@ async def test_file_upload_with_datetime_object(
     honcho_client, client_type = client_fixture
 
     text_content = "Test file with datetime object"
-    from datetime import datetime, timezone
+    from datetime import datetime
     from io import BytesIO
 
     text_file = BytesIO(text_content.encode("utf-8"))
     text_file.name = "test_datetime.txt"
 
-    test_timestamp = datetime(2023, 3, 10, 8, 45, 20, tzinfo=timezone.utc)
+    test_timestamp = datetime(2023, 3, 10, 8, 45, 20, tzinfo=UTC)
 
     if client_type == "async":
         session = await honcho_client.aio.session(id="test-session-datetime")

--- a/tests/sdk_typescript/conftest.py
+++ b/tests/sdk_typescript/conftest.py
@@ -58,7 +58,7 @@ def find_free_port() -> int:
 @pytest.fixture(scope="module")
 def ts_db_session(
     db_engine: AsyncEngine,
-) -> Generator[async_sessionmaker[AsyncSession], None, None]:
+) -> Generator[async_sessionmaker[AsyncSession]]:
     """Create a session factory for the TypeScript test module."""
     Session = async_sessionmaker(bind=db_engine, expire_on_commit=False)
     yield Session
@@ -71,7 +71,7 @@ _ts_session_factory: async_sessionmaker[AsyncSession] | None = None
 @pytest.fixture(scope="module")
 def ts_test_server(
     ts_db_session: async_sessionmaker[AsyncSession],
-) -> Generator[str, None, None]:
+) -> Generator[str]:
     """
     Start a real HTTP server for TypeScript SDK tests.
 

--- a/tests/startup/test_embedding_validator.py
+++ b/tests/startup/test_embedding_validator.py
@@ -179,9 +179,9 @@ def test_vector_store_dimensions_explicit_set_warns(
     messages = [
         str(w.message) for w in captured if issubclass(w.category, DeprecationWarning)
     ]
-    assert any(
-        "VECTOR_STORE_DIMENSIONS is deprecated" in m for m in messages
-    ), f"expected deprecation warning, got {messages!r}"
+    assert any("VECTOR_STORE_DIMENSIONS is deprecated" in m for m in messages), (
+        f"expected deprecation warning, got {messages!r}"
+    )
 
 
 def test_non_1536_pgvector_without_migrated_no_longer_raises_at_config_time() -> None:

--- a/tests/test_advanced_filters.py
+++ b/tests/test_advanced_filters.py
@@ -3,7 +3,7 @@ Tests for advanced filter functionality including logical operators,
 comparison operators, and wildcards across multiple models.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any, TypedDict
 
 import pytest
@@ -111,21 +111,21 @@ async def test_logical_operators_and_filters(
     found_names = [item["id"] for item in data["items"]]
     expected_names = [peer_names[i] for i in expected_peer_indices]
 
-    assert len(found_names) == len(
-        expected_names
-    ), f"Expected {len(expected_names)} peers for {description}, got {len(found_names)}"
+    assert len(found_names) == len(expected_names), (
+        f"Expected {len(expected_names)} peers for {description}, got {len(found_names)}"
+    )
 
     for expected_name in expected_names:
-        assert (
-            expected_name in found_names
-        ), f"Expected peer {expected_name} in results for {description}"
+        assert expected_name in found_names, (
+            f"Expected peer {expected_name} in results for {description}"
+        )
 
     # Verify unexpected peers are not included
     for i, peer_name in enumerate(peer_names):
         if i not in expected_peer_indices:
-            assert (
-                peer_name not in found_names
-            ), f"Unexpected peer {peer_name} found in results for {description}"
+            assert peer_name not in found_names, (
+                f"Unexpected peer {peer_name} found in results for {description}"
+            )
 
 
 @pytest.mark.parametrize(
@@ -224,21 +224,21 @@ async def test_comparison_operators_filters(
     ]
     found_contents = [item["content"] for item in data["items"]]
 
-    assert (
-        len(found_contents) == len(expected_contents)
-    ), f"Expected {len(expected_contents)} messages for {description}, got {len(found_contents)}"
+    assert len(found_contents) == len(expected_contents), (
+        f"Expected {len(expected_contents)} messages for {description}, got {len(found_contents)}"
+    )
 
     for expected_content in expected_contents:
-        assert (
-            expected_content in found_contents
-        ), f"Expected message '{expected_content}' in results for {description}"
+        assert expected_content in found_contents, (
+            f"Expected message '{expected_content}' in results for {description}"
+        )
 
     # Verify unexpected messages are not included
     for i, message_config in enumerate(message_configs):
         if i not in expected_message_indices:
-            assert (
-                message_config["content"] not in found_contents
-            ), f"Unexpected message '{message_config['content']}' found in results for {description}"
+            assert message_config["content"] not in found_contents, (
+                f"Unexpected message '{message_config['content']}' found in results for {description}"
+            )
 
 
 @pytest.mark.asyncio
@@ -1645,7 +1645,7 @@ async def test_real_datetime_column_filtering(
     )
 
     # Test datetime filtering with various formats
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     one_minute_ago = now - timedelta(minutes=1)
 
     # Test ISO format
@@ -1660,7 +1660,7 @@ async def test_real_datetime_column_filtering(
     assert peer2_name in found_names
 
     # Test date-only format
-    today = datetime.now(timezone.utc).date().isoformat()
+    today = datetime.now(UTC).date().isoformat()
     response = client.post(
         f"/v3/workspaces/{test_workspace.name}/peers/list",
         json={"filters": {"created_at": {"gte": today}}},

--- a/tests/test_datetime_parsing.py
+++ b/tests/test_datetime_parsing.py
@@ -5,7 +5,7 @@ This test suite covers edge cases for timezone handling, format validation,
 security considerations, and integration with the filtering system.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Any
 
 import pytest
@@ -35,7 +35,7 @@ class TestParseDatetimeISO:
 
         for iso_string in test_cases:
             result = parse_datetime_iso(iso_string)
-            assert result.tzinfo == timezone.utc
+            assert result.tzinfo == UTC
             assert isinstance(result, datetime)
 
     def test_parse_plus_zero_format(self):
@@ -48,7 +48,7 @@ class TestParseDatetimeISO:
 
         for iso_string in test_cases:
             result = parse_datetime_iso(iso_string)
-            assert result.tzinfo == timezone.utc
+            assert result.tzinfo == UTC
             assert isinstance(result, datetime)
 
     def test_parse_without_timezone(self):
@@ -60,7 +60,7 @@ class TestParseDatetimeISO:
 
         for iso_string in test_cases:
             result = parse_datetime_iso(iso_string)
-            assert result.tzinfo == timezone.utc
+            assert result.tzinfo == UTC
             assert isinstance(result, datetime)
 
     def test_equivalency_between_formats(self):
@@ -72,9 +72,7 @@ class TestParseDatetimeISO:
         result_none = parse_datetime_iso(base_time)
 
         assert result_z == result_plus == result_none
-        assert all(
-            r.tzinfo == timezone.utc for r in [result_z, result_plus, result_none]
-        )
+        assert all(r.tzinfo == UTC for r in [result_z, result_plus, result_none])
 
     def test_microseconds_precision(self):
         """Test handling of microseconds precision."""
@@ -101,7 +99,7 @@ class TestParseDatetimeISO:
 
         for iso_string in edge_cases:
             result = parse_datetime_iso(iso_string)
-            assert result.tzinfo == timezone.utc
+            assert result.tzinfo == UTC
             assert isinstance(result, datetime)
 
     def test_invalid_formats_raise_errors(self):
@@ -139,7 +137,7 @@ class TestParseDatetimeISO:
         for permissive_input in permissive_cases:
             result = parse_datetime_iso(permissive_input)
             assert isinstance(result, datetime)
-            assert result.tzinfo == timezone.utc
+            assert result.tzinfo == UTC
 
     def test_malicious_injection_attempts(self):
         """Test that potential SQL injection attempts in datetime strings fail safely."""
@@ -184,7 +182,7 @@ class TestParseDatetimeISO:
         for whitespace_input in whitespace_cases:
             result = parse_datetime_iso(whitespace_input)
             assert isinstance(result, datetime)
-            assert result.tzinfo == timezone.utc
+            assert result.tzinfo == UTC
 
         # Invalid whitespace with newlines should be rejected
         invalid_whitespace_cases = [
@@ -218,7 +216,7 @@ class TestFormatDatetimeUTC:
 
     def test_format_utc_datetime(self):
         """Test formatting UTC datetime objects."""
-        dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
         result = format_datetime_utc(dt)
         assert result == "2023-01-01T12:00:00Z"
 
@@ -238,13 +236,13 @@ class TestFormatDatetimeUTC:
 
     def test_format_with_microseconds(self):
         """Test formatting datetimes with microseconds. They should be removed."""
-        dt = datetime(2023, 1, 1, 12, 0, 0, 123456, tzinfo=timezone.utc)
+        dt = datetime(2023, 1, 1, 12, 0, 0, 123456, tzinfo=UTC)
         result = format_datetime_utc(dt)
         assert result == "2023-01-01T12:00:00Z"
 
     def test_roundtrip_consistency(self):
         """Test that format -> parse -> format is consistent."""
-        original_dt = datetime(2023, 1, 1, 12, 30, 45, 0, tzinfo=timezone.utc)
+        original_dt = datetime(2023, 1, 1, 12, 30, 45, 0, tzinfo=UTC)
 
         # Format to string
         formatted = format_datetime_utc(original_dt)
@@ -269,7 +267,7 @@ class TestUTCNowISO:
         # Should be parseable
         parsed = parse_datetime_iso(result)
         assert isinstance(parsed, datetime)
-        assert parsed.tzinfo == timezone.utc
+        assert parsed.tzinfo == UTC
 
     def test_format_consistency(self):
         """Test that utc_now_iso uses consistent Z format."""
@@ -294,13 +292,13 @@ class TestFilterDatetimeValidation:
             result = _validate_datetime_string(valid_input)
             assert result is not None
             assert isinstance(result, datetime)
-            assert result.tzinfo == timezone.utc  # Should have UTC timezone
+            assert result.tzinfo == UTC  # Should have UTC timezone
 
         # Date-only format should also be timezone-aware
         date_only_result = _validate_datetime_string("2023-01-01")
         assert date_only_result is not None
         assert isinstance(date_only_result, datetime)
-        assert date_only_result.tzinfo == timezone.utc  # Should assume UTC
+        assert date_only_result.tzinfo == UTC  # Should assume UTC
 
     def test_validate_invalid_formats_return_none(self):
         """Test that invalid formats return None rather than raising exceptions."""
@@ -369,7 +367,7 @@ class TestDatetimeEdgeCasesIntegration:
 
         for transition_time in [spring_forward, fall_back]:
             result = parse_datetime_iso(transition_time)
-            assert result.tzinfo == timezone.utc
+            assert result.tzinfo == UTC
 
     def test_year_boundary_handling(self):
         """Test handling of year boundary dates."""
@@ -383,7 +381,7 @@ class TestDatetimeEdgeCasesIntegration:
         for boundary_case in boundary_cases:
             result = parse_datetime_iso(boundary_case)
             assert isinstance(result, datetime)
-            assert result.tzinfo == timezone.utc
+            assert result.tzinfo == UTC
 
     def test_extreme_date_values(self):
         """Test handling of extreme date values within reasonable bounds."""
@@ -398,7 +396,7 @@ class TestDatetimeEdgeCasesIntegration:
         for extreme_case in extreme_cases:
             result = parse_datetime_iso(extreme_case)
             assert isinstance(result, datetime)
-            assert result.tzinfo == timezone.utc
+            assert result.tzinfo == UTC
 
     def test_consistency_across_functions(self):
         """Test that all datetime functions work consistently together."""
@@ -415,7 +413,7 @@ class TestDatetimeEdgeCasesIntegration:
         validated = _validate_datetime_string(reformatted)
 
         assert validated is not None
-        assert validated.tzinfo == timezone.utc
+        assert validated.tzinfo == UTC
         assert abs((validated - now_dt).total_seconds()) < 1  # Should be very close
 
 
@@ -425,7 +423,7 @@ class TestTimezoneHandlingEdgeCases:
     def test_timezone_info_preservation(self):
         """Test that timezone information is correctly handled and converted."""
         # Test various timezone inputs
-        utc_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        utc_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
         naive_dt = datetime(2023, 1, 1, 12, 0, 0)  # No timezone
 
         # Both should format to the same UTC string when naive assumes UTC
@@ -446,7 +444,7 @@ class TestTimezoneHandlingEdgeCases:
 
         # When parsed back, should be equivalent UTC time
         parsed_utc = parse_datetime_iso(utc_formatted)
-        assert parsed_utc.tzinfo == timezone.utc
+        assert parsed_utc.tzinfo == UTC
         assert parsed_utc.hour == 12  # 7 AM EST = 12 PM UTC
 
     def test_timezone_edge_cases_around_midnight(self):
@@ -477,12 +475,12 @@ class TestErrorHandlingAndRecovery:
         for partial_case in time_cases:
             result = _validate_datetime_string(partial_case)
             assert result is not None
-            assert result.tzinfo == timezone.utc  # Should assume UTC
+            assert result.tzinfo == UTC  # Should assume UTC
 
         # Date-only should also be timezone-aware with UTC assumption
         date_result = _validate_datetime_string("2023-01-01")
         assert date_result is not None
-        assert date_result.tzinfo == timezone.utc  # Should assume UTC
+        assert date_result.tzinfo == UTC  # Should assume UTC
 
     def test_graceful_degradation_on_errors(self):
         """Test that datetime parsing fails gracefully without crashing."""

--- a/tests/test_deriver_metrics.py
+++ b/tests/test_deriver_metrics.py
@@ -339,9 +339,7 @@ class TestLifespanScheduler:
             patch.object(main_module, "close_cache", AsyncMock()),
             patch.object(main_module, "shutdown_telemetry", AsyncMock()),
             patch.object(main_module, "engine", AsyncMock()),
-            patch.object(
-                main_module, "DeriverMetricsPoller", return_value=AsyncMock()
-            ),
+            patch.object(main_module, "DeriverMetricsPoller", return_value=AsyncMock()),
             patch.object(main_module, "ReconcilerScheduler", return_value=scheduler),
             patch.object(main_module, "set_reconciler_scheduler"),
             patch(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -33,7 +33,7 @@ async def test_peer_perspective_search_single_session(
     await db_session.flush()
 
     # Add peer1 to session
-    join_time = datetime.datetime.now(datetime.timezone.utc)
+    join_time = datetime.datetime.now(datetime.UTC)
     await db_session.execute(
         models.session_peers_table.insert().values(
             workspace_name=workspace.name,
@@ -101,7 +101,7 @@ async def test_peer_perspective_search_multiple_sessions(
     await db_session.flush()
 
     # Add peer1 to both sessions
-    join_time = datetime.datetime.now(datetime.timezone.utc)
+    join_time = datetime.datetime.now(datetime.UTC)
     for session in [session1, session2]:
         await db_session.execute(
             models.session_peers_table.insert().values(
@@ -169,7 +169,7 @@ async def test_peer_perspective_search_temporal_constraints(
     await db_session.flush()
 
     # Define time windows
-    base_time = datetime.datetime.now(datetime.timezone.utc)
+    base_time = datetime.datetime.now(datetime.UTC)
     join_time = base_time + datetime.timedelta(seconds=10)
     leave_time = base_time + datetime.timedelta(seconds=20)
 
@@ -247,7 +247,7 @@ async def test_peer_perspective_search_active_member(
     await db_session.flush()
 
     # Add peer1 to session (still active, left_at is NULL)
-    join_time = datetime.datetime.now(datetime.timezone.utc)
+    join_time = datetime.datetime.now(datetime.UTC)
     await db_session.execute(
         models.session_peers_table.insert().values(
             workspace_name=workspace.name,
@@ -314,7 +314,7 @@ async def test_peer_perspective_search_no_sessions(
     await db_session.flush()
 
     # Add peer2 to session
-    join_time = datetime.datetime.now(datetime.timezone.utc)
+    join_time = datetime.datetime.now(datetime.UTC)
     await db_session.execute(
         models.session_peers_table.insert().values(
             workspace_name=workspace.name,
@@ -371,7 +371,7 @@ async def test_peer_perspective_search_boundary_timestamps(
     await db_session.flush()
 
     # Define exact timestamps
-    join_time = datetime.datetime.now(datetime.timezone.utc)
+    join_time = datetime.datetime.now(datetime.UTC)
     leave_time = join_time + datetime.timedelta(seconds=10)
 
     # Add peer1 to session
@@ -440,9 +440,7 @@ async def _setup_multi_session_workspace(db_session: AsyncSession):
     db_session.add_all([session1, session2])
     await db_session.flush()
 
-    join_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-        minutes=10
-    )
+    join_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=10)
 
     # peer1 is only in session1
     await db_session.execute(
@@ -611,7 +609,7 @@ async def test_grep_messages_observer_scoping_empty_when_no_sessions(
             workspace_name=workspace.name,
             session_name=session.name,
             peer_name=other.name,
-            joined_at=datetime.datetime.now(datetime.timezone.utc),
+            joined_at=datetime.datetime.now(datetime.UTC),
             left_at=None,
         )
     )
@@ -623,7 +621,7 @@ async def test_grep_messages_observer_scoping_empty_when_no_sessions(
         peer_name=other.name,
         workspace_name=workspace.name,
         seq_in_session=1,
-        created_at=datetime.datetime.now(datetime.timezone.utc),
+        created_at=datetime.datetime.now(datetime.UTC),
     )
     db_session.add(msg)
     await db_session.commit()
@@ -658,9 +656,7 @@ async def test_grep_messages_observer_scoping_left_session_still_visible(
     db_session.add(session)
     await db_session.flush()
 
-    base_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-        minutes=10
-    )
+    base_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=10)
     join_time = base_time
     leave_time = base_time + datetime.timedelta(minutes=5)
 
@@ -720,9 +716,7 @@ async def test_peer_perspective_search_after_active_readd(
     db_session.add_all([workspace, peer1, peer2, session])
     await db_session.flush()
 
-    past_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-        hours=1
-    )
+    past_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
     await db_session.execute(
         models.session_peers_table.insert().values(
             workspace_name=workspace.name,
@@ -762,7 +756,7 @@ async def test_peer_perspective_search_after_active_readd(
             models.SessionPeer.peer_name == peer1.name,
             models.SessionPeer.workspace_name == workspace.name,
         )
-        .values(left_at=datetime.datetime.now(datetime.timezone.utc))
+        .values(left_at=datetime.datetime.now(datetime.UTC))
     )
     await db_session.commit()
 

--- a/tests/utils/test_agent_tools.py
+++ b/tests/utils/test_agent_tools.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import Callable
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -81,7 +81,7 @@ async def tool_test_data(
     await db_session.flush()
 
     # Create messages in the session
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     messages: list[models.Message] = []
     for i in range(5):
         peer_name = peer2.name if i % 2 == 0 else peer1.name
@@ -380,7 +380,7 @@ class TestCreateObservations:
             session_name=session.name,
             workspace_name=workspace.name,
             message_ids=[],
-            message_created_at=str(datetime.now(timezone.utc)),
+            message_created_at=str(datetime.now(UTC)),
         )
 
         assert isinstance(result, ObservationsCreatedResult)
@@ -443,7 +443,7 @@ class TestCreateObservations:
             session_name=session.name,
             workspace_name=workspace.name,
             message_ids=[],
-            message_created_at=str(datetime.now(timezone.utc)),
+            message_created_at=str(datetime.now(UTC)),
         )
 
         assert isinstance(result, ObservationsCreatedResult)
@@ -502,7 +502,7 @@ class TestCreateObservations:
             session_name=session.name,
             workspace_name=workspace.name,
             message_ids=[],
-            message_created_at=str(datetime.now(timezone.utc)),
+            message_created_at=str(datetime.now(UTC)),
         )
 
         assert isinstance(result, ObservationsCreatedResult)
@@ -557,7 +557,7 @@ class TestCreateObservations:
             session_name=session.name,
             workspace_name=workspace.name,
             message_ids=[],
-            message_created_at=str(datetime.now(timezone.utc)),
+            message_created_at=str(datetime.now(UTC)),
         )
 
         assert isinstance(result, ObservationsCreatedResult)
@@ -593,7 +593,7 @@ class TestCreateObservations:
             session_name=session.name,
             workspace_name=workspace.name,
             message_ids=[],
-            message_created_at=str(datetime.now(timezone.utc)),
+            message_created_at=str(datetime.now(UTC)),
         )
 
         assert isinstance(result, ObservationsCreatedResult)
@@ -652,7 +652,7 @@ class TestCreateObservations:
             session_name=session.name,
             workspace_name=workspace.name,
             message_ids=[],
-            message_created_at=str(datetime.now(timezone.utc)),
+            message_created_at=str(datetime.now(UTC)),
         )
 
         assert isinstance(result, ObservationsCreatedResult)
@@ -931,7 +931,7 @@ class TestSearchMemory:
                 content="Relevant fallback message",
                 seq_in_session=1,
                 token_count=5,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
             return [([msg], [msg])]
 
@@ -1097,7 +1097,7 @@ class TestSearchMessagesTemporal:
                 content="Relevant temporal fallback message",
                 seq_in_session=1,
                 token_count=5,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
             return [([msg], [msg])]
 
@@ -1132,7 +1132,7 @@ class TestGetMessagesByDateRange:
         ctx = make_tool_context()
 
         # Get messages from today
-        today = datetime.now(timezone.utc).date().isoformat()
+        today = datetime.now(UTC).date().isoformat()
         result = await _handle_get_messages_by_date_range(
             ctx, {"after_date": today, "limit": 10}
         )
@@ -1633,7 +1633,7 @@ class TestExtractPreferences:
             content="I prefer brief responses and always include code examples",
             seq_in_session=100,
             token_count=20,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         db_session.add(preference_msg)
         await db_session.flush()
@@ -1682,7 +1682,7 @@ class TestExtractPreferences:
                 content=f"Relevant from {query}",
                 seq_in_session=1,
                 token_count=5,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
             return [([msg], [])]
 

--- a/uv.lock
+++ b/uv.lock
@@ -983,7 +983,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.7" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "ruff", specifier = ">=0.11.2" },
+    { name = "ruff", specifier = "==0.15.12" },
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "sqlalchemy-utils", specifier = ">=0.41.2" },
 ]


### PR DESCRIPTION
## Description

- Pin ruff==0.15.12 in dev deps and match the pre-commit rev
- Apply ruff check --fix and ruff format across the tree
- Ignore UP040/UP042/UP046/UP047 (PEP 695 generics, StrEnum) as
  behavior changes to adopt deliberately
- Add ruff check + format --check job to staticanalysis.yml
- Fixed a pre-push alembic test hook by sharing db connection

## Proofs

CI passing

## Checklist

 [ ] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated static analysis checks and formatting standards for improved code quality and consistency.
  - Standardized UTC date and time handling across the application and test suite.

- **Refactor**
  - Improved migration execution flexibility when working with existing database connections.
  - Simplified type annotations and modernized Python compatibility patterns.

- **Tests**
  - Updated test formatting and validation tooling without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->