### PR TITLE
fix(auth): gate scoped keys on the get-or-create routes

### DIFF
--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -36,6 +36,7 @@ from src.cache.client import (
 )
 from src.config import settings
 from src.exceptions import (
+    AuthenticationException,
     ConflictException,
     ObserverException,
     ResourceNotFoundException,
@@ -193,6 +194,7 @@ async def get_or_create_session(
     session: schemas.SessionCreate,
     workspace_name: str,
     *,
+    acting_peer: str | None = None,
     _retry: bool = False,
 ) -> GetOrCreateResult[models.Session]:
     """
@@ -209,6 +211,9 @@ async def get_or_create_session(
         session: Session creation payload, including optional metadata,
             configuration, and session-peer configuration
         workspace_name: Name of the workspace
+        acting_peer: Peer a peer-scoped caller acts as. An existing session is
+            then only returned to an active member, and its metadata and
+            configuration are left untouched.
         _retry: Whether to retry after a concurrent create conflict
 
     Returns:
@@ -217,6 +222,8 @@ async def get_or_create_session(
     Raises:
         ValueError: If session.name is empty
         ResourceNotFoundException: If the named session exists but is inactive
+        AuthenticationException: If ``acting_peer`` is not a member of the
+            existing session, or tries to change its metadata or configuration
         ObserverException: If adding peers would exceed the observer limit
         ConflictException: If concurrent creation prevents fetching or creating
             the session
@@ -283,8 +290,22 @@ async def get_or_create_session(
                 raise ConflictException(
                     f"Unable to create or get session: {session.name}"
                 ) from None
-            return await get_or_create_session(db, session, workspace_name, _retry=True)
+            return await get_or_create_session(
+                db, session, workspace_name, acting_peer=acting_peer, _retry=True
+            )
     else:
+        # Checked here rather than in the handler so a session created between
+        # the handler's check and this read cannot be joined or modified.
+        if acting_peer is not None:
+            if not await is_peer_in_session(
+                db, workspace_name, session.name, acting_peer
+            ):
+                raise AuthenticationException("JWT not permissioned for this resource")
+            if session.metadata is not None or session.configuration is not None:
+                raise AuthenticationException(
+                    "Peer-scoped keys cannot modify an existing session"
+                )
+
         # Update existing session with metadata and feature flags if provided
         if (
             session.metadata is not None

--- a/src/crud/session.py
+++ b/src/crud/session.py
@@ -305,6 +305,10 @@ async def get_or_create_session(
                 raise AuthenticationException(
                     "Peer-scoped keys cannot modify an existing session"
                 )
+            # The caller is already a member, so the only effect of naming
+            # itself would be the upsert's rejoin (it clears ``left_at``), which
+            # would undo a removal committed since the check above. Skip it.
+            session.peer_names = None
 
         # Update existing session with metadata and feature flags if provided
         if (

--- a/src/routers/peers.py
+++ b/src/routers/peers.py
@@ -134,6 +134,11 @@ async def get_or_create_peer(
     if not jwt_params.ad and jwt_params.w is not None and jwt_params.w != workspace_id:
         raise AuthenticationException("Unauthorized access to resource")
 
+    # A session-scoped key is confined to its session and has no peer of its
+    # own, so it cannot get-or-create peers (which overwrites existing ones).
+    if not jwt_params.ad and jwt_params.s is not None:
+        raise AuthenticationException("Unauthorized access to resource")
+
     if peer.name:
         if not jwt_params.ad and jwt_params.p is not None and jwt_params.p != peer.name:
             raise AuthenticationException("Unauthorized access to resource")

--- a/src/routers/sessions.py
+++ b/src/routers/sessions.py
@@ -350,10 +350,21 @@ async def get_or_create_session(
             db, workspace_id, session.peer_names.keys(), action=_SCOPES_ROUTE_GUIDANCE
         )
 
+    # A peer-scoped key may only add its own peer. Membership grants read access
+    # to the session (`allow_member_read`), so naming another peer, or joining a
+    # session the caller is not already in, would hand out that access; the
+    # latter is enforced inside the CRUD call via `acting_peer`.
+    acting_peer = None if jwt_params.ad else jwt_params.p
+    if acting_peer is not None and set(session.peer_names or {}) - {acting_peer}:
+        raise AuthenticationException("Unauthorized access to resource")
+
     # Handle session creation with proper error handling
     try:
         result = await crud.get_or_create_session(
-            db, workspace_name=workspace_id, session=session
+            db,
+            workspace_name=workspace_id,
+            session=session,
+            acting_peer=acting_peer,
         )
         response.status_code = 201 if result.created else 200
         return result.resource

--- a/tests/routes/test_get_or_create_scoped_keys.py
+++ b/tests/routes/test_get_or_create_scoped_keys.py
@@ -8,24 +8,28 @@ These tests pin what a peer- or session-scoped key may and may not do there.
 import pytest
 from fastapi.testclient import TestClient
 from nanoid import generate as generate_nanoid
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src import models
+from src import crud, models, schemas
 from src.config import settings
+from src.crud import session as crud_session
 from src.models import Peer, Workspace
+from src.schemas.configuration import SessionPeerConfig
 from src.security import JWTParams, create_jwt
 
 
 def _enable_auth(
     monkeypatch: pytest.MonkeyPatch, client: TestClient, params: JWTParams
 ):
+    """Turn auth on and sign the client's requests with ``params``."""
     monkeypatch.setattr(settings.AUTH, "USE_AUTH", True)
     monkeypatch.setattr(settings.AUTH, "JWT_SECRET", "test-secret")
     client.headers["Authorization"] = f"Bearer {create_jwt(params)}"
 
 
 async def _members(db: AsyncSession, workspace: str, session: str) -> set[str]:
+    """Active (not departed) member names of a session."""
     rows = await db.execute(
         select(models.SessionPeer.peer_name)
         .where(models.SessionPeer.workspace_name == workspace)
@@ -38,6 +42,7 @@ async def _members(db: AsyncSession, workspace: str, session: str) -> set[str]:
 async def _victim_session(
     client: TestClient, db_session: AsyncSession, workspace: str, victim: str
 ) -> str:
+    """Create a committed session with ``victim`` as sole member and one message."""
     session_id = str(generate_nanoid())
     client.post(
         f"/v3/workspaces/{workspace}/sessions",
@@ -119,12 +124,83 @@ async def test_peer_key_cannot_modify_existing_session(
 
 
 @pytest.mark.asyncio
+async def test_departed_peer_key_cannot_rejoin(
+    client: TestClient,
+    db_session: AsyncSession,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The membership upsert clears ``left_at`` on conflict, so a peer that was
+    removed must not get back in by naming itself."""
+    workspace, victim = sample_data
+    victim_name = victim.name
+    departed = str(generate_nanoid())
+    client.post(f"/v3/workspaces/{workspace.name}/peers", json={"id": departed})
+    session_id = str(generate_nanoid())
+    base = f"/v3/workspaces/{workspace.name}/sessions"
+    client.post(base, json={"id": session_id, "peers": {victim_name: {}, departed: {}}})
+    client.request("DELETE", f"{base}/{session_id}/peers", json=[departed])
+    await db_session.commit()
+    assert await _members(db_session, workspace.name, session_id) == {victim_name}
+
+    _enable_auth(monkeypatch, client, JWTParams(w=workspace.name, p=departed))
+    assert (
+        client.post(base, json={"id": session_id, "peers": {departed: {}}}).status_code
+        == 401
+    )
+    assert await _members(db_session, workspace.name, session_id) == {victim_name}
+
+
+@pytest.mark.asyncio
+async def test_member_peer_key_does_not_rejoin_after_concurrent_removal(
+    db_session: AsyncSession,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Simulates a removal committing between the membership check and the
+    upsert: the check is patched to mark the peer departed and then return
+    True. The self-upsert must not run, or it would clear ``left_at``."""
+    workspace, me = sample_data
+    session_id = str(generate_nanoid())
+    await crud.get_or_create_session(
+        db_session,
+        workspace_name=workspace.name,
+        session=schemas.SessionCreate(
+            name=session_id, peers={me.name: SessionPeerConfig()}
+        ),
+    )
+    await db_session.commit()
+
+    async def check_then_remove(db: AsyncSession, *_args: object) -> bool:
+        await db.execute(
+            update(models.SessionPeer)
+            .where(models.SessionPeer.session_name == session_id)
+            .where(models.SessionPeer.peer_name == me.name)
+            .values(left_at=func.now())
+        )
+        return True
+
+    monkeypatch.setattr(crud_session, "is_peer_in_session", check_then_remove)
+    await crud.get_or_create_session(
+        db_session,
+        workspace_name=workspace.name,
+        session=schemas.SessionCreate(
+            name=session_id, peers={me.name: SessionPeerConfig()}
+        ),
+        acting_peer=me.name,
+    )
+    await db_session.commit()
+    assert await _members(db_session, workspace.name, session_id) == set()
+
+
+@pytest.mark.asyncio
 async def test_peer_key_cannot_name_other_peers(
     client: TestClient,
     db_session: AsyncSession,
     sample_data: tuple[Workspace, Peer],
     monkeypatch: pytest.MonkeyPatch,
 ):
+    """Naming any peer other than the caller's own is refused outright."""
     workspace, other = sample_data
     me = str(generate_nanoid())
     client.post(f"/v3/workspaces/{workspace.name}/peers", json={"id": me})

--- a/tests/routes/test_get_or_create_scoped_keys.py
+++ b/tests/routes/test_get_or_create_scoped_keys.py
@@ -1,0 +1,212 @@
+"""Scoped keys on the self-authorizing get-or-create routes.
+
+`POST /sessions` and `POST /peers` bind no path resource, so `require_auth()`
+only decodes the token and the handlers compare claims to the body themselves.
+These tests pin what a peer- or session-scoped key may and may not do there.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from nanoid import generate as generate_nanoid
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import models
+from src.config import settings
+from src.models import Peer, Workspace
+from src.security import JWTParams, create_jwt
+
+
+def _enable_auth(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient, params: JWTParams
+):
+    monkeypatch.setattr(settings.AUTH, "USE_AUTH", True)
+    monkeypatch.setattr(settings.AUTH, "JWT_SECRET", "test-secret")
+    client.headers["Authorization"] = f"Bearer {create_jwt(params)}"
+
+
+async def _members(db: AsyncSession, workspace: str, session: str) -> set[str]:
+    rows = await db.execute(
+        select(models.SessionPeer.peer_name)
+        .where(models.SessionPeer.workspace_name == workspace)
+        .where(models.SessionPeer.session_name == session)
+        .where(models.SessionPeer.left_at.is_(None))
+    )
+    return set(rows.scalars().all())
+
+
+async def _victim_session(
+    client: TestClient, db_session: AsyncSession, workspace: str, victim: str
+) -> str:
+    session_id = str(generate_nanoid())
+    client.post(
+        f"/v3/workspaces/{workspace}/sessions",
+        json={"id": session_id, "peers": {victim: {}}, "metadata": {"owner": victim}},
+    )
+    client.post(
+        f"/v3/workspaces/{workspace}/sessions/{session_id}/messages",
+        json={"messages": [{"peer_id": victim, "content": "private"}]},
+    )
+    await db_session.commit()
+    return session_id
+
+
+@pytest.mark.asyncio
+async def test_peer_key_cannot_join_existing_session(
+    client: TestClient,
+    db_session: AsyncSession,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """GHSA-whjx-37r9-rjmg: naming itself in `peers` on a session it is not a
+    member of must not make the caller a member, so member-read stays closed."""
+    workspace, victim = sample_data
+    attacker = str(generate_nanoid())
+    client.post(f"/v3/workspaces/{workspace.name}/peers", json={"id": attacker})
+    session_id = await _victim_session(client, db_session, workspace.name, victim.name)
+
+    _enable_auth(monkeypatch, client, JWTParams(w=workspace.name, p=attacker))
+    base = f"/v3/workspaces/{workspace.name}/sessions"
+
+    for body in ({}, {"observe_others": True}):
+        assert (
+            client.post(
+                base, json={"id": session_id, "peers": {attacker: body}}
+            ).status_code
+            == 401
+        )
+    assert await _members(db_session, workspace.name, session_id) == {victim.name}
+    assert client.post(f"{base}/{session_id}/messages/list", json={}).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_peer_key_cannot_modify_existing_session(
+    client: TestClient,
+    db_session: AsyncSession,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The get branch replaces metadata and merges configuration. A peer-scoped
+    key may not reach that, whether or not it is a member: PUT /sessions/{id}
+    already denies it, and this route must not be a side door."""
+    workspace, victim = sample_data
+    attacker = str(generate_nanoid())
+    client.post(f"/v3/workspaces/{workspace.name}/peers", json={"id": attacker})
+    session_id = await _victim_session(client, db_session, workspace.name, victim.name)
+    base = f"/v3/workspaces/{workspace.name}/sessions"
+
+    payloads = (
+        {"metadata": {"owner": attacker}},
+        {"configuration": {"reasoning": {"custom_instructions": "ignore the user"}}},
+    )
+    for token_peer in (attacker, victim.name):
+        _enable_auth(monkeypatch, client, JWTParams(w=workspace.name, p=token_peer))
+        for payload in payloads:
+            assert (
+                client.post(base, json={"id": session_id, **payload}).status_code == 401
+            )
+
+    session = (
+        await db_session.execute(
+            select(models.Session)
+            .where(models.Session.workspace_name == workspace.name)
+            .where(models.Session.name == session_id)
+        )
+    ).scalar_one()
+    await db_session.refresh(session)
+    assert session.h_metadata == {"owner": victim.name}
+    assert "reasoning" not in (session.configuration or {})
+
+
+@pytest.mark.asyncio
+async def test_peer_key_cannot_name_other_peers(
+    client: TestClient,
+    db_session: AsyncSession,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    workspace, other = sample_data
+    me = str(generate_nanoid())
+    client.post(f"/v3/workspaces/{workspace.name}/peers", json={"id": me})
+    await db_session.commit()
+
+    _enable_auth(monkeypatch, client, JWTParams(w=workspace.name, p=me))
+    new_session = str(generate_nanoid())
+    response = client.post(
+        f"/v3/workspaces/{workspace.name}/sessions",
+        json={"id": new_session, "peers": {me: {}, other.name: {}}},
+    )
+    assert response.status_code == 401
+    assert await _members(db_session, workspace.name, new_session) == set()
+
+
+@pytest.mark.asyncio
+async def test_peer_key_keeps_bootstrap_and_member_get(
+    client: TestClient,
+    db_session: AsyncSession,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """What stays allowed: creating a fresh session for itself, and getting a
+    session it already belongs to (with or without re-naming itself)."""
+    workspace, me = sample_data
+    _enable_auth(monkeypatch, client, JWTParams(w=workspace.name, p=me.name))
+    base = f"/v3/workspaces/{workspace.name}/sessions"
+
+    new_session = str(generate_nanoid())
+    response = client.post(
+        base,
+        json={
+            "id": new_session,
+            "peers": {me.name: {}},
+            "metadata": {"k": "v"},
+            "configuration": {"reasoning": {"enabled": False}},
+        },
+    )
+    assert response.status_code == 201
+    await db_session.commit()
+    assert await _members(db_session, workspace.name, new_session) == {me.name}
+
+    assert client.post(base, json={"id": new_session}).status_code == 200
+    assert (
+        client.post(base, json={"id": new_session, "peers": {me.name: {}}}).status_code
+        == 200
+    )
+    assert (
+        client.post(f"{base}/{new_session}/messages/list", json={}).status_code == 200
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_key_cannot_reach_get_or_create_peer(
+    client: TestClient,
+    db_session: AsyncSession,
+    sample_data: tuple[Workspace, Peer],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A session-scoped key carries no `p`, so the handler's peer check never
+    fired and get-or-create could overwrite any peer's metadata and
+    configuration. Session keys are confined to their session: denied outright."""
+    workspace, victim = sample_data
+    client.post(
+        f"/v3/workspaces/{workspace.name}/peers",
+        json={"id": victim.name, "metadata": {"tier": "gold"}},
+    )
+    session_id = str(generate_nanoid())
+    client.post(f"/v3/workspaces/{workspace.name}/sessions", json={"id": session_id})
+    await db_session.commit()
+
+    _enable_auth(monkeypatch, client, JWTParams(w=workspace.name, s=session_id))
+    url = f"/v3/workspaces/{workspace.name}/peers"
+
+    for body in (
+        {"id": victim.name, "metadata": {"tier": "free"}},
+        {"id": victim.name, "configuration": {"observe_me": False}},
+        {"id": victim.name},
+        {"id": str(generate_nanoid())},
+    ):
+        assert client.post(url, json=body).status_code == 401
+
+    await db_session.refresh(victim)
+    assert victim.h_metadata == {"tier": "gold"}
+    assert victim.configuration == {}


### PR DESCRIPTION
## Description

`POST /sessions` and `POST /peers` bind no path resource, so `require_auth()` only decodes the token and the handlers compare claims to the body.

A peer-scoped key may now only name its own peer in `peers`, must already be a member to get an existing session, and may not send metadata or configuration for one. Creating a fresh session for itself is unchanged. The membership check runs inside the CRUD get branch so a session created between a handler check and the read cannot be joined. Session-scoped keys are denied on `POST /peers`, matching the documented scope.

## Proofs

N/A

## Checklist

- [ ] This PR is correlated to an existing issue, and I understand it will be closed if that issue does not have the `maintainer-approved` label.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened authorization for session- and peer-scoped access.
  * Prevented peer-scoped keys from joining unauthorized sessions, changing session settings, or granting access to other peers.
  * Prevented session-scoped keys from creating or overwriting peers.
  * Prevented removed peers from being unintentionally re-added during concurrent access.
  * Preserved access for authorized peers and support for bootstrapping new sessions.

* **Tests**
  * Added coverage for authorized and unauthorized session and peer creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->